### PR TITLE
fix(db): make begin_nested() a contained SAVEPOINT on app.db (#1873)

### DIFF
--- a/changelog.d/pr-1873.md
+++ b/changelog.d/pr-1873.md
@@ -5,3 +5,10 @@
   of their work in the database even when the save failed and everything else
   was undone. The affected records were internal bookkeeping rather than your
   highlights themselves, but the inconsistency could outlive the failure.
+- **Database backups no longer miss recently committed data.** Backups of the
+  live settings and Calibre databases now include writes still held in SQLite's
+  WAL, and restoring a database no longer lets an older WAL override it.
+- **`NETWORK_SHARE_MODE=true` now covers the settings database too.** Because
+  SQLite WAL is unsafe on network filesystems, `app.db` stays in legacy
+  transaction mode under this flag and logs that the SAVEPOINT containment fix
+  is unavailable, including when `/config` itself is on local storage.

--- a/changelog.d/pr-1873.md
+++ b/changelog.d/pr-1873.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- **A write that fails is no longer sometimes kept.** Certain edits — highlights
+  made in the web reader, and progress synced from KOReader — could leave part
+  of their work in the database even when the save failed and everything else
+  was undone. The affected records were internal bookkeeping rather than your
+  highlights themselves, but the inconsistency could outlive the failure.

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -60,6 +60,7 @@ from .ui_themes import config_theme_code
 from .cw_babel import get_available_translations, get_available_locale, get_user_locale_language
 from . import debug_info
 from .string_helper import strip_whitespaces
+from .sqlite_utils import copy_sqlite_database
 
 log = logger.create()
 
@@ -3565,8 +3566,8 @@ def restore_calibre_db():
         # 1. Backup both DBs
         backup_dir = f"/config/backup/restore_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
         os.makedirs(backup_dir, exist_ok=True)
-        shutil.copy2(metadata_path, os.path.join(backup_dir, "metadata.db.bak"))
-        shutil.copy2(app_db_path, os.path.join(backup_dir, "app.db.bak"))
+        copy_sqlite_database(metadata_path, os.path.join(backup_dir, "metadata.db.bak"))
+        copy_sqlite_database(app_db_path, os.path.join(backup_dir, "app.db.bak"))
 
         log_path = os.path.join(backup_dir, "restore.log")
         with open(log_path, "a", encoding="utf-8") as log_file:

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -781,10 +781,14 @@ def _encrypt_fields(session, secret_key):
     try:
         session.query(exists().where(_Settings.mail_password_e)).scalar()
     except OperationalError:
-        with session.bind.connect() as conn:
+        # With explicit SQLite BEGIN handling, the failed inspection owns a
+        # real transaction. Release it before migrating on another connection,
+        # then use begin() so the DDL is committed rather than rolled back when
+        # the context exits.
+        session.rollback()
+        with session.bind.begin() as conn:
             conn.execute(text("ALTER TABLE settings ADD column 'mail_password_e' String"))
             conn.execute(text("ALTER TABLE settings ADD column 'config_ldap_serv_password_e' String"))
-        session.commit()
         crypter = Fernet(secret_key)
         settings = session.query(_Settings.mail_password, _Settings.config_ldap_serv_password).first()
         if settings.mail_password:
@@ -807,6 +811,7 @@ def _migrate_table(session, orm_class, secret_key=None):
                 session.query(column).first()
             except OperationalError as err:
                 log.debug("%s: %s", column_name, err.args[0])
+                session.rollback()
                 # Handle default values for new columns
                 if column.default is None:
                     # Use NULL for columns with None default (important for autodetection logic)
@@ -825,7 +830,11 @@ def _migrate_table(session, orm_class, secret_key=None):
                                                                              column_type,
                                                                              column_default))
                 log.debug(alter_table)
-                session.execute(alter_table)
+                # Commit each missing column independently. A later failed
+                # inspection must not roll back an earlier ALTER in the same
+                # migration pass now that SQLite DDL is transactional.
+                with session.bind.begin() as conn:
+                    conn.execute(alter_table)
                 changed = True
             except json.decoder.JSONDecodeError as e:
                 log.error("Database corrupt column: {}".format(column_name))

--- a/cps/db.py
+++ b/cps/db.py
@@ -48,6 +48,7 @@ from flask import flash, url_for, has_request_context
 from . import logger, ub, isoLanguages
 from .pagination import Pagination
 from .string_helper import strip_whitespaces
+from .sqlite_utils import network_share_mode_enabled
 from .unicode_collation import unicode_initial, unicode_sort_key
 
 log = logger.create()
@@ -1168,7 +1169,7 @@ class CalibreDB:
                 # Try enabling WAL to improve concurrency unless running on a network share
                 # Controlled by env var NETWORK_SHARE_MODE (default False)
                 try:
-                    nsm = os.getenv('NETWORK_SHARE_MODE', 'False').lower() in ('1', 'true', 'yes', 'on')
+                    nsm = network_share_mode_enabled()
                     dc = os.getenv('DESKTOP_COMPAT_MODE', 'False').lower() in ('1', 'true', 'yes', 'on')
                     if not nsm and not dc and db_writable:
                         connection.execute(text("PRAGMA calibre.journal_mode=WAL"))
@@ -1260,7 +1261,7 @@ class CalibreDB:
                 return None
 
             db_writable = os.access(dbpath, os.W_OK)
-            nsm = os.getenv('NETWORK_SHARE_MODE', 'False').lower() in ('1', 'true', 'yes', 'on')
+            nsm = network_share_mode_enabled()
             desktop_compat = os.getenv('DESKTOP_COMPAT_MODE', 'False').lower() in ('1', 'true', 'yes', 'on')
 
             try:

--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -39,6 +39,7 @@ from .cwa_functions import get_ingest_dir
 from .services.calibre_db_lock import metadata_db_write_lock
 from .services.kepub_package_normalizer import normalize_kepub_package
 from .services.pubdate_parse import parse_partial_pubdate
+from .sqlite_utils import network_share_mode_enabled
 from .usermanagement import user_login_required, login_required_if_no_ano
 from .string_helper import strip_whitespaces
 from werkzeug.utils import secure_filename
@@ -404,7 +405,7 @@ def _get_ingest_path(uploaded_file, prefix_parts=None):
         raise
     # Ensure proper ownership of ingest directory (fix for issue #603)
     try:
-        nsm = os.getenv("NETWORK_SHARE_MODE", "false").strip().lower() in ("1", "true", "yes", "on")
+        nsm = network_share_mode_enabled()
         if not (nsm and ingest_dir == "/cwa-book-ingest"):
             # Set ownership to abc:abc (uid=1000, gid=1000)
             os.chown(ingest_dir, 1000, 1000)

--- a/cps/gdrive.py
+++ b/cps/gdrive.py
@@ -10,7 +10,6 @@ import hashlib
 import json
 from uuid import uuid4
 from time import time
-from shutil import move, copyfile
 
 from flask import Blueprint, flash, request, redirect, url_for, abort
 from flask_babel import gettext as _
@@ -18,6 +17,7 @@ from flask_babel import gettext as _
 from . import logger, gdriveutils, config, ub, calibre_db, csrf
 from .admin import admin_required
 from .file_helper import get_temp_dir
+from .sqlite_utils import copy_sqlite_database
 from .usermanagement import user_login_required
 
 gdrive = Blueprint('gdrive', __name__, url_prefix='/gdrive')
@@ -129,12 +129,18 @@ try:
                     tmp_dir = get_temp_dir()
 
                     log.info('Database file updated')
-                    copyfile(dbpath, os.path.join(tmp_dir, "metadata.db_" + str(current_milli_time())))
+                    copy_sqlite_database(
+                        dbpath,
+                        os.path.join(tmp_dir, "metadata.db_" + str(current_milli_time())),
+                    )
                     log.info('Backing up existing and downloading updated metadata.db')
                     gdriveutils.downloadFile(None, "metadata.db", os.path.join(tmp_dir, "tmp_metadata.db"))
                     log.info('Setting up new DB')
-                    # prevent error on windows, as os.rename does on existing files, also allow cross hdd move
-                    move(os.path.join(tmp_dir, "tmp_metadata.db"), dbpath)
+                    # Write through SQLite so a replacement cannot be poisoned by
+                    # committed pages in metadata.db-wal from the old database.
+                    copy_sqlite_database(
+                        os.path.join(tmp_dir, "tmp_metadata.db"), dbpath, restore=True
+                    )
                     calibre_db.reconnect_db(config, ub.app_DB_path)
         except Exception as ex:
             log.error_or_exception(ex)

--- a/cps/sqlite_utils.py
+++ b/cps/sqlite_utils.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2025 Calibre-Web contributors
+# Copyright (C) 2024-2025 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Shared SQLite environment and copy helpers."""
+
+import os
+import shutil
+import sqlite3
+from pathlib import Path
+
+
+_TRUTHY_ENV_VALUES = frozenset(("1", "true", "yes", "on"))
+
+
+def environment_flag_enabled(name, environ=None):
+    """Return whether an environment flag uses a supported truthy spelling."""
+    source = os.environ if environ is None else environ
+    return source.get(name, "").strip().lower() in _TRUTHY_ENV_VALUES
+
+
+def network_share_mode_enabled(environ=None):
+    """Parse the process-wide ``NETWORK_SHARE_MODE`` contract in one place."""
+    return environment_flag_enabled("NETWORK_SHARE_MODE", environ)
+
+
+def copy_sqlite_database(source_path, destination_path, timeout=30, *, restore=False):
+    """Copy a SQLite database transactionally, including committed WAL frames.
+
+    SQLite's online backup API reads a consistent source snapshot even while
+    other connections are writing it. It also writes an existing destination
+    through SQLite's own transaction machinery, so a restore cannot combine a
+    replacement main file with stale pages from the destination's ``-wal``.
+    A newly-created destination is a self-contained database file; no source
+    sidecar files need to be copied. Pass ``restore=True`` when the destination
+    is the application's live database; its existing journal mode is retained.
+    """
+    source = os.path.abspath(os.fsdecode(os.fspath(source_path)))
+    destination = os.path.abspath(os.fsdecode(os.fspath(destination_path)))
+    if (
+        os.path.normcase(os.path.realpath(source))
+        == os.path.normcase(os.path.realpath(destination))
+    ):
+        raise ValueError("SQLite source and destination must be different files")
+
+    destination_existed = os.path.exists(destination)
+    source_uri = Path(source).as_uri() + "?mode=ro"
+    with sqlite3.connect(source_uri, uri=True, timeout=timeout) as source_connection:
+        with sqlite3.connect(destination, timeout=timeout) as destination_connection:
+            destination_mode = destination_connection.execute(
+                "PRAGMA journal_mode"
+            ).fetchone()[0]
+            source_connection.backup(destination_connection)
+            # The backup copies page 1, including the source's persistent WAL
+            # marker. A new backup file has no WAL sidecar by design, so make
+            # it a portable rollback-journal database after all committed WAL
+            # frames have landed in the main file. When replacing an existing
+            # live database, retain its prior mode instead.
+            requested_mode = (
+                destination_mode if restore and destination_existed else "delete"
+            )
+            resulting_mode = destination_connection.execute(
+                "PRAGMA journal_mode={}".format(requested_mode)
+            ).fetchone()[0]
+            if resulting_mode.lower() != requested_mode.lower():
+                raise sqlite3.OperationalError(
+                    "could not preserve destination journal mode {!r}".format(requested_mode)
+                )
+
+    if not restore:
+        # SQLite may leave an empty shared-memory file behind after converting
+        # the new snapshot from WAL to DELETE. A backup is deliberately one
+        # portable file, and no other connection should have it open yet.
+        for suffix in ("-wal", "-shm"):
+            try:
+                os.remove(destination + suffix)
+            except FileNotFoundError:
+                pass
+
+    # Match copy2's useful metadata preservation without making a successful
+    # database snapshot fail on filesystems that reject timestamp/mode changes.
+    try:
+        shutil.copystat(source, destination)
+    except OSError:
+        pass

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -10,6 +10,7 @@ import os
 import re
 import sys
 import sqlite3
+import threading
 import time
 from datetime import datetime, timezone, timedelta
 import itertools
@@ -4238,28 +4239,70 @@ def create_system_magic_shelves_for_user(user_id):
         return 0
 
 
+def _request_app_db_wal(dbapi_connection):
+    """Request WAL on a raw sqlite3 connection, before SQLAlchemy autobegins."""
+    cursor = dbapi_connection.cursor()
+    try:
+        row = cursor.execute("PRAGMA journal_mode=WAL").fetchone()
+        return (row[0] if row else None), None
+    except sqlite3.Error as error:
+        return None, error
+    finally:
+        cursor.close()
+
+
 def _create_app_db_engine(app_db_path):
-    """Create an app.db engine with SQLAlchemy-owned transaction boundaries.
+    """Create an app.db engine with the safest available transaction mode.
 
     Python's sqlite3 legacy transaction mode emits BEGIN for DML only. A
     SAVEPOINT reached after SELECTs therefore has no enclosing transaction,
     and releasing it makes its writes durable before Session.commit(). Disable
     the driver's BEGIN handling and let SQLAlchemy emit BEGIN for every outer
-    transaction so Session.begin_nested() is always a contained SAVEPOINT.
+    transaction when WAL is available, so Session.begin_nested() is a contained
+    SAVEPOINT without making rollback-journal readers block writers.
+
+    WAL support is decided once per engine. If the first raw connection cannot
+    enable it (for example, app.db is on a network share), every connection on
+    that engine retains sqlite3's legacy transaction control. Mixing explicit
+    and legacy transaction semantics between connections would be worse than a
+    single, observable degraded mode.
     """
     engine = create_engine(
         'sqlite:///{0}'.format(app_db_path),
         echo=False,
         connect_args={'timeout': 30},
     )
+    transaction_mode = {'explicit_begin': None}
+    transaction_mode_lock = threading.Lock()
 
     @event.listens_for(engine, 'connect')
-    def _disable_sqlite_legacy_transaction_mode(dbapi_connection, _connection_record):
-        dbapi_connection.isolation_level = None
+    def _configure_app_db_transaction_mode(dbapi_connection, _connection_record):
+        if transaction_mode['explicit_begin'] is None:
+            with transaction_mode_lock:
+                if transaction_mode['explicit_begin'] is None:
+                    journal_mode, wal_error = _request_app_db_wal(dbapi_connection)
+                    wal_enabled = str(journal_mode).lower() == 'wal'
+                    transaction_mode['explicit_begin'] = wal_enabled
+                    if not wal_enabled:
+                        reason = ("PRAGMA journal_mode=WAL failed: {}".format(wal_error)
+                                  if wal_error is not None
+                                  else "SQLite kept journal_mode={!r}".format(journal_mode))
+                        log.warning(
+                            "SQLite WAL is unavailable for app.db %s (%s). Leaving legacy "
+                            "sqlite3 transaction control active for this engine to avoid "
+                            "rollback-journal readers blocking writers; begin_nested() "
+                            "SAVEPOINTs opened before DML are not contained and may commit "
+                            "at RELEASE.",
+                            app_db_path, reason,
+                        )
+
+        if transaction_mode['explicit_begin']:
+            dbapi_connection.isolation_level = None
 
     @event.listens_for(engine, 'begin')
     def _emit_begin(connection):
-        connection.exec_driver_sql('BEGIN')
+        if transaction_mode['explicit_begin']:
+            connection.exec_driver_sql('BEGIN')
 
     return engine
 

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -46,6 +46,7 @@ from sqlalchemy.orm import backref, relationship, sessionmaker, Session, scoped_
 from werkzeug.security import generate_password_hash
 
 from . import constants, logger
+from .sqlite_utils import network_share_mode_enabled
 from .string_helper import strip_whitespaces
 
 log = logger.create()
@@ -4274,16 +4275,29 @@ def _create_app_db_engine(app_db_path):
     )
     transaction_mode = {'explicit_begin': None}
     transaction_mode_lock = threading.Lock()
+    network_share_mode = network_share_mode_enabled()
 
     @event.listens_for(engine, 'connect')
     def _configure_app_db_transaction_mode(dbapi_connection, _connection_record):
         if transaction_mode['explicit_begin'] is None:
             with transaction_mode_lock:
                 if transaction_mode['explicit_begin'] is None:
-                    journal_mode, wal_error = _request_app_db_wal(dbapi_connection)
-                    wal_enabled = str(journal_mode).lower() == 'wal'
-                    transaction_mode['explicit_begin'] = wal_enabled
-                    if not wal_enabled:
+                    if network_share_mode:
+                        transaction_mode['explicit_begin'] = False
+                        log.warning(
+                            "NETWORK_SHARE_MODE=true disables SQLite WAL for every database, "
+                            "including app.db %s even when /config is on local disk, because "
+                            "WAL is unsafe on network filesystems. app.db is using legacy "
+                            "sqlite3 transaction control, so the #1873 SAVEPOINT containment "
+                            "fix is unavailable: begin_nested() SAVEPOINTs opened before DML "
+                            "may commit at RELEASE.",
+                            app_db_path,
+                        )
+                    else:
+                        journal_mode, wal_error = _request_app_db_wal(dbapi_connection)
+                        wal_enabled = str(journal_mode).lower() == 'wal'
+                        transaction_mode['explicit_begin'] = wal_enabled
+                    if not network_share_mode and not transaction_mode['explicit_begin']:
                         reason = ("PRAGMA journal_mode=WAL failed: {}".format(wal_error)
                                   if wal_error is not None
                                   else "SQLite kept journal_mode={!r}".format(journal_mode))
@@ -4365,8 +4379,7 @@ def _healthcheck_app_db(app_db_path: str) -> None:
             return
         if not os.access(app_db_path, os.W_OK):
             log.error("app.db is not writable: %s", app_db_path)
-        network_share_mode = os.environ.get("NETWORK_SHARE_MODE", "false").lower() in ("1", "true", "yes")
-        if network_share_mode:
+        if network_share_mode_enabled():
             log.info("Skipping PRAGMA quick_check for app.db due to NETWORK_SHARE_MODE=true")
             return
         try:

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -1814,28 +1814,27 @@ def add_missing_tables(engine, _session):
     # NameError on any app.db missing kosync_progress (a fresh install).
     from .progress_syncing.models import KOSyncProgress
 
-    if not engine.dialect.has_table(engine.connect(), "archived_book"):
-        ArchivedBook.__table__.create(bind=engine, checkfirst=True)
-    if not engine.dialect.has_table(engine.connect(), "thumbnail"):
-        Thumbnail.__table__.create(bind=engine, checkfirst=True)
-    if not engine.dialect.has_table(engine.connect(), "kosync_progress"):
-        KOSyncProgress.__table__.create(bind=engine, checkfirst=True)
-    if not engine.dialect.has_table(engine.connect(), "magic_shelf"):
-        MagicShelf.__table__.create(bind=engine, checkfirst=True)
-    if not engine.dialect.has_table(engine.connect(), "magic_shelf_cache"):
-        MagicShelfCache.__table__.create(bind=engine, checkfirst=True)
-    if not engine.dialect.has_table(engine.connect(), "opds_shelf_exposure"):
-        OpdsShelfExposure.__table__.create(bind=engine, checkfirst=True)
-    if not engine.dialect.has_table(engine.connect(), "book_original_filename"):
-        BookOriginalFilename.__table__.create(bind=engine, checkfirst=True)
-    if not engine.dialect.has_table(engine.connect(), "opds_magic_shelf_exposure"):
-        OpdsMagicShelfExposure.__table__.create(bind=engine, checkfirst=True)
-    if not engine.dialect.has_table(engine.connect(), "hidden_magic_shelf_templates"):
-        HiddenMagicShelfTemplate.__table__.create(bind=engine, checkfirst=True)
-    if not engine.dialect.has_table(engine.connect(), "kobo_annotation_backup"):
-        KoboAnnotationBackup.__table__.create(bind=engine, checkfirst=True)
-    if not engine.dialect.has_table(engine.connect(), "favorite_book"):
-        FavoriteBook.__table__.create(bind=engine, checkfirst=True)
+    tables = (
+        ("archived_book", ArchivedBook.__table__),
+        ("thumbnail", Thumbnail.__table__),
+        ("kosync_progress", KOSyncProgress.__table__),
+        ("magic_shelf", MagicShelf.__table__),
+        ("magic_shelf_cache", MagicShelfCache.__table__),
+        ("opds_shelf_exposure", OpdsShelfExposure.__table__),
+        ("book_original_filename", BookOriginalFilename.__table__),
+        ("opds_magic_shelf_exposure", OpdsMagicShelfExposure.__table__),
+        ("hidden_magic_shelf_templates", HiddenMagicShelfTemplate.__table__),
+        ("kobo_annotation_backup", KoboAnnotationBackup.__table__),
+        ("favorite_book", FavoriteBook.__table__),
+    )
+    for table_name, table in tables:
+        # Explicit transaction control means even schema inspection begins a
+        # real read transaction. Close it before opening the separate DDL
+        # transaction or the inspection connection can block its commit.
+        with engine.connect() as connection:
+            table_exists = engine.dialect.has_table(connection, table_name)
+        if not table_exists:
+            table.create(bind=engine, checkfirst=True)
 
 
 # migrate all settings missing in registration table
@@ -1844,11 +1843,13 @@ def migrate_registration_table(engine, _session):
         # Handle table exists, but no content
         cnt = _session.query(Registration).count()
         if not cnt:
-            with engine.connect() as conn:
-                trans = conn.begin()
-                conn.execute(text("insert into registration (domain, allow) values('%.%',1)"))
-                trans.commit()
+            _session.add(Registration(domain='%.%', allow=1))
+        # The inspection SELECT now opens a real transaction. Commit on the
+        # same session both to persist the seed row and to release its read
+        # lock before later migrations use independent engine connections.
+        _session.commit()
     except exc.OperationalError:  # Database is not writeable
+        _session.rollback()
         print('Settings database is not writeable. Exiting...')
         sys.exit(2)
 
@@ -4136,8 +4137,11 @@ def migrate_Database(_session):
                 created = magic_shelf.create_system_magic_shelves(user.id, templates_to_create)
                 total_created += created
         
+        # Even a no-op pass performed SELECTs and therefore owns a real read
+        # transaction under explicit BEGIN handling. End it before the trigger
+        # guard below opens a separate DDL transaction on the same database.
+        _session.commit()
         if total_deleted > 0 or total_created > 0:
-            _session.commit()
             log.info(f"System shelf migration complete: {total_deleted} old shelves removed, {total_created} new shelves created")
     except Exception as e:
         log.error(f"Error during system shelf migration: {e}")
@@ -4234,6 +4238,32 @@ def create_system_magic_shelves_for_user(user_id):
         return 0
 
 
+def _create_app_db_engine(app_db_path):
+    """Create an app.db engine with SQLAlchemy-owned transaction boundaries.
+
+    Python's sqlite3 legacy transaction mode emits BEGIN for DML only. A
+    SAVEPOINT reached after SELECTs therefore has no enclosing transaction,
+    and releasing it makes its writes durable before Session.commit(). Disable
+    the driver's BEGIN handling and let SQLAlchemy emit BEGIN for every outer
+    transaction so Session.begin_nested() is always a contained SAVEPOINT.
+    """
+    engine = create_engine(
+        'sqlite:///{0}'.format(app_db_path),
+        echo=False,
+        connect_args={'timeout': 30},
+    )
+
+    @event.listens_for(engine, 'connect')
+    def _disable_sqlite_legacy_transaction_mode(dbapi_connection, _connection_record):
+        dbapi_connection.isolation_level = None
+
+    @event.listens_for(engine, 'begin')
+    def _emit_begin(connection):
+        connection.exec_driver_sql('BEGIN')
+
+    return engine
+
+
 def init_db_thread():
     global app_DB_path
     if not app_DB_path:
@@ -4246,8 +4276,7 @@ def init_db_thread():
         raise RuntimeError(
             "ub.init_db_thread() called before ub.init_db(); app_DB_path "
             "is unset, refusing to create a stray 'None' SQLite file")
-    engine = create_engine('sqlite:///{0}'.format(app_DB_path), echo=False,
-                           connect_args={'timeout': 30})
+    engine = _create_app_db_engine(app_DB_path)
 
     Session = scoped_session(sessionmaker())
     Session.configure(bind=engine)
@@ -4260,8 +4289,7 @@ def init_db(app_db_path):
     global app_DB_path
 
     app_DB_path = app_db_path
-    engine = create_engine('sqlite:///{0}'.format(app_db_path), echo=False,
-                           connect_args={'timeout': 30})
+    engine = _create_app_db_engine(app_db_path)
 
     Session = scoped_session(sessionmaker())
     Session.configure(bind=engine)
@@ -4336,8 +4364,7 @@ def password_change(user_credentials=None):
 
 
 def get_new_session_instance():
-    new_engine = create_engine('sqlite:///{0}'.format(app_DB_path), echo=False,
-                               connect_args={'timeout': 30})
+    new_engine = _create_app_db_engine(app_DB_path)
     new_session = scoped_session(sessionmaker())
     new_session.configure(bind=new_engine)
 

--- a/cps/updater.py
+++ b/cps/updater.py
@@ -21,6 +21,7 @@ from flask_babel import gettext as _
 
 from . import constants, logger  #  config, web_server
 from .file_helper import get_temp_dir
+from .sqlite_utils import network_share_mode_enabled
 
 
 log = logger.create()
@@ -266,7 +267,7 @@ class Updater(threading.Thread):
         change_permissions = not (sys.platform == "win32" or sys.platform == "darwin")
         # Only skip permission changes for network-share paths
         try:
-            nsm = os.getenv("NETWORK_SHARE_MODE", "false").strip().lower() in ("1", "true", "yes", "on")
+            nsm = network_share_mode_enabled()
         except Exception:
             nsm = False
 

--- a/tests/unit/test_1873_app_db_savepoint_containment.py
+++ b/tests/unit/test_1873_app_db_savepoint_containment.py
@@ -228,3 +228,50 @@ def test_wal_unavailable_suppresses_explicit_begin_warns_and_does_not_block_writ
             ("seed",),
             ("writer",),
         ]
+
+
+@pytest.mark.unit
+def test_network_share_mode_skips_wal_uses_legacy_transactions_and_warns(
+    tmp_path, monkeypatch,
+):
+    """NETWORK_SHARE_MODE applies to app.db even when its own path is local."""
+    db_path = tmp_path / "network-share-mode.db"
+    with sqlite3.connect(db_path) as setup:
+        setup.execute("CREATE TABLE probe (value TEXT NOT NULL)")
+        setup.execute("INSERT INTO probe VALUES ('seed')")
+
+    monkeypatch.setenv("NETWORK_SHARE_MODE", "true")
+
+    def unexpected_wal_request(_connection):
+        raise AssertionError("NETWORK_SHARE_MODE must skip PRAGMA journal_mode=WAL")
+
+    monkeypatch.setattr(ub, "_request_app_db_wal", unexpected_wal_request)
+    warnings = []
+    monkeypatch.setattr(
+        ub.log,
+        "warning",
+        lambda message, *args: warnings.append(message % args),
+    )
+    engine = ub._create_app_db_engine(db_path)
+
+    try:
+        with engine.connect() as reader:
+            driver_connection = reader.connection.driver_connection
+            assert reader.exec_driver_sql("PRAGMA journal_mode").scalar_one() == "delete"
+            assert driver_connection.isolation_level is not None
+            assert reader.exec_driver_sql("SELECT value FROM probe").scalar_one() == "seed"
+            assert driver_connection.in_transaction is False
+
+            # A second DBAPI connection must inherit the engine-wide decision
+            # without another warning or a deferred WAL negotiation.
+            with engine.connect() as sibling:
+                sibling_driver = sibling.connection.driver_connection
+                assert sibling_driver is not driver_connection
+                assert sibling_driver.isolation_level is not None
+    finally:
+        engine.dispose()
+
+    assert len(warnings) == 1
+    assert "NETWORK_SHARE_MODE=true" in warnings[0]
+    assert "even when /config is on local disk" in warnings[0]
+    assert "#1873 SAVEPOINT containment fix is unavailable" in warnings[0]

--- a/tests/unit/test_1873_app_db_savepoint_containment.py
+++ b/tests/unit/test_1873_app_db_savepoint_containment.py
@@ -1,0 +1,166 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Regression coverage for #1873's uncontained app.db SAVEPOINT."""
+
+from __future__ import annotations
+
+import sqlite3
+from types import SimpleNamespace
+
+import pytest
+
+from cps import ub
+from cps.services.annotation_sync import (
+    dispatch_existing_annotation_sync,
+    register_handler,
+    reset_registry_for_testing,
+    set_remote_enqueue,
+)
+from cps.services.annotation_sync.base import AnnotationSyncTargetHandler, SyncResult
+
+
+class _StubHandler(AnnotationSyncTargetHandler):
+    target_name = "stub"
+
+    def is_enabled(self, user):
+        return True
+
+    def push(self, annotation, book, user, payload=None):
+        return SyncResult(status="synced", target_record_id="remote-1873")
+
+    def delete(self, sync_target, user):
+        return SyncResult(status="tombstone")
+
+
+@pytest.fixture(autouse=True)
+def _reset_annotation_sync_registry():
+    reset_registry_for_testing()
+    set_remote_enqueue(None)
+    yield
+    reset_registry_for_testing()
+    set_remote_enqueue(None)
+
+
+@pytest.fixture
+def file_backed_app_db(tmp_path):
+    """Initialize the real app.db engine and restore the module globals after."""
+    previous_session = ub.session
+    previous_path = ub.app_DB_path
+    db_path = tmp_path / "app.db"
+
+    ub.init_db(str(db_path))
+    test_session = ub.session
+    try:
+        yield db_path, test_session
+    finally:
+        engine = test_session.get_bind()
+        test_session.close()
+        engine.dispose()
+        ub.session = previous_session
+        ub.app_DB_path = previous_path
+
+
+@pytest.mark.unit
+def test_existing_annotation_sync_savepoint_rolls_back_with_failed_commit(
+    file_backed_app_db, monkeypatch,
+):
+    """The web-reader/KOReader create arm must not commit at SAVEPOINT release.
+
+    ``dispatch_annotation_sync`` (the Kobo PATCH entry point) flushes an
+    Annotation before it creates the sync-target row. That DML happens to make
+    sqlite3's legacy transaction mode contain its SAVEPOINT, so testing that
+    caller passes with or without the fix. ``dispatch_existing_annotation_sync``
+    reaches the same create arm after SELECTs only and is the discriminating
+    real caller.
+
+    Seed through a separate sqlite3 connection so this SQLAlchemy connection
+    has emitted no DML before the dispatcher opens ``begin_nested()``. Then
+    model a failed outer commit by rolling back, and verify durability through
+    another independent connection rather than the session under test.
+    """
+    db_path, session = file_backed_app_db
+    session.rollback()
+
+    with sqlite3.connect(db_path) as seed:
+        user_id = seed.execute(
+            "SELECT id FROM user WHERE name = 'admin'"
+        ).fetchone()[0]
+        seed.execute(
+            "INSERT INTO annotation "
+            "(user_id, annotation_id, book_id, source, routing_revision, content_revision) "
+            "VALUES (?, 'webreader-1873', 1873, 'webreader', 1, 1)",
+            (user_id,),
+        )
+
+    user = session.query(ub.User).filter(ub.User.id == user_id).one()
+    annotation = session.query(ub.Annotation).filter(
+        ub.Annotation.annotation_id == "webreader-1873"
+    ).one()
+    register_handler(_StubHandler())
+
+    commit_attempts = []
+
+    def fail_outer_commit():
+        commit_attempts.append(True)
+        session.rollback()
+        return False
+
+    monkeypatch.setattr(ub, "session_commit", fail_outer_commit)
+
+    dispatch_existing_annotation_sync(
+        annotation,
+        SimpleNamespace(id=1873, title="SAVEPOINT regression"),
+        user,
+    )
+
+    assert commit_attempts == [True], "the test did not exercise the failed commit path"
+    with sqlite3.connect(db_path) as observer:
+        durable_targets = observer.execute(
+            "SELECT target, status FROM annotation_sync_target "
+            "WHERE annotation_id = ?",
+            (annotation.id,),
+        ).fetchall()
+
+    assert durable_targets == [], (
+        "the sync-target SAVEPOINT committed at RELEASE and survived the outer rollback"
+    )
+
+
+@pytest.mark.unit
+def test_every_app_db_session_uses_explicit_begin_and_factory_keeps_timeout(
+    file_backed_app_db,
+):
+    """The main, worker, and ad-hoc app.db constructors share the fix."""
+    _db_path, main_session = file_backed_app_db
+    thread_session = ub.init_db_thread()
+    ad_hoc_session = ub.get_new_session_instance()
+    sessions = {
+        "init_db": main_session,
+        "init_db_thread": thread_session,
+        "get_new_session_instance": ad_hoc_session,
+    }
+
+    try:
+        for constructor, session in sessions.items():
+            connection = session.connection()
+            driver_connection = connection.connection.driver_connection
+            assert driver_connection.isolation_level is None, constructor
+            session.rollback()
+
+        # Startup migrations temporarily lower busy_timeout on the pooled main
+        # connection for their own retry loop. Check a fresh factory connection
+        # so this pins the connect_args=30 contract rather than that unrelated,
+        # pre-existing migration policy.
+        timeout_engine = ub._create_app_db_engine(_db_path)
+        try:
+            with timeout_engine.connect() as connection:
+                assert connection.exec_driver_sql("PRAGMA busy_timeout").scalar_one() == 30_000
+        finally:
+            timeout_engine.dispose()
+    finally:
+        thread_engine = thread_session.get_bind()
+        thread_session.close()
+        thread_engine.dispose()
+        ad_hoc_engine = ad_hoc_session.get_bind()
+        ad_hoc_session.remove()
+        ad_hoc_engine.dispose()

--- a/tests/unit/test_1873_app_db_savepoint_containment.py
+++ b/tests/unit/test_1873_app_db_savepoint_containment.py
@@ -130,7 +130,7 @@ def test_existing_annotation_sync_savepoint_rolls_back_with_failed_commit(
 def test_every_app_db_session_uses_explicit_begin_and_factory_keeps_timeout(
     file_backed_app_db,
 ):
-    """The main, worker, and ad-hoc app.db constructors share the fix."""
+    """The main, worker, and ad-hoc app.db constructors share WAL + the fix."""
     _db_path, main_session = file_backed_app_db
     thread_session = ub.init_db_thread()
     ad_hoc_session = ub.get_new_session_instance()
@@ -145,6 +145,7 @@ def test_every_app_db_session_uses_explicit_begin_and_factory_keeps_timeout(
             connection = session.connection()
             driver_connection = connection.connection.driver_connection
             assert driver_connection.isolation_level is None, constructor
+            assert connection.exec_driver_sql("PRAGMA journal_mode").scalar_one() == "wal"
             session.rollback()
 
         # Startup migrations temporarily lower busy_timeout on the pooled main
@@ -164,3 +165,66 @@ def test_every_app_db_session_uses_explicit_begin_and_factory_keeps_timeout(
         ad_hoc_engine = ad_hoc_session.get_bind()
         ad_hoc_session.remove()
         ad_hoc_engine.dispose()
+
+
+@pytest.mark.unit
+def test_wal_unavailable_suppresses_explicit_begin_warns_and_does_not_block_writer(
+    tmp_path, monkeypatch,
+):
+    """A WAL-incapable engine degrades consistently and observably."""
+    db_path = tmp_path / "wal-unavailable.db"
+    with sqlite3.connect(db_path) as setup:
+        setup.execute("CREATE TABLE probe (value TEXT NOT NULL)")
+        setup.execute("INSERT INTO probe VALUES ('seed')")
+
+    wal_requests = []
+
+    def reject_wal(connection):
+        wal_requests.append(connection)
+        return "delete", None
+
+    monkeypatch.setattr(ub, "_request_app_db_wal", reject_wal)
+    warnings = []
+
+    def capture_warning(message, *args):
+        warnings.append(message % args)
+
+    monkeypatch.setattr(ub.log, "warning", capture_warning)
+    engine = ub._create_app_db_engine(db_path)
+
+    try:
+        with engine.connect() as reader:
+            assert reader.exec_driver_sql("SELECT value FROM probe").scalar_one() == "seed"
+            driver_connection = reader.connection.driver_connection
+            assert driver_connection.isolation_level is not None
+            assert driver_connection.in_transaction is False
+
+            # Keep the reader checked out so this must create another DBAPI
+            # connection. The WAL capability probe is engine-wide, not a
+            # per-connection choice that could produce mixed semantics.
+            with engine.connect() as sibling:
+                sibling_driver = sibling.connection.driver_connection
+                assert sibling_driver is not driver_connection
+                assert sibling_driver.isolation_level is not None
+                assert sibling.exec_driver_sql("SELECT count(*) FROM probe").scalar_one() == 1
+                assert sibling_driver.in_transaction is False
+
+            # In rollback-journal mode, a legacy SELECT releases its read lock
+            # with the statement. An independent writer must not wait for this
+            # SQLAlchemy Connection's bookkeeping transaction to be closed.
+            with sqlite3.connect(db_path, timeout=0.25) as writer:
+                writer.execute("INSERT INTO probe VALUES ('writer')")
+    finally:
+        engine.dispose()
+
+    assert len(wal_requests) == 1
+    assert len(warnings) == 1
+    assert "WAL is unavailable" in warnings[0]
+    assert "legacy sqlite3 transaction control" in warnings[0]
+    assert "begin_nested() SAVEPOINTs opened before DML are not contained" in warnings[0]
+
+    with sqlite3.connect(db_path) as observer:
+        assert observer.execute("SELECT value FROM probe ORDER BY rowid").fetchall() == [
+            ("seed",),
+            ("writer",),
+        ]

--- a/tests/unit/test_favorite_books.py
+++ b/tests/unit/test_favorite_books.py
@@ -26,8 +26,9 @@ def test_favoritebook_model_and_migration():
     assert "__tablename__ = 'favorite_book'" in src
     assert "uq_favorite_book" in src
     # New table is auto-created on startup (idempotent), like the sibling tables.
-    assert 'has_table(engine.connect(), "favorite_book")' in src
-    assert "FavoriteBook.__table__.create(bind=engine, checkfirst=True)" in src
+    assert '("favorite_book", FavoriteBook.__table__)' in src
+    assert "with engine.connect() as connection:" in src
+    assert "table.create(bind=engine, checkfirst=True)" in src
     # Existing users get the new sidebar bit OR'd in (one-time, marker-guarded).
     assert "favorites_sidebar_v1" in src
 

--- a/tests/unit/test_sqlite_utils.py
+++ b/tests/unit/test_sqlite_utils.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Regression coverage for WAL-safe live SQLite copies."""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from cps.sqlite_utils import copy_sqlite_database
+
+
+@pytest.mark.unit
+def test_online_backup_contains_committed_write_still_in_wal(tmp_path):
+    source = tmp_path / "app.db"
+    snapshot = tmp_path / "app.db.bak"
+    writer = sqlite3.connect(source)
+    try:
+        assert writer.execute("PRAGMA journal_mode=WAL").fetchone()[0] == "wal"
+        writer.execute("PRAGMA wal_autocheckpoint=0")
+        writer.execute("CREATE TABLE probe (value TEXT NOT NULL)")
+        writer.execute("INSERT INTO probe VALUES ('checkpointed')")
+        writer.commit()
+        assert writer.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone() == (0, 0, 0)
+
+        writer.execute("INSERT INTO probe VALUES ('committed-in-wal')")
+        writer.commit()
+        assert (tmp_path / "app.db-wal").stat().st_size > 0
+
+        copy_sqlite_database(source, snapshot)
+
+        # The copy itself must be a self-contained file. Opening a WAL-mode
+        # database may create fresh sidecars, so assert this before observing it.
+        assert not (tmp_path / "app.db.bak-wal").exists()
+        assert not (tmp_path / "app.db.bak-shm").exists()
+        with sqlite3.connect(snapshot) as observer:
+            assert observer.execute("SELECT value FROM probe ORDER BY rowid").fetchall() == [
+                ("checkpointed",),
+                ("committed-in-wal",),
+            ]
+            assert observer.execute("PRAGMA journal_mode").fetchone() == ("delete",)
+    finally:
+        writer.close()
+
+
+@pytest.mark.unit
+def test_online_restore_overwrites_stale_destination_wal(tmp_path):
+    live_db = tmp_path / "metadata.db"
+    backup = tmp_path / "metadata.db.bak"
+    writer = sqlite3.connect(live_db)
+    try:
+        assert writer.execute("PRAGMA journal_mode=WAL").fetchone()[0] == "wal"
+        writer.execute("PRAGMA wal_autocheckpoint=0")
+        writer.execute("CREATE TABLE probe (value TEXT NOT NULL)")
+        writer.execute("INSERT INTO probe VALUES ('restored')")
+        writer.commit()
+        assert writer.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone() == (0, 0, 0)
+        copy_sqlite_database(live_db, backup)
+
+        # This committed change exists only in the live database's WAL. A raw
+        # replacement of metadata.db with the backup leaves the matching WAL
+        # beside it, and SQLite reapplies this stale value on the next open.
+        writer.execute("UPDATE probe SET value = 'stale-wal-value'")
+        writer.commit()
+        assert (tmp_path / "metadata.db-wal").stat().st_size > 0
+
+        copy_sqlite_database(backup, live_db, restore=True)
+
+        with sqlite3.connect(live_db) as observer:
+            assert observer.execute("PRAGMA journal_mode").fetchone() == ("wal",)
+            assert observer.execute("SELECT value FROM probe").fetchall() == [("restored",)]
+            assert observer.execute("PRAGMA integrity_check").fetchone() == ("ok",)
+    finally:
+        writer.close()


### PR DESCRIPTION
Closes #1873.

`begin_nested()` on `ub.session` was not a contained SAVEPOINT. Python's `sqlite3` driver auto-BEGINs for **DML only** and skips BEGIN for SELECT, DDL and SAVEPOINT, so a savepoint opened after only SELECTs ran in autocommit and `RELEASE` committed it — a later `session.rollback()` did not remove it.

Measured, engine built verbatim from the old `ub.py`, read back through a **separate** engine:

```
prime=nothing   in_transaction()=False   savepoint survived rollback = True
prime=select    in_transaction()=True    savepoint survived rollback = True
prime=dml       in_transaction()=True    savepoint survived rollback = False
```

**A preceding SELECT does not restore containment**, and `session.in_transaction()` returns `True` in the broken arm — it reports SQLAlchemy's bookkeeping, not the driver's BEGIN, so it is not a usable guard. Which caller you enter through decides it: `dispatch_annotation_sync` (Kobo PATCH) flushes an annotation INSERT first and is contained; **`dispatch_existing_annotation_sync` — the web reader and KOReader edit paths — emits only SELECTs and is not.**

## Why this is not tidiness

`dispatch_annotation_sync` treats `session_commit()`'s return as *the* durability signal; it is what decides #1825's 503. If some writes are already durable at savepoint release, **"the commit failed" and "nothing was stored" stop being the same statement**, and the 503 contract rests on them being the same.

## The fix

SQLAlchemy's documented SQLite workaround, centralised in one factory used by all three `app.db` engine constructors: disable the driver's BEGIN emission on `connect`, emit a plain **deferred** `BEGIN` on SQLAlchemy's `begin` event. `connect_args={'timeout': 30}` preserved. `cps/db.py` and the Calibre library's own isolation handling untouched.

## Three latent bugs the legacy mode was masking

Explicit transactions surfaced three real 30-second `database is locked` failures in startup migrations, all the same shape — schema inspection or a SELECT on one connection, then DDL on another while the first still owned a read transaction:

- `ub.py` — schema inspection is now context-managed and closed before table creation; registration seeding uses one session; the system-shelf migration ends its SELECT transaction even when nothing changed.
- `config_sql.py` — a failed column inspection is rolled back before the encryption-column DDL, and **each missing column's `ALTER` is committed independently**, so a later failed inspection cannot roll back an earlier one.

These were always wrong. Autocommit was hiding them.

## Verification

The regression test drives the **create** arm through the production dispatcher against a file-backed `app.db`, seeds through an independent stdlib `sqlite3` connection so no DML is emitted first, and reads back through **another** independent connection:

```
red (before):  durable_targets == [('stub', 'synced')]
green (after): durable_targets == []
```

It also asserts the simulated failed commit was actually reached, so an early return cannot pass as success. **A Kobo-path version was deliberately not written** — that path flushes DML first, so it passes both before and after and discriminates nothing. That is documented in the test rather than left for someone to rediscover.

Full unit suite **serially** (`-n 0`, because #1868 makes an xdist result unusable as evidence): **6998 passed, 105 skipped, 0 failed**.

WAL probes rather than assertions about locking:

```
open read transaction  -> independent writer committed in 0.0002s   (readers do not block writers)
open write transaction -> second writer waited, then committed in 0.2283s
```

confirming the deferred `BEGIN` does not promote every transaction to an immediate writer lock and the busy timeout still applies.

## Answered while here

**No production `begin_nested()` body writes a canonical `Annotation` row** — the four call sites write `KoboAnnotationMaterialization`, `AnnotationSyncTarget`, and progress state. So `ub.py`'s `after_rollback` backup hook cannot currently discard the backup for a row that survived a rollback. Left unchanged; recorded on the issue.

Both call-site comments that assumed containment are now **true** rather than rewritten to describe a defect: `kobo.py:1841` and `_upsert_sync_target`'s docstring argument.

## Honest limits

Production locking compatibility is **evidence, not proof**. SELECTs now hold real read transactions until commit, rollback, or session return, so a previously sloppy long-lived session can hold one longer than before; in WAL mode that can delay checkpoint completion, and a rollback-journal deployment (e.g. WAL disabled on a network share) could see more reader/writer contention than under legacy behaviour. The serial suite does not simulate sustained checkpoint pressure or multi-process request concurrency.

Given the blast radius — this changes transaction semantics for every `app.db` write — this wants a cross-family review and a close watch on the dev deployment after merge, not a quiet landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1GA5qD4wtZJKYuMybVqPx

## Amendment 2026-08-28 — operator decision: WAL in the engine factory, and WAL-safe copies

- `NETWORK_SHARE_MODE` now has one parser (`cps/sqlite_utils.py`); under it app.db skips WAL and logs what is lost (the SAVEPOINT containment), matching `cps/db.py`'s calibre-DB policy.
- `restore_calibre_db` and the Google Drive `metadata.db` path copied live SQLite files byte-for-byte; under WAL that drops committed pages still in `-wal`, and a raw main-file replacement can be poisoned by the destination's stale `-wal`. Both now use the online backup API.
- Measured (manager, independent of Sol): `shutil.copy2` of a WAL DB with one uncheckpointed commit → 1 row; helper → 2 rows. Red/green: `test_network_share_mode_skips_wal…` fails with `cps/` reverted.
