### PR TITLE
fix(annotations): report a rolled-back write instead of answering success (#1874)

### DIFF
--- a/changelog.d/issue-1874.md
+++ b/changelog.d/issue-1874.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- **A highlight that fails to save no longer looks saved.** If the database
+  rejected the write, the web reader still showed the highlight as created and
+  a delete still reported success — the change was gone but nothing said so.
+  Those paths now report the failure, and KOReader is told its push did not
+  land instead of being acknowledged.

--- a/cps/annotations.py
+++ b/cps/annotations.py
@@ -1177,7 +1177,7 @@ def create_annotation(payload, *, user_id, book, session, commit,
             hidden=False,
         )
         session.add(row)
-        commit()
+        _commit_required(commit)
         return row
 
     # The SPA epub.js reader produces a portable EPUB CFI (not a KoboSpan). Accept
@@ -1214,7 +1214,7 @@ def create_annotation(payload, *, user_id, book, session, commit,
             hidden=False,
         )
         session.add(row)
-        commit()
+        _commit_required(commit)
         return row
 
     end_span = (payload.get("end_kobospan") or "").strip() or start_span
@@ -1249,7 +1249,7 @@ def create_annotation(payload, *, user_id, book, session, commit,
         _ensure_cfi_range(row, book)
     except Exception as e:  # pragma: no cover - defensive
         log.warning("annotations: cfi compute on create failed: %s", e)
-    commit()
+    _commit_required(commit)
     return row
 
 
@@ -1338,8 +1338,10 @@ def reassign_annotation(annotation_id, *, user_id, book_id, assigned_device_publ
             else:
                 state.desired = True
         if commit is not None:
-            if commit() is False:
-                raise AssignmentError("database_error")
+            try:
+                _commit_required(commit)
+            except RuntimeError as error:
+                raise AssignmentError("database_error") from error
         else:
             session.flush()
         return row
@@ -1370,8 +1372,10 @@ def reassign_annotation(annotation_id, *, user_id, book_id, assigned_device_publ
     row.assigned_device_id = target_id
     row.routing_revision = (row.routing_revision or 1) + 1
     if commit is not None:
-        if commit() is False:
-            raise AssignmentError("database_error")
+        try:
+            _commit_required(commit)
+        except RuntimeError as error:
+            raise AssignmentError("database_error") from error
     else:
         session.flush()
     return row
@@ -1411,7 +1415,7 @@ def delete_annotation(annotation_id, *, user_id, book_id, session, commit):
         return None
     row.hidden = True
     row.last_synced = datetime.now(timezone.utc)
-    commit()
+    _commit_required(commit)
     return row
 
 
@@ -1446,6 +1450,8 @@ def annotations_create(book_id):
         )
     except ValueError as e:
         return jsonify({"error": "bad_anchor", "message": str(e)}), 400
+    except (RuntimeError, SQLAlchemyError):
+        return _database_error_response("single annotation create")
     _fanout_to_sync_targets(row, book)
     # Resolve the device map, or the row we just attributed answers
     # origin_device_id: null and the reader renders "Unknown device" for the
@@ -1524,10 +1530,13 @@ def annotation_assignments_bulk():
 def annotations_delete(book_id, annotation_id):
     """Soft-delete a highlight + tombstone any remote sync targets."""
     _resolve_book_or_404(book_id)
-    row = delete_annotation(
-        annotation_id, user_id=current_user.id, book_id=book_id,
-        session=ub.session, commit=ub.session_commit,
-    )
+    try:
+        row = delete_annotation(
+            annotation_id, user_id=current_user.id, book_id=book_id,
+            session=ub.session, commit=ub.session_commit,
+        )
+    except (RuntimeError, SQLAlchemyError):
+        return _database_error_response("single annotation delete")
     if row is None:
         abort(404)
     # Propagate the delete to any remote sync targets (Hardcover) — no-op when

--- a/cps/progress_syncing/protocols/koreader_annotations.py
+++ b/cps/progress_syncing/protocols/koreader_annotations.py
@@ -46,8 +46,10 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 from flask import request
+from sqlalchemy.exc import SQLAlchemyError
 
 from ... import csrf, logger, ub
+from ...annotations import _commit_required
 from .kosync import (
     kosync,
     authenticate_user,
@@ -55,6 +57,7 @@ from .kosync import (
     create_sync_response,
     is_valid_key_field,
     _require_kosync_enabled,
+    ERROR_INTERNAL,
     ERROR_UNAUTHORIZED_USER,
     ERROR_DOCUMENT_FIELD_MISSING,
 )
@@ -192,7 +195,7 @@ def _apply_deletes(deleted_ids, *, user, book, session, commit, source) -> int:
     for row in stale:
         row.hidden = True
         row.last_synced = _now()
-    commit()
+    _commit_required(commit)
 
     for row in stale:
         try:
@@ -430,12 +433,20 @@ def push_annotations():
     except Exception:
         log.warning("KOReader annotation attribution failed", exc_info=True)
 
-    summary = apply_push(
-        annotations, user=user, book=book,
-        session=ub.session, commit=ub.session_commit,
-        deleted_ids=deleted_ids, delete_source=delete_source,
-        origin_device_id=origin_device_id,
-    )
+    try:
+        summary = apply_push(
+            annotations, user=user, book=book,
+            session=ub.session, commit=ub.session_commit,
+            deleted_ids=deleted_ids, delete_source=delete_source,
+            origin_device_id=origin_device_id,
+        )
+    except (RuntimeError, SQLAlchemyError):
+        ub.session.rollback()
+        log.exception(
+            "KOReader annotation push database write failed: user=%s book=%s document=%s",
+            user.id, book_id, _loggable(document),
+        )
+        return _reject(user, document, ERROR_INTERNAL, "Database error", status=503)
     summary["document"] = document
     # `reconciled` means the device NAMED deletions on this push, not that any
     # row matched — naming an id that is already hidden or unknown is a no-op

--- a/cps/services/annotation_portable.py
+++ b/cps/services/annotation_portable.py
@@ -268,7 +268,11 @@ def apply_portable(payload, *, user_id, book, session, commit,
 
     row.last_synced = _now()
     try:
-        commit()
+        # Keep the commit contract shared with every annotation writer. Import
+        # at call time so this dependency-light service does not pull in the
+        # Flask blueprint merely to project rows on the read path.
+        from cps.annotations import _commit_required
+        _commit_required(commit)
     except exc.IntegrityError:
         # A parallel device may have inserted the same canonical identity
         # after our SELECT. Roll back this losing INSERT and replay as an

--- a/tests/unit/test_1874_annotation_commit_guards.py
+++ b/tests/unit/test_1874_annotation_commit_guards.py
@@ -1,0 +1,293 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Issue #1874 — annotation writers must not acknowledge rolled-back writes.
+
+Every test drives the real caller boundary rather than merely asserting that a
+helper raises: Flask routing for the web reader and bulk assignment APIs, and
+the KOReader PUT protocol for portable upserts and named deletes.
+"""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from cps import calibre_db, ub
+
+
+pytestmark = pytest.mark.unit
+
+annotations = importlib.import_module("cps.annotations")
+koreader_annotations = importlib.import_module(
+    "cps.progress_syncing.protocols.koreader_annotations"
+)
+kosync = importlib.import_module("cps.progress_syncing.protocols.kosync")
+
+
+@pytest.fixture
+def database(tmp_path, monkeypatch):
+    from cps import constants
+    from cps.services import annotation_backup
+
+    annotation_backup.reset_for_tests()
+    monkeypatch.setattr(annotation_backup, "WORKER_AUTOSTART", False)
+    monkeypatch.setattr(constants, "CONFIG_DIR", str(tmp_path))
+
+    engine = create_engine("sqlite:///:memory:", future=True)
+    ub.Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine, future=True)()
+    session.execute(text("PRAGMA foreign_keys=ON"))
+    user = ub.User(name="reader", email="reader@example.invalid", role=0, password="x")
+    session.add(user)
+    session.commit()
+    monkeypatch.setattr(ub, "session", session)
+
+    yield session, user
+
+    session.close()
+    annotation_backup.reset_for_tests()
+
+
+def _failed_commit(session):
+    def commit():
+        # Match ub.session_commit's failure contract, including its rollback.
+        session.rollback()
+        return False
+
+    return commit
+
+
+@pytest.fixture
+def web_routes(database, monkeypatch):
+    session, user = database
+    book = SimpleNamespace(
+        id=7,
+        uuid="b3d1b38b-74fd-43b7-a796-996e5a6a8b04",
+        title="Commit Guard",
+        data=[],
+    )
+    monkeypatch.setattr(annotations, "current_user", user, raising=False)
+    monkeypatch.setattr(annotations, "_resolve_book_or_404", lambda _book_id: book)
+
+    app = Flask(__name__)
+    # The auth decorator is outside this defect. Register the wrapped route
+    # bodies so requests still traverse Flask routing, request parsing, and
+    # response serialization without fabricating a login-manager stack.
+    app.add_url_rule(
+        "/annotations/<int:book_id>",
+        "annotations_create_1874",
+        annotations.annotations_create.__wrapped__,
+        methods=["POST"],
+    )
+    app.add_url_rule(
+        "/annotations/<int:book_id>/<annotation_id>",
+        "annotations_delete_1874",
+        annotations.annotations_delete.__wrapped__,
+        methods=["DELETE"],
+    )
+    app.add_url_rule(
+        "/api/annotations/assignments/bulk",
+        "annotation_assignments_bulk_1874",
+        annotations.annotation_assignments_bulk.__wrapped__,
+        methods=["POST"],
+    )
+    return app.test_client(), session, user, book
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "position_type": "unanchored",
+            "note_text": "A standalone note",
+        },
+        {
+            "cfi_range": "epubcfi(/6/4!/4/2,/1:0,/1:9)",
+            "highlighted_text": "A CFI highlight",
+        },
+        {
+            "start_kobospan": "kobo.1.1",
+            "end_kobospan": "kobo.1.1",
+            "highlighted_text": "A KoboSpan highlight",
+        },
+    ],
+    ids=["unanchored", "cfi", "kobospan"],
+)
+def test_web_create_route_reports_each_commit_failure(
+    web_routes, monkeypatch, payload,
+):
+    client, session, _user, _book = web_routes
+    fanned_out = []
+    monkeypatch.setattr(ub, "session_commit", _failed_commit(session))
+    monkeypatch.setattr(
+        annotations, "_fanout_to_sync_targets",
+        lambda *args: fanned_out.append(args),
+    )
+
+    response = client.post("/annotations/7", json=payload)
+
+    assert response.status_code == 500
+    assert response.get_json() == {"error": "database_error"}
+    assert fanned_out == []
+    assert session.query(ub.Annotation).count() == 0
+
+
+def test_bulk_reassignment_route_reports_commit_failure(web_routes, monkeypatch):
+    client, session, user, _book = web_routes
+    target = ub.Device(
+        user_id=user.id,
+        kind="kobo",
+        display_name="Target",
+        active=True,
+        created_by="auto",
+    )
+    row = ub.Annotation(
+        user_id=user.id,
+        book_id=7,
+        annotation_id="reassign-me",
+        source="webreader",
+    )
+    session.add_all([target, row])
+    session.commit()
+    monkeypatch.setattr(ub, "session_commit", _failed_commit(session))
+
+    response = client.post("/api/annotations/assignments/bulk", json={
+        "assigned_device_id": target.public_id,
+        "items": [{
+            "book_id": 7,
+            "annotation_id": row.annotation_id,
+            "expected_routing_revision": 1,
+        }],
+    })
+
+    assert response.status_code == 200
+    assert response.get_json() == {"results": [{
+        "annotation_id": "reassign-me",
+        "ok": False,
+        "error_code": "database_error",
+    }]}
+    session.refresh(row)
+    assert row.assigned_device_id is None
+
+
+def test_web_delete_route_reports_commit_failure_before_fanout(
+    web_routes, monkeypatch,
+):
+    client, session, user, _book = web_routes
+    row = ub.Annotation(
+        user_id=user.id,
+        book_id=7,
+        annotation_id="delete-me",
+        source="webreader",
+        hidden=False,
+    )
+    session.add(row)
+    session.commit()
+    monkeypatch.setattr(ub, "session_commit", _failed_commit(session))
+
+    from cps.services import annotation_sync
+    fanned_out = []
+    monkeypatch.setattr(
+        annotation_sync,
+        "dispatch_annotation_deletes",
+        lambda *args, **kwargs: fanned_out.append((args, kwargs)),
+    )
+
+    response = client.delete("/annotations/7/delete-me")
+
+    assert response.status_code == 500
+    assert response.get_json() == {"error": "database_error"}
+    assert fanned_out == []
+    session.refresh(row)
+    assert row.hidden is False
+
+
+@pytest.fixture
+def koreader_route(database, monkeypatch):
+    session, user = database
+    book = SimpleNamespace(
+        id=7,
+        uuid="b3d1b38b-74fd-43b7-a796-996e5a6a8b04",
+        title="Commit Guard",
+    )
+    monkeypatch.setattr(koreader_annotations, "_require_kosync_enabled", lambda: None)
+    monkeypatch.setattr(koreader_annotations, "authenticate_user", lambda: user)
+    monkeypatch.setattr(
+        koreader_annotations,
+        "get_book_by_checksum",
+        lambda document: (book.id, "EPUB", book.title, "book.epub", "koreader"),
+    )
+    monkeypatch.setattr(calibre_db, "get_book", lambda _book_id: book)
+
+    app = Flask(__name__)
+    app.register_blueprint(kosync.kosync)
+    return app.test_client(), session, user, book
+
+
+def test_koreader_route_reports_apply_portable_commit_failure(
+    koreader_route, monkeypatch,
+):
+    client, session, _user, _book = koreader_route
+    monkeypatch.setattr(ub, "session_commit", _failed_commit(session))
+
+    from cps.services import annotation_sync
+    fanned_out = []
+    monkeypatch.setattr(
+        annotation_sync,
+        "dispatch_existing_annotation_sync",
+        lambda *args, **kwargs: fanned_out.append((args, kwargs)),
+    )
+
+    response = client.put("/kosync/syncs/annotations", json={
+        "document": "digest-1874",
+        "annotations": [{
+            "annotation_id": "portable-create",
+            "highlighted_text": "Must land before acknowledgement",
+        }],
+    })
+
+    assert response.status_code == 503
+    assert response.get_json() == {"error": 2000, "message": "Database error"}
+    assert fanned_out == []
+    assert session.query(ub.Annotation).count() == 0
+
+
+def test_koreader_route_reports_named_delete_commit_failure_before_fanout(
+    koreader_route, monkeypatch,
+):
+    client, session, user, _book = koreader_route
+    row = ub.Annotation(
+        user_id=user.id,
+        book_id=7,
+        annotation_id="portable-delete",
+        source="koreader",
+        hidden=False,
+    )
+    session.add(row)
+    session.commit()
+    monkeypatch.setattr(ub, "session_commit", _failed_commit(session))
+
+    from cps.services import annotation_sync
+    fanned_out = []
+    monkeypatch.setattr(
+        annotation_sync,
+        "dispatch_annotation_deletes",
+        lambda *args, **kwargs: fanned_out.append((args, kwargs)),
+    )
+
+    response = client.put("/kosync/syncs/annotations", json={
+        "document": "digest-1874",
+        "annotations": [],
+        "deleted": ["portable-delete"],
+    })
+
+    assert response.status_code == 503
+    assert response.get_json() == {"error": 2000, "message": "Database error"}
+    assert fanned_out == []
+    session.refresh(row)
+    assert row.hidden is False


### PR DESCRIPTION
Closes the first finding on #1874.

`ub.session_commit()` returns **False** on a rolled-back write rather than raising. Its own docstring (`ub.py:4365`) says callers whose answer to the user depends on the write landing MUST check it, and cites the precedent:

> #1318 — the previous `""` return could not express failure, so **a rolled-back bookmark was still answered 201**

That is the *present* tense for four call sites:

| path | answered | actually |
|---|---|---|
| web reader `POST /annotations/<book_id>` | **201** | the highlight may have rolled back |
| web reader `DELETE` | **200** | the highlight may still be there — and a later fan-out can push it back to Hardcover |
| KOReader named deletes | `deleted: 1` | not deleted |
| portable path behind KOReader's `PUT` | **200** | not stored |

**Nothing new was designed.** The guard (`_commit_required`), the raise, the route handler (`annotations_edit`'s `except (RuntimeError, SQLAlchemyError)`) and five correct usages in the same file all already existed. These sites never adopted them.

## Correction to my own enumeration, and what the tool got wrong

I listed `reassign_annotation` as unguarded. **It was not** — both branches already did `if commit() is False: raise AssignmentError("database_error")`.

My AST sweep classified *"checks the return inline"* identically to *"ignores the return"*, because it only looked for a call to `_commit_required` alongside a bare `commit()` call. Four real sites, one false positive. The untouched pre-fix run is **6 failed, 1 passed** — and the 1 is reassignment.

That is the mirror of the loose-query problem from earlier tonight: a shape query blind to an inline check **over**-reports, where a query blind to a relative path **under**-reports. Both are the same defect — the query answering a narrower question than the one being asked — and it is why the mutation counts are the evidence and the enumeration was only the lead.

## The two judgement calls, reasoned rather than assumed

**Reassignment keeps its own vocabulary.** It has a per-item result contract: one failed reassignment must appear alongside successful items without aborting the bulk response. `_commit_required` is now the single guard, and its `RuntimeError` is translated to `AssignmentError("database_error")` at the boundary rather than a second guard being introduced.

**KOReader and portable are not Flask routes**, so "report the failure" had to be decided. `apply_portable`'s only production consumer is KOReader's `apply_push` — an exhaustive search found no separate portable-file import entry point. Returning `skipped` would still be an HTTP 200; a new action would expand the portable action vocabulary and summary protocol. Instead the `RuntimeError` propagates to the real `PUT /kosync/syncs/annotations` boundary, which returns the protocol's existing internal-error code at **HTTP 503** — a response the shipped plugin's own API specification already declares for `push_annotations`, and whose client treats only 200 as success.

## Verification, at caller boundaries rather than function boundaries

Real Flask routing for create / delete / bulk-assign, and the actual registered KOSync blueprint for both portable creation and named deletion, with `ub.session_commit` forced to roll back and return False. Every failed-write case also asserts **the row did not persist** and **the fan-out did not run** — not merely that a function raised.

```
untouched pre-fix branch:   6 failed, 1 passed
guards removed (mutation):  7 failed, 0 passed
guards restored:            7 passed, 0 failed
full unit suite serially (-n 0, per #1868): 7003 passed, 105 skipped, 0 failed
```

## Not claimed

No built container and no physical KOReader. The device-visible behaviour rests on the observed server response plus the plugin's declared 503 contract and its client source — not on a hardware run.

Remaining classes on this surface, still unswept and tracked on #1874: per-caller transaction-state assumptions (#1873, whose fix is open as #1888) and repetition/accumulation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1GA5qD4wtZJKYuMybVqPx
