### PR TITLE
fix(kobo): capture the spool root and age bound when async work is created (#1868)

### DIFF
--- a/changelog.d/issue-1868-spool.md
+++ b/changelog.d/issue-1868-spool.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- **Kobo annotation recovery copies could be deleted by maintenance meant for a
+  different folder.** The background job that expires old recovery records
+  looked up which folder to clean when it eventually ran, rather than when it
+  was scheduled, so a change in between could point it somewhere else. It now
+  carries its target with it.

--- a/cps/services/kobo_patch_spool.py
+++ b/cps/services/kobo_patch_spool.py
@@ -227,6 +227,8 @@ def stage_patch(*, raw_body, entitlement_id, user_id, origin_device_id):
         )
         return None
     try:
+        root = _spool_root()
+        max_age_seconds = MAX_AGE_SECONDS
         raw_body = bytes(raw_body)
         spool_id = secrets.token_hex(16)
         attempt_id = secrets.token_hex(16)
@@ -251,7 +253,7 @@ def stage_patch(*, raw_body, entitlement_id, user_id, origin_device_id):
         record["replay_identity_sha256"] = _replay_identity_sha256(record)
         compressed = _compress(record)
         spool_id, path, attempt_id, reused = _run_off_hub_bounded(
-            _write_or_reuse_record, record, compressed,
+            _write_or_reuse_record, record, compressed, root, max_age_seconds,
         )
         log.info(
             "Kobo PATCH recovery body %s spool_id=%s user_id=%s bytes=%s",
@@ -302,12 +304,14 @@ class PatchSpoolTicket:
         if status not in _VALID_OUTCOMES - {"staged"}:
             raise ValueError("invalid Kobo PATCH dispatch outcome")
         try:
+            max_age_seconds = MAX_AGE_SECONDS
             new_path, applied = _run_off_hub_bounded(
                 _mark_dispatch_outcome_blocking,
                 self.path,
                 self.spool_id,
                 self.attempt_id,
                 status,
+                max_age_seconds,
             )
             self.path = Path(new_path)
             if not applied:
@@ -486,13 +490,15 @@ def _record_inventory(root):
     return inventory
 
 
-def _select_victims(inventory, *, incoming_bytes, replacing_path=None):
+def _select_victims(
+    inventory, *, incoming_bytes, max_age_seconds, replacing_path=None,
+):
     replacing_path = Path(replacing_path) if replacing_path is not None else None
     active = [item for item in inventory if item["path"] != replacing_path]
     victims = []
     now = time.time()
     for item in active:
-        if now - item["mtime"] > MAX_AGE_SECONDS:
+        if now - item["mtime"] > max_age_seconds:
             victims.append(item)
 
     survivors = [item for item in active if item not in victims]
@@ -669,8 +675,10 @@ def _find_matching_replay_identity_locked(inventory, incoming):
     return matches
 
 
-def _write_or_reuse_record(incoming, compressed):
-    root = _spool_root()
+def _write_or_reuse_record(
+    incoming, compressed, root, max_age_seconds,
+):
+    root = Path(root)
     with _PROCESS_LOCK:
         _ensure_private_root(root)
         with _locked_root(root):
@@ -704,6 +712,7 @@ def _write_or_reuse_record(incoming, compressed):
                 victims = _select_victims(
                     deduplicated_inventory,
                     incoming_bytes=len(compressed),
+                    max_age_seconds=max_age_seconds,
                     replacing_path=existing_path,
                 )
                 victims = duplicate_paths + victims
@@ -712,7 +721,9 @@ def _write_or_reuse_record(incoming, compressed):
                     incoming["replay_identity_sha256"],
                     "staged",
                 )
-                _schedule_retention(root, time.time() + MAX_AGE_SECONDS)
+                _schedule_retention(
+                    root, time.time() + max_age_seconds, max_age_seconds,
+                )
                 _install_record_locked(
                     path,
                     compressed,
@@ -727,13 +738,17 @@ def _write_or_reuse_record(incoming, compressed):
                 )
             else:
                 victims = _select_victims(
-                    inventory, incoming_bytes=len(compressed),
+                    inventory,
+                    incoming_bytes=len(compressed),
+                    max_age_seconds=max_age_seconds,
                 )
                 path = root / (
                     f"patch-{time.time_ns():020d}-{incoming['spool_id']}-"
                     f"{incoming['replay_identity_sha256']}-staged.json.gz"
                 )
-                _schedule_retention(root, time.time() + MAX_AGE_SECONDS)
+                _schedule_retention(
+                    root, time.time() + max_age_seconds, max_age_seconds,
+                )
                 _install_record_locked(
                     path, compressed, victims=victims,
                 )
@@ -759,7 +774,7 @@ def _find_record_path_by_spool_id_locked(root, spool_id):
 
 
 def _mark_dispatch_outcome_blocking(
-    path, spool_id, attempt_id, status,
+    path, spool_id, attempt_id, status, max_age_seconds,
 ):
     path = Path(path)
     root = path.parent
@@ -781,7 +796,10 @@ def _mark_dispatch_outcome_blocking(
             compressed = _compress(record)
             inventory = _record_inventory(root)
             victims = _select_victims(
-                inventory, incoming_bytes=len(compressed), replacing_path=path,
+                inventory,
+                incoming_bytes=len(compressed),
+                max_age_seconds=max_age_seconds,
+                replacing_path=path,
             )
             new_path = _path_with_status(path, status)
             _install_record_locked(
@@ -831,7 +849,7 @@ def load_spooled_patch(path):
     return record
 
 
-def _expire_root_blocking(root):
+def _expire_root_blocking(root, max_age_seconds):
     root = Path(root)
     if not root.exists():
         return None
@@ -842,7 +860,7 @@ def _expire_root_blocking(root):
             now = time.time()
             expired = [
                 item for item in inventory
-                if now - item["mtime"] > MAX_AGE_SECONDS
+                if now - item["mtime"] > max_age_seconds
             ]
             for item in expired:
                 item["path"].unlink(missing_ok=True)
@@ -851,25 +869,25 @@ def _expire_root_blocking(root):
             survivors = [item for item in inventory if item not in expired]
             if not survivors:
                 return None
-            return min(item["mtime"] + MAX_AGE_SECONDS for item in survivors)
+            return min(item["mtime"] + max_age_seconds for item in survivors)
 
 
-def _retention_timer_fired(root, deadline):
+def _retention_timer_fired(root, deadline, max_age_seconds):
     key = str(Path(root))
     with _RETENTION_TIMERS_LOCK:
         current = _RETENTION_TIMERS.get(key)
         if current is not None and current[0] == deadline:
             _RETENTION_TIMERS.pop(key, None)
     try:
-        next_deadline = _expire_root_blocking(root)
+        next_deadline = _expire_root_blocking(root, max_age_seconds)
     except Exception:
         log.error("Kobo PATCH recovery age maintenance failed", exc_info=True)
         next_deadline = time.time() + 1.0
     if next_deadline is not None:
-        _schedule_retention(root, next_deadline)
+        _schedule_retention(root, next_deadline, max_age_seconds)
 
 
-def _schedule_retention(root, deadline):
+def _schedule_retention(root, deadline, max_age_seconds):
     root = Path(root)
     key = str(root)
     with _RETENTION_TIMERS_LOCK:
@@ -881,22 +899,21 @@ def _schedule_retention(root, deadline):
         timer = threading.Timer(
             max(0.001, deadline - time.time()),
             _retention_timer_fired,
-            args=(root, deadline),
+            args=(root, deadline, max_age_seconds),
         )
         timer.daemon = True
         _RETENTION_TIMERS[key] = (deadline, timer)
         timer.start()
 
 
-def _bootstrap_retention():
-    root = _spool_root()
+def _bootstrap_retention(root, max_age_seconds):
     try:
-        next_deadline = _expire_root_blocking(root)
+        next_deadline = _expire_root_blocking(root, max_age_seconds)
     except Exception:
         log.error("Kobo PATCH recovery startup maintenance failed", exc_info=True)
         return
     if next_deadline is not None:
-        _schedule_retention(root, next_deadline)
+        _schedule_retention(root, next_deadline, max_age_seconds)
 
 
 def start_retention_maintenance():
@@ -905,8 +922,11 @@ def start_retention_maintenance():
     with _RETENTION_TIMERS_LOCK:
         if _RETENTION_STARTED:
             return True
+        root = _spool_root()
+        max_age_seconds = MAX_AGE_SECONDS
         thread = threading.Thread(
             target=_bootstrap_retention,
+            args=(root, max_age_seconds),
             name="kobo-patch-spool-retention-bootstrap",
             daemon=True,
         )
@@ -923,10 +943,11 @@ def start_retention_maintenance():
 
 def iter_replay_candidates():
     root = _spool_root()
+    max_age_seconds = MAX_AGE_SECONDS
     if not root.exists():
         return
     try:
-        _expire_root_blocking(root)
+        _expire_root_blocking(root, max_age_seconds)
     except Exception:
         log.error("Kobo PATCH recovery age maintenance failed", exc_info=True)
     for path in _record_paths(root):

--- a/tests/unit/test_f5c1146_kobo_patch_recovery_spool.py
+++ b/tests/unit/test_f5c1146_kobo_patch_recovery_spool.py
@@ -65,6 +65,19 @@ def _wait_for_full_request_io_capacity(spool, timeout=2):
     return capacity
 
 
+@pytest.fixture(autouse=True)
+def _cancel_spool_retention_timers_after_test():
+    """Secondary test isolation; production dependency capture is the fix."""
+    yield
+    spool = _module()
+    with spool._RETENTION_TIMERS_LOCK:
+        timers = [timer for _deadline, timer in spool._RETENTION_TIMERS.values()]
+        spool._RETENTION_TIMERS.clear()
+        spool._RETENTION_STARTED = False
+    for timer in timers:
+        timer.cancel()
+
+
 def _hold_advisory_lock(lock_path, ready, release):
     """Hold the real cross-process spool lock until the parent releases it."""
     fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
@@ -744,15 +757,13 @@ def test_timed_out_stage_finishes_and_does_not_poison_its_successor(
         "book-next": threading.Event(),
     }
 
-    def _stall_first(incoming, compressed, cancelled=None):
+    def _stall_first(incoming, compressed, root, max_age_seconds):
         entitlement_id = incoming["entitlement_id"]
         try:
             if entitlement_id == "book-slow":
                 first_started.set()
                 assert release_first.wait(2), "test did not release the slow write"
-            if cancelled is None:
-                return real_write(incoming, compressed)
-            return real_write(incoming, compressed, cancelled)
+            return real_write(incoming, compressed, root, max_age_seconds)
         finally:
             workers_finished[entitlement_id].set()
 
@@ -890,6 +901,157 @@ def test_startup_retention_expires_records_before_any_new_patch(monkeypatch, tmp
         time.sleep(0.01)
 
     assert not ticket.path.exists(), "startup did not enforce age without a PATCH"
+
+
+@pytest.mark.unit
+def test_startup_retention_captures_root_and_age_before_thread_runs(
+    monkeypatch, tmp_path,
+):
+    """A late bootstrap must retain the context that created its work."""
+    spool = _module()
+    spawning_root = tmp_path / "spawning-test-spool"
+    next_test_root = tmp_path / "next-test-spool"
+    spawning_root.mkdir()
+    next_test_root.mkdir()
+
+    def _seed_records(root, *, count, age_seconds):
+        for index in range(count):
+            path = root / f"patch-{index:020d}-dispatch_completed.json.gz"
+            path.write_bytes(b"record contents are irrelevant to age expiry")
+            mtime = spool.time.time() - age_seconds
+            os.utime(path, (mtime, mtime))
+
+    # The spawning root's record survives only if the original age bound is
+    # captured. The next test's records are old enough to be deleted under
+    # either bound, so they survive only if the original root is captured.
+    _seed_records(spawning_root, count=1, age_seconds=1)
+    _seed_records(next_test_root, count=3, age_seconds=120)
+    active_root = [spawning_root]
+    monkeypatch.setattr(spool, "_spool_root", lambda: active_root[0])
+    monkeypatch.setattr(spool, "MAX_AGE_SECONDS", 60)
+    monkeypatch.setattr(spool, "_RETENTION_STARTED", False)
+
+    deferred_threads = []
+
+    class _DeferredThread:
+        def __init__(self, *, target, name, daemon, args=()):
+            self.target = target
+            self.args = args
+            self.name = name
+            self.daemon = daemon
+            deferred_threads.append(self)
+
+        def start(self):
+            return None
+
+        def run(self):
+            self.target(*self.args)
+
+    monkeypatch.setattr(spool, "threading", SimpleNamespace(Thread=_DeferredThread))
+    monkeypatch.setattr(spool, "_schedule_retention", lambda *_args: None)
+
+    assert spool.start_retention_maintenance() is True
+    [bootstrap] = deferred_threads
+
+    # Model pytest undoing the spawning test's patches and installing the next
+    # test's different root and much shorter age bound before the OS runs the
+    # daemon thread.
+    active_root[0] = next_test_root
+    monkeypatch.setattr(spool, "MAX_AGE_SECONDS", 0.05)
+    bootstrap.run()
+
+    assert len(list(spawning_root.glob("patch-*.json.gz"))) == 1, (
+        "the bootstrap re-read the age bound after its caller moved on"
+    )
+    assert len(list(next_test_root.glob("patch-*.json.gz"))) == 3, (
+        "the bootstrap expired records belonging to the next test"
+    )
+
+
+@pytest.mark.unit
+def test_stage_patch_captures_root_and_age_before_storage_worker_runs(
+    monkeypatch, tmp_path,
+):
+    """The gevent threadpool gets immutable path and retention inputs too."""
+    spool = _module()
+    spawning_root = tmp_path / "spawning-request-spool"
+    next_root = tmp_path / "later-context-spool"
+    active_root = [spawning_root]
+    monkeypatch.setattr(spool, "_spool_root", lambda: active_root[0])
+    monkeypatch.setattr(spool, "MAX_AGE_SECONDS", 60)
+    scheduled = []
+    monkeypatch.setattr(
+        spool,
+        "_schedule_retention",
+        lambda root, deadline, max_age: scheduled.append(
+            (Path(root), deadline, max_age)
+        ),
+    )
+
+    def _run_after_context_changes(function, *args):
+        active_root[0] = next_root
+        monkeypatch.setattr(spool, "MAX_AGE_SECONDS", 0.05)
+        return function(*args)
+
+    monkeypatch.setattr(spool, "_run_off_hub_bounded", _run_after_context_changes)
+
+    ticket = spool.stage_patch(
+        raw_body=RAW_PATCH,
+        entitlement_id=BOOK_UUID,
+        user_id=7,
+        origin_device_id=None,
+    )
+
+    assert ticket is not None
+    assert ticket.path.parent == spawning_root
+    assert not next_root.exists()
+    [(scheduled_root, _deadline, scheduled_age)] = scheduled
+    assert scheduled_root == spawning_root
+    assert scheduled_age == 60
+
+
+@pytest.mark.unit
+def test_retention_timer_keeps_age_bound_from_when_it_was_scheduled(
+    monkeypatch, tmp_path,
+):
+    """A timer firing later cannot inherit another context's age bound."""
+    spool = _module()
+    root = tmp_path / "timer-spool"
+    root.mkdir()
+    record = root / "patch-00000000000000000000-dispatch_completed.json.gz"
+    record.write_bytes(b"record contents are irrelevant to age expiry")
+    mtime = spool.time.time() - 1
+    os.utime(record, (mtime, mtime))
+    monkeypatch.setattr(spool, "_RETENTION_TIMERS", {})
+
+    deferred_timers = []
+
+    class _DeferredTimer:
+        def __init__(self, interval, target, args=()):
+            self.interval = interval
+            self.target = target
+            self.args = args
+            self.daemon = False
+            deferred_timers.append(self)
+
+        def start(self):
+            return None
+
+        def cancel(self):
+            return None
+
+        def fire(self):
+            self.target(*self.args)
+
+    monkeypatch.setattr(spool, "threading", SimpleNamespace(Timer=_DeferredTimer))
+    deadline = spool.time.time() + 59
+    spool._schedule_retention(root, deadline, 60)
+    first_timer = deferred_timers[0]
+
+    monkeypatch.setattr(spool, "MAX_AGE_SECONDS", 0.05)
+    first_timer.fire()
+
+    assert record.exists(), "the timer re-read a shorter age bound when it fired"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Closes the remaining half of #1868.

`_bootstrap_retention` called `_spool_root()` **inside its daemon thread**, and `start_retention_maintenance()` spawned that thread with no arguments — so everything the work depended on was resolved whenever the OS happened to schedule it. `MAX_AGE_SECONDS` was read at run time too, in the timer callback and in the gevent storage worker.

In the suite `_spool_root` is monkeypatched per test. Under load the daemon is scheduled **late** — after the spawning test's patch is undone and the *next* test's is in place — so it resolved that test's root and expired **its** records, with a sibling test's `MAX_AGE_SECONDS = 0.05` making everything in range eligible. Constructed directly rather than waited for:

```
Test Y staged 3 records in ITS OWN root
After test X's leaked bootstrap thread ran: 0 remain
```

### Correcting a claim I made and then propagated

I originally wrote that this mechanism "matches the observed failing pair exactly" on #1877's CI — `test_patch_spool_is_bounded_and_never_stores_request_headers` and `test_full_spool_never_evicts_an_unresolved_recovery_record`. **That was inferred from the test names and it is wrong.** The actual assertion in that log is:

```
FAILED …::test_patch_spool_is_bounded_and_never_stores_request_headers - assert None is not None
FAILED …::test_full_spool_never_evicts_an_unresolved_recovery_record   - assert None is not None
```

`assert ticket is not None`. That is `stage_patch` returning `None` — a ticket lost to the 0.1s `REQUEST_IO_TIMEOUT_SECONDS` under CI load, which is what #1891 addresses. **This race destroys records; it does not produce a `None` ticket.** Two real mechanisms, the same two tests, and only one of them caused that particular red.

What this fix rests on is not that CI run. It is the constructed reproduction above and the mutation below.

## Three hypotheses died getting here

Each killed by running the arm where it should have mattered, rather than by argument:

- **Leaked retention timers** — refuted; the file passes alone under `-n 4`.
- **The ingest `ProcessLock`** — real, and it is `test_1094`'s cause (fixed by #1877), not this one.
- **#1877's per-pid tempdir** — refuted by a repro using explicit roots, and separately by four clean `-n 4` runs on that branch against a red one on `main`.

## The fix

All three asynchronous mechanisms now receive their mutable inputs as arguments instead of resolving them at execution time: the bootstrap thread, the retention `Timer`, and the gevent storage threadpool. A sweep confirms there is no fourth `Thread`, `Timer` or threadpool site in the module.

One discipline covers this and the two defects already fixed here — #1816 resolved eviction ordering wrongly, #1860 scheduled retention after the durable install: **capture what the work depends on when the work is created, not when it runs.**

## The startup race this raised is answered, not assumed

The bootstrap **cannot** be scheduled before the config determining the spool root exists: `constants` resolves `CONFIG_DIR` at import, `main()` completes `create_app()` first, and `start_retention_maintenance()` is called only afterwards. No production assignment later changes `CONFIG_DIR`, and there is no other production caller.

So this was a test-context race, not a production one. Creation-time capture is still the right contract, because it makes the asynchronous work self-contained rather than dependent on what the module looks like later.

## Verification

The deterministic regression detects failure to capture **either** dependency independently, by giving the two roots different record ages — re-reading only the age bound deletes the spawning root's record; re-reading the root deletes the next root's three. Two more pin the gevent worker and the timer callback.

```
mutation (restore run-time resolution):  AssertionError: the bootstrap expired
                                         records belonging to the next test
                                         assert 0 == 3
restored:                                35 passed
```

An autouse fixture cancelling the file's retention timers is included and documented **in the fixture itself** as secondary isolation, not the fix.

#1860's ordering invariant is intact at both `_write_or_reuse_record` install sites, and the eviction policy is unchanged: only `dispatch_completed` is capacity-evictable.

**Evidence is five runs, not one green** — this issue exists because a single green was once treated as an answer:

```
serial (-n 0):  7037 passed, 105 skipped, 0 failed
-n 4 run 1:     7037 passed          run 4:  7037 passed
-n 4 run 2:     7037 passed          run 5:  7037 passed
-n 4 run 3:     1 failed — test_s6_ingest_service_shutdown.py (unrelated: a real
                shell service whose watcher.pids file was missing; it does not
                import the spool, and a focused rerun passed)
```

**The Kobo spool failing set was empty in all five**, and the two historical failures from this class did not recur.

That one non-green run is worth recording rather than smoothing over: it is a *different* flake, in a test that launches a real shell service, and it should not be read as noise just because it is not this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1GA5qD4wtZJKYuMybVqPx

---

**Rebased onto `e85cb7581` (#1891) on 2026-08-25.** The branch had gone `CONFLICTING` because #1891 rewrote overlapping regions of the same module and test file. Three conflict regions needed a judgment, all resolved in favour of keeping #1891's current shape and applying this fix's capture to it:

- `_write_or_reuse_record(incoming, compressed, root, max_age_seconds)` — keeps #1891's no-cancellation, admitted-work-continues handoff; the captured values are added to that signature rather than restoring the older one.
- `_mark_dispatch_outcome_blocking(..., max_age_seconds)` — same, only the captured age is added.
- The test file's conflicting header resolved as a literal union: #1891's `_wait_for_full_request_io_capacity` and this branch's autouse retention-timer cleanup fixture both kept. No test case or assertion was dropped; two fakes were adapted to #1891's current worker signature.

Re-verified after the rebase, independently of the authoring leg: the mutation arm still goes red (reverting only the bootstrap capture fails `test_startup_retention_captures_root_and_age_before_thread_runs`) and green when restored; the file is 39/39 serial and 39/39 on two separate `-n 4` runs. Full trail in `state/completed.log`.
