### PR TITLE
test(kobo): make the exchange-capture tests deterministic

### DIFF
--- a/tests/unit/test_kobo_reading_services_exchange_capture.py
+++ b/tests/unit/test_kobo_reading_services_exchange_capture.py
@@ -9,7 +9,7 @@ import importlib
 import json
 import os
 import stat
-import time
+import threading
 from types import SimpleNamespace
 
 import gevent
@@ -28,11 +28,22 @@ def _module():
     return importlib.import_module("cps.services.kobo_exchange_capture")
 
 
-def _enable(monkeypatch, tmp_path):
+def _run_capture_io_inline(monkeypatch, capture):
+    """Keep persistence-focused tests independent of the request deadline."""
+    monkeypatch.setattr(
+        capture,
+        "_run_off_hub_bounded",
+        lambda _scope, function: function(),
+    )
+
+
+def _enable(monkeypatch, tmp_path, *, run_io_inline=True):
     capture = _module()
     root = tmp_path / "private-captures"
     monkeypatch.setenv(capture.ENABLE_ENV, ACK)
     monkeypatch.setattr(capture, "_capture_root", lambda: root)
+    if run_io_inline:
+        _run_capture_io_inline(monkeypatch, capture)
     return capture, root
 
 
@@ -291,6 +302,7 @@ def test_unauthenticated_patch_401_captures_body_with_explicit_provenance_outsid
     monkeypatch, tmp_path,
 ):
     capture = _module()
+    _run_capture_io_inline(monkeypatch, capture)
     unauthenticated_root = tmp_path / "unauthenticated-exchange-captures"
     recovery_spool_root = tmp_path / "recovery-spool-must-stay-empty"
     monkeypatch.setenv(capture.ENABLE_ENV, ACK)
@@ -419,31 +431,35 @@ def test_unauthenticated_capture_churn_cannot_evict_authenticated_diagnostics(
 
 @pytest.mark.unit
 def test_capture_persistence_yields_to_gevent_hub(monkeypatch, tmp_path):
-    capture, _root = _enable(monkeypatch, tmp_path)
+    capture, _root = _enable(monkeypatch, tmp_path, run_io_inline=False)
+    monkeypatch.setattr(capture, "REQUEST_IO_TIMEOUT_SECONDS", 5.0)
     session = capture.begin_capture(
         exchange="annotations_patch", method="PATCH", path="/annotations/book",
         query_string=b"", headers=[], body=b'{"updatedAnnotations":[]}',
         authentication="authenticated", user_id=7,
     )
-    original_persist = session._persist
+    request_thread = threading.get_ident()
+    release_worker = threading.Event()
+    worker_threads = []
     events = []
 
-    def slow_native_io():
-        time.sleep(0.05)
-        original_persist()
+    def native_io_waiting_on_hub():
+        worker_threads.append(threading.get_ident())
+        assert release_worker.wait(2), "hub greenlet did not release capture worker"
         events.append("persisted")
 
     def hub_ticker():
-        gevent.sleep(0.01)
         events.append("hub-ran")
+        release_worker.set()
 
-    monkeypatch.setattr(session, "_persist", slow_native_io)
+    monkeypatch.setattr(session, "_persist", native_io_waiting_on_hub)
     ticker = gevent.spawn(hub_ticker)
 
     assert _finish(session) is True
-    ticker.join(timeout=1)
+    ticker.get(timeout=1)
 
     assert events == ["hub-ran", "persisted"]
+    assert worker_threads != [request_thread]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
`tests/unit/test_kobo_reading_services_exchange_capture.py` was nondeterministic in the fast lane, and a *different* subset failed on each run. It blocked an unrelated release PR (#1897) whose diff touches no Python at all.

**Cause.** `CaptureSession.finish()` persists through `_run_off_hub_bounded`, which is bounded by `REQUEST_IO_TIMEOUT_SECONDS = 0.1`. That deadline is deliberate — capture is best-effort and must never stall a Kobo request — so under load the production path correctly fails open and `finish()` returns `False`. Tests that only care about *what* was captured were nonetheless racing that deadline and asserting `True`.

**Fix, test-side only.** `cps/services/kobo_exchange_capture.py` is untouched, so the shipped fail-open behaviour is unchanged. Content-focused tests now run the capture IO inline and stop racing the deadline. The one test that exists to pin off-hub behaviour, `test_capture_persistence_yields_to_gevent_hub`, keeps the real `_run_off_hub_bounded` path with a 5s timeout, replaces the `time.sleep`/`gevent.sleep` handshake with a deterministic `threading.Event`, and gains a new assertion that persistence ran off the request thread — so hub-yielding is pinned harder than before. No assertion was deleted, skipped, xfailed or wrapped in a retry.

**Evidence.** Before: CI Fast Tests failed 3 tests, local run 1 failed a different 2, local run 2 failed 1 — all against unmodified `main` code. After: the file was run 15 consecutive times, 15/15 green.

Records the flake and its resolution in the pending-findings ledger.
