### PR TITLE
fix(settings): a misplaced click can no longer erase every CWA setting (#1694)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,6 +289,12 @@ is for things you can see or feel when running the app.
   marker the old cover badge used, driven by the same sync state your Kobo and
   KOReader already write. Reported by @magdalar and @JamesHACS (#1702).
 
+- **CWA Settings no longer lets one misplaced click erase every CWA setting.**
+  Reset All CWA Settings has moved out of Save's primary, rightmost position,
+  no longer looks like the main action, and now asks for confirmation that
+  names the full loss before changing anything. Both controls can now be
+  translated without breaking what the server does. Reported by @iroQuai in
+  #1694.
 - **Highlights now work in the chapters of a book that keeps many chapters in
   one file — the shape almost every Project Gutenberg book has.** A Kobo
   recognises a chapter by the file it lives in, not by a link into the middle of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,12 +289,6 @@ is for things you can see or feel when running the app.
   marker the old cover badge used, driven by the same sync state your Kobo and
   KOReader already write. Reported by @magdalar and @JamesHACS (#1702).
 
-- **CWA Settings no longer lets one misplaced click erase every CWA setting.**
-  Reset All CWA Settings has moved out of Save's primary, rightmost position,
-  no longer looks like the main action, and now asks for confirmation that
-  names the full loss before changing anything. Both controls can now be
-  translated without breaking what the server does. Reported by @iroQuai in
-  #1694.
 - **Highlights now work in the chapters of a book that keeps many chapters in
   one file — the shape almost every Project Gutenberg book has.** A Kobo
   recognises a chapter by the file it lives in, not by a link into the middle of

--- a/changelog.d/1694.md
+++ b/changelog.d/1694.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- **CWA Settings no longer lets one misplaced click erase every CWA setting.**
+  Reset All CWA Settings has moved out of Save's primary, rightmost position,
+  no longer looks like the main action, and now asks for confirmation that
+  names the full loss before changing anything. Both controls can now be
+  translated without breaking what the server does. Reported by @iroQuai in
+  #1694.

--- a/cps/cwa_functions.py
+++ b/cps/cwa_functions.py
@@ -806,7 +806,16 @@ def set_cwa_settings():
         string_settings.append(f"convert_retained_{format}")
 
     if request.method == 'POST':
-        if request.form['submit_button'] == "Submit":
+        action = request.form.get('settings_action')
+        if action is None:
+            # Compatibility for forms rendered before the action values were
+            # decoupled from their English display labels (#1694).
+            action = {
+                "Submit": "save",
+                "Apply Default Settings": "reset",
+            }.get(request.form.get('submit_button'))
+
+        if action == "save":
             result = {"auto_convert_ignored_formats":[], "auto_ingest_ignored_formats":[], "auto_convert_retained_formats":[]}
             # set boolean_settings
             for setting in boolean_settings:
@@ -1070,7 +1079,7 @@ def set_cwa_settings():
                     "KOReader sync disabled: checksum backfill will stop after container restart."
                 )
 
-        elif request.form['submit_button'] == "Apply Default Settings":
+        elif action == "reset":
             cwa_db = CWA_DB()
             duplicate_criteria_changed = False
             try:

--- a/cps/static/css/cwa.css
+++ b/cps/static/css/cwa.css
@@ -231,3 +231,61 @@ body.blur .btn-secondary:focus,
 body.blur .btn-secondary:active {
     background-color: #ffffff;
 }
+
+/* CWA Settings deliberately does not use btn-default / btn-primary for its
+   reset and save pair. caliBlur assigns those two classes the opposite visual
+   hierarchy from Bootstrap, so action-specific colors are resolved here,
+   after both theme stylesheets. */
+.cwa-settings-actions {
+    --cwa-settings-reset-bg: #ffffff;
+    --cwa-settings-reset-bg-interactive: #e6e6e6;
+    --cwa-settings-reset-color: #333333;
+    --cwa-settings-reset-border: #cccccc;
+    --cwa-settings-reset-border-interactive: #adadad;
+    --cwa-settings-save-bg: #337ab7;
+    --cwa-settings-save-bg-interactive: #1c5484;
+    --cwa-settings-save-color: #ffffff;
+    --cwa-settings-save-border: #2e6da4;
+    --cwa-settings-save-border-interactive: #204d74;
+}
+
+body.blur .cwa-settings-actions {
+    --cwa-settings-reset-bg: rgba(22, 31, 39, 0.7);
+    --cwa-settings-reset-bg-interactive: rgba(255, 255, 255, 0.3);
+    --cwa-settings-reset-color: #ffffff;
+    --cwa-settings-reset-border: rgba(255, 255, 255, 0.25);
+    --cwa-settings-reset-border-interactive: rgba(255, 255, 255, 0.3);
+    --cwa-settings-save-bg: #cc7b19;
+    --cwa-settings-save-bg-interactive: #e59029;
+    --cwa-settings-save-color: #ffffff;
+    --cwa-settings-save-border: #cc7b19;
+    --cwa-settings-save-border-interactive: #e59029;
+}
+
+.cwa-settings-actions .cwa-settings-reset-action {
+    color: var(--cwa-settings-reset-color);
+    background-color: var(--cwa-settings-reset-bg);
+    border: 1px solid var(--cwa-settings-reset-border);
+}
+
+.cwa-settings-actions .cwa-settings-reset-action:hover,
+.cwa-settings-actions .cwa-settings-reset-action:focus,
+.cwa-settings-actions .cwa-settings-reset-action:active {
+    color: var(--cwa-settings-reset-color);
+    background-color: var(--cwa-settings-reset-bg-interactive);
+    border-color: var(--cwa-settings-reset-border-interactive);
+}
+
+.cwa-settings-actions .cwa-settings-save-action {
+    color: var(--cwa-settings-save-color);
+    background-color: var(--cwa-settings-save-bg);
+    border: 1px solid var(--cwa-settings-save-border);
+}
+
+.cwa-settings-actions .cwa-settings-save-action:hover,
+.cwa-settings-actions .cwa-settings-save-action:focus,
+.cwa-settings-actions .cwa-settings-save-action:active {
+    color: var(--cwa-settings-save-color);
+    background-color: var(--cwa-settings-save-bg-interactive);
+    border-color: var(--cwa-settings-save-border-interactive);
+}

--- a/cps/static/css/cwa.css
+++ b/cps/static/css/cwa.css
@@ -263,6 +263,7 @@ body.blur .cwa-settings-actions {
 }
 
 .cwa-settings-actions .cwa-settings-reset-action {
+    order: 1;
     color: var(--cwa-settings-reset-color);
     background-color: var(--cwa-settings-reset-bg);
     border: 1px solid var(--cwa-settings-reset-border);
@@ -277,6 +278,7 @@ body.blur .cwa-settings-actions {
 }
 
 .cwa-settings-actions .cwa-settings-save-action {
+    order: 2;
     color: var(--cwa-settings-save-color);
     background-color: var(--cwa-settings-save-bg);
     border: 1px solid var(--cwa-settings-save-border);

--- a/cps/templates/cwa_settings.html
+++ b/cps/templates/cwa_settings.html
@@ -1245,8 +1245,8 @@
 
     <br>
     <div class="cwa-settings-actions" style="margin-top: -2rem; max-width: 900px; justify-self: center; margin-bottom: 1rem; display: flex; flex-direction: row; flex-wrap: wrap; gap: 0.75rem; width: -webkit-fill-available; justify-content: flex-end; margin-left: 2rem; margin-right: 2rem;">
-      <button type="submit" name="settings_action" value="reset" class="btn cwa-settings-reset-action" data-confirm="{{ _('Reset every CWA setting to its default? All of your current CWA settings will be permanently lost.') }}" onclick="return confirm(this.dataset.confirm);">{{ _('Reset All CWA Settings') }}</button>
       <button type="submit" name="settings_action" value="save" class="btn cwa-settings-save-action">{{ _('Save') }}</button>
+      <button type="submit" name="settings_action" value="reset" class="btn cwa-settings-reset-action" data-confirm="{{ _('Reset every CWA setting to its default? All of your current CWA settings will be permanently lost.') }}" onclick="return confirm(this.dataset.confirm);">{{ _('Reset All CWA Settings') }}</button>
     </div>
     <br>
 

--- a/cps/templates/cwa_settings.html
+++ b/cps/templates/cwa_settings.html
@@ -1244,9 +1244,9 @@
     <br>
 
     <br>
-    <div style="margin-top: -2rem; max-width: 900px; justify-self: center; margin-bottom: 1rem; display: flex; flex-direction: row; flex-wrap: wrap; gap: 0.75rem; width: -webkit-fill-available; justify-content: flex-end; margin-left: 2rem; margin-right: 2rem;">
-      <button type="submit" name="settings_action" value="reset" class="btn btn-default" data-confirm="{{ _('Reset every CWA setting to its default? All of your current CWA settings will be permanently lost.') }}" onclick="return confirm(this.dataset.confirm);">{{ _('Reset All CWA Settings') }}</button>
-      <button type="submit" name="settings_action" value="save" class="btn btn-primary">{{ _('Save') }}</button>
+    <div class="cwa-settings-actions" style="margin-top: -2rem; max-width: 900px; justify-self: center; margin-bottom: 1rem; display: flex; flex-direction: row; flex-wrap: wrap; gap: 0.75rem; width: -webkit-fill-available; justify-content: flex-end; margin-left: 2rem; margin-right: 2rem;">
+      <button type="submit" name="settings_action" value="reset" class="btn cwa-settings-reset-action" data-confirm="{{ _('Reset every CWA setting to its default? All of your current CWA settings will be permanently lost.') }}" onclick="return confirm(this.dataset.confirm);">{{ _('Reset All CWA Settings') }}</button>
+      <button type="submit" name="settings_action" value="save" class="btn cwa-settings-save-action">{{ _('Save') }}</button>
     </div>
     <br>
 

--- a/cps/templates/cwa_settings.html
+++ b/cps/templates/cwa_settings.html
@@ -1244,9 +1244,9 @@
     <br>
 
     <br>
-    <div style="margin-top: -2rem; max-width: 900px; justify-self: center; margin-bottom: 1rem; display: flex; flex-direction: row; flex-wrap: wrap; width: -webkit-fill-available; justify-content: space-between; margin-left: 2rem; margin-right: 2rem;">
-      <input type="submit" name="submit_button" value="Submit" class="btn btn-default">
-      <input type="submit" name="submit_button" value="Apply Default Settings" class="btn btn-danger">
+    <div style="margin-top: -2rem; max-width: 900px; justify-self: center; margin-bottom: 1rem; display: flex; flex-direction: row; flex-wrap: wrap; gap: 0.75rem; width: -webkit-fill-available; justify-content: flex-end; margin-left: 2rem; margin-right: 2rem;">
+      <button type="submit" name="settings_action" value="reset" class="btn btn-default" data-confirm="{{ _('Reset every CWA setting to its default? All of your current CWA settings will be permanently lost.') }}" onclick="return confirm(this.dataset.confirm);">{{ _('Reset All CWA Settings') }}</button>
+      <button type="submit" name="settings_action" value="save" class="btn btn-primary">{{ _('Save') }}</button>
     </div>
     <br>
 

--- a/cps/templates/email_edit.html
+++ b/cps/templates/email_edit.html
@@ -21,7 +21,7 @@
         {% if content.mail_gmail_token == {} %}
         <button type="submit" id="gmail_server" name="gmail" value="submit" class="btn btn-default">{{_('Setup Gmail Account')}}</button>
         {% else %}
-        <button type="submit" id="invalidate_server" name="invalidate" value="submit" class="btn btn-danger">{{_('Revoke Gmail Access')}}</button>
+        <button type="submit" id="invalidate_server" name="invalidate" value="submit" class="btn btn-danger" data-confirm="{{ _('Revoke Gmail access? You will need to authorize Gmail again to use it.') }}" onclick="return confirm(this.dataset.confirm);">{{_('Revoke Gmail Access')}}</button>
         {% endif %}
       </div>
     </div>

--- a/cps/templates/kobo_reconcile.html
+++ b/cps/templates/kobo_reconcile.html
@@ -75,7 +75,7 @@
       {% endfor %}
     </tbody>
   </table>
-    <button class="btn btn-danger" type="submit">
+    <button class="btn btn-danger" type="submit" data-confirm="{{ _('Archive the selected books on the next Kobo sync?') }}" onclick="return confirm(this.dataset.confirm);">
       {{ _('Archive selected books on the next Kobo sync') }}
     </button>
   </form>

--- a/tests/unit/test_1694_cwa_settings_reset_safety.py
+++ b/tests/unit/test_1694_cwa_settings_reset_safety.py
@@ -4,6 +4,7 @@
 """Regression coverage for the destructive CWA Settings reset (#1694)."""
 
 import inspect
+import re
 from pathlib import Path
 
 import flask
@@ -12,6 +13,8 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CWA_SETTINGS_TEMPLATE = REPO_ROOT / "cps" / "templates" / "cwa_settings.html"
+CWA_CSS = REPO_ROOT / "cps" / "static" / "css" / "cwa.css"
+LAYOUT_TEMPLATE = REPO_ROOT / "cps" / "templates" / "layout.html"
 
 
 class _SettingsDB:
@@ -119,16 +122,93 @@ def test_route_keeps_cached_english_forms_working(
     assert _SettingsDB.reset_calls == expected_reset_calls
 
 
-def test_template_makes_save_primary_and_confirms_the_full_reset():
+def _css_declarations(source, selector):
+    source = re.sub(r"/\*.*?\*/", "", source, flags=re.DOTALL)
+    for match in re.finditer(r"([^{}]+)\{([^{}]*)\}", source):
+        selectors = {item.strip() for item in match.group(1).split(",")}
+        if selector not in selectors:
+            continue
+        return {
+            name.strip(): value.strip()
+            for declaration in match.group(2).split(";")
+            if ":" in declaration
+            for name, value in [declaration.split(":", 1)]
+        }
+    raise AssertionError(f"Missing CSS selector: {selector}")
+
+
+def _rgb_chroma(color):
+    if color.startswith("#"):
+        value = color.removeprefix("#")
+        assert len(value) == 6, f"Unsupported hex color: {color}"
+        channels = tuple(int(value[index:index + 2], 16) for index in (0, 2, 4))
+    else:
+        match = re.fullmatch(
+            r"rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)(?:\s*,\s*[\d.]+)?\s*\)",
+            color,
+        )
+        assert match, f"Unsupported CSS color: {color}"
+        channels = tuple(int(channel) for channel in match.groups())
+    return max(channels) - min(channels)
+
+
+def test_template_confirms_the_full_reset_and_keeps_save_rightmost():
     source = CWA_SETTINGS_TEMPLATE.read_text(encoding="utf-8")
     reset = source.index('name="settings_action" value="reset"')
     save = source.index('name="settings_action" value="save"')
 
     assert reset < save, "Reset must remain left of the rightmost Save action"
-    assert 'value="reset" class="btn btn-default"' in source
-    assert 'value="save" class="btn btn-primary"' in source
     assert "Reset every CWA setting to its default?" in source
     assert "All of your current CWA settings will be permanently lost." in source
     assert 'onclick="return confirm(this.dataset.confirm);"' in source
     assert "{{ _('Reset All CWA Settings') }}" in source
     assert "{{ _('Save') }}" in source
+
+
+@pytest.mark.parametrize(
+    ("theme_selector", "state_suffix"),
+    [
+        (None, ""),
+        (None, "-interactive"),
+        ("body.blur .cwa-settings-actions", ""),
+        ("body.blur .cwa-settings-actions", "-interactive"),
+    ],
+)
+def test_save_is_the_color_accent_in_both_themes(theme_selector, state_suffix):
+    template = CWA_SETTINGS_TEMPLATE.read_text(encoding="utf-8")
+    css = CWA_CSS.read_text(encoding="utf-8")
+    layout = LAYOUT_TEMPLATE.read_text(encoding="utf-8")
+
+    reset_tag = re.search(r'<button[^>]+value="reset"[^>]*>', template).group(0)
+    save_tag = re.search(r'<button[^>]+value="save"[^>]*>', template).group(0)
+    assert "cwa-settings-actions" in template
+    assert "cwa-settings-reset-action" in reset_tag
+    assert "cwa-settings-save-action" in save_tag
+    assert "btn-default" not in reset_tag and "btn-primary" not in reset_tag
+    assert "btn-default" not in save_tag and "btn-primary" not in save_tag
+
+    # cwa.css is the final theme stylesheet, so these action-specific rules
+    # are the declarations a browser resolves after caliBlur's global button
+    # inversion. Compare the actual resolved colors, not Bootstrap class names.
+    assert layout.index("css/caliBlur.css") < layout.index("css/cwa.css")
+    variables = _css_declarations(css, ".cwa-settings-actions")
+    if theme_selector:
+        variables.update(_css_declarations(css, theme_selector))
+
+    if state_suffix:
+        reset_selector = ".cwa-settings-actions .cwa-settings-reset-action:hover"
+        save_selector = ".cwa-settings-actions .cwa-settings-save-action:hover"
+    else:
+        reset_selector = ".cwa-settings-actions .cwa-settings-reset-action"
+        save_selector = ".cwa-settings-actions .cwa-settings-save-action"
+
+    reset_variable = f"--cwa-settings-reset-bg{state_suffix}"
+    save_variable = f"--cwa-settings-save-bg{state_suffix}"
+    assert _css_declarations(css, reset_selector)["background-color"] == f"var({reset_variable})"
+    assert _css_declarations(css, save_selector)["background-color"] == f"var({save_variable})"
+
+    reset_color = variables[reset_variable]
+    save_color = variables[save_variable]
+    assert _rgb_chroma(save_color) > _rgb_chroma(reset_color), (
+        f"Save must remain the color accent: reset={reset_color}, save={save_color}"
+    )

--- a/tests/unit/test_1694_cwa_settings_reset_safety.py
+++ b/tests/unit/test_1694_cwa_settings_reset_safety.py
@@ -1,0 +1,134 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Regression coverage for the destructive CWA Settings reset (#1694)."""
+
+import inspect
+from pathlib import Path
+
+import flask
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CWA_SETTINGS_TEMPLATE = REPO_ROOT / "cps" / "templates" / "cwa_settings.html"
+
+
+class _SettingsDB:
+    defaults = {"auto_convert_target_format": "epub"}
+    stored = {"auto_convert_target_format": "mobi"}
+    reset_calls = []
+    update_calls = []
+
+    def __init__(self):
+        self.cwa_default_settings = dict(self.defaults)
+        self.cwa_settings = dict(self.stored)
+
+    def get_cwa_settings(self):
+        return dict(self.stored)
+
+    def update_cwa_settings(self, settings):
+        self.__class__.stored.update(settings)
+        self.__class__.update_calls.append(dict(settings))
+
+    def set_default_settings(self, force=False):
+        self.__class__.stored = dict(self.defaults)
+        self.__class__.reset_calls.append(force)
+
+    def execute_write(self, _query, _params=()):
+        return None
+
+
+@pytest.fixture
+def settings_client(monkeypatch):
+    from cps import cwa_functions, schedule
+
+    _SettingsDB.stored = {"auto_convert_target_format": "mobi"}
+    _SettingsDB.reset_calls = []
+    _SettingsDB.update_calls = []
+
+    monkeypatch.setattr(cwa_functions, "CWA_DB", _SettingsDB)
+    monkeypatch.setattr(cwa_functions, "INTEGER_SETTINGS", ())
+    monkeypatch.setattr(cwa_functions, "FLOAT_SETTINGS", ())
+    monkeypatch.setattr(cwa_functions, "JSON_SETTINGS", ())
+    monkeypatch.setattr(cwa_functions, "_", lambda text, **_kwargs: text)
+    monkeypatch.setattr(cwa_functions.config, "config_kobo_sync_magic_shelves", False, raising=False)
+    monkeypatch.setattr(cwa_functions.config, "config_hardcover_sync", False, raising=False)
+    monkeypatch.setattr(cwa_functions.config, "save", lambda: None)
+    monkeypatch.setattr(cwa_functions.config, "resolved_hardcover_token", lambda: None)
+    monkeypatch.setattr(schedule, "refresh_hardcover_auto_fetch", lambda: None)
+    monkeypatch.setattr(cwa_functions, "get_next_duplicate_scan_run", lambda _settings: None)
+    monkeypatch.setattr(
+        cwa_functions,
+        "render_title_template",
+        lambda _template, **context: {"settings": context["cwa_settings"]},
+    )
+
+    app = flask.Flask(__name__)
+    app.config.update(TESTING=True)
+    app.register_blueprint(cwa_functions.cwa_settings)
+    app.view_functions["cwa_settings.set_cwa_settings"] = inspect.unwrap(
+        cwa_functions.set_cwa_settings
+    )
+    return app.test_client()
+
+
+def test_route_dispatches_stable_actions_without_english_labels(settings_client):
+    reset_response = settings_client.post(
+        "/cwa-settings",
+        data={"settings_action": "reset"},
+    )
+
+    assert reset_response.status_code == 200
+    assert _SettingsDB.reset_calls == [True]
+    assert _SettingsDB.stored == _SettingsDB.defaults
+
+    save_response = settings_client.post(
+        "/cwa-settings",
+        data={
+            "settings_action": "save",
+            "auto_convert_target_format": "azw3",
+        },
+    )
+
+    assert save_response.status_code == 200
+    assert _SettingsDB.update_calls[-1]["auto_convert_target_format"] == "azw3"
+    assert _SettingsDB.stored["auto_convert_target_format"] == "azw3"
+
+
+@pytest.mark.parametrize(
+    ("legacy_label", "expected_target", "expected_reset_calls"),
+    [
+        ("Submit", "azw3", []),
+        ("Apply Default Settings", "epub", [True]),
+    ],
+)
+def test_route_keeps_cached_english_forms_working(
+    settings_client, legacy_label, expected_target, expected_reset_calls
+):
+    response = settings_client.post(
+        "/cwa-settings",
+        data={
+            "submit_button": legacy_label,
+            "auto_convert_target_format": "azw3",
+        },
+    )
+
+    assert response.status_code == 200
+    assert _SettingsDB.stored["auto_convert_target_format"] == expected_target
+    assert _SettingsDB.reset_calls == expected_reset_calls
+
+
+def test_template_makes_save_primary_and_confirms_the_full_reset():
+    source = CWA_SETTINGS_TEMPLATE.read_text(encoding="utf-8")
+    reset = source.index('name="settings_action" value="reset"')
+    save = source.index('name="settings_action" value="save"')
+
+    assert reset < save, "Reset must remain left of the rightmost Save action"
+    assert 'value="reset" class="btn btn-default"' in source
+    assert 'value="save" class="btn btn-primary"' in source
+    assert "Reset every CWA setting to its default?" in source
+    assert "All of your current CWA settings will be permanently lost." in source
+    assert 'onclick="return confirm(this.dataset.confirm);"' in source
+    assert "{{ _('Reset All CWA Settings') }}" in source
+    assert "{{ _('Save') }}" in source

--- a/tests/unit/test_1694_cwa_settings_reset_safety.py
+++ b/tests/unit/test_1694_cwa_settings_reset_safety.py
@@ -5,16 +5,21 @@
 
 import inspect
 import re
+from collections import defaultdict
 from pathlib import Path
+from types import SimpleNamespace
 
 import flask
+import jinja2
 import pytest
+from lxml import html
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CWA_SETTINGS_TEMPLATE = REPO_ROOT / "cps" / "templates" / "cwa_settings.html"
 CWA_CSS = REPO_ROOT / "cps" / "static" / "css" / "cwa.css"
 LAYOUT_TEMPLATE = REPO_ROOT / "cps" / "templates" / "layout.html"
+TEMPLATE_DIR = REPO_ROOT / "cps" / "templates"
 
 
 class _SettingsDB:
@@ -152,12 +157,90 @@ def _rgb_chroma(color):
     return max(channels) - min(channels)
 
 
-def test_template_confirms_the_full_reset_and_keeps_save_rightmost():
-    source = CWA_SETTINGS_TEMPLATE.read_text(encoding="utf-8")
-    reset = source.index('name="settings_action" value="reset"')
-    save = source.index('name="settings_action" value="save"')
+def _render_cwa_settings_template():
+    def translate(message, **values):
+        return message % values if values else message
 
-    assert reset < save, "Reset must remain left of the rightmost Save action"
+    environment = jinja2.Environment(
+        loader=jinja2.ChoiceLoader([
+            jinja2.DictLoader({
+                "layout.html": (
+                    "{% block flash %}{% endblock %}"
+                    "{% block header %}{% endblock %}"
+                    "{% block body %}{% endblock %}"
+                ),
+            }),
+            jinja2.FileSystemLoader(str(TEMPLATE_DIR)),
+        ]),
+        autoescape=True,
+    )
+    return environment.get_template("cwa_settings.html").render(
+        _=translate,
+        autoingest_options=(),
+        config=SimpleNamespace(
+            config_timezone="UTC",
+            hardcover_sync_enabled=lambda: False,
+        ),
+        cwa_settings=defaultdict(lambda: False),
+        hardcover_token_available=False,
+        ignorable_formats=(),
+        next_duplicate_scan_run=None,
+        target_formats=(),
+        title="CWA Settings",
+        url_for=lambda endpoint: f"/{endpoint}",
+    )
+
+
+def _inline_declarations(element):
+    return {
+        name.strip(): value.strip()
+        for declaration in element.get("style", "").split(";")
+        if ":" in declaration
+        for name, value in [declaration.split(":", 1)]
+    }
+
+
+def test_rendered_template_makes_save_default_and_keeps_it_rightmost():
+    source = CWA_SETTINGS_TEMPLATE.read_text(encoding="utf-8")
+    document = html.fromstring(_render_cwa_settings_template())
+    form = document.xpath("//form")[0]
+    action_row = form.xpath(
+        './/div[contains(concat(" ", normalize-space(@class), " "), '
+        '" cwa-settings-actions ")]'
+    )[0]
+    action_buttons = action_row.xpath('./button[@type="submit"]')
+    dom_actions = [button.get("value") for button in action_buttons]
+
+    assert dom_actions == ["save", "reset"], (
+        "Save must be the first submit control in DOM order so implicit "
+        "form submission cannot target Reset"
+    )
+
+    all_submit_controls = form.xpath(
+        './/button[not(@type) or @type="submit"] | .//input[@type="submit"]'
+    )
+    assert all_submit_controls[0].get("value") == "save"
+
+    row_style = _inline_declarations(action_row)
+    assert row_style["display"] == "flex"
+    css = CWA_CSS.read_text(encoding="utf-8")
+
+    def flex_order(button):
+        action_class = next(
+            class_name
+            for class_name in button.get("class", "").split()
+            if class_name.startswith("cwa-settings-") and class_name.endswith("-action")
+        )
+        selector = f".cwa-settings-actions .{action_class}"
+        return int(_css_declarations(css, selector)["order"])
+
+    visual_actions = [
+        button.get("value") for button in sorted(action_buttons, key=flex_order)
+    ]
+    assert visual_actions == ["reset", "save"], (
+        "Reset must render left of the rightmost Save action"
+    )
+
     assert "Reset every CWA setting to its default?" in source
     assert "All of your current CWA settings will be permanently lost." in source
     assert 'onclick="return confirm(this.dataset.confirm);"' in source

--- a/tests/unit/test_hardcover_configuration_cluster.py
+++ b/tests/unit/test_hardcover_configuration_cluster.py
@@ -509,10 +509,9 @@ def test_applying_cwa_defaults_restores_the_rollback_mirror():
     ]
 
     source = (REPO_ROOT / "cps/cwa_functions.py").read_text(encoding="utf-8")
-    defaults_branch = source.split(
-        'elif request.form[\'submit_button\'] == "Apply Default Settings":', 1
-    )[1]
-    assert "_mirror_hardcover_sync_for_rollback(cwa_db)" in defaults_branch
+    defaults_call = source.index("cwa_db.set_default_settings(force=True)")
+    mirror_call = source.index("_mirror_hardcover_sync_for_rollback(cwa_db)", defaults_call)
+    assert mirror_call > defaults_call
 
 
 def test_scheduler_logs_disabled_and_missing_token_as_distinct_states(


### PR DESCRIPTION
Closes #1694.

@iroQuai hit **Save** on the Classic *Calibre-Web NextGen User Settings* page by reaching for the most prominent button on the right — and reset every CWA setting they had. The page was laid out against them: the two controls were a `justify-content: space-between` flex row with the grey **Submit** on the left and the red **Apply Default Settings** on the right, which is where every other dialog in this app puts the *confirming* action. Nothing sat between the click and the write.

## What changes

- **The reset is confirm-gated**, with wording that states the full scope of the loss — `set_default_settings(force=True)` rewrites the whole CWA settings table (auto-conversion targets, ingest behaviour, duplicate-detection criteria, Kobo/metadata options), not just the section you were looking at.
- **Save is rightmost and is the accent colour; the reset is neutral and sits to its left.** Colours are resolved in `cwa.css` under `.cwa-settings-actions` rather than via `btn-default`/`btn-primary`, because caliBlur assigns those two classes the opposite visual hierarchy from Bootstrap — using them would have inverted the fix in the dark theme.
- **Save is the form's default button**, so pressing Enter in any field on this long form saves rather than aiming at the destructive action.
- **Dispatch is decoupled from the English display label.** The route now switches on a stable `settings_action` value (`save` / `reset`) instead of comparing `submit_button` to the literal strings `"Submit"` and `"Apply Default Settings"`, so the buttons can finally be translated. A compatibility branch keeps forms rendered by the previous build working.
- Two other unconfirmed destructive submits found in the same audit are now gated: **Revoke Gmail Access** (`email_edit.html`) and **Archive selected books on the next Kobo sync** (`kobo_reconcile.html`).

## Verification

Evidence trail is in `state/completed.log` (`redgreen-verified` / `practical-verified` rows for this branch); it is not reproduced here.

## Known limitation

The new button labels and confirmation strings are new msgids and ship untranslated in all 29 languages until a translation pass runs — the same gap recorded in the findings ledger for `update-translations.yml`. This is a net improvement for translators, since the previous labels could not be translated at all without breaking the form's dispatch.
