### PR TITLE
test(kobo): a leaked spool permit can no longer take innocent tests down with it

### DIFF
--- a/tests/unit/test_f5c1146_kobo_patch_recovery_spool.py
+++ b/tests/unit/test_f5c1146_kobo_patch_recovery_spool.py
@@ -65,6 +65,28 @@ def _wait_for_full_request_io_capacity(spool, timeout=2):
     return capacity
 
 
+def _require_full_request_io_capacity(spool, boundary):
+    """Fail the permit owner, then restore isolation for the next test."""
+    capacity = _wait_for_full_request_io_capacity(spool)
+    if capacity == [True, True, False]:
+        return
+    spool._reset_request_io_slots_after_fork()
+    pytest.fail(
+        "Kobo PATCH request I/O permit leak "
+        f"{boundary}: expected [True, True, False], observed {capacity}; "
+        "resetting capacity so later tests are not poisoned"
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_request_io_capacity():
+    """Attribute permit leaks to their owner instead of the next test."""
+    spool = _module()
+    _require_full_request_io_capacity(spool, "before test setup")
+    yield
+    _require_full_request_io_capacity(spool, "during test teardown")
+
+
 @pytest.fixture(autouse=True)
 def _cancel_spool_retention_timers_after_test():
     """Secondary test isolation; production dependency capture is the fix."""
@@ -635,10 +657,15 @@ def test_forked_child_recovers_full_request_io_capacity(monkeypatch, tmp_path):
     ready = [threading.Event(), threading.Event()]
 
     def _hold_slot(signal):
-        assert spool._REQUEST_IO_SLOTS.acquire(blocking=False)
-        signal.set()
-        assert release.wait(5)
-        spool._REQUEST_IO_SLOTS.release()
+        slots = spool._REQUEST_IO_SLOTS
+        acquired = slots.acquire(blocking=False)
+        try:
+            assert acquired
+            signal.set()
+            assert release.wait(5)
+        finally:
+            if acquired:
+                slots.release()
 
     holders = [
         threading.Thread(target=_hold_slot, args=(signal,), daemon=True)
@@ -646,20 +673,25 @@ def test_forked_child_recovers_full_request_io_capacity(monkeypatch, tmp_path):
     ]
     for holder in holders:
         holder.start()
-    assert all(signal.wait(2) for signal in ready)
-
-    context = multiprocessing.get_context("fork")
-    result_parent, result_child = context.Pipe(duplex=False)
-    child = context.Process(
-        target=_stage_in_forked_child, args=(root, result_child),
-    )
-    child.start()
+    child = None
     try:
+        assert all(signal.wait(2) for signal in ready), (
+            "Kobo PATCH request I/O permit leak prevented both parent holders "
+            "from acquiring capacity"
+        )
+
+        context = multiprocessing.get_context("fork")
+        result_parent, result_child = context.Pipe(duplex=False)
+        child = context.Process(
+            target=_stage_in_forked_child, args=(root, result_child),
+        )
+        child.start()
         assert result_parent.poll(5), "forked child did not report its stage"
         body, capacity, process_lock_inherited_locked = result_parent.recv()
     finally:
         release.set()
-        child.join(5)
+        if child is not None:
+            child.join(5)
         for holder in holders:
             holder.join(5)
 
@@ -733,13 +765,17 @@ def test_spawn_enqueue_then_raise_releases_the_permit_exactly_once(
     [(_path, record)] = _records(spool, root)
     assert record["body"] == RAW_PATCH
 
-    assert spool._REQUEST_IO_SLOTS.acquire(blocking=False)
-    assert spool._REQUEST_IO_SLOTS.acquire(blocking=False)
+    capacity = []
     try:
-        assert not spool._REQUEST_IO_SLOTS.acquire(blocking=False)
+        capacity = [
+            spool._REQUEST_IO_SLOTS.acquire(blocking=False)
+            for _index in range(spool.MAX_PENDING_IO_OPERATIONS + 1)
+        ]
+        assert capacity == [True, True, False]
     finally:
-        spool._REQUEST_IO_SLOTS.release()
-        spool._REQUEST_IO_SLOTS.release()
+        for acquired in capacity:
+            if acquired:
+                spool._REQUEST_IO_SLOTS.release()
 
 
 @pytest.mark.unit
@@ -804,9 +840,12 @@ def test_timed_out_stage_finishes_and_does_not_poison_its_successor(
 def test_pending_spool_work_is_bounded(monkeypatch, tmp_path):
     """Two pending operations cannot grow into an unbounded memory queue."""
     spool, root = _root(monkeypatch, tmp_path)
-    assert spool._REQUEST_IO_SLOTS.acquire(blocking=False)
-    assert spool._REQUEST_IO_SLOTS.acquire(blocking=False)
+    acquired = []
     try:
+        for _index in range(spool.MAX_PENDING_IO_OPERATIONS):
+            permit = spool._REQUEST_IO_SLOTS.acquire(blocking=False)
+            acquired.append(permit)
+            assert permit
         started = time.monotonic()
         ticket = spool.stage_patch(
             raw_body=RAW_PATCH, entitlement_id=BOOK_UUID,
@@ -814,8 +853,9 @@ def test_pending_spool_work_is_bounded(monkeypatch, tmp_path):
         )
         elapsed = time.monotonic() - started
     finally:
-        spool._REQUEST_IO_SLOTS.release()
-        spool._REQUEST_IO_SLOTS.release()
+        for permit in acquired:
+            if permit:
+                spool._REQUEST_IO_SLOTS.release()
 
     assert ticket is None
     assert elapsed < 0.05


### PR DESCRIPTION
## Why

CI run [32949533470](https://github.com/new-usemame/Calibre-Web-NextGen/actions/runs/32949533470) turned the required **Test Suite Summary** check red on PR #1905 — an unrelated settings-confirmation change that touches no Kobo code. Three tests failed, all in `tests/unit/test_f5c1146_kobo_patch_recovery_spool.py`:

```
FAILED test_forked_child_recovers_full_request_io_capacity          - assert False
FAILED test_spawn_enqueue_then_raise_releases_the_permit_exactly_once - AssertionError: assert False
FAILED test_timed_out_stage_finishes_and_does_not_poison_its_successor - assert False
```

A rerun of the same head with no code change went green, which is the definition of a flake in the one check the autonomous-merge gate reads.

## Root cause

**Not a product defect.** `cps/services/kobo_patch_spool.py` is sound: `_RequestIOPermit` acquires non-blocking and releases release-once inside a `finally`. Nothing in this PR touches product code.

The defect is test-side, and it has two halves:

1. **The trigger.** A test can start while a *legitimate* background storage worker from the previous test still holds a `_REQUEST_IO_SLOTS` permit — that is by design here, since `stage_patch` can return `None` on its deadline while the worker keeps going. `test_forked_child_recovers_full_request_io_capacity` assumed full capacity instead of waiting for it, so one of its two `_hold_slot` threads failed `assert acquire(blocking=False)`.

2. **The amplifier.** That test's `assert all(signal.wait(2) for signal in ready)` sat **before** the `try:` whose `finally` sets `release`. When it failed, `release` was never set; the *surviving* holder thread then failed `assert release.wait(5)` and died **without reaching `spool._REQUEST_IO_SLOTS.release()`**. One permit was leaked permanently into the worker process, poisoning every later test in it.

CI runs this lane with `--dist=loadfile`, so the whole file lands on one worker, and with `--maxfail=3`, so a single transient hiccup aborts the entire run.

## Fix

Tests only — 1 file, +62/-22.

- A module-scoped autouse fixture checks full permit capacity **before setup and at teardown**. If capacity is not restored within the bounded wait, it fails **the test that owns the leak**, names it, and resets the semaphore so later tests are not poisoned. Attribution instead of cascade.
- Every place a *test* takes a permit directly now releases it in a `finally`, so no assertion failure — in the test body or in a helper thread — can leak one. This covers `_hold_slot`, `test_spawn_enqueue_then_raise_releases_the_permit_exactly_once`, and `test_pending_spool_work_is_bounded`.
- The forked-child test's readiness assertion moved inside the `try:` whose `finally` sets `release` and joins the holders.

No assertion was weakened, skipped, xfailed, or quarantined; no timeout was padded. The exact `capacity == [True, True, False]` checks and the release-once permit accounting are unchanged.

## Verification

**Red/green is the presence and absence of collateral damage, not a plain pass/fail.** The control is a session-start pytest plugin that holds **one** permit for 3s, mimicking a previous test's still-running worker under load, run against a pristine worktree at `e4d551e82`:

| | result |
|---|---|
| before (main) | `3 failed, 1 passed` — the two innocent tests taken down with the guilty one, matching the CI signature exactly, including `test_spool_uses_the_hub_owned_threadpool` passing in between |
| after (this branch) | `3 passed, 1 error` — only the test whose precondition was genuinely violated, reported as `Kobo PATCH request I/O permit leak before test setup: expected [True, True, False], observed [True, False, False]` |

Also observed: the file passes serially, 39/39.

**Blast radius.** The change is confined to one test module; `git diff --stat` shows no file outside `tests/` touched.

Tier: `needs-review`. Release target: none — CI hygiene, no user-facing behaviour, so no `CHANGELOG.md` or `CHANGES-vs-upstream.md` row.
