### PR TITLE
fix(spa): stop offering "Make public" to users the server will refuse (#1734)

### DIFF
--- a/changelog.d/pr-1908.md
+++ b/changelog.d/pr-1908.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **"Make public" is no longer offered on a shelf you are not allowed to
+  share.** Sharing a shelf needs the "Edit public shelves" permission, and the
+  server has always refused without it, but the New UI's shelf page showed the
+  button to every owner — so clicking it only ever produced *"you are not
+  allowed to edit shelves"*. The control is now hidden when the permission is
+  absent, matching the classic UI. "Make private" is unaffected. Reported by
+  @iroQuai.

--- a/frontend/src/lib/shelfVisibility.ts
+++ b/frontend/src/lib/shelfVisibility.ts
@@ -1,0 +1,17 @@
+export type ShelfVisibilityAction = 'make-public' | 'make-private';
+
+type ShelfVisibilityCapabilities = {
+  canEdit: boolean;
+  canMakePublic: boolean;
+  isPublic: boolean;
+};
+
+export function getShelfVisibilityAction({
+  canEdit,
+  canMakePublic,
+  isPublic,
+}: ShelfVisibilityCapabilities): ShelfVisibilityAction | null {
+  if (!canEdit) return null;
+  if (isPublic) return 'make-private';
+  return canMakePublic ? 'make-public' : null;
+}

--- a/frontend/src/pages/Shelf.tsx
+++ b/frontend/src/pages/Shelf.tsx
@@ -17,6 +17,7 @@ import { ApiError } from '../lib/api';
 import { useT } from '../lib/i18n';
 import styles from './Shelf.module.css';
 import { useCardActionsHidden } from '../lib/useCardActionsHidden';
+import { getShelfVisibilityAction } from '../lib/shelfVisibility';
 
 function dedupAppend(prev: Book[], next: Book[]): Book[] {
   const seen = new Set(prev.map((b) => b.id));
@@ -95,6 +96,11 @@ export function Shelf({ id }: { id: string }) {
   const total = data.total;
   const hasMore = books.length < total;
   const canEdit = data.can_edit;
+  const visibilityAction = getShelfVisibilityAction({
+    canEdit,
+    canMakePublic: !!me?.role?.edit_shelfs,
+    isPublic: data.is_public,
+  });
 
   const startRename = () => {
     setDraftName(data.name);
@@ -134,8 +140,9 @@ export function Shelf({ id }: { id: string }) {
   };
 
   const toggleVisibility = () => {
+    if (!visibilityAction) return;
     setActionError(null);
-    updateShelf.mutate({ is_public: !data.is_public }, {
+    updateShelf.mutate({ is_public: visibilityAction === 'make-public' }, {
       onError: (err) => setActionError(err instanceof ApiError ? err.message : t('Could not update shelf.')),
     });
   };
@@ -237,10 +244,14 @@ export function Shelf({ id }: { id: string }) {
               <button className={styles.manageBtn} onClick={startRename}>
                 <Pencil size={14} /> {t('Rename')}
               </button>
-              <button className={styles.manageBtn} onClick={toggleVisibility} disabled={updateShelf.isPending}>
-                {data.is_public ? <Lock size={14} /> : <Globe size={14} />}
-                {data.is_public ? t('Make private') : t('Make public')}
-              </button>
+              {visibilityAction && (
+                <button className={styles.manageBtn} onClick={toggleVisibility} disabled={updateShelf.isPending}>
+                  {visibilityAction === 'make-private'
+                    ? <Lock size={14} aria-hidden="true" focusable={false} />
+                    : <Globe size={14} aria-hidden="true" focusable={false} />}
+                  {visibilityAction === 'make-private' ? t('Make private') : t('Make public')}
+                </button>
+              )}
               {me?.features?.kobo_sync && (
                 <button className={data.kobo_sync ? styles.manageBtnActive : styles.manageBtn}
                   onClick={toggleKoboSync} disabled={updateShelf.isPending}>

--- a/frontend/tests/unit/shelfVisibility.test.ts
+++ b/frontend/tests/unit/shelfVisibility.test.ts
@@ -1,0 +1,38 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getShelfVisibilityAction } from '../../src/lib/shelfVisibility.ts';
+
+describe('getShelfVisibilityAction', () => {
+  test('does not offer make public to an owner without the edit_shelfs role', () => {
+    assert.equal(getShelfVisibilityAction({
+      canEdit: true,
+      canMakePublic: false,
+      isPublic: false,
+    }), null);
+  });
+
+  test('offers make public to an owner with the edit_shelfs role', () => {
+    assert.equal(getShelfVisibilityAction({
+      canEdit: true,
+      canMakePublic: true,
+      isPublic: false,
+    }), 'make-public');
+  });
+
+  test('offers make private to any editor of a public shelf', () => {
+    assert.equal(getShelfVisibilityAction({
+      canEdit: true,
+      canMakePublic: false,
+      isPublic: true,
+    }), 'make-private');
+  });
+
+  test('does not offer a visibility action to a viewer without edit access', () => {
+    assert.equal(getShelfVisibilityAction({
+      canEdit: false,
+      canMakePublic: true,
+      isPublic: true,
+    }), null);
+  });
+});


### PR DESCRIPTION
Closes item 2 of #1734.

## The bug

The shelf page rendered the visibility button for anyone who could edit the shelf — i.e. its owner. Making a shelf public is a *separate* permission: `POST /api/v1/shelves/<id>` answers 403 unless the caller holds `edit_shelfs`. An ordinary owner was shown a button whose only outcome was an error, which is exactly what @iroQuai reported: *"the 'make shelve public' option is available, but triggers a 'you are not allowed to edit shelves' error."*

## Why hiding the control is the correct side of the fix

The permission is inherited and unchanged, not something this fork introduced. Verified in three places on `main`:

- `cps/shelf.py` `create_edit_shelf`: `if not current_user.role_edit_shelfs() and to_save.get("is_public") == "on"` → *"Sorry you are not allowed to create a public shelf"*.
- `cps/templates/shelf_edit.html:11`: the classic "Share with Everyone" checkbox is wrapped in `{% if current_user.role_edit_shelfs() %}` — the classic UI has always **hidden** this control rather than offering-then-refusing.
- `cps/api/shelves.py:138` and `:174`: the same check on both the create and update paths, present since the shelves API landed in 914b1975f (2026-06-26), i.e. predating the #1786 capability-flag work.

The New UI's own create form (`frontend/src/pages/Shelves.tsx:23`) already gated on `me.role.edit_shelfs`. The shelf page's manage row was the single outlier. This restores parity in both directions.

`Make private` is untouched — the server gates only the public direction.

## Shape

`getShelfVisibilityAction()` is the one decision both the button and its click handler read, so the rendered label and the request it sends can no longer disagree. That is the actual class of bug here, not just this one button.

## Evidence

- **Red/green:** `frontend/tests/unit/shelfVisibility.test.ts`, 4/4 pass. Reverting the fix at its choice point (`return canMakePublic ? 'make-public' : null` → `return 'make-public'`) fails with `actual: 'make-public', expected: null` — the exact pre-fix symptom. The suite auto-globs into Fast Tests via `tests/unit/test_frontend_unit_suites_run.py`.
- **Typecheck:** `npx tsc --noEmit` clean.
- **User-visible flow:** the failing flow is reporter-observed on a real install (#1734 item 2); the refusal it produced is the 403 cited above, read at source on all three enforcement points.
- Blast radius is one button's render condition on one SPA page. No server change, no new dependency, no route change.

Labelled `needs-review`.

