### PR TITLE
test(spa): pin the shelf visibility controls in a browser, and stop the changelog guard forcing release notes onto browser tests

### DIFF
--- a/changelog.d/1734-shelf-visibility-e2e.md
+++ b/changelog.d/1734-shelf-visibility-e2e.md
@@ -1,5 +1,0 @@
-### Fixed
-
-- **Shelf visibility controls stay aligned with the owner's permissions.**
-  Browser coverage now guards the hidden, “Make public,” and “Make private”
-  states on the rendered shelf page.

--- a/changelog.d/1734-shelf-visibility-e2e.md
+++ b/changelog.d/1734-shelf-visibility-e2e.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- **Shelf visibility controls stay aligned with the owner's permissions.**
+  Browser coverage now guards the hidden, “Make public,” and “Make private”
+  states on the rendered shelf page.

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -5,12 +5,12 @@ entry in a separate Markdown file under this directory. That keeps concurrent
 branches away from the shared `CHANGELOG.md` insertion point.
 
 A fragment is not required when every changed path is confined to `findings/`,
-`notes/`, `docs/`, `tests/`, this `changelog.d/README.md` file, or the guard
-implementation itself at `scripts/check_changelog_diff.py`. Those paths contain
-evidence ledgers, working notes, documentation, verification code, or CI policy
-rather than application behavior. This is an all-paths exemption: a pull
-request that mixes any of them with shipping code or assets still needs a
-fragment. Unlisted paths require a fragment by default.
+`notes/`, `docs/`, `tests/`, `frontend/e2e/`, this `changelog.d/README.md` file,
+or the guard implementation itself at `scripts/check_changelog_diff.py`. Those
+paths contain evidence ledgers, working notes, documentation, verification code,
+or CI policy rather than application behavior. This is an all-paths exemption:
+a pull request that mixes any of them with shipping code or assets still needs
+a fragment. Unlisted paths require a fragment by default.
 
 Name the file after the PR when its number is known, or use a short stable slug:
 

--- a/frontend/e2e/shelf-visibility.spec.ts
+++ b/frontend/e2e/shelf-visibility.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect, Page } from '@playwright/test';
+
+/*
+ * #1734 / #1908 — an ordinary shelf owner was offered "Make public" even
+ * though the server requires edit_shelfs for that direction. The decision
+ * helper has unit coverage; these route-mocked cases pin its rendered-page
+ * wiring so the control cannot drift away from the role and shelf payloads.
+ */
+
+const SHELF_ID = 1734;
+const SHELF_NAME = 'Visibility fixture';
+
+const json = (body: unknown) => ({
+  status: 200,
+  contentType: 'application/json',
+  body: JSON.stringify(body),
+});
+
+async function mockShelfPage(page: Page, editShelfs: boolean, isPublic: boolean) {
+  await page.route('**/api/v1/auth/me', (route) => route.fulfill(json({
+    id: 1734,
+    name: 'Shelf owner',
+    locale: 'en',
+    theme: 'dark',
+    role: {
+      anonymous: false,
+      admin: false,
+      viewer: true,
+      download: true,
+      edit_shelfs: editShelfs,
+    },
+    features: {
+      anon_browse: false,
+      hide_books: true,
+      mail_configured: false,
+      public_registration: false,
+      kobo_sync: false,
+    },
+    instance_name: 'Calibre-Web NextGen',
+    display: { books_per_page: 24, random_books: 4 },
+    catalog: { default_filter: null },
+    avatar: null,
+  })));
+
+  await page.route(`**/api/v1/shelves/${SHELF_ID}?**`, (route) => route.fulfill(json({
+    id: SHELF_ID,
+    name: SHELF_NAME,
+    is_public: isPublic,
+    is_owner: true,
+    kobo_sync: false,
+    count: 0,
+    items: [],
+    page: 1,
+    per_page: 24,
+    total: 0,
+    can_edit: true,
+  })));
+}
+
+async function openMockedShelf(page: Page) {
+  await page.goto(`/app/shelf/${SHELF_ID}`);
+  await expect(page.getByRole('heading', { level: 1, name: SHELF_NAME })).toBeVisible();
+}
+
+test.describe('#1734 shelf visibility control', () => {
+  test('does not offer Make public to an owner without edit_shelfs', async ({ page }) => {
+    await mockShelfPage(page, false, false);
+    await openMockedShelf(page);
+
+    await expect(page.getByRole('button', { name: 'Make public', exact: true })).toHaveCount(0);
+  });
+
+  test('offers Make public to an owner with edit_shelfs', async ({ page }) => {
+    await mockShelfPage(page, true, false);
+    await openMockedShelf(page);
+
+    await expect(page.getByRole('button', { name: 'Make public', exact: true })).toBeVisible();
+  });
+
+  test('still offers Make private on an editable public shelf', async ({ page }) => {
+    await mockShelfPage(page, true, true);
+    await openMockedShelf(page);
+
+    await expect(page.getByRole('button', { name: 'Make private', exact: true })).toBeVisible();
+  });
+});

--- a/scripts/check_changelog_diff.py
+++ b/scripts/check_changelog_diff.py
@@ -14,7 +14,14 @@ import sys
 RELEASE_HEADING = re.compile(r"^## \[(v\d+\.\d+\.\d+)\]", re.MULTILINE)
 ENTRY_LEAD = re.compile(r"^- \*\*", re.MULTILINE)
 FRAGMENT_PATH = re.compile(r"^changelog\.d/[A-Za-z0-9][A-Za-z0-9._-]*\.md$")
-NON_SHIPPING_PATH_PREFIXES = ("docs/", "findings/", "notes/", "tests/", "wiki-src/")
+NON_SHIPPING_PATH_PREFIXES = (
+    "docs/",
+    "findings/",
+    "frontend/e2e/",
+    "notes/",
+    "tests/",
+    "wiki-src/",
+)
 NON_SHIPPING_PATHS = frozenset(
     {"changelog.d/README.md", "scripts/check_changelog_diff.py"}
 )

--- a/tests/unit/test_changelog_diff_guard.py
+++ b/tests/unit/test_changelog_diff_guard.py
@@ -157,6 +157,18 @@ def test_findings_ledger_only_pr_does_not_require_a_changelog_entry():
     assert changelog_requirement_errors(["findings/kobo/F-66edbc.md"]) == []
 
 
+def test_frontend_e2e_only_pr_does_not_require_a_changelog_entry():
+    assert changelog_requirement_errors(["frontend/e2e/shelf-visibility.spec.ts"]) == []
+
+
+def test_mixing_frontend_e2e_with_shipping_frontend_still_requires_an_entry():
+    errors = changelog_requirement_errors(
+        ["frontend/e2e/shelf-visibility.spec.ts", "frontend/src/pages/Shelf.tsx"]
+    )
+    assert len(errors) == 1
+    assert "shipping paths" in errors[0]
+
+
 def test_mixing_a_findings_ledger_with_shipping_code_requires_an_entry():
     errors = changelog_requirement_errors(
         ["findings/kobo/F-66edbc.md", "cps/readingservices.py"]


### PR DESCRIPTION
Follow-on to #1908, which merged as `437a3bcbd`.

## Why

#1908 hid the shelf page's "Make public" control from owners the server refuses. That fix was proven at the decision-function level — `getShelfVisibilityAction()` has unit coverage — but nothing exercised the *rendered* page, which is where the render condition and the payloads actually meet. Hard rule 10: a user-facing change carries evidence of the user-facing flow, not just the function under test.

## What is here

**1. Browser coverage for the three states** (`frontend/e2e/shelf-visibility.spec.ts`). Route-mocked `/api/v1/auth/me` and the shelf detail payload, in the idiom `guest-reader.spec.ts` established:

- owner without `edit_shelfs` → no "Make public" button
- owner with `edit_shelfs` → "Make public" visible
- editable public shelf → "Make private" still visible

Each case asserts the shelf `<h1>` first, so a page that failed to render cannot pass the negative case by rendering nothing.

**2. The changelog guard no longer forces browser tests to invent release notes** (`scripts/check_changelog_diff.py`, `changelog.d/README.md`).

Writing the spec surfaced this: the guard exempts `tests/` but not `frontend/e2e/`, so a test-only PR had to add a `### Fixed` fragment — which would have shipped release notes announcing a behaviour change that had already shipped under its own fragment in #1908. Two "Fixed" entries, one of them describing test coverage as a fix.

`changelog.d/README.md` already states the principle: fragments aren't required for paths holding "evidence ledgers, working notes, documentation, verification code, or CI policy rather than application behavior". `frontend/e2e/` is verification code by that exact rationale and was simply missing from the list. Added there, and the README updated to match so prose and implementation agree.

The exemption stays **all-paths**: mixing `frontend/e2e/` with shipping code still requires a fragment, and that is now pinned by a test.

## Evidence

- **Spec, green:** `npx playwright test e2e/shelf-visibility.spec.ts --project=desktop` → 4 passed, three consecutive runs. Across both viewport projects: 7 passed.
- **Spec, red:** mutating `frontend/src/lib/shelfVisibility.ts:16` to `return canMakePublic ? 'make-public' : 'make-public'`, rebuilding the Docker image and recreating the container, fails exactly the intended case — *"does not offer Make public to an owner without edit_shelfs: Expected button count: 0, Received button count: 1"* (1 failed, 3 passed). The mutation was reverted and the image rebuilt from fixed source.
- **Guard, red/green:** `test_frontend_e2e_only_pr_does_not_require_a_changelog_entry` fails before the exemption (1 failed) and passes after (1 passed). `test_mixing_frontend_e2e_with_shipping_frontend_still_requires_an_entry` proves `frontend/src/` is still protected. Full guard suite: 23 passed.
- **Real branch-level guard:** `python3 scripts/check_changelog_diff.py 437a3bcbd HEAD` passes.
- No `frontend/src/`, server, dependency, lockfile or license change.

Labelled `needs-review`.
