### PR TITLE
fix(ingest): the ProcessLock can no longer be stolen from a live holder (#1892)

### DIFF
--- a/changelog.d/issue-1892.md
+++ b/changelog.d/issue-1892.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Two ingest runs can no longer run at once.**

--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -169,7 +169,7 @@ DUPLICATE_FULL_SCAN_WAIT_INTERVAL_SECONDS = 2
 DUPLICATE_FULL_SCAN_WAIT_TIMEOUT_SECONDS = int(os.environ.get("CWA_DUPLICATE_FULL_SCAN_WAIT_TIMEOUT_SECONDS", "7200"))
 
 class ProcessLock:
-    """Robust process lock using both file locking and PID tracking"""
+    """Process lock using flock for ownership and the PID for diagnostics."""
 
     def __init__(self, lock_name="ingest_processor"):
         self.lock_name = lock_name
@@ -180,8 +180,9 @@ class ProcessLock:
     def acquire(self, timeout=5):
         """Acquire the lock with timeout. Returns True if successful, False if another process has it."""
         try:
-            # Try to open/create the lock file
-            self.lock_file = open(self.lock_path, 'w+')
+            # Keep one stable inode: truncating or unlinking a contended lock file
+            # would let another opener acquire a different inode.
+            self.lock_file = open(self.lock_path, 'a+')
 
             # Try to acquire an exclusive lock with timeout
             start_time = time.time()
@@ -189,21 +190,19 @@ class ProcessLock:
                 try:
                     fcntl.flock(self.lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
 
-                    # Successfully acquired lock, write our PID
+                    # Successfully acquired lock, replace the diagnostic PID.
                     self.lock_file.seek(0)
+                    self.lock_file.truncate()
                     self.lock_file.write(str(os.getpid()))
                     self.lock_file.flush()
-                    self.lock_file.truncate()  # Truncate at current position to remove any leftover data
 
                     self.acquired = True
                     print(f"[ingest-processor] Lock acquired successfully (PID: {os.getpid()})")
                     return True
 
                 except (IOError, OSError):
-                    # Lock is held by another process
-                    # Check if the holding process is still alive
-                    if self._check_stale_lock():
-                        continue  # Try again as we cleaned up a stale lock
+                    # The flock is authoritative. PID text is only diagnostic;
+                    # invalid text cannot make a contended lock stale.
                     time.sleep(0.1)  # Brief wait before retry
 
             # Timeout reached
@@ -228,59 +227,6 @@ class ProcessLock:
             pass
         return "unknown"
 
-    def _check_stale_lock(self):
-        """Check if the lock is stale (holding process no longer exists) and clean it up"""
-        try:
-            if not self.lock_file:
-                return False
-
-            self.lock_file.seek(0)
-            pid_str = self.lock_file.read().strip()
-
-            if not pid_str.isdigit():
-                print("[ingest-processor] Lock file contains invalid PID, treating as stale")
-                return self._cleanup_stale_lock()
-
-            holding_pid = int(pid_str)
-
-            # Check if process is still running
-            try:
-                os.kill(holding_pid, 0)  # Signal 0 just checks if process exists
-                return False  # Process is still running
-            except ProcessLookupError:
-                # Process doesn't exist, lock is stale
-                print(f"[ingest-processor] Detected stale lock from non-existent process {holding_pid}, cleaning up")
-                return self._cleanup_stale_lock()
-            except PermissionError:
-                # Process exists but we can't signal it (different user), assume it's running
-                return False
-
-        except Exception as e:
-            print(f"[ingest-processor] Error checking stale lock: {e}")
-            return False
-
-    def _cleanup_stale_lock(self):
-        """Clean up a stale lock file"""
-        try:
-            if self.lock_file:
-                try:
-                    fcntl.flock(self.lock_file.fileno(), fcntl.LOCK_UN)
-                except (OSError, IOError):
-                    # We might not have had the lock in the first place
-                    pass
-                self.lock_file.close()
-                self.lock_file = None
-
-            # Remove the lock file
-            if os.path.exists(self.lock_path):
-                os.remove(self.lock_path)
-                print(f"[ingest-processor] Cleaned up stale lock file: {self.lock_path}")
-
-            return True
-        except Exception as e:
-            print(f"[ingest-processor] Error cleaning up stale lock: {e}")
-            return False
-
     def release(self):
         """Release the lock"""
         if self.acquired and self.lock_file:
@@ -288,10 +234,6 @@ class ProcessLock:
                 fcntl.flock(self.lock_file.fileno(), fcntl.LOCK_UN)
                 self.lock_file.close()
                 self.lock_file = None
-
-                # Remove lock file
-                if os.path.exists(self.lock_path):
-                    os.remove(self.lock_path)
 
                 self.acquired = False
                 print(f"[ingest-processor] Lock released (PID: {os.getpid()})")

--- a/tests/unit/test_ingest_processor_startup.py
+++ b/tests/unit/test_ingest_processor_startup.py
@@ -94,6 +94,78 @@ def test_failed_runtime_initialization_is_not_retried(monkeypatch, tmp_path):
     assert acquire_calls == 1
 
 
+def _process_lock_class(monkeypatch, tmp_path):
+    scripts_dir = Path(__file__).resolve().parents[2] / "scripts"
+    monkeypatch.syspath_prepend(str(scripts_dir))
+    ingest_processor = importlib.import_module("ingest_processor")
+    monkeypatch.setattr(
+        ingest_processor.tempfile,
+        "gettempdir",
+        lambda: str(tmp_path),
+    )
+    return ingest_processor.ProcessLock
+
+
+def test_process_lock_live_holder_cannot_be_stolen(monkeypatch, tmp_path):
+    process_lock_class = _process_lock_class(monkeypatch, tmp_path)
+    lock_path = tmp_path / "live-holder.lock"
+    holder = process_lock_class("live-holder")
+    contenders = []
+
+    try:
+        assert holder.acquire(timeout=0.1)
+
+        contender = process_lock_class("live-holder")
+        contenders.append(contender)
+        assert contender.acquire(timeout=0.1) is False
+        assert lock_path.exists(), "live holder's lock file was unlinked by contender"
+        assert lock_path.read_text() == str(os.getpid())
+
+        second_contender = process_lock_class("live-holder")
+        contenders.append(second_contender)
+        assert second_contender.acquire(timeout=0.1) is False
+    finally:
+        for contender in contenders:
+            contender.release()
+        holder.release()
+
+
+def test_process_lock_invalid_pid_cannot_override_live_flock(monkeypatch, tmp_path):
+    process_lock_class = _process_lock_class(monkeypatch, tmp_path)
+    lock_path = tmp_path / "invalid-pid.lock"
+    holder = process_lock_class("invalid-pid")
+    contender = process_lock_class("invalid-pid")
+
+    try:
+        assert holder.acquire(timeout=0.1)
+        lock_path.write_text("not-a-pid")
+
+        assert contender.acquire(timeout=0.1) is False
+        assert lock_path.exists()
+        assert lock_path.read_text() == "not-a-pid"
+    finally:
+        contender.release()
+        holder.release()
+
+
+def test_process_lock_reclaims_dead_pid_file(monkeypatch, tmp_path):
+    process_lock_class = _process_lock_class(monkeypatch, tmp_path)
+    lock_path = tmp_path / "stale-holder.lock"
+    exited_process = subprocess.Popen([sys.executable, "-c", "pass"])
+    exited_process.wait(timeout=5)
+    dead_pid = exited_process.pid
+    lock_path.write_text(str(dead_pid))
+    lock = process_lock_class("stale-holder")
+
+    try:
+        with pytest.raises(ProcessLookupError):
+            os.kill(dead_pid, 0)
+        assert lock.acquire(timeout=0.1)
+        assert lock_path.read_text() == str(os.getpid())
+    finally:
+        lock.release()
+
+
 def test_optional_cps_modules_retry_after_partial_load(monkeypatch, tmp_path):
     scripts_dir = Path(__file__).resolve().parents[2] / "scripts"
     monkeypatch.syspath_prepend(str(scripts_dir))


### PR DESCRIPTION
Closes #1892.

**Mechanism** — `open(path, 'w+')` truncated the live holder's PID before the contender had a lock; `_check_stale_lock` then read an empty file, treated it as stale, and unlinked the live lock, so the next ingest acquired a fresh inode while the first still ran. The reviewer on #1877 measured this directly.

**Fix** — the flock is the sole authority. Open without truncation (`a+`), write the PID only after `flock` succeeds (diagnostic only), never unlink on release, and drop the PID-driven stale reclamation — a dead holder's flock is released by the kernel, so that logic was unnecessary and was the theft vector.

**Evidence (OBSERVED, run by the manager independently of the implementer's report)** — on unmodified code: `test_process_lock_live_holder_cannot_be_stolen` and `test_process_lock_invalid_pid_cannot_override_live_flock` fail (`live holder's lock file was unlinked by contender`); with the fix: 6/6, run twice. Implemented by Sol (codex thread `01a04539-6c5a-7233-8fa0-f909d66227ba`); diff reviewed by the manager. Trail: `state/completed.log`.

Left out on purpose: `cps/admin.py`'s `/tmp/restore_calibre_db.lock` is a different mechanism (`os.path.exists` sentinel), noted on #1892 as related.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014omupDzCoyNoDkq3WhRBry
