### PR TITLE
fix(admin): last-resort restore uses a real lock and refuses while ingest runs (#1915)

### DIFF
--- a/changelog.d/issue-1915.md
+++ b/changelog.d/issue-1915.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Database restores now recover from stale locks and refuse to run while ingest or cover enforcement is active.**

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -21,6 +21,7 @@ import shutil
 import subprocess
 import tempfile
 import fcntl
+import errno
 
 from flask import Blueprint, current_app, flash, redirect, url_for, abort, request, make_response, send_from_directory, g, Response, jsonify
 from markupsafe import Markup
@@ -3531,18 +3532,71 @@ def test_metadata():
         log.error("Metadata test failed: %s", e)
         return json.dumps({'success': False, 'message': _('An unknown error occurred.')}), 200
 
+def _acquire_restore_file_lock(lock_name):
+    """Acquire a persistent, non-truncating lock file or return None if held."""
+    lock_path = os.path.join(tempfile.gettempdir(), lock_name)
+    lock_handle = open(lock_path, "a+", encoding="utf-8")
+    try:
+        fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError as error:
+        lock_handle.close()
+        if error.errno in (errno.EACCES, errno.EAGAIN):
+            return None
+        raise
+    except Exception:
+        lock_handle.close()
+        raise
+    return lock_handle
+
+
+def _release_restore_locks(lock_handles):
+    for handle in lock_handles:
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        except Exception:
+            pass
+        try:
+            handle.close()
+        except Exception:
+            pass
+
+
+def _acquire_restore_lock():
+    return _acquire_restore_file_lock("restore_calibre_db.lock")
+
+
+def _acquire_restore_service_locks():
+    """Pause restore-sensitive services, returning the blocker if one is active."""
+    lock_handles = []
+    try:
+        for lock_name, service_name in (
+            ("ingest_processor.lock", "ingest"),
+            ("cover_enforcer.lock", "cover_enforcer"),
+        ):
+            handle = _acquire_restore_file_lock(lock_name)
+            if handle is None:
+                _release_restore_locks(lock_handles)
+                return [], service_name
+            lock_handles.append(handle)
+    except Exception:
+        _release_restore_locks(lock_handles)
+        raise
+    return lock_handles, None
+
+
 # --- Last Resort Calibre DB Restore ---
 @admi.route("/admin/restore_calibre_db", methods=["POST"])
 @user_login_required
 @admin_required
 def restore_calibre_db():
     """Restore Calibre metadata.db and clean app.db book-linked tables (last resort recovery)."""
-    lock_path = "/tmp/restore_calibre_db.lock"
-    service_lock_handles = []
+    lock_handles = []
     try:
-        if os.path.exists(lock_path):
+        restore_lock = _acquire_restore_lock()
+        if restore_lock is None:
             flash(_("Restore already in progress."), category="error")
             return redirect(url_for("admin.db_configuration"))
+        lock_handles.append(restore_lock)
 
         if not config.config_calibre_dir:
             flash(_("Restore failed: Calibre library path is not configured."), category="error")
@@ -3558,9 +3612,14 @@ def restore_calibre_db():
             flash(_("Restore failed: app.db not found at %(path)s", path=app_db_path), category="error")
             return redirect(url_for("admin.db_configuration"))
 
-        # Create lock file
-        with open(lock_path, "w", encoding="utf-8") as lock_file:
-            lock_file.write(str(os.getpid()))
+        service_lock_handles, blocking_service = _acquire_restore_service_locks()
+        if blocking_service == "ingest":
+            flash(_("An ingest run is in progress; try again when it finishes."), category="error")
+            return redirect(url_for("admin.db_configuration"))
+        if blocking_service == "cover_enforcer":
+            flash(_("Cover enforcement is in progress; try again when it finishes."), category="error")
+            return redirect(url_for("admin.db_configuration"))
+        lock_handles.extend(service_lock_handles)
 
         # 1. Backup both DBs
         backup_dir = f"/config/backup/restore_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
@@ -3571,27 +3630,6 @@ def restore_calibre_db():
         log_path = os.path.join(backup_dir, "restore.log")
         with open(log_path, "a", encoding="utf-8") as log_file:
             log_file.write(f"Restore started at {datetime.now().isoformat()}\n")
-
-        # Pause background services and close active sessions to reduce lock contention
-        try:
-            ingest_lock_path = os.path.join(tempfile.gettempdir(), "ingest_processor.lock")
-            ingest_lock = open(ingest_lock_path, "w")
-            fcntl.flock(ingest_lock.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-            ingest_lock.write("restore_calibre_db")
-            ingest_lock.flush()
-            service_lock_handles.append(ingest_lock)
-        except Exception as e:
-            log.warning("Failed to lock ingest processor: %s", e)
-
-        try:
-            cover_lock_path = os.path.join(tempfile.gettempdir(), "cover_enforcer.lock")
-            cover_lock = open(cover_lock_path, "w")
-            fcntl.flock(cover_lock.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-            cover_lock.write("restore_calibre_db")
-            cover_lock.flush()
-            service_lock_handles.append(cover_lock)
-        except Exception as e:
-            log.warning("Failed to lock cover enforcer: %s", e)
 
         # Close active sessions to reduce lock contention
         try:
@@ -3673,20 +3711,4 @@ def restore_calibre_db():
         flash(_("Restore failed: %(err)s", err=str(e)), category="error")
         return redirect(url_for("admin.db_configuration"))
     finally:
-        try:
-            if os.path.exists(lock_path):
-                os.remove(lock_path)
-        except Exception:
-            pass
-        try:
-            for handle in service_lock_handles:
-                try:
-                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
-                except Exception:
-                    pass
-                try:
-                    handle.close()
-                except Exception:
-                    pass
-        except Exception:
-            pass
+        _release_restore_locks(lock_handles)

--- a/tests/unit/test_1915_restore_lock.py
+++ b/tests/unit/test_1915_restore_lock.py
@@ -1,0 +1,150 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Regression coverage for the last-resort restore's process locks (#1915)."""
+
+import fcntl
+import inspect
+import os
+
+import pytest
+
+from cps import admin
+
+
+pytestmark = pytest.mark.unit
+
+
+def _restore_lock_api():
+    acquire = getattr(admin, "_acquire_restore_lock", None)
+    release = getattr(admin, "_release_restore_locks", None)
+    assert callable(acquire), "restore flock acquisition seam is missing"
+    assert callable(release), "restore flock release seam is missing"
+    return acquire, release
+
+
+def _service_lock_api():
+    acquire = getattr(admin, "_acquire_restore_service_locks", None)
+    release = getattr(admin, "_release_restore_locks", None)
+    assert callable(acquire), "service-lock pause decision seam is missing"
+    assert callable(release), "restore flock release seam is missing"
+    return acquire, release
+
+
+def test_dead_pid_sentinel_does_not_block_restore(monkeypatch, tmp_path):
+    monkeypatch.setattr(admin.tempfile, "gettempdir", lambda: str(tmp_path))
+    lock_path = tmp_path / "restore_calibre_db.lock"
+    lock_path.write_text("999999", encoding="utf-8")
+    acquire, release = _restore_lock_api()
+
+    handle = acquire()
+
+    try:
+        assert handle is not None
+        assert lock_path.read_text(encoding="utf-8") == "999999"
+    finally:
+        release([handle] if handle is not None else [])
+
+
+def test_held_ingest_lock_refuses_before_backup_or_copy(monkeypatch, tmp_path):
+    monkeypatch.setattr(admin.tempfile, "gettempdir", lambda: str(tmp_path))
+    acquire, release = _service_lock_api()
+    ingest_path = tmp_path / "ingest_processor.lock"
+    ingest_holder = open(ingest_path, "a+", encoding="utf-8")
+    fcntl.flock(ingest_holder.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    backup_dir = tmp_path / "backup"
+    metadata_db = tmp_path / "metadata.db"
+    app_db = tmp_path / "app.db"
+    metadata_db.write_bytes(b"metadata-before")
+    app_db.write_bytes(b"app-before")
+    copy_calls = []
+    monkeypatch.setattr(
+        admin.shutil,
+        "copy2",
+        lambda source, destination: copy_calls.append((source, destination)),
+    )
+
+    handles = []
+    try:
+        handles, blocking_service = acquire()
+        if blocking_service is None:
+            backup_dir.mkdir()
+            admin.shutil.copy2(metadata_db, backup_dir / "metadata.db.bak")
+            admin.shutil.copy2(app_db, backup_dir / "app.db.bak")
+
+        assert blocking_service == "ingest"
+        assert not backup_dir.exists()
+        assert copy_calls == []
+        assert metadata_db.read_bytes() == b"metadata-before"
+        assert app_db.read_bytes() == b"app-before"
+
+        handler_source = inspect.getsource(admin.restore_calibre_db)
+        decision_index = handler_source.find("_acquire_restore_service_locks()")
+        backup_index = handler_source.index("os.makedirs(backup_dir")
+        assert 0 <= decision_index < backup_index, (
+            "the service-lock refusal decision must precede backup creation"
+        )
+    finally:
+        release(handles)
+        fcntl.flock(ingest_holder.fileno(), fcntl.LOCK_UN)
+        ingest_holder.close()
+
+
+@pytest.mark.parametrize(
+    ("lock_name", "blocking_service"),
+    [
+        ("ingest_processor.lock", "ingest"),
+        ("cover_enforcer.lock", "cover_enforcer"),
+    ],
+)
+def test_held_service_lock_is_a_hard_refusal(
+    monkeypatch, tmp_path, lock_name, blocking_service
+):
+    monkeypatch.setattr(admin.tempfile, "gettempdir", lambda: str(tmp_path))
+    acquire, release = _service_lock_api()
+    holder = open(tmp_path / lock_name, "a+", encoding="utf-8")
+    fcntl.flock(holder.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+    handles = []
+    try:
+        handles, blocked_by = acquire()
+
+        assert handles == []
+        assert blocked_by == blocking_service
+    finally:
+        release(handles)
+        fcntl.flock(holder.fileno(), fcntl.LOCK_UN)
+        holder.close()
+
+
+def test_two_concurrent_restore_acquirers_allow_exactly_one(monkeypatch, tmp_path):
+    monkeypatch.setattr(admin.tempfile, "gettempdir", lambda: str(tmp_path))
+    acquire, release = _restore_lock_api()
+
+    handles = [acquire(), acquire()]
+
+    try:
+        assert sum(handle is not None for handle in handles) == 1
+    finally:
+        release([handle for handle in handles if handle is not None])
+
+
+def test_restore_lock_paths_are_never_unlinked_or_truncated():
+    source = inspect.getsource(admin.restore_calibre_db)
+    acquire = getattr(admin, "_acquire_restore_file_lock", None)
+    assert callable(acquire), "shared non-truncating flock seam is missing"
+    acquire_source = inspect.getsource(acquire)
+
+    assert "os.remove(lock_path)" not in source
+    assert 'open(lock_path, "a+"' in acquire_source
+    assert 'open(lock_path, "w"' not in acquire_source
+
+
+def test_service_lock_refusals_have_translatable_admin_messages():
+    source = inspect.getsource(admin.restore_calibre_db)
+
+    assert '_("An ingest run is in progress; try again when it finishes.")' in source
+    assert '_("Cover enforcement is in progress; try again when it finishes.")' in source


### PR DESCRIPTION
Closes #1915.

**Mechanism** — `restore_calibre_db()` guarded itself with `os.path.exists("/tmp/restore_calibre_db.lock")`: a killed restore left the sentinel behind and the last-resort button said "already in progress" forever (TOCTOU between two admins too). A failed `flock` on the ingest/cover-enforcer locks was only a `log.warning`, so restore proceeded against a `metadata.db` an ingest was writing. It also opened those locks with `"w"` — pre-#1914, restore was itself a #1892-style lock thief.

**Fix** — three non-truncating `flock`s under `tempfile.gettempdir()` (kernel releases a dead holder's), a held service lock is a hard refusal with a translatable flash decided before any backup/copy, and no lock path is ever unlinked. Handler behaviour otherwise unchanged.

**Evidence (OBSERVED by the manager, independently of the implementer's report)** — Sol's red on unmodified code was "seam missing" (the new functions don't exist), which proves the refactor, not the defect — so I mutated each seam back to the old semantics on the fixed tree: `exists()⇒held` → the dead-sentinel test reds; held-service-lock⇒proceed → the three refusal tests red; no flock → those plus the concurrency test red. Green: 7/7 ×2, and `test_ingest_processor_startup.py` 6/6.

**Honest limit** — the handler's own "refuse before backup" ordering is pinned by source order in one test, not executed through Flask; the seams are what the tests run. Implemented by Sol (codex thread in `state/completed.log`); diff reviewed by the manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014omupDzCoyNoDkq3WhRBry
