### PR TITLE
fix(annotations): a failed local commit no longer sends the remote delete anyway (#1875)

### DIFF
--- a/changelog.d/issue-1875.md
+++ b/changelog.d/issue-1875.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Remote annotation updates are no longer queued when the matching local database change could not be saved.**

--- a/cps/services/annotation_sync/__init__.py
+++ b/cps/services/annotation_sync/__init__.py
@@ -690,7 +690,7 @@ def dispatch_annotation_sync(payload_annotations, book, user, *, origin_device_i
     return all_persisted
 
 
-def dispatch_existing_annotation_sync(annotation, book, user) -> None:
+def dispatch_existing_annotation_sync(annotation, book, user) -> bool:
     """Push an already-persisted Annotation row to each enabled sync target.
 
     The Kobo PATCH path (``dispatch_annotation_sync``) upserts the row from a
@@ -698,23 +698,33 @@ def dispatch_existing_annotation_sync(annotation, book, user) -> None:
     exist, so this is their fan-out entry point. Same per-handler semantics:
     skip disabled handlers, never re-push a tombstoned target, record the
     result on the AnnotationSyncTarget row.
+
+    Returns ``False`` when the local commit fails and ``True`` otherwise.
     """
     from cps import ub
     if annotation is None:
-        return
+        return True
+    annotation_id = annotation.annotation_id
     jobs = []
     if _background_enqueue() is not None:
         if _mark_pending(ub.session, annotation, user):
             jobs.append({"op": "push", "annotation": annotation.id, "book": book.id})
     else:
         push_annotation_to_handlers(ub.session, annotation, book, user)
-    ub.session_commit()
+    if ub.session_commit() is False:
+        log.error(
+            "Annotation sync commit failed: user=%s annotation_id=%s job_count=%d; "
+            "remote enqueue skipped",
+            user.id, annotation_id, len(jobs),
+        )
+        return False
     _enqueue(user, jobs, book=book)
+    return True
 
 
 def dispatch_annotation_deletes(
     deleted_ids, user, book_id=None, *, deletable_sources,
-) -> None:
+) -> bool:
     """For each annotation_id, transition non-tombstone sync_targets via
     handler.delete AND soft-delete the local Annotation row by setting
     ``hidden=True``.
@@ -728,11 +738,14 @@ def dispatch_annotation_deletes(
     Once authorised, local soft-delete happens independently of any enabled
     sync target. Recovery is symmetric: a subsequent create/update PATCH for
     the same annotation_id un-hides it via ``_upsert_annotation``.
+
+    Returns ``False`` when the local commit fails and ``True`` otherwise.
     """
     from cps import ub
     if not deleted_ids:
-        return
+        return True
     jobs = []
+    affected_ids = []
     for annotation_id in deleted_ids:
         if not isinstance(annotation_id, str) or not annotation_id:
             # A malformed member has no addressable annotation identity. Skip
@@ -779,12 +792,20 @@ def dispatch_annotation_deletes(
         ann.hidden = True
         ann.content_revision = (ann.content_revision or 1) + 1
         ann.server_modified_at = _now()
+        affected_ids.append(annotation_id)
         log.info(
             "annotation_sync: soft-delete annotation_id=%s (hidden=True)",
             annotation_id,
         )
-    ub.session_commit()
+    if ub.session_commit() is False:
+        log.error(
+            "Annotation delete commit failed: user=%s annotation_ids=%s job_count=%d; "
+            "remote enqueue skipped",
+            user.id, affected_ids, len(jobs),
+        )
+        return False
     _enqueue(user, jobs)
+    return True
 
 
 # Auto-register Hardcover at import time.

--- a/tests/unit/test_1875_commit_gates_remote_enqueue.py
+++ b/tests/unit/test_1875_commit_gates_remote_enqueue.py
@@ -1,0 +1,234 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Issue #1875 — rolled-back annotation writes must not reach the worker."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from cps import ub
+from cps.services import annotation_sync
+from cps.services.annotation_sync.base import AnnotationSyncTargetHandler, SyncResult
+
+
+pytestmark = pytest.mark.unit
+
+BOOK = SimpleNamespace(id=7, title="Commit Gate")
+PAYLOAD = {
+    "id": "uuid-a",
+    "highlightedText": "hi",
+    "highlightColor": "yellow",
+    "noteText": None,
+    "location": {"span": {"chapterProgress": 0.5}},
+}
+
+
+class StubHandler(AnnotationSyncTargetHandler):
+    target_name = "stub"
+
+    def is_enabled(self, user):
+        return True
+
+    def push(self, annotation, book, user, payload=None):
+        return SyncResult(status="synced", target_record_id="remote-1")
+
+    def delete(self, sync_target, user):
+        return SyncResult(
+            status="tombstone", target_record_id=sync_target.target_record_id,
+        )
+
+
+@pytest.fixture(autouse=True)
+def _reset_dispatcher():
+    annotation_sync.reset_registry_for_testing()
+    annotation_sync.set_remote_enqueue(None)
+    yield
+    annotation_sync.reset_registry_for_testing()
+    annotation_sync.set_remote_enqueue(None)
+
+
+@pytest.fixture
+def database(tmp_path, monkeypatch):
+    from cps.services import annotation_backup
+
+    annotation_backup.reset_for_tests()
+    monkeypatch.setattr(annotation_backup, "WORKER_AUTOSTART", False)
+    db_path = tmp_path / "ub.db"
+    engine = create_engine(
+        f"sqlite:///{db_path}", connect_args={"timeout": 30},
+    )
+    ub.Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    session.execute(text("PRAGMA foreign_keys=ON"))
+    user = ub.User(
+        name="u", email="u@example.invalid", role=0, password="x",
+        hardcover_token="token",
+    )
+    session.add(user)
+    session.commit()
+    monkeypatch.setattr(ub, "session", session)
+    annotation_sync.register_handler(StubHandler())
+
+    yield db_path, session, user
+
+    session.close()
+    engine.dispose()
+    annotation_backup.reset_for_tests()
+
+
+def _commit_success(session):
+    def commit():
+        session.commit()
+        return True
+
+    return commit
+
+
+def _commit_failure(session):
+    def commit():
+        session.rollback()
+        return False
+
+    return commit
+
+
+def _capture_jobs():
+    enqueued = []
+    annotation_sync.set_remote_enqueue(
+        lambda _user, jobs: enqueued.extend(jobs),
+    )
+    return enqueued
+
+
+def _seed_synced_annotation(session, user, monkeypatch):
+    annotation_sync.set_remote_enqueue(None)
+    monkeypatch.setattr(ub, "session_commit", _commit_success(session))
+    annotation_sync.dispatch_annotation_sync([PAYLOAD], BOOK, user)
+    annotation = session.query(ub.Annotation).one()
+    target = session.query(ub.AnnotationSyncTarget).one()
+    assert target.status == "synced"
+    return annotation, target
+
+
+def _seed_existing_annotation(session, user):
+    annotation = ub.Annotation(
+        user_id=user.id,
+        book_id=BOOK.id,
+        annotation_id="uuid-existing",
+        source="webreader",
+        highlighted_text="keep me",
+        hidden=False,
+        content_revision=3,
+    )
+    session.add(annotation)
+    session.commit()
+    return annotation
+
+
+def _independent_row(db_path, statement):
+    engine = create_engine(f"sqlite:///{db_path}")
+    try:
+        with engine.connect() as connection:
+            row = connection.execute(text(statement)).one()
+            return tuple(row)
+    finally:
+        engine.dispose()
+
+
+def test_delete_commit_failure_does_not_enqueue_tombstone(
+    database, monkeypatch, caplog,
+):
+    db_path, session, user = database
+    _seed_synced_annotation(session, user, monkeypatch)
+    enqueued = _capture_jobs()
+    monkeypatch.setattr(ub, "session_commit", _commit_failure(session))
+    caplog.set_level("ERROR", logger="cps.services.annotation_sync")
+
+    result = annotation_sync.dispatch_annotation_deletes(
+        ["uuid-a"], user, book_id=BOOK.id, deletable_sources={"kobo"},
+    )
+    persisted = _independent_row(
+        db_path,
+        "SELECT hidden, content_revision FROM annotation "
+        "WHERE annotation_id = 'uuid-a'",
+    )
+
+    assert enqueued == [], "delete job reached remote enqueue after commit failure"
+    assert persisted == (0, 1), "independent reader saw a rolled-back soft-delete"
+    assert result is False
+    assert (
+        f"user={user.id} annotation_ids=['uuid-a'] job_count=1" in caplog.text
+    )
+
+
+def test_existing_sync_commit_failure_does_not_enqueue_push(
+    database, monkeypatch, caplog,
+):
+    db_path, session, user = database
+    annotation = _seed_existing_annotation(session, user)
+    enqueued = _capture_jobs()
+    monkeypatch.setattr(ub, "session_commit", _commit_failure(session))
+    caplog.set_level("ERROR", logger="cps.services.annotation_sync")
+
+    result = annotation_sync.dispatch_existing_annotation_sync(annotation, BOOK, user)
+    persisted = _independent_row(
+        db_path,
+        "SELECT hidden, content_revision "
+        "FROM annotation WHERE annotation_id = 'uuid-existing'",
+    )
+
+    assert enqueued == [], "push job reached remote enqueue after commit failure"
+    assert persisted == (0, 3), "independent reader saw a changed annotation row"
+    assert result is False
+    assert (
+        f"user={user.id} annotation_id=uuid-existing job_count=1" in caplog.text
+    )
+
+
+def test_delete_commit_success_enqueues_tombstone_exactly_once(
+    database, monkeypatch,
+):
+    db_path, session, user = database
+    _annotation, target = _seed_synced_annotation(session, user, monkeypatch)
+    target_id = target.id
+    enqueued = _capture_jobs()
+    monkeypatch.setattr(ub, "session_commit", _commit_success(session))
+
+    result = annotation_sync.dispatch_annotation_deletes(
+        ["uuid-a"], user, book_id=BOOK.id, deletable_sources={"kobo"},
+    )
+
+    assert enqueued == [{"op": "delete", "sync_target": target_id}]
+    assert _independent_row(
+        db_path,
+        "SELECT hidden, content_revision FROM annotation "
+        "WHERE annotation_id = 'uuid-a'",
+    ) == (1, 2)
+    assert result is True
+
+
+def test_existing_sync_commit_success_enqueues_push_exactly_once(
+    database, monkeypatch,
+):
+    db_path, session, user = database
+    annotation = _seed_existing_annotation(session, user)
+    annotation_id = annotation.id
+    enqueued = _capture_jobs()
+    monkeypatch.setattr(ub, "session_commit", _commit_success(session))
+
+    result = annotation_sync.dispatch_existing_annotation_sync(annotation, BOOK, user)
+
+    assert enqueued == [{
+        "op": "push", "annotation": annotation_id, "book": BOOK.id,
+    }]
+    assert _independent_row(
+        db_path,
+        "SELECT hidden, content_revision, "
+        "(SELECT COUNT(*) FROM annotation_sync_target WHERE status = 'pending') "
+        "FROM annotation WHERE annotation_id = 'uuid-existing'",
+    ) == (0, 3, 1)
+    assert result is True


### PR DESCRIPTION
Closes #1875.

**Mechanism** — `dispatch_annotation_deletes` (`:786`) and `dispatch_existing_annotation_sync` (`:711`) discarded `ub.session_commit()`'s strict `True`/`False` result and called `_enqueue` on the next line. A failed commit rolled back the local soft-delete while the tombstone job still reached the worker: deleted on Hardcover, live in CWNG, and re-pushable as a fresh create later. All three clients (Kobo, web reader, KOReader) reach these functions.

**Fix** — both sites gate the enqueue on the commit result, `log.error` with user + annotation ids + job count, and return `False`/`True` (callers ignore it today; nothing raises through the best-effort fan-out boundaries). `run_jobs_inline:121` is left to #1871; SAVEPOINT design to #1873.

**Evidence (OBSERVED by the manager, independently of the implementer)** — file-backed SQLite, real dispatchers, stub handler, enqueue captured, verifying read on an independent engine. Old code: 4 failed (`delete job reached remote enqueue after commit failure` / `push job …`; the two positive controls also fail on the new return value). Fixed: 4/4 ×2, plus the 79 existing annotation-sync unit tests green. Implemented by Sol; diff reviewed by the manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014omupDzCoyNoDkq3WhRBry
