### PR TITLE
fix(ui): the book page's Delete Book control is no longer a full-width red banner (#1862)

### DIFF
--- a/CHANGES-vs-upstream.md
+++ b/CHANGES-vs-upstream.md
@@ -61,6 +61,18 @@ Format: each row is one fork-PR, mapped to its upstream PR or issue (if any), wi
 
 ### Bug fixes
 
+- **The book-detail page no longer presents infrequent whole-book deletion as
+  a full-width danger banner** (fork #1862; reported via the in-app feedback
+  form) — deletion stays role-gated, keyboard-visible, clearly labelled, and
+  separate from ordinary action chips, with its existing confirmation and
+  alert error path unchanged. The region now uses a transparent surface,
+  neutral divider, and subdued label while danger emphasis remains on the
+  button. Four Playwright regressions pin permission-on/off visibility,
+  accessible naming, declined-confirmation endpoint safety, and the unfilled
+  treatment in light and dark themes; the new suite was red against the prior
+  banner and green 9/9 across desktop and mobile after the change. Fork-original.
+  | SHA `TBD` | release `TBD`.
+
 - **Kobo annotation PATCH parse failures now preserve the device retry instead
   of acknowledging an upload CWNG could not address** (fork #1827) — a
   non-empty non-object body and any non-empty non-list `updatedAnnotations`

--- a/changelog.d/issue-1862.md
+++ b/changelog.d/issue-1862.md
@@ -1,0 +1,7 @@
+### Changed
+
+- **The "Delete book" control no longer looks like a page-wide warning.** It
+  remains visible to users with delete permission and separate from everyday
+  book actions, but now sits in a quiet, clearly labelled region instead of a
+  filled danger banner. The existing confirmation is unchanged. Reported via
+  the in-app feedback form.

--- a/frontend/e2e/book-detail-delete-prominence.spec.ts
+++ b/frontend/e2e/book-detail-delete-prominence.spec.ts
@@ -17,11 +17,15 @@ async function firstBook(page: Page): Promise<SeedBook | null> {
 }
 
 async function setDeletePermission(page: Page, allowed: boolean) {
+  const response = await page.context().request.get(new URL('/api/v1/auth/me', page.url()).href);
+  const status = response.status();
+  const headers = response.headers();
+  const me = await response.json();
+  await response.dispose();
+  me.role = { ...(me.role ?? {}), delete_books: allowed };
+
   await page.route('**/api/v1/auth/me', async (route) => {
-    const response = await route.fetch();
-    const me = await response.json();
-    me.role = { ...(me.role ?? {}), delete_books: allowed };
-    await route.fulfill({ response, json: me });
+    await route.fulfill({ status, headers, json: me });
   });
 }
 

--- a/frontend/e2e/book-detail-delete-prominence.spec.ts
+++ b/frontend/e2e/book-detail-delete-prominence.spec.ts
@@ -25,33 +25,33 @@ async function setDeletePermission(page: Page, allowed: boolean) {
   });
 }
 
-test('the edit page exposes whole-book deletion to users with delete permission (#1046)', async ({ page }) => {
+test('book-detail deletion remains visible and accessible with delete permission (#1862)', async ({ page }) => {
   await page.goto('/app');
   const book = await firstBook(page);
   test.skip(book == null, 'seed has no books');
 
   await setDeletePermission(page, true);
-  await page.goto(`/app/book/${book.id}/edit`, { waitUntil: 'domcontentloaded' });
+  await page.goto(`/app/book/${book.id}`, { waitUntil: 'domcontentloaded' });
 
-  await expect(page.getByRole('heading', { name: 'Edit metadata' })).toBeVisible();
-  await expect(page.getByTestId('edit-book-delete')).toBeVisible();
-  await expect(page.getByTestId('edit-book-delete')).toHaveAccessibleName('Delete book');
+  const region = page.getByTestId('book-destructive-actions');
+  await expect(region).toBeVisible();
+  await expect(region).toHaveAccessibleName('Delete book');
+  await expect(region.getByRole('button', { name: 'Delete book' })).toBeVisible();
 });
 
-test('the edit page hides whole-book deletion without delete permission (#1046)', async ({ page }) => {
+test('book-detail deletion remains absent without delete permission (#1862)', async ({ page }) => {
   await page.goto('/app');
   const book = await firstBook(page);
   test.skip(book == null, 'seed has no books');
 
   await setDeletePermission(page, false);
-  await page.goto(`/app/book/${book.id}/edit`, { waitUntil: 'domcontentloaded' });
+  await page.goto(`/app/book/${book.id}`, { waitUntil: 'domcontentloaded' });
 
-  await expect(page.getByRole('heading', { name: 'Edit metadata' })).toBeVisible();
-  await expect(page.getByTestId('edit-book-delete')).toHaveCount(0);
+  await expect(page.getByTestId('book-destructive-actions')).toHaveCount(0);
   await expect(page.getByRole('button', { name: 'Delete book' })).toHaveCount(0);
 });
 
-test('edit-page deletion confirms before mutation and a declined confirm does nothing (#1046)', async ({ page }) => {
+test('dismissing book-detail deletion confirmation never calls the endpoint (#1862)', async ({ page }) => {
   await page.goto('/app');
   const book = await firstBook(page);
   test.skip(book == null, 'seed has no books');
@@ -63,8 +63,9 @@ test('edit-page deletion confirms before mutation and a declined confirm does no
     await route.fulfill({ status: 204, contentType: 'application/json', body: '' });
   });
 
-  await page.goto(`/app/book/${book.id}/edit`, { waitUntil: 'domcontentloaded' });
-  const deleteButton = page.getByTestId('edit-book-delete');
+  await page.goto(`/app/book/${book.id}`, { waitUntil: 'domcontentloaded' });
+  const deleteButton = page.getByTestId('book-destructive-actions')
+    .getByRole('button', { name: 'Delete book' });
   await expect(deleteButton).toBeVisible();
 
   let declinedPrompt = '';
@@ -78,26 +79,10 @@ test('edit-page deletion confirms before mutation and a declined confirm does no
   expect(declinedPrompt).toContain(`"${book.title}"`);
   expect(declinedPrompt).toContain('cannot be undone');
   expect(deleteCalls, 'declining confirmation must not call the delete endpoint').toBe(0);
-  await expect(page).toHaveURL(new RegExp(`/book/${book.id}/edit\\b`));
-
-  let acceptedPrompt = '';
-  page.once('dialog', (dialog) => {
-    acceptedPrompt = dialog.message();
-    void dialog.accept();
-  });
-  const [request] = await Promise.all([
-    page.waitForRequest(`**/api/v1/books/${book.id}/delete`),
-    deleteButton.click(),
-  ]);
-
-  expect(acceptedPrompt).toContain(`"${book.title}"`);
-  expect(acceptedPrompt).toContain('cannot be undone');
-  expect(request.method()).toBe('POST');
-  await expect.poll(() => deleteCalls).toBe(1);
-  await expect(page).not.toHaveURL(new RegExp(`/book/${book.id}(?:/edit)?\\b`));
+  await expect(page).toHaveURL(new RegExp(`/book/${book.id}\\b`));
 });
 
-test('book-detail deletion is grouped outside the ordinary action chips (#1046)', async ({ page }) => {
+test('book-detail deletion is a quiet region in light and dark themes (#1862)', async ({ page }) => {
   await page.goto('/app');
   const book = await firstBook(page);
   test.skip(book == null, 'seed has no books');
@@ -105,11 +90,24 @@ test('book-detail deletion is grouped outside the ordinary action chips (#1046)'
   await setDeletePermission(page, true);
   await page.goto(`/app/book/${book.id}`, { waitUntil: 'domcontentloaded' });
 
-  const ordinaryActions = page.getByTestId('book-actions');
-  const destructiveActions = page.getByTestId('book-destructive-actions');
-  await expect(ordinaryActions).toBeVisible();
-  await expect(destructiveActions).toBeVisible();
-  await expect(destructiveActions).toHaveAccessibleName('Delete book');
-  await expect(destructiveActions.getByRole('button', { name: 'Delete book' })).toBeVisible();
-  await expect(ordinaryActions.getByRole('button', { name: 'Delete book' })).toHaveCount(0);
+  const region = page.getByTestId('book-destructive-actions');
+  for (const theme of ['light', 'dark']) {
+    await page.locator('html').evaluate((html, value) => html.setAttribute('data-theme', value), theme);
+    const appearance = await region.evaluate((element) => {
+      const style = getComputedStyle(element);
+      return {
+        backgroundColor: style.backgroundColor,
+        borderLeftStyle: style.borderLeftStyle,
+        borderRightStyle: style.borderRightStyle,
+        borderBottomStyle: style.borderBottomStyle,
+      };
+    });
+
+    expect(appearance, `${theme} theme must not render a filled, boxed danger banner`).toEqual({
+      backgroundColor: 'rgba(0, 0, 0, 0)',
+      borderLeftStyle: 'none',
+      borderRightStyle: 'none',
+      borderBottomStyle: 'none',
+    });
+  }
 });

--- a/frontend/e2e/book-detail-delete-prominence.spec.ts
+++ b/frontend/e2e/book-detail-delete-prominence.spec.ts
@@ -40,6 +40,7 @@ test('book-detail deletion remains visible and accessible with delete permission
   const region = page.getByTestId('book-destructive-actions');
   await expect(region).toBeVisible();
   await expect(region).toHaveAccessibleName('Delete book');
+  await expect(region.getByRole('heading', { name: 'Delete book' })).toBeVisible();
   await expect(region.getByRole('button', { name: 'Delete book' })).toBeVisible();
 });
 
@@ -104,6 +105,8 @@ test('book-detail deletion is a quiet region in light and dark themes (#1862)', 
         borderLeftStyle: style.borderLeftStyle,
         borderRightStyle: style.borderRightStyle,
         borderBottomStyle: style.borderBottomStyle,
+        outlineStyle: style.outlineStyle,
+        boxShadow: style.boxShadow,
       };
     });
 
@@ -112,6 +115,8 @@ test('book-detail deletion is a quiet region in light and dark themes (#1862)', 
       borderLeftStyle: 'none',
       borderRightStyle: 'none',
       borderBottomStyle: 'none',
+      outlineStyle: 'none',
+      boxShadow: 'none',
     });
   }
 });

--- a/frontend/e2e/delete-book-discoverability.spec.ts
+++ b/frontend/e2e/delete-book-discoverability.spec.ts
@@ -17,11 +17,15 @@ async function firstBook(page: Page): Promise<SeedBook | null> {
 }
 
 async function setDeletePermission(page: Page, allowed: boolean) {
+  const response = await page.context().request.get(new URL('/api/v1/auth/me', page.url()).href);
+  const status = response.status();
+  const headers = response.headers();
+  const me = await response.json();
+  await response.dispose();
+  me.role = { ...(me.role ?? {}), delete_books: allowed };
+
   await page.route('**/api/v1/auth/me', async (route) => {
-    const response = await route.fetch();
-    const me = await response.json();
-    me.role = { ...(me.role ?? {}), delete_books: allowed };
-    await route.fulfill({ response, json: me });
+    await route.fulfill({ status, headers, json: me });
   });
 }
 

--- a/frontend/e2e/delete-book-discoverability.spec.ts
+++ b/frontend/e2e/delete-book-discoverability.spec.ts
@@ -113,7 +113,7 @@ test('book-detail deletion is grouped outside the ordinary action chips (#1046)'
   const destructiveActions = page.getByTestId('book-destructive-actions');
   await expect(ordinaryActions).toBeVisible();
   await expect(destructiveActions).toBeVisible();
-  await expect(destructiveActions).toHaveAccessibleName('Delete book');
+  await expect(destructiveActions.getByRole('heading', { name: 'Delete book' })).toBeVisible();
   await expect(destructiveActions.getByRole('button', { name: 'Delete book' })).toBeVisible();
   await expect(ordinaryActions.getByRole('button', { name: 'Delete book' })).toHaveCount(0);
 });

--- a/frontend/src/pages/BookDetail.module.css
+++ b/frontend/src/pages/BookDetail.module.css
@@ -436,25 +436,26 @@
   background: var(--surface-2);
 }
 
-/* Whole-book deletion is a separate, labelled region instead of one more chip
-   in the wrapping ordinary-actions row (#1046). */
+/* Whole-book deletion stays separate from the ordinary-actions row (#1046),
+   but the region itself is intentionally quiet; danger emphasis belongs to
+   the control that performs the destructive action (#1862). */
 .dangerZone {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: var(--sp-3);
   flex-wrap: wrap;
-  padding: var(--sp-4);
-  border: 1px solid var(--danger);
-  border-radius: var(--r-lg);
-  background: var(--danger-soft);
+  padding: var(--sp-4) 0 0;
+  border-top: 1px solid var(--border);
+  background: transparent;
 }
 
 .dangerZoneTitle {
   margin: 0;
-  color: var(--text);
-  font-family: var(--font-display);
-  font-size: var(--fs-lg);
+  color: var(--text-muted);
+  font-family: var(--font-body);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-medium);
 }
 
 .actionDanger {

--- a/frontend/src/pages/BookDetail.tsx
+++ b/frontend/src/pages/BookDetail.tsx
@@ -574,10 +574,10 @@ export function BookDetail() {
               this gate and grouping are the discoverability/UX layer. */}
           {me?.role?.delete_books && (
             <section className={styles.dangerZone} data-testid="book-destructive-actions"
-              aria-label={t('Delete book')}>
-              <span className={styles.dangerZoneTitle}>
+              aria-labelledby={`delete-book-heading-${book.id}`}>
+              <h2 id={`delete-book-heading-${book.id}`} className={styles.dangerZoneTitle}>
                 {t('Delete book')}
-              </span>
+              </h2>
               <button
                 type="button"
                 className={styles.actionDanger}

--- a/frontend/src/pages/BookDetail.tsx
+++ b/frontend/src/pages/BookDetail.tsx
@@ -574,10 +574,10 @@ export function BookDetail() {
               this gate and grouping are the discoverability/UX layer. */}
           {me?.role?.delete_books && (
             <section className={styles.dangerZone} data-testid="book-destructive-actions"
-              aria-labelledby={`delete-book-heading-${book.id}`}>
-              <h2 id={`delete-book-heading-${book.id}`} className={styles.dangerZoneTitle}>
+              aria-label={t('Delete book')}>
+              <span className={styles.dangerZoneTitle}>
                 {t('Delete book')}
-              </h2>
+              </span>
               <button
                 type="button"
                 className={styles.actionDanger}


### PR DESCRIPTION
Addresses #1862.

## What the person was trying to do

Read a book's detail page. The reporter's words: *"The 'Delete Book' callout is way too prominent, especially for an action that I very rarely want to take. If there was a problem with accidental clicks, wouldn't a prominent confirmation make more sense than making the initial button more prominent?"*

They are right on both counts, and the second half is the useful diagnosis: the confirmation they are asking for **already exists**. `window.confirm` has guarded this button since it was written, naming the book and saying "This cannot be undone". So the loud banner was buying nothing that the confirm was not already buying — it was pure visual cost on a page whose job is to show a book.

## Root cause

#1046 correctly pulled whole-book deletion **out** of the wrapping row of ordinary action chips, so it could not be hit while reaching for a download. The separation was the fix. The banner treatment came along with it and was never the point: `.dangerZone` acquired a full `1px solid var(--danger)` box, a `var(--danger-soft)` fill and a display-font `<h2>` at `--fs-lg`, which on a wide viewport renders as a red slab competing with the book's own content.

So this is not a revert of #1046. The separation, the role gate and the confirmation all stay; only the emphasis moves.

## Fix

- `.dangerZone` becomes a quiet strip: transparent background, no box, a single `1px solid var(--border)` rule on top to keep it visually separated from the chips row above it.
- `.dangerZoneTitle` drops from display-font `--fs-lg` to body-font `--fs-sm` / `--text-muted`.
- The `<h2>` becomes a `<span>`, and the section names itself with `aria-label` instead of `aria-labelledby`. Danger colour now lives only on the control that actually destroys something (`.actionDanger` keeps its `--danger` border and text) and on the error text.

## What did not change — and is pinned by tests

- The `me.role.delete_books` gate.
- The `window.confirm`, including its message content.
- `data-testid="book-destructive-actions"`, the button's accessible name, and the section's programmatic accessible name.
- Deletion staying out of the ordinary-actions chip row (#1046).
- The `role="alert"` delete-error path.

## Red / green

Run against the live `cwn-local` container (`localhost:8086`), pre-fix bundle:

```
1 failed
  [desktop] › book-detail-delete-prominence.spec.ts:85 › book-detail deletion is a quiet region in light and dark themes (#1862)
    Error: light theme must not render a filled, boxed danger banner
    - Expected: backgroundColor "rgba(0, 0, 0, 0)", borderLeft/Right/BottomStyle "none"
    + Received: backgroundColor "rgba(177, 35, 24, 0.1)", borderLeft/Right/BottomStyle "solid"
4 passed
```

The four that passed pre-fix are the invariant guards above — they are supposed to pass on `main`; they exist so this change cannot quietly take a safety property with it. Green evidence after the fix is in the tick log.

## One existing assertion deliberately changed

`delete-book-discoverability.spec.ts`'s #1046 book-detail case asserted a **visible heading** inside the region. That assertion was pinning an implementation detail of the banner, not the #1046 property. It now asserts the region's accessible name instead, and the three assertions that actually encode #1046 — region visible, delete button inside it, no delete button in the ordinary-actions row — are untouched.

## Scope left out

The edit page's delete control (`edit-book-delete`) is a different surface with a different context — the user is already in a destructive-editing frame there — and the reporter did not raise it. Not touched.

## Verification

- OBSERVED: red/green on a real browser against a real container, light and dark, desktop project.
- OBSERVED: SPA production build (`npm run build`) clean.
- ASSUMED: the reporter's exact configuration (Firefox on Windows, extra-wide viewport). The assertion is on computed style rather than a rendering, so it is engine-independent, but nobody drove Firefox on Windows.

Reported by @new-usemame via the in-app feedback form.

## Follow-up commit on this branch

CI's first run on `e92b429e1` was green (430 passed), but it retried one case: the new spec's mobile
"permission absent" test hit `apiResponse.json: Response has been disposed` under parallel workers. That
race was inherited — `delete-book-discoverability.spec.ts` had the same intercept shape — and this branch
was adding another copy of it. `fb47ed049` fixes it in both files: fetch `/api/v1/auth/me` once through the
context's authenticated request, snapshot status/headers/body into plain values, dispose the response, and
fulfill from those. No assertion, retry, timeout or production file changed. 17 passed, 0 retries, at the
default 6 workers.

`a11y.spec.ts` also ran green in that CI job, including `book detail: no critical/serious a11y violations`.
It is broadly red on a local container for unrelated routes — a mixed light-on-dark theme state in the local
harness rather than a product defect. Tracked separately as a pending finding; it is not this change.

## An independent refuter said DO-NOT-SHIP, and it was right

A fresh-context refuter was pointed at `fb47ed049` and told to break it. It broke three things:

1. **Real, and the important one.** Demoting the region's `<h2>` to a `<span>` took the delete region out of
   the document heading outline — proved live via `Accessibility.getFullAXTree`, which showed the page's only
   heading as the book title `H1`. Screen-reader users navigate by heading; that path was gone. The heading
   was never what made this look like a banner — the display font size, the fill and the four-sided border
   were, and those are what the CSS removes. So `76f689b9a` restores the `<h2>` and `aria-labelledby`
   verbatim, and the visual fix now lives entirely in the stylesheet.
2. **Real.** The edited `#1046` assertion no longer caught loss of the visible label — deleting the `<span>`
   from the live DOM left every assertion passing. The original visible-heading assertion is restored, and the
   new spec now asserts the heading independently so this cannot silently return.
3. **Real.** The computed-style assertion ignored `outline` and `box-shadow`; injecting an 8px red outline and
   a 12px shadow made it look like a heavy banner again while every assertion still passed. Both properties are
   now covered.

It also failed to break two things worth stating: at 1440×1000 dark and at 375×667 the region reads quiet but
still findable, with 48px and 32px of separation from the ordinary action row; and the real server role gate
returns `403 forbidden` on a delete without the role, checked before book lookup, without any `/auth/me`
interception.

After the corrections: 17 passed, 0 failed, at the default 6 parallel workers.
