### PR TITLE
fix(ingest): the persistent lock file no longer depends on who created it (#1914 follow-up, #1919)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -476,7 +476,7 @@ jobs:
           #                      Tests (test_translations_compile.py), so
           #                      routing them through a full image build
           #                      would buy nothing and stall every locale PR.
-          if echo "$files" | grep -qE '^(Dockerfile$|[^/]*requirements[^/]*\.txt$|root/|cps/.*\.py$|tests/(docker|integration)/|\.github/workflows/tests\.yml$)'; then
+          if echo "$files" | grep -qE '^(Dockerfile$|[^/]*requirements[^/]*\.txt$|root/|cps/.*\.py$|scripts/.*\.py$|tests/(docker|integration)/|\.github/workflows/tests\.yml$)'; then
             echo "build=true" >> "$GITHUB_OUTPUT"
           else
             echo "build=false" >> "$GITHUB_OUTPUT"

--- a/changelog.d/issue-1914-followup.md
+++ b/changelog.d/issue-1914-followup.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Ingest keeps working after the post-batch follow-up.**

--- a/root/etc/s6-overlay/s6-rc.d/cwa-ingest-service/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-ingest-service/run
@@ -343,7 +343,7 @@ run_post_batch_follow_up() {
         if [ -n "${CWA_INGEST_POST_BATCH_CMD:-}" ]; then
                 "$CWA_INGEST_POST_BATCH_CMD"
         else
-                python3 /app/calibre-web-automated/scripts/ingest_processor.py --post-batch-follow-up
+                cwa-as-abc python3 /app/calibre-web-automated/scripts/ingest_processor.py --post-batch-follow-up
         fi
 }
 

--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -182,7 +182,20 @@ class ProcessLock:
         try:
             # Keep one stable inode: truncating or unlinking a contended lock file
             # would let another opener acquire a different inode.
-            self.lock_file = open(self.lock_path, 'a+')
+            lock_existed = os.path.exists(self.lock_path)
+            lock_writable = True
+            try:
+                lock_fd = os.open(self.lock_path, os.O_RDWR | os.O_CREAT, 0o666)
+            except PermissionError:
+                lock_fd = os.open(self.lock_path, os.O_RDONLY)
+                lock_writable = False
+            else:
+                if not lock_existed:
+                    try:
+                        os.fchmod(lock_fd, 0o666)
+                    except OSError:
+                        pass
+            self.lock_file = os.fdopen(lock_fd, 'r+' if lock_writable else 'r')
 
             # Try to acquire an exclusive lock with timeout
             start_time = time.time()
@@ -190,11 +203,13 @@ class ProcessLock:
                 try:
                     fcntl.flock(self.lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
 
-                    # Successfully acquired lock, replace the diagnostic PID.
-                    self.lock_file.seek(0)
-                    self.lock_file.truncate()
-                    self.lock_file.write(str(os.getpid()))
-                    self.lock_file.flush()
+                    # Successfully acquired lock. Replace the diagnostic PID
+                    # only when this user can write the persistent inode.
+                    if lock_writable:
+                        self.lock_file.seek(0)
+                        self.lock_file.truncate()
+                        self.lock_file.write(str(os.getpid()))
+                        self.lock_file.flush()
 
                     self.acquired = True
                     print(f"[ingest-processor] Lock acquired successfully (PID: {os.getpid()})")

--- a/tests/unit/test_ingest_processor_startup.py
+++ b/tests/unit/test_ingest_processor_startup.py
@@ -166,6 +166,31 @@ def test_process_lock_reclaims_dead_pid_file(monkeypatch, tmp_path):
         lock.release()
 
 
+def test_process_lock_read_only_file_remains_lockable(monkeypatch, tmp_path):
+    process_lock_class = _process_lock_class(monkeypatch, tmp_path)
+    lock_path = tmp_path / "read-only.lock"
+    original_contents = "previous-holder"
+    lock_path.write_text(original_contents)
+    lock_path.chmod(0o444)
+    holder = process_lock_class("read-only")
+    contender = process_lock_class("read-only")
+
+    try:
+        assert holder.acquire(timeout=0.1)
+        assert lock_path.exists()
+        assert lock_path.read_text() == original_contents
+
+        assert contender.acquire(timeout=0.1) is False
+        assert lock_path.exists()
+        assert lock_path.read_text() == original_contents
+    finally:
+        contender.release()
+        holder.release()
+
+    assert lock_path.exists()
+    assert lock_path.read_text() == original_contents
+
+
 def test_optional_cps_modules_retry_after_partial_load(monkeypatch, tmp_path):
     scripts_dir = Path(__file__).resolve().parents[2] / "scripts"
     monkeypatch.syspath_prepend(str(scripts_dir))


### PR DESCRIPTION
Fix-forward for the `main` integration red introduced by #1914; closes #1919.

**Mechanism** — #1914 correctly stopped unlinking the lock on release, which exposed that per-file ingest runs as `abc` (`cwa-as-abc`) while `--post-batch-follow-up` ran as root. A root-owned `/tmp/ingest_processor.lock` made every later `abc` `open()` fail with `EACCES`, caught by `acquire()`'s broad except → `False` → ingest cancelled. `main` run 33121354344: 7 `test_ingest_pipeline.py` tests red, all after the first batch's follow-up. The #1914 PR skipped the integration lane because the build-path regex omitted `scripts/*.py` (#1919).

**Fix** — create the lock `0666` (`os.open` + best-effort `fchmod`); when the file can't be opened for writing, fall back to `O_RDONLY` — `flock` needs no write access — and skip the diagnostic PID write; run the follow-up as `abc` too; add `scripts/.*\.py$` to the build-path regex so this PR's own Integration lane is a hard gate.

**Evidence** — unit (OBSERVED by the manager): a pre-existing `0o444` lock file → old code `Error acquiring lock: [Errno 13] Permission denied` and the test fails; fixed: 7/7 ×2. The Docker lane on this PR is the end-to-end confirmation; the root-vs-abc `EACCES` inside the container is ASSUMED until it goes green. Implemented by Sol; diff reviewed by the manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014omupDzCoyNoDkq3WhRBry
