### PR TITLE
fix(ingest): an .acsm is fulfilled even when Auto-Convert is off (#984)

### DIFF
--- a/changelog.d/1921.md
+++ b/changelog.d/1921.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- **An `.acsm` is fulfilled even when Auto-Convert is off.** An Adobe fulfilment ticket only
+  reached its Calibre plugin when Auto-Convert was enabled; with the setting off — or with `acsm`
+  on the Auto-Convert ignore list — ingest stopped short and printed guidance telling you to
+  install a plugin you already had. A ticket is not a book, so the plugin is the only path to one;
+  it now runs on every path. Books are unaffected: with Auto-Convert off, a book still imports in
+  its original format. Reported by @jakejoh, following @auspex's original report.

--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -2415,7 +2415,8 @@ def main(filepath=None):
             print(f"\n[ingest-processor]: No conversion needed for {nbp.filename}, is audiobook, importing now...", flush=True)
             nbp.add_book_to_library(filepath, False, Path(nbp.filename).suffix)
         else:
-            if nbp.auto_convert_on and nbp.can_convert: # File can be converted to target format and Auto-Converter is on
+            fulfilment_ticket = not is_a_book_format(nbp.input_format)
+            if nbp.can_convert and (nbp.auto_convert_on or fulfilment_ticket): # File can be converted, or must be fulfilled because the original is not a book
 
                 # Tracks whether a conversion was actually run. The ignore-list
                 # branch below reports convert_successful=False having already
@@ -2423,14 +2424,18 @@ def main(filepath=None):
                 # it as a failed conversion and import a second copy.
                 conversion_attempted = False
 
-                if nbp.input_format in nbp.convert_ignored_formats: # File could be converted & the converter is activated but the user has specified files of this format should not be converted
-                    if is_a_book_format(nbp.input_format):
-                        print(f"\n[ingest-processor]: {nbp.filename} not in target format but user has told CWA not to convert this format so importing the file anyway...", flush=True)
-                        nbp.add_book_to_library(filepath)
-                    else:
-                        _fail_not_a_book_input(nbp, filepath)
+                if fulfilment_ticket and not nbp.auto_convert_on:
+                    print(f"\n[ingest-processor]: {nbp.filename} is a {nbp.input_format.upper()} fulfilment ticket, not a book; running its fulfilment plugin even though CWA Auto-Convert is deactivated...", flush=True)
+                elif fulfilment_ticket and nbp.input_format in nbp.convert_ignored_formats:
+                    print(f"\n[ingest-processor]: {nbp.filename} is a {nbp.input_format.upper()} fulfilment ticket, not a book; running its fulfilment plugin even though this format is on the Auto-Convert ignore list...", flush=True)
+
+                if nbp.input_format in nbp.convert_ignored_formats and not fulfilment_ticket: # User has specified that this book format should not be converted
+                    print(f"\n[ingest-processor]: {nbp.filename} not in target format but user has told CWA not to convert this format so importing the file anyway...", flush=True)
+                    nbp.add_book_to_library(filepath)
                     convert_successful = False
                 elif nbp.target_format == "kepub": # File is not in the convert ignore list and target is kepub, so we start the kepub conversion process
+                    # A ticket takes this route too: convert_to_kepub() first fulfils
+                    # non-EPUB input to an EPUB, then gives that book to kepubify.
                     conversion_attempted = True
                     convert_successful, converted_filepath = nbp.convert_to_kepub()
                 else: # File is not in the convert ignore list and target is not kepub, so we start the regular conversion process

--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -1494,7 +1494,8 @@ class NewBookProcessor:
                                                    converter_output=getattr(e, 'output', None))
             if guidance:
                 print(f"\n[ingest-processor]: {guidance}\n", flush=True)
-            self.backup(self.filepath, backup_type="failed")
+            if self.backup(self.filepath, backup_type="failed") and not is_a_book_format(self.input_format):
+                _remove_completed_import_manifest(self.filepath)
             return False, ""
 
         except subprocess.TimeoutExpired:
@@ -1507,14 +1508,16 @@ class NewBookProcessor:
                   f"the wait for the file to finish copying in, so a slow copy leaves less time to convert.\n"
                   f"A large or image-heavy book can legitimately need longer — raise 'Ingest Timeout' in CWA Settings "
                   f"to allow more time.", flush=True)
-            self.backup(self.filepath, backup_type="failed")
+            if self.backup(self.filepath, backup_type="failed") and not is_a_book_format(self.input_format):
+                _remove_completed_import_manifest(self.filepath)
             return False, ""
 
         except OSError as e:
             # ebook-convert missing or not executable. Still a conversion
             # failure, so it must not fall through as an unhandled exception.
             print(f"\n[ingest-processor]: CON_ERROR: could not run the converter for {self.filename}: {e}", flush=True)
-            self.backup(self.filepath, backup_type="failed")
+            if self.backup(self.filepath, backup_type="failed") and not is_a_book_format(self.input_format):
+                _remove_completed_import_manifest(self.filepath)
             return False, ""
 
 

--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -2428,9 +2428,9 @@ def main(filepath=None):
                 conversion_attempted = False
 
                 if fulfilment_ticket and not nbp.auto_convert_on:
-                    print(f"\n[ingest-processor]: {nbp.filename} is a {nbp.input_format.upper()} fulfilment ticket, not a book; running its fulfilment plugin even though CWA Auto-Convert is deactivated...", flush=True)
+                    print(f"\n[ingest-processor]: {nbp.filename} is an {nbp.input_format.upper()} fulfilment ticket, not a book; running its fulfilment plugin even though CWA Auto-Convert is deactivated...", flush=True)
                 elif fulfilment_ticket and nbp.input_format in nbp.convert_ignored_formats:
-                    print(f"\n[ingest-processor]: {nbp.filename} is a {nbp.input_format.upper()} fulfilment ticket, not a book; running its fulfilment plugin even though this format is on the Auto-Convert ignore list...", flush=True)
+                    print(f"\n[ingest-processor]: {nbp.filename} is an {nbp.input_format.upper()} fulfilment ticket, not a book; running its fulfilment plugin even though this format is on the Auto-Convert ignore list...", flush=True)
 
                 if nbp.input_format in nbp.convert_ignored_formats and not fulfilment_ticket: # User has specified that this book format should not be converted
                     print(f"\n[ingest-processor]: {nbp.filename} not in target format but user has told CWA not to convert this format so importing the file anyway...", flush=True)

--- a/tests/unit/test_1094_failed_conversion_imports_original.py
+++ b/tests/unit/test_1094_failed_conversion_imports_original.py
@@ -673,7 +673,7 @@ class TestNotABookFormatsAreNotRescued:
         assert import_manifest.read_text() == '{"action": "import"}'
 
 
-class TestAutoConvertOffDoesNotImportTickets:
+class TestFailedTicketFulfilmentDoesNotImportTickets:
     @staticmethod
     def _run(
         monkeypatch,
@@ -696,6 +696,22 @@ class TestAutoConvertOffDoesNotImportTickets:
             fake.is_target_format = is_target_format
             if convert_ignored:
                 fake.convert_ignored_formats = [fmt]
+
+            # A real failed ticket conversion owns its backup and guidance.
+            # Model that contract here so this class keeps testing the main()
+            # dispatch without reducing convert_book() to an impossible bare
+            # False that has discarded the user-facing failure handling.
+            def _failed_ticket_conversion(end_format=None):
+                fake.convert_book_calls += 1
+                fake.backup(filepath, backup_type="failed")
+                guidance = ingest_processor.conversion_failure_guidance(
+                    fmt, fake.filename
+                )
+                if guidance:
+                    print(f"\n[ingest-processor]: {guidance}\n", flush=True)
+                return False, ""
+
+            fake.convert_book = _failed_ticket_conversion
             holder["fake"] = fake
             return fake
 
@@ -708,7 +724,10 @@ class TestAutoConvertOffDoesNotImportTickets:
         return holder["fake"], str(source), capsys.readouterr().out
 
     @staticmethod
-    def _assert_ticket_was_failed_not_imported(fake, source, output, notice):
+    def _assert_ticket_was_failed_not_imported(
+        fake, source, output, notice, conversion_attempted=True
+    ):
+        assert fake.convert_book_calls == int(conversion_attempted)
         assert fake.imported == []
         assert fake.backed_up == [(source, "failed")]
         assert fake.delete_current_file_calls == 1
@@ -716,7 +735,7 @@ class TestAutoConvertOffDoesNotImportTickets:
         assert "processed_books/failed" in output
         assert "is currently unsupported / is not a known ebook format" not in output
 
-    def test_lcpl_gets_guidance_and_never_becomes_a_book(
+    def test_failed_lcpl_fulfilment_gets_guidance_and_never_becomes_a_book(
         self, monkeypatch, tmp_path, capsys
     ):
         result = self._run(monkeypatch, tmp_path, capsys, "lcpl")
@@ -724,7 +743,7 @@ class TestAutoConvertOffDoesNotImportTickets:
             *result, notice="LCPL_NOTICE:"
         )
 
-    def test_acsm_gets_guidance_and_never_becomes_a_book(
+    def test_failed_acsm_fulfilment_gets_guidance_and_never_becomes_a_book(
         self, monkeypatch, tmp_path, capsys
     ):
         result = self._run(monkeypatch, tmp_path, capsys, "acsm")
@@ -732,7 +751,7 @@ class TestAutoConvertOffDoesNotImportTickets:
             *result, notice="ACSM_NOTICE:"
         )
 
-    def test_ignored_lcpl_conversion_never_imports_the_licence(
+    def test_ignored_lcpl_is_fulfilled_but_failure_never_imports_the_licence(
         self, monkeypatch, tmp_path, capsys
     ):
         result = self._run(
@@ -759,7 +778,7 @@ class TestAutoConvertOffDoesNotImportTickets:
             is_target_format=True,
         )
         self._assert_ticket_was_failed_not_imported(
-            *result, notice="LCPL_NOTICE:"
+            *result, notice="LCPL_NOTICE:", conversion_attempted=False
         )
 
 

--- a/tests/unit/test_984_ticket_fulfilment_without_auto_convert.py
+++ b/tests/unit/test_984_ticket_fulfilment_without_auto_convert.py
@@ -1,0 +1,244 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Fork #984: fulfilment tickets must run their converter even when ordinary
+book conversion is disabled.
+
+An ACSM or LCPL file is a ticket/licence, not a book that can be imported in
+its original format.  Auto-Convert OFF and the per-format conversion ignore
+list therefore cannot use the ordinary "import the original" fallback: the
+plugin-backed converter is the only path that can produce a book.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = str(REPO_ROOT / "scripts")
+
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+import ingest_processor  # noqa: E402
+
+_REAL_CONVERT_BOOK = ingest_processor.NewBookProcessor.convert_book
+
+
+class _FakeProcessor:
+    def __init__(
+        self,
+        filepath,
+        *,
+        input_format,
+        auto_convert_on,
+        convert_result,
+        target_format="epub",
+        convert_ignored_formats=(),
+        use_real_converter=False,
+    ):
+        self.filepath = filepath
+        self.filename = os.path.basename(filepath)
+        self.input_format = input_format
+        self.target_format = target_format
+        self.tmp_conversion_dir = os.path.join(
+            os.path.dirname(filepath), "tmp_conversion"
+        ) + os.sep
+        self.ingest_ignored_formats = []
+        self.convert_ignored_formats = list(convert_ignored_formats)
+        self.convert_retained_formats = []
+        self.cwa_settings = {
+            "ingest_timeout_minutes": 15,
+            "auto_backup_conversions": False,
+        }
+        self.calibre_env = os.environ.copy()
+        self.is_target_format = False
+        self.auto_convert_on = auto_convert_on
+        self.can_convert = True
+        self.last_added_book_id = None
+        self._convert_result = convert_result
+        self._use_real_converter = use_real_converter
+        self.imported = []
+        self.convert_book_calls = []
+        self.convert_to_kepub_calls = 0
+        self.backed_up = []
+
+    def is_file_in_use(self, timeout=None):
+        return True
+
+    def is_supported_audiobook(self):
+        return False
+
+    def convert_book(self, end_format=None):
+        self.convert_book_calls.append(end_format)
+        if self._use_real_converter:
+            return _REAL_CONVERT_BOOK(self, end_format=end_format)
+        return self._convert_result
+
+    def convert_to_kepub(self):
+        self.convert_to_kepub_calls += 1
+        return self._convert_result
+
+    def add_book_to_library(self, filepath, *args, **kwargs):
+        self.imported.append(filepath)
+
+    def backup(self, filepath, backup_type):
+        self.backed_up.append((filepath, backup_type))
+        return True
+
+    def set_library_permissions(self):
+        pass
+
+    def delete_current_file(self):
+        pass
+
+
+def _run_main(
+    monkeypatch,
+    tmp_path,
+    *,
+    input_format,
+    auto_convert_on,
+    convert_result,
+    target_format="epub",
+    convert_ignored_formats=(),
+    use_real_converter=False,
+):
+    source = tmp_path / f"Library Ticket.{input_format}"
+    source.write_text("ticket or book contents")
+    holder = {}
+
+    def _factory(filepath):
+        fake = _FakeProcessor(
+            filepath,
+            input_format=input_format,
+            auto_convert_on=auto_convert_on,
+            convert_result=convert_result,
+            target_format=target_format,
+            convert_ignored_formats=convert_ignored_formats,
+            use_real_converter=use_real_converter,
+        )
+        holder["fake"] = fake
+        return fake
+
+    monkeypatch.setattr(ingest_processor, "NewBookProcessor", _factory)
+    monkeypatch.setattr(ingest_processor, "initialize_runtime", lambda: True)
+    monkeypatch.setattr(
+        ingest_processor, "_acquire_process_lock_or_exit", lambda: None
+    )
+
+    assert ingest_processor.main(str(source)) == 0
+    return holder["fake"], str(source)
+
+
+@pytest.mark.parametrize("ticket_format", ["acsm", "lcpl"])
+def test_ticket_is_fulfilled_when_auto_convert_is_off(
+    monkeypatch, tmp_path, capsys, ticket_format
+):
+    converted = str(tmp_path / f"Library Ticket.{ticket_format}.epub")
+    fake, source = _run_main(
+        monkeypatch,
+        tmp_path,
+        input_format=ticket_format,
+        auto_convert_on=False,
+        convert_result=(True, converted),
+    )
+
+    output = capsys.readouterr().out
+    assert fake.convert_book_calls == [None]
+    assert fake.imported == [converted]
+    assert source not in fake.imported
+    assert "fulfilment ticket" in output
+    assert "Auto-Convert is deactivated" in output
+
+
+@pytest.mark.parametrize("ticket_format", ["acsm", "lcpl"])
+def test_ticket_is_fulfilled_even_when_its_format_is_ignored(
+    monkeypatch, tmp_path, capsys, ticket_format
+):
+    converted = str(tmp_path / f"Library Ticket.{ticket_format}.epub")
+    fake, source = _run_main(
+        monkeypatch,
+        tmp_path,
+        input_format=ticket_format,
+        auto_convert_on=True,
+        convert_result=(True, converted),
+        convert_ignored_formats=(ticket_format,),
+    )
+
+    assert fake.convert_book_calls == [None]
+    assert fake.imported == [converted]
+    assert source not in fake.imported
+    assert "Auto-Convert ignore list" in capsys.readouterr().out
+
+
+def test_real_book_is_still_imported_as_is_when_auto_convert_is_off(
+    monkeypatch, tmp_path
+):
+    fake, source = _run_main(
+        monkeypatch,
+        tmp_path,
+        input_format="pdf",
+        auto_convert_on=False,
+        convert_result=(True, str(tmp_path / "converted.epub")),
+    )
+
+    assert fake.convert_book_calls == []
+    assert fake.convert_to_kepub_calls == 0
+    assert fake.imported == [source]
+
+
+def test_failed_ticket_fulfilment_keeps_plugin_reason_and_preserves_original(
+    monkeypatch, tmp_path, capsys
+):
+    plugin_output = (
+        "ValueError: No plugin to handle input format: acsm\n"
+        "DeACSM v0.0.16: Trying to parse file Library Ticket.acsm\n"
+        "DeACSM v0.0.16: ADE auth is missing or broken\n"
+    )
+
+    def _fail(cmd, *args, **kwargs):
+        raise subprocess.CalledProcessError(1, cmd, output=plugin_output)
+
+    monkeypatch.setattr(ingest_processor, "_run_converter_streaming", _fail)
+    fake, source = _run_main(
+        monkeypatch,
+        tmp_path,
+        input_format="acsm",
+        auto_convert_on=False,
+        convert_result=(False, ""),
+        use_real_converter=True,
+    )
+
+    output = capsys.readouterr().out
+    assert fake.convert_book_calls == [None]
+    assert fake.imported == []
+    assert fake.backed_up == [(source, "failed")]
+    assert "ADE auth is missing or broken" in output
+    assert "An ACSM-capable Calibre plugin is installed and did run" in output
+    assert "place the ACSM Input plugin zip" not in output
+
+
+def test_acsm_targeting_kepub_uses_the_two_stage_fulfilment_route(
+    monkeypatch, tmp_path
+):
+    converted = str(tmp_path / "Library Ticket.kepub")
+    fake, source = _run_main(
+        monkeypatch,
+        tmp_path,
+        input_format="acsm",
+        auto_convert_on=False,
+        convert_result=(True, converted),
+        target_format="kepub",
+    )
+
+    assert fake.convert_to_kepub_calls == 1
+    assert fake.convert_book_calls == []
+    assert fake.imported == [converted]
+    assert source not in fake.imported

--- a/tests/unit/test_984_ticket_fulfilment_without_auto_convert.py
+++ b/tests/unit/test_984_ticket_fulfilment_without_auto_convert.py
@@ -197,6 +197,11 @@ def test_real_book_is_still_imported_as_is_when_auto_convert_is_off(
 def test_failed_ticket_fulfilment_keeps_plugin_reason_and_preserves_original(
     monkeypatch, tmp_path, capsys
 ):
+    source_path = tmp_path / "Library Ticket.acsm"
+    import_manifest = Path(str(source_path) + ".cwa.json")
+    import_manifest.write_text('{"action": "import"}')
+    failed_manifest = Path(str(source_path) + ".cwa.failed.json")
+    failed_manifest.write_text("preserve this")
     plugin_output = (
         "ValueError: No plugin to handle input format: acsm\n"
         "DeACSM v0.0.16: Trying to parse file Library Ticket.acsm\n"
@@ -220,6 +225,8 @@ def test_failed_ticket_fulfilment_keeps_plugin_reason_and_preserves_original(
     assert fake.convert_book_calls == [None]
     assert fake.imported == []
     assert fake.backed_up == [(source, "failed")]
+    assert not import_manifest.exists()
+    assert failed_manifest.read_text() == "preserve this"
     assert "ADE auth is missing or broken" in output
     assert "An ACSM-capable Calibre plugin is installed and did run" in output
     assert "place the ACSM Input plugin zip" not in output


### PR DESCRIPTION
An Adobe `.acsm` fulfilment ticket only reached the converter when CWA's **Auto-Convert** setting
was ON. With it OFF, the ingest processor took the "not in target format, Auto-Convert is
deactivated, import the file anyway" branch, discovered that an `.acsm` is not a book, and
dead-ended in `_fail_not_a_book_input()` — printing guidance that tells the user to install an
ACSM plugin they already have installed and running.

Reported by @jakejoh on #984 (2026-08-27):

> it works, but requires auto-convert to be enabled. otherwise there is a log entry saying sth
> like *no suitable plugin found*

## Why the old branch was wrong

The "import the original anyway" behaviour is correct for real book formats — a user who turned
Auto-Convert off wants their `.mobi` filed as a `.mobi`. It is meaningless for a ticket format
(`.acsm`, `.lcpl`): there is no book in the file to import, and the only route to the book is
through the converter, where an ACSM-capable input plugin fulfils the ticket. So Auto-Convert,
a preference about *format conversion*, was silently gating *fulfilment*, which is not a
conversion the user ever asked to disable.

The same dead end existed when `acsm` was listed in `auto_convert_ignored_formats`.

## What changed

`scripts/ingest_processor.py` — ticket formats (`_NOT_A_BOOK_FORMATS`) are now routed to the
converter on every path, independent of the Auto-Convert setting and the convert-ignore list.
Real book formats keep their existing behaviour on both paths.

Failure behaviour is unchanged: when the ticket genuinely cannot be fulfilled, nothing junk is
imported, the original is preserved in `processed_books/failed`, its upload sidecar is cleaned
up, and the log still prints the plugin-aware guidance from #984 — the message that repeats
DeACSM's own reason rather than telling you to install what you have.

## Not closed by this

#1228 (fulfilling `.acsm` through `calibredb add`, for File Type plugins like DeACSM that never
register an input format with `ebook-convert`) is a separate route and stays open. This PR fixes
who gets to reach the existing converter path, not what that path can fulfil.

<!-- evidence trail: state/completed.log, state/sol-delegation/issue-984/ -->

## Verification

Regression tests: `tests/unit/test_984_ticket_fulfilment_without_auto_convert.py` (7 cases —
ACSM and LCPL with Auto-Convert off, both on the convert-ignore list, the real-book
anti-overreach guard, the plugin-reason-preserved failure case, the kepub two-stage route, and
the sidecar cleanup). 6 of 7 red before the routing fix; the seventh red before the sidecar fix.
`tests/unit/test_1094_failed_conversion_imports_original.py` was updated where its stub encoded
the old immediate-rejection contract — its guarantees (a ticket is never imported, is preserved
to `failed`, and prints its notice) are unchanged and still asserted. 116 passed across the five
related files; 421 passed across every unit file that touches `ingest_processor`.

Driven end to end in a real container (`cwn-local`, Auto-Convert OFF — the reporter's setting):

- **Before** — the `.acsm` never reached the converter. No `START_CON`, no `ebook-convert`
  invocation, and the "install an ACSM plugin" notice, which is the bug as reported.
- **After** — `probe.acsm is an ACSM fulfilment ticket, not a book; running its fulfilment plugin
  even though CWA Auto-Convert is deactivated...` followed by `START_CON` and a real
  `ebook-convert` run. That container has no ACSM plugin installed, so fulfilment then failed and
  the "no plugin installed" wording is the correct one there; the ticket was preserved in
  `processed_books/failed`, the `action=import` sidecar was removed, its `.cwa.failed.json`
  sibling survived, and nothing junk was imported.

**Assumed link, stated plainly:** a *successful* fulfilment was not observed. That needs an
installed, Adobe-authorized ACSM plugin, which this machine does not have — the same constraint
recorded on #1228. What is observed is that the ticket now reaches the plugin-backed converter on
the path where it previously could not.


---

**Cross-family review (2026-08-28, head `1eaef08a`).** Reviewed by K3 (independent of Sol, which
authored the change), verdict **MERGE**, no blockers. It traced every dispatch path against the old
condition and confirmed: a ticket is never imported as a book on any route (ignore-list, stale
target-format, kepub, all three failure modes); a book with Auto-Convert off still imports its
original; the ignore-list book path is unchanged; #1094's rescue-import stays book-only; the sidecar
removal is correctly short-circuited so a failed backup keeps its manifest. It also verified the new
tests genuinely fail on unfixed code.

Three non-blocking findings — all pre-existing, none introduced here — are recorded in the pending
findings ledger rather than this thread: the kepub-target failure path orphans a `.cwa.json` sidecar
(`PF-2026-08-28T04-00-02Z-35369`, confirmed OBSERVED by the manager); a ticket the converter cannot
accept at all still gets the unhelpful "unsupported format" message with no failed-backup
(`…-35380`); and `convert_retained_formats` can attach a raw licence file to the book it fulfilled
(`…-35391`).

`/security-review` not required: the change adds no route, no auth/session/CSRF surface, no
crypto/secret handling, and no new subprocess invocation or path construction — it re-routes control
flow into converter and manifest helpers that already existed unchanged.
