### PR TITLE
changelog guard: translation-only diffs no longer need a release-note fragment

### DIFF
--- a/scripts/check_changelog_diff.py
+++ b/scripts/check_changelog_diff.py
@@ -15,6 +15,10 @@ RELEASE_HEADING = re.compile(r"^## \[(v\d+\.\d+\.\d+)\]", re.MULTILINE)
 ENTRY_LEAD = re.compile(r"^- \*\*", re.MULTILINE)
 FRAGMENT_PATH = re.compile(r"^changelog\.d/[A-Za-z0-9][A-Za-z0-9._-]*\.md$")
 NON_SHIPPING_PATH_PREFIXES = (
+    # Translation refreshes ship, but a .po/.pot-only diff is not a release-note
+    # event an outside translator should have to author (operator ruling
+    # 2026-08-27; #1896 was forced to invent a fragment).
+    "cps/translations/",
     "docs/",
     "findings/",
     "frontend/e2e/",
@@ -23,7 +27,7 @@ NON_SHIPPING_PATH_PREFIXES = (
     "wiki-src/",
 )
 NON_SHIPPING_PATHS = frozenset(
-    {"changelog.d/README.md", "scripts/check_changelog_diff.py"}
+    {"changelog.d/README.md", "messages.pot", "scripts/check_changelog_diff.py"}
 )
 
 

--- a/tests/unit/test_changelog_diff_guard.py
+++ b/tests/unit/test_changelog_diff_guard.py
@@ -169,6 +169,20 @@ def test_mixing_frontend_e2e_with_shipping_frontend_still_requires_an_entry():
     assert "shipping paths" in errors[0]
 
 
+def test_translation_only_pr_does_not_require_a_changelog_entry():
+    assert changelog_requirement_errors(
+        ["cps/translations/ru/LC_MESSAGES/messages.po", "messages.pot"]
+    ) == []
+
+
+def test_mixing_a_translation_with_shipping_code_requires_an_entry():
+    errors = changelog_requirement_errors(
+        ["cps/translations/ru/LC_MESSAGES/messages.po", "cps/web.py"]
+    )
+    assert len(errors) == 1
+    assert "shipping paths" in errors[0]
+
+
 def test_mixing_a_findings_ledger_with_shipping_code_requires_an_entry():
     errors = changelog_requirement_errors(
         ["findings/kobo/F-66edbc.md", "cps/readingservices.py"]


### PR DESCRIPTION
## What
`cps/translations/` and `messages.pot` are now non-shipping for the changelog-fragment guard, the same shape as the `wiki-src/` and `frontend/e2e/` exemptions. A translation-only PR (.po/.pot) no longer needs a `changelog.d/` fragment; a diff that mixes a translation with shipping code still does.

## Why
Operator ruling 2026-08-27: outside translators should not have to author release notes for a `.po` refresh. #1896 (ru) had to invent a fragment to pass the guard.

## Evidence
- Red/green: with the parent commit's constants the new test `test_translation_only_pr_does_not_require_a_changelog_entry` fails (1 failed / 24 passed); with this change 25 passed. OBSERVED locally and independently by the cross-family reviewer.
- Independent review (Sol, cross-family): VERDICT MERGE, 0 defects; LOW note that the directory prefix would also exempt a hypothetical future code file under `cps/translations/` — the tree holds only `*/LC_MESSAGES/messages.po` (28 files, OBSERVED via `git ls-tree`).
- Security review: not required (no auth/session/subprocess/paths/routes).
- No dependencies, licences or external URLs touched.
