### PR TITLE
feat: per-key runtime path overrides replace dirs.json (closes #1611)

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,9 +234,15 @@ process environment instead of editing `dirs.json` inside the installation:
 | `CWA_TMP_CONVERSION_DIR` | `tmp_conversion_dir` | `/config/.cwa_conversion_tmp` |
 
 Each non-blank environment value wins for its key. If it is unset or blank,
-CWNG reads that key from the file selected by `CWA_DIRS_JSON`; a missing,
-invalid, or blank file value falls back to the compiled-in default. Existing
-hand-edited `dirs.json` files therefore remain supported.
+CWNG reads that key from the file selected by `CWA_DIRS_JSON`; a missing or
+malformed file, a non-object document, or a null/blank value falls back to the
+compiled-in default. Existing hand-edited `dirs.json` files therefore remain
+supported.
+
+Runtime path values are trimmed and must be absolute paths without a `..`
+component. A non-blank environment or `dirs.json` value that violates that
+contract stops the affected startup service with an error instead of letting a
+relative path reach file watchers or recursive ownership operations.
 
 For example, a systemd unit can load a packager-owned file:
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Library, settings, users, OAuth tokens, and KOReader sync state are preserved. S
 - [What's included](#whats-included)
 - [Quick start](#quick-start)
 - [Full Docker Compose setup](#full-docker-compose-setup)
+- [Runtime path overrides for packagers](#runtime-path-overrides-for-packagers)
 - [First run](#first-run)
 - [Migrating](#migrating)
   - [From upstream CWA](#from-upstream-cwa)
@@ -175,6 +176,12 @@ services:
       # limit. Free; sign up at https://comicvine.gamespot.com/api/
       # - COMICVINE_API_KEY=...
 
+      # Optional: override paths inside the container. The matching
+      # volume targets below must use the same paths.
+      # - CWA_INGEST_FOLDER=/cwa-book-ingest
+      # - CWA_CALIBRE_LIBRARY_DIR=/calibre-library
+      # - CWA_TMP_CONVERSION_DIR=/config/.cwa_conversion_tmp
+
     volumes:
       # Settings, user database, logs. Empty folder for new installs;
       # for existing CWA users, point at your existing /config.
@@ -212,6 +219,42 @@ services:
 | `/cwa-book-ingest` | Drop zone for new books | Files here are **deleted** after processing. Don't park books here long-term. |
 
 > Don't nest the binds. All three should be separate top-level folders. Putting `ingest` inside `library` produces recursive ingest behavior.
+
+---
+
+## Runtime path overrides for packagers
+
+Bare-metal and distro packages can configure all three runtime paths from the
+process environment instead of editing `dirs.json` inside the installation:
+
+| Environment variable | `dirs.json` fallback | Compiled-in default |
+|---|---|---|
+| `CWA_INGEST_FOLDER` | `ingest_folder` | `/cwa-book-ingest` |
+| `CWA_CALIBRE_LIBRARY_DIR` | `calibre_library_dir` | `/calibre-library` |
+| `CWA_TMP_CONVERSION_DIR` | `tmp_conversion_dir` | `/config/.cwa_conversion_tmp` |
+
+Each non-blank environment value wins for its key. If it is unset or blank,
+CWNG reads that key from the file selected by `CWA_DIRS_JSON`; a missing,
+invalid, or blank file value falls back to the compiled-in default. Existing
+hand-edited `dirs.json` files therefore remain supported.
+
+For example, a systemd unit can load a packager-owned file:
+
+```ini
+[Service]
+EnvironmentFile=/etc/calibre-web-nextgen/paths.env
+```
+
+```bash
+CWA_INGEST_FOLDER=/srv/calibre-web-nextgen/ingest
+CWA_CALIBRE_LIBRARY_DIR=/srv/calibre/library
+CWA_TMP_CONVERSION_DIR=/var/cache/calibre-web-nextgen/conversion
+```
+
+When `CWA_CALIBRE_LIBRARY_DIR` is set, it is authoritative. Automatic library
+discovery will leave `dirs.json` unchanged; if discovery finds a different
+library, startup stops and reports both paths so the environment file can be
+corrected.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -239,10 +239,12 @@ malformed file, a non-object document, or a null/blank value falls back to the
 compiled-in default. Existing hand-edited `dirs.json` files therefore remain
 supported.
 
-Runtime path values are trimmed and must be absolute paths without a `..`
-component. A non-blank environment or `dirs.json` value that violates that
-contract stops the affected startup service with an error instead of letting a
-relative path reach file watchers or recursive ownership operations.
+Runtime path values are trimmed and lexically normalized, and must be absolute,
+non-root paths without a `..` component. Repeated separators, `.` components,
+and trailing separators are collapsed without resolving symlinks. A non-blank
+environment or `dirs.json` value that violates that contract stops the affected
+startup service instead of letting an unsafe path reach file watchers or
+recursive ownership operations.
 
 For example, a systemd unit can load a packager-owned file:
 

--- a/changelog.d/1611.md
+++ b/changelog.d/1611.md
@@ -1,0 +1,7 @@
+### Added
+
+- **Runtime data paths can be configured without editing the installation.**
+  Packagers can set `CWA_INGEST_FOLDER`, `CWA_CALIBRE_LIBRARY_DIR`, and
+  `CWA_TMP_CONVERSION_DIR` from the process environment while existing
+  `dirs.json` values remain supported as fallbacks. Requested with
+  @chloeroform and @Thovi98 in #1611.

--- a/changelog.d/1611.md
+++ b/changelog.d/1611.md
@@ -4,4 +4,5 @@
   Packagers can set `CWA_INGEST_FOLDER`, `CWA_CALIBRE_LIBRARY_DIR`, and
   `CWA_TMP_CONVERSION_DIR` from the process environment while existing
   `dirs.json` values remain supported as fallbacks. Requested with
-  @chloeroform and @Thovi98 in #1611.
+  @chloeroform and @Thovi98 in #1611. Runtime values are validated as absolute,
+  traversal-free paths before startup services use them.

--- a/changelog.d/1611.md
+++ b/changelog.d/1611.md
@@ -4,5 +4,6 @@
   Packagers can set `CWA_INGEST_FOLDER`, `CWA_CALIBRE_LIBRARY_DIR`, and
   `CWA_TMP_CONVERSION_DIR` from the process environment while existing
   `dirs.json` values remain supported as fallbacks. Requested with
-  @chloeroform and @Thovi98 in #1611. Runtime values are validated as absolute,
-  traversal-free paths before startup services use them.
+  @chloeroform and @Thovi98 in #1611. Runtime values are normalized and
+  validated as non-root, absolute, traversal-free paths before startup services
+  use them.

--- a/cps/constants.py
+++ b/cps/constants.py
@@ -8,6 +8,7 @@
 from importlib import metadata
 import json
 import logging
+import posixpath
 import sys
 import os
 import threading
@@ -67,6 +68,9 @@ def _validated_runtime_dir(value, source):
     """Mirror scripts/app_paths.py's runtime-directory safety contract."""
     configured = value.strip()
     path = Path(configured)
+    normalised = posixpath.normpath(
+        '/' + configured.lstrip('/') if path.is_absolute() else configured
+    )
     if (
         not configured
         or '\x00' in configured
@@ -74,12 +78,13 @@ def _validated_runtime_dir(value, source):
         or '\r' in configured
         or not path.is_absolute()
         or '..' in path.parts
+        or normalised == '/'
     ):
         raise RuntimePathError(
-            f"{source} must be an absolute path without '..' components; "
+            f"{source} must be a non-root absolute path without '..' components; "
             f"got {value!r}"
         )
-    return configured
+    return normalised
 
 
 def _configured_dir(key, env_name, default):

--- a/cps/constants.py
+++ b/cps/constants.py
@@ -6,8 +6,11 @@
 # See CONTRIBUTORS for full list of authors.
 
 from importlib import metadata
+import json
+import logging
 import sys
 import os
+import threading
 from collections import namedtuple
 
 from flask_babel import gettext as _
@@ -44,6 +47,66 @@ SCRIPTS_DIR         = os.path.join(BASE_DIR, 'scripts')
 _dirs_json_override = (os.environ.get('CWA_DIRS_JSON') or '').strip()
 DIRS_JSON           = (os.path.join(BASE_DIR, _dirs_json_override) if _dirs_json_override
                        else os.path.join(BASE_DIR, 'dirs.json'))
+
+DEFAULT_INGEST_FOLDER = '/cwa-book-ingest'
+DEFAULT_LIBRARY_DIR = '/calibre-library'
+DEFAULT_TMP_CONVERSION_DIR = '/config/.cwa_conversion_tmp'
+
+_DIRS_JSON_LOGGED_KEYS = set()
+_DIRS_JSON_LOG_LOCK = threading.Lock()
+_dirs_logger = logging.getLogger(__name__)
+_dirs_environ = os.environ
+
+
+def _configured_dir(key, env_name, default):
+    """Resolve one runtime directory through environment, file, then default."""
+    override = _dirs_environ.get(env_name)
+    if override is not None and override.strip():
+        return override.strip()
+
+    try:
+        with open(DIRS_JSON, 'r', encoding='utf-8') as config_file:
+            configured_dirs = json.load(config_file)
+    except (OSError, ValueError, TypeError):
+        configured_dirs = {}
+
+    configured = configured_dirs.get(key) if isinstance(configured_dirs, dict) else None
+    if isinstance(configured, str) and configured.strip():
+        configured = configured.strip()
+        with _DIRS_JSON_LOG_LOCK:
+            if key not in _DIRS_JSON_LOGGED_KEYS:
+                _DIRS_JSON_LOGGED_KEYS.add(key)
+                _dirs_logger.info(
+                    "Using dirs.json fallback %s=%s from %s",
+                    key,
+                    configured,
+                    DIRS_JSON,
+                )
+        return configured
+    return default
+
+
+def ingest_folder():
+    """Configured ingest directory, without adding a trailing separator."""
+    return _configured_dir(
+        'ingest_folder', 'CWA_INGEST_FOLDER', DEFAULT_INGEST_FOLDER
+    )
+
+
+def calibre_library_dir():
+    """Configured Calibre library directory, without a trailing separator."""
+    return _configured_dir(
+        'calibre_library_dir', 'CWA_CALIBRE_LIBRARY_DIR', DEFAULT_LIBRARY_DIR
+    )
+
+
+def tmp_conversion_dir():
+    """Configured conversion scratch directory, without a trailing separator."""
+    return _configured_dir(
+        'tmp_conversion_dir',
+        'CWA_TMP_CONVERSION_DIR',
+        DEFAULT_TMP_CONVERSION_DIR,
+    )
 
 # Cache dir - use CACHE_DIR environment variable, otherwise use the default directory: cps/cache
 DEFAULT_CACHE_DIR   = os.path.join(BASE_DIR, 'cps', 'cache')

--- a/cps/constants.py
+++ b/cps/constants.py
@@ -12,6 +12,7 @@ import sys
 import os
 import threading
 from collections import namedtuple
+from pathlib import Path
 
 from flask_babel import gettext as _
 
@@ -58,11 +59,34 @@ _dirs_logger = logging.getLogger(__name__)
 _dirs_environ = os.environ
 
 
+class RuntimePathError(ValueError):
+    """A configured runtime directory is unsafe or cannot name one path."""
+
+
+def _validated_runtime_dir(value, source):
+    """Mirror scripts/app_paths.py's runtime-directory safety contract."""
+    configured = value.strip()
+    path = Path(configured)
+    if (
+        not configured
+        or '\x00' in configured
+        or '\n' in configured
+        or '\r' in configured
+        or not path.is_absolute()
+        or '..' in path.parts
+    ):
+        raise RuntimePathError(
+            f"{source} must be an absolute path without '..' components; "
+            f"got {value!r}"
+        )
+    return configured
+
+
 def _configured_dir(key, env_name, default):
     """Resolve one runtime directory through environment, file, then default."""
     override = _dirs_environ.get(env_name)
     if override is not None and override.strip():
-        return override.strip()
+        return _validated_runtime_dir(override, env_name)
 
     try:
         with open(DIRS_JSON, 'r', encoding='utf-8') as config_file:
@@ -72,7 +96,9 @@ def _configured_dir(key, env_name, default):
 
     configured = configured_dirs.get(key) if isinstance(configured_dirs, dict) else None
     if isinstance(configured, str) and configured.strip():
-        configured = configured.strip()
+        configured = _validated_runtime_dir(
+            configured, f"{key} in {DIRS_JSON}"
+        )
         with _DIRS_JSON_LOG_LOCK:
             if key not in _DIRS_JSON_LOGGED_KEYS:
                 _DIRS_JSON_LOGGED_KEYS.add(key)
@@ -83,7 +109,7 @@ def _configured_dir(key, env_name, default):
                     DIRS_JSON,
                 )
         return configured
-    return default
+    return _validated_runtime_dir(default, f"compiled-in default for {key}")
 
 
 def ingest_folder():

--- a/cps/cwa_functions.py
+++ b/cps/cwa_functions.py
@@ -8,7 +8,7 @@ from flask import Blueprint, redirect, flash, url_for, request, send_from_direct
 from flask_babel import gettext as _, lazy_gettext as _l
 
 from . import logger, config, constants, csrf, helper, ub, calibre_db
-from .constants import DIRS_JSON, LOG_ARCHIVE
+from .constants import LOG_ARCHIVE
 from .metadata_constants import DEFAULT_METADATA_PROVIDER_HIERARCHY_JSON
 from .usermanagement import login_required_if_no_ano, user_login_required
 from .admin import admin_required
@@ -214,9 +214,7 @@ def cwa_switch_theme():
 ##————————————————————————————————————————————————————————————————————————————##
 
 def get_ingest_dir():
-    with open(DIRS_JSON, 'r') as f:
-        dirs = json.load(f)
-        return dirs['ingest_folder']
+    return constants.ingest_folder()
 
 def get_ingest_status():
     """Read the current ingest service status"""
@@ -1958,12 +1956,7 @@ def convert_library_start(queue):
     queue.put(cl_process)
 
 def get_tmp_conversion_dir() -> str:
-    dirs = {}
-    with open(DIRS_JSON, 'r') as f:
-        dirs: dict[str, str] = json.load(f)
-    tmp_conversion_dir = f"{dirs['tmp_conversion_dir']}/"
-
-    return tmp_conversion_dir
+    return f"{constants.tmp_conversion_dir()}/"
 
 def empty_tmp_con_dir(tmp_conversion_dir) -> None:
     try:

--- a/cps/web.py
+++ b/cps/web.py
@@ -32,7 +32,6 @@ from werkzeug.datastructures import Headers
 from werkzeug.security import generate_password_hash, check_password_hash
 
 from . import constants, logger, isoLanguages, services, helper, spa, oauth_auto_redirect
-from .constants import DIRS_JSON
 from . import db, ub, config, app
 from . import calibre_db, kobo_sync_status
 from .services.ereader_send import send_includes_own_address
@@ -576,11 +575,7 @@ def get_sort_function(sort_param, data):
 
 
 def cwa_get_library_location() -> str:
-    dirs = {}
-    with open(DIRS_JSON, 'r') as f:
-        dirs: dict[str, str] = json.load(f)
-    library_dir = dirs['calibre_library_dir']
-    return library_dir
+    return constants.calibre_library_dir()
 
 def cwa_get_num_books_in_library() -> int:
     try:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,11 @@ services:
       # Skip the automatic library detection/mount at startup. When enabled, the auto-library service will not run.
       # Accepts: true/yes/1 to disable auto-mount (default: false)
       # - DISABLE_LIBRARY_AUTOMOUNT=false
+      # Optional: override the paths used inside the container. If changed,
+      # update the matching volume targets below to the same paths.
+      # - CWA_INGEST_FOLDER=/cwa-book-ingest
+      # - CWA_CALIBRE_LIBRARY_DIR=/calibre-library
+      # - CWA_TMP_CONVERSION_DIR=/config/.cwa_conversion_tmp
     volumes:
       # CW users migrating should stop their existing CW instance, make a copy of the config folder, and bind that here to carry over all of their user settings etc.
       - /path/to/config/folder:/config

--- a/root/etc/s6-overlay/s6-rc.d/cwa-auto-library/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-auto-library/run
@@ -16,3 +16,5 @@ if [[ ${exit_code} -eq 0 ]]; then
 else
     echo "[cwa-auto-library] Service did not complete successfully (exit code: ${exit_code}). Ending service..."
 fi
+
+exit "${exit_code}"

--- a/root/etc/s6-overlay/s6-rc.d/cwa-checksum-backfill/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-checksum-backfill/run
@@ -11,7 +11,19 @@
 echo "[cwa-checksum-backfill] Waiting for CWA service to be ready..."
 
 CWA_APP_PATHS="${CWA_APP_PATHS:-/app/calibre-web-automated/scripts/app_paths.py}"
-library_path="$(python3 "${CWA_APP_PATHS}" calibre_library_dir)"
+if ! library_path="$(python3 "${CWA_APP_PATHS}" calibre_library_dir)"; then
+  echo "[cwa-checksum-backfill] ERROR: runtime library path resolver failed; refusing to inspect an unknown database"
+  exit 1
+fi
+case "$library_path" in
+  ""|*$'\n'*|*$'\r'*|*/../*|*/..)
+    echo "[cwa-checksum-backfill] ERROR: runtime library path resolver returned an unsafe path; refusing to continue"
+    exit 1 ;;
+  /*) ;;
+  *)
+    echo "[cwa-checksum-backfill] ERROR: runtime library path resolver returned a non-absolute path; refusing to continue"
+    exit 1 ;;
+esac
 metadata_db="${library_path%/}/metadata.db"
 metadata_uri="$(python3 - "$metadata_db" <<'PY'
 import sys

--- a/root/etc/s6-overlay/s6-rc.d/cwa-checksum-backfill/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-checksum-backfill/run
@@ -10,19 +10,8 @@
 
 echo "[cwa-checksum-backfill] Waiting for CWA service to be ready..."
 
-dirs_json="${CWA_DIRS_JSON:-/app/calibre-web-automated/dirs.json}"
-library_path="$(python3 - "$dirs_json" <<'PY'
-import json
-import sys
-
-try:
-    with open(sys.argv[1], "r", encoding="utf-8") as config_file:
-        configured = json.load(config_file).get("calibre_library_dir")
-    print(configured if isinstance(configured, str) and configured.strip() else "/calibre-library")
-except (OSError, ValueError, TypeError):
-    print("/calibre-library")
-PY
-)"
+CWA_APP_PATHS="${CWA_APP_PATHS:-/app/calibre-web-automated/scripts/app_paths.py}"
+library_path="$(python3 "${CWA_APP_PATHS}" calibre_library_dir)"
 metadata_db="${library_path%/}/metadata.db"
 metadata_uri="$(python3 - "$metadata_db" <<'PY'
 import sys

--- a/root/etc/s6-overlay/s6-rc.d/cwa-checksum-backfill/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-checksum-backfill/run
@@ -16,7 +16,7 @@ if ! library_path="$(python3 "${CWA_APP_PATHS}" calibre_library_dir)"; then
   exit 1
 fi
 case "$library_path" in
-  ""|*$'\n'*|*$'\r'*|*/../*|*/..)
+  ""|"/"|*$'\n'*|*$'\r'*|*/../*|*/..)
     echo "[cwa-checksum-backfill] ERROR: runtime library path resolver returned an unsafe path; refusing to continue"
     exit 1 ;;
   /*) ;;

--- a/root/etc/s6-overlay/s6-rc.d/cwa-ingest-service/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-ingest-service/run
@@ -2,7 +2,10 @@
 
 echo "========== STARTING CWA-INGEST SERVICE =========="
 
-WATCH_FOLDER=${WATCH_FOLDER:-$(grep -o '"ingest_folder": "[^"]*' /app/calibre-web-automated/dirs.json | grep -o '[^"]*$')}
+# CWA_INGEST_FOLDER is the public path override. WATCH_FOLDER remains a
+# backwards-compatible service-local fallback when the public knob is unset.
+CWA_APP_PATHS="${CWA_APP_PATHS:-/app/calibre-web-automated/scripts/app_paths.py}"
+WATCH_FOLDER=${CWA_INGEST_FOLDER:-${WATCH_FOLDER:-$(python3 "${CWA_APP_PATHS}" ingest_folder)}}
 echo "[cwa-ingest-service] Watching folder: $WATCH_FOLDER"
 
 # Create queue file for retry processing (persistent across restarts)

--- a/root/etc/s6-overlay/s6-rc.d/cwa-ingest-service/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-ingest-service/run
@@ -3,9 +3,25 @@
 echo "========== STARTING CWA-INGEST SERVICE =========="
 
 # CWA_INGEST_FOLDER is the public path override. WATCH_FOLDER remains a
-# backwards-compatible service-local fallback when the public knob is unset.
+# backwards-compatible service-local override only when the public knob is
+# genuinely unset; unlike a command substitution it cannot hide a resolver
+# failure because the resolver is still mandatory on the normal path.
 CWA_APP_PATHS="${CWA_APP_PATHS:-/app/calibre-web-automated/scripts/app_paths.py}"
-WATCH_FOLDER=${CWA_INGEST_FOLDER:-${WATCH_FOLDER:-$(python3 "${CWA_APP_PATHS}" ingest_folder)}}
+if [ "${CWA_INGEST_FOLDER+x}" = "x" ] || [ -z "${WATCH_FOLDER:-}" ]; then
+        if ! WATCH_FOLDER="$(python3 "${CWA_APP_PATHS}" ingest_folder)"; then
+                echo "[cwa-ingest-service] ERROR: runtime ingest path resolver failed; refusing to start a watcher"
+                exit 1
+        fi
+fi
+case "$WATCH_FOLDER" in
+        ""|*$'\n'*|*$'\r'*|*/../*|*/..)
+                echo "[cwa-ingest-service] ERROR: runtime ingest path resolver returned an unsafe path; refusing to start a watcher"
+                exit 1 ;;
+        /*) ;;
+        *)
+                echo "[cwa-ingest-service] ERROR: runtime ingest path resolver returned a non-absolute path; refusing to start a watcher"
+                exit 1 ;;
+esac
 echo "[cwa-ingest-service] Watching folder: $WATCH_FOLDER"
 
 # Create queue file for retry processing (persistent across restarts)

--- a/root/etc/s6-overlay/s6-rc.d/cwa-ingest-service/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-ingest-service/run
@@ -14,7 +14,7 @@ if [ "${CWA_INGEST_FOLDER+x}" = "x" ] || [ -z "${WATCH_FOLDER:-}" ]; then
         fi
 fi
 case "$WATCH_FOLDER" in
-        ""|*$'\n'*|*$'\r'*|*/../*|*/..)
+        ""|"/"|*$'\n'*|*$'\r'*|*/../*|*/..)
                 echo "[cwa-ingest-service] ERROR: runtime ingest path resolver returned an unsafe path; refusing to start a watcher"
                 exit 1 ;;
         /*) ;;

--- a/root/etc/s6-overlay/s6-rc.d/cwa-init/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-init/run
@@ -171,20 +171,28 @@ fi
 # Ensure the resolved ingest directory exists and is writable. app_paths keeps
 # the environment -> dirs.json -> default precedence identical to Python.
 CWA_APP_PATHS="${CWA_APP_PATHS:-/app/calibre-web-automated/scripts/app_paths.py}"
-INGEST_DIR=$(python3 "${CWA_APP_PATHS}" ingest_folder)
-if [ -n "$INGEST_DIR" ]; then
-  # Create directory if missing
-  mkdir -p "$INGEST_DIR" 2>/dev/null || true
-  # Set ownership unless network share mode (only skip for /cwa-book-ingest)
-  if [ "${NETWORK_SHARE_MODE,,}" = "true" ] || [ "${NETWORK_SHARE_MODE}" = "1" ] || [ "${NETWORK_SHARE_MODE,,}" = "yes" ] || [ "${NETWORK_SHARE_MODE,,}" = "on" ]; then
-    if [ "$INGEST_DIR" = "/cwa-book-ingest" ]; then
-      echo "[cwa-init] NETWORK_SHARE_MODE=true detected; skipping chown of $INGEST_DIR"
-    else
-      chown -R abc:abc "$INGEST_DIR" 2>/dev/null || true
-    fi
-  else
-    chown -R abc:abc "$INGEST_DIR" 2>/dev/null || true
-  fi
+if ! INGEST_DIR="$(python3 "${CWA_APP_PATHS}" ingest_folder)"; then
+  echo "[cwa-init] ERROR: runtime ingest path resolver failed; refusing to prepare an unknown path"
+  exit 1
+fi
+case "$INGEST_DIR" in
+  ""|*$'\n'*|*$'\r'*|*/../*|*/..)
+    echo "[cwa-init] ERROR: runtime ingest path resolver returned an unsafe path; refusing to continue"
+    exit 1 ;;
+  /*) ;;
+  *)
+    echo "[cwa-init] ERROR: runtime ingest path resolver returned a non-absolute path; refusing to continue"
+    exit 1 ;;
+esac
+
+# Create directory if missing
+mkdir -p "$INGEST_DIR" 2>/dev/null || true
+# A network share is exempt regardless of which supported configuration layer
+# supplied its mount point.
+if [ "${NETWORK_SHARE_MODE,,}" = "true" ] || [ "${NETWORK_SHARE_MODE}" = "1" ] || [ "${NETWORK_SHARE_MODE,,}" = "yes" ] || [ "${NETWORK_SHARE_MODE,,}" = "on" ]; then
+  echo "[cwa-init] NETWORK_SHARE_MODE=true detected; skipping chown of $INGEST_DIR"
+else
+  chown -R abc:abc "$INGEST_DIR" 2>/dev/null || true
 fi
 
 # For Calibre Plugins

--- a/root/etc/s6-overlay/s6-rc.d/cwa-init/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-init/run
@@ -176,7 +176,7 @@ if ! INGEST_DIR="$(python3 "${CWA_APP_PATHS}" ingest_folder)"; then
   exit 1
 fi
 case "$INGEST_DIR" in
-  ""|*$'\n'*|*$'\r'*|*/../*|*/..)
+  ""|"/"|*$'\n'*|*$'\r'*|*/../*|*/..)
     echo "[cwa-init] ERROR: runtime ingest path resolver returned an unsafe path; refusing to continue"
     exit 1 ;;
   /*) ;;

--- a/root/etc/s6-overlay/s6-rc.d/cwa-init/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-init/run
@@ -168,16 +168,10 @@ if [ "$(realpath -m -- "${CWA_LEGACY_TEMP_DIR}" 2>/dev/null || echo "${CWA_LEGAC
   rm -rf "${CWA_LEGACY_TEMP_DIR}" 2>/dev/null || true
 fi
 
-# Ensure ingest directory exists and is writable (matches dirs.json)
-INGEST_DIR=$(python3 - <<'PY'
-import json
-try:
-    with open('/app/calibre-web-automated/dirs.json', 'r', encoding='utf-8') as f:
-        print(json.load(f).get('ingest_folder', '').strip())
-except Exception:
-    print('')
-PY
-)
+# Ensure the resolved ingest directory exists and is writable. app_paths keeps
+# the environment -> dirs.json -> default precedence identical to Python.
+CWA_APP_PATHS="${CWA_APP_PATHS:-/app/calibre-web-automated/scripts/app_paths.py}"
+INGEST_DIR=$(python3 "${CWA_APP_PATHS}" ingest_folder)
 if [ -n "$INGEST_DIR" ]; then
   # Create directory if missing
   mkdir -p "$INGEST_DIR" 2>/dev/null || true

--- a/scripts/app_paths.py
+++ b/scripts/app_paths.py
@@ -56,6 +56,12 @@ launch environment already had (it picks the interpreter and the code), but do
 not plumb any of these through from a request, a config page, or anything a
 library user can influence.
 
+The three runtime directories are nevertheless validated before use because
+container startup passes them to recursive ownership operations. They must be
+absolute, single-line paths without a ``..`` component; an invalid non-blank
+configuration fails loudly instead of being interpreted relative to a service's
+working directory.
+
 The ``/config`` default is kept exactly as scripts/ already had it. The
 container sets ``CALIBRE_DBPATH=/config`` as a Docker ``ENV`` (the #1162 fix),
 so that default never fires there — and de-hardcoding the *app* root must not
@@ -84,6 +90,7 @@ __all__ = [
     "DEFAULT_INGEST_FOLDER",
     "DEFAULT_LIBRARY_DIR",
     "DEFAULT_TMP_CONVERSION_DIR",
+    "RuntimePathError",
 ]
 
 #: Where the *container* keeps the writable state. The Dockerfile sets
@@ -105,6 +112,36 @@ DEFAULT_TMP_CONVERSION_DIR = "/config/.cwa_conversion_tmp"
 
 _DIRS_JSON_LOGGED_KEYS = set()
 _DIRS_JSON_LOG_LOCK = threading.Lock()
+
+
+class RuntimePathError(ValueError):
+    """A configured runtime directory is unsafe or cannot name one path."""
+
+
+def _validated_runtime_dir(value, source):
+    """Return a trimmed absolute directory or reject the launch configuration.
+
+    These values eventually reach recursive ownership operations during
+    container startup.  In particular, resolving ``..`` relative to
+    ``/config`` can turn that operation into a walk of ``/``.  Keep the text
+    shape (including a caller-supplied trailing slash), but require one
+    absolute, single-line path with no parent traversal component.
+    """
+    configured = value.strip()
+    path = Path(configured)
+    if (
+        not configured
+        or "\x00" in configured
+        or "\n" in configured
+        or "\r" in configured
+        or not path.is_absolute()
+        or ".." in path.parts
+    ):
+        raise RuntimePathError(
+            f"{source} must be an absolute path without '..' components; "
+            f"got {value!r}"
+        )
+    return configured
 
 
 def _env_path(name):
@@ -271,7 +308,7 @@ def _configured_dir(key, env_name, default, dirs_json_path=None):
     """Resolve one runtime directory through environment, file, then default."""
     override = os.environ.get(env_name)
     if override is not None and override.strip():
-        return override.strip()
+        return _validated_runtime_dir(override, env_name)
 
     config_path = Path(dirs_json_path) if dirs_json_path else dirs_json()
     try:
@@ -282,7 +319,9 @@ def _configured_dir(key, env_name, default, dirs_json_path=None):
 
     configured = configured_dirs.get(key) if isinstance(configured_dirs, dict) else None
     if isinstance(configured, str) and configured.strip():
-        configured = configured.strip()
+        configured = _validated_runtime_dir(
+            configured, f"{key} in {config_path}"
+        )
         with _DIRS_JSON_LOG_LOCK:
             if key not in _DIRS_JSON_LOGGED_KEYS:
                 _DIRS_JSON_LOGGED_KEYS.add(key)
@@ -292,7 +331,7 @@ def _configured_dir(key, env_name, default, dirs_json_path=None):
                     file=sys.stderr,
                 )
         return configured
-    return default
+    return _validated_runtime_dir(default, f"compiled-in default for {key}")
 
 
 def ingest_folder(dirs_json_path=None):
@@ -340,11 +379,19 @@ def _main(argv=None):
             file=sys.stderr,
         )
         return 2
-    if args[0] == "all":
-        for resolver in commands.values():
-            print(resolver())
-    else:
-        print(commands[args[0]]())
+    try:
+        if args[0] == "all":
+            # Resolve every value before printing any of them. Shell callers
+            # consume this as a three-line transaction and must never receive
+            # a valid-looking prefix followed by a failure.
+            resolved = [resolver() for resolver in commands.values()]
+            for value in resolved:
+                print(value)
+        else:
+            print(commands[args[0]]())
+    except RuntimePathError as error:
+        print(f"[cwa-paths] ERROR: {error}", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/scripts/app_paths.py
+++ b/scripts/app_paths.py
@@ -70,6 +70,7 @@ quietly relocate anybody's *databases*.
 
 import json
 import os
+import posixpath
 import sys
 import threading
 from pathlib import Path
@@ -119,16 +120,20 @@ class RuntimePathError(ValueError):
 
 
 def _validated_runtime_dir(value, source):
-    """Return a trimmed absolute directory or reject the launch configuration.
+    """Return a lexical absolute directory or reject launch configuration.
 
     These values eventually reach recursive ownership operations during
-    container startup.  In particular, resolving ``..`` relative to
-    ``/config`` can turn that operation into a walk of ``/``.  Keep the text
-    shape (including a caller-supplied trailing slash), but require one
-    absolute, single-line path with no parent traversal component.
+    container startup. Resolving ``..`` relative to ``/config`` or accepting a
+    root-equivalent spelling can turn that operation into a walk of ``/``.
+    Normalise repeated separators, ``.`` components, and trailing separators
+    without resolving symlinks, then require one non-root absolute, single-line
+    path with no parent traversal component.
     """
     configured = value.strip()
     path = Path(configured)
+    normalised = posixpath.normpath(
+        "/" + configured.lstrip("/") if path.is_absolute() else configured
+    )
     if (
         not configured
         or "\x00" in configured
@@ -136,12 +141,13 @@ def _validated_runtime_dir(value, source):
         or "\r" in configured
         or not path.is_absolute()
         or ".." in path.parts
+        or normalised == "/"
     ):
         raise RuntimePathError(
-            f"{source} must be an absolute path without '..' components; "
+            f"{source} must be a non-root absolute path without '..' components; "
             f"got {value!r}"
         )
-    return configured
+    return normalised
 
 
 def _env_path(name):

--- a/scripts/app_paths.py
+++ b/scripts/app_paths.py
@@ -25,20 +25,27 @@ What                 Environment override                  Default
 app root             ``CWA_APP_ROOT``                       parent of this file's dir
 config dir           ``CALIBRE_DBPATH``                     same as ``cps`` (app root)
 ``dirs.json``        ``CWA_DIRS_JSON``                      ``<app root>/dirs.json``
+ingest folder        ``CWA_INGEST_FOLDER``                  ``/cwa-book-ingest``
+library directory    ``CWA_CALIBRE_LIBRARY_DIR``            ``/calibre-library``
+conversion temp      ``CWA_TMP_CONVERSION_DIR``             ``/config/.cwa_conversion_tmp``
 ``app.db``           ``CWA_APP_DB_PATH``, ``CALIBRE_DBPATH`` ``<config dir>/app.db``
 ===================  ====================================  =========================
 
+The three runtime directories use their matching key in ``dirs.json`` between
+the environment override and the compiled-in default.
+
 Every default here has to match what ``cps`` resolves to, because the two
 halves of the install read and write the same files. Where they disagree, the
-disagreement is invisible in Docker — the image sets the environment variables
-explicitly — and silent everywhere else: scripts seed a database the app never
-opens. Both known cases were fixed together in the #1462 follow-up.
+disagreement is easy to miss in Docker — the image supplies its layout through
+environment values and the shipped ``dirs.json`` — and silent everywhere else:
+scripts seed a database the app never opens. Both known cases were fixed
+together in the #1462 follow-up.
 
 Deliberately dependency-free and free of any ``cps`` import: ``auto_library.py``
 runs before the Flask stack is usable, and ``cover_enforcer.py`` has to survive
 an environment where importing ``cps`` fails outright.
 
-**These four variables are trusted configuration, not user input.** They are read
+**These launch variables are trusted configuration, not user input.** They are read
 from the launch environment — the Dockerfile, the s6 service definitions, or a
 packager's systemd unit — and they were already trusted that way before this
 module existed. Centralising them does widen what one of them reaches:
@@ -55,8 +62,10 @@ so that default never fires there — and de-hardcoding the *app* root must not
 quietly relocate anybody's *databases*.
 """
 
+import json
 import os
 import sys
+import threading
 from pathlib import Path
 
 __all__ = [
@@ -64,12 +73,17 @@ __all__ = [
     "config_dir",
     "stray_legacy_config_dir",
     "dirs_json",
+    "ingest_folder",
+    "calibre_library_dir",
+    "tmp_conversion_dir",
     "app_db_path",
     "scripts_dir",
     "script_path",
     "ensure_app_root_on_sys_path",
     "DEFAULT_CONFIG_DIR",
+    "DEFAULT_INGEST_FOLDER",
     "DEFAULT_LIBRARY_DIR",
+    "DEFAULT_TMP_CONVERSION_DIR",
 ]
 
 #: Where the *container* keeps the writable state. The Dockerfile sets
@@ -79,8 +93,18 @@ __all__ = [
 #: puts config here" is worth being able to reference.
 DEFAULT_CONFIG_DIR = "/config"
 
+#: Container ingest mount, used when neither the environment nor dirs.json
+#: supplies a usable path.
+DEFAULT_INGEST_FOLDER = "/cwa-book-ingest"
+
 #: Legacy library root, used as a last resort by :mod:`library_paths`.
 DEFAULT_LIBRARY_DIR = "/calibre-library"
+
+#: Container conversion scratch directory, used as the final fallback.
+DEFAULT_TMP_CONVERSION_DIR = "/config/.cwa_conversion_tmp"
+
+_DIRS_JSON_LOGGED_KEYS = set()
+_DIRS_JSON_LOG_LOCK = threading.Lock()
 
 
 def _env_path(name):
@@ -243,6 +267,87 @@ def dirs_json():
     return app_root() / "dirs.json"
 
 
+def _configured_dir(key, env_name, default, dirs_json_path=None):
+    """Resolve one runtime directory through environment, file, then default."""
+    override = os.environ.get(env_name)
+    if override is not None and override.strip():
+        return override.strip()
+
+    config_path = Path(dirs_json_path) if dirs_json_path else dirs_json()
+    try:
+        with config_path.open("r", encoding="utf-8") as config_file:
+            configured_dirs = json.load(config_file)
+    except (OSError, ValueError, TypeError):
+        configured_dirs = {}
+
+    configured = configured_dirs.get(key) if isinstance(configured_dirs, dict) else None
+    if isinstance(configured, str) and configured.strip():
+        configured = configured.strip()
+        with _DIRS_JSON_LOG_LOCK:
+            if key not in _DIRS_JSON_LOGGED_KEYS:
+                _DIRS_JSON_LOGGED_KEYS.add(key)
+                print(
+                    f"[cwa-paths] Using dirs.json fallback {key}={configured} "
+                    f"from {config_path}",
+                    file=sys.stderr,
+                )
+        return configured
+    return default
+
+
+def ingest_folder(dirs_json_path=None):
+    """Configured ingest directory, without adding a trailing separator."""
+    return _configured_dir(
+        "ingest_folder",
+        "CWA_INGEST_FOLDER",
+        DEFAULT_INGEST_FOLDER,
+        dirs_json_path,
+    )
+
+
+def calibre_library_dir(dirs_json_path=None):
+    """Configured Calibre library directory, without a trailing separator."""
+    return _configured_dir(
+        "calibre_library_dir",
+        "CWA_CALIBRE_LIBRARY_DIR",
+        DEFAULT_LIBRARY_DIR,
+        dirs_json_path,
+    )
+
+
+def tmp_conversion_dir(dirs_json_path=None):
+    """Configured conversion scratch directory, without a trailing separator."""
+    return _configured_dir(
+        "tmp_conversion_dir",
+        "CWA_TMP_CONVERSION_DIR",
+        DEFAULT_TMP_CONVERSION_DIR,
+        dirs_json_path,
+    )
+
+
+def _main(argv=None):
+    """Expose the same resolver to shell-based s6 consumers."""
+    args = sys.argv[1:] if argv is None else argv
+    commands = {
+        "ingest_folder": ingest_folder,
+        "calibre_library_dir": calibre_library_dir,
+        "tmp_conversion_dir": tmp_conversion_dir,
+    }
+    if len(args) != 1 or args[0] not in {*commands, "all"}:
+        print(
+            "usage: app_paths.py "
+            "{ingest_folder|calibre_library_dir|tmp_conversion_dir|all}",
+            file=sys.stderr,
+        )
+        return 2
+    if args[0] == "all":
+        for resolver in commands.values():
+            print(resolver())
+    else:
+        print(commands[args[0]]())
+    return 0
+
+
 def ensure_app_root_on_sys_path():
     """Put the app root on ``sys.path`` so ``import cps...`` works.
 
@@ -253,3 +358,7 @@ def ensure_app_root_on_sys_path():
     if root not in sys.path:
         sys.path.insert(0, root)
     return root
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/scripts/auto_library.py
+++ b/scripts/auto_library.py
@@ -367,7 +367,7 @@ class AutoLibrary:
         else:
             return False
 
-    # Sets the library's location in both dirs.json and the CW db
+    # Persists the selected library without contradicting an environment override.
     def set_library_location(self):
         if self.metadb_path is not None and os.path.exists(self.metadb_path):
             self.update_dirs_json()
@@ -397,7 +397,26 @@ class AutoLibrary:
 
     # Update the dirs.json file with the new library location (lib_path))
     def update_dirs_json(self):
-        """Updates the location of the calibre library stored in dirs.json with the found library"""
+        """Update dirs.json unless the environment is the authoritative source."""
+        environment_library = os.environ.get("CWA_CALIBRE_LIBRARY_DIR", "").strip()
+        if environment_library:
+            if os.path.normpath(environment_library) != os.path.normpath(self.lib_path):
+                print(
+                    "[cwa-auto-library]: ERROR: discovered library "
+                    f"'{self.lib_path}' conflicts with authoritative "
+                    f"CWA_CALIBRE_LIBRARY_DIR='{environment_library}'."
+                )
+                print(
+                    "[cwa-auto-library]: dirs.json and app.db were left unchanged. "
+                    "Set CWA_CALIBRE_LIBRARY_DIR to the directory containing the "
+                    "selected metadata.db, then restart."
+                )
+                sys.exit(1)
+            print(
+                "[cwa-auto-library] CWA_CALIBRE_LIBRARY_DIR is authoritative; "
+                "leaving dirs.json unchanged."
+            )
+            return
         try:
             print("[cwa-auto-library] Updating dirs.json with new library location...")
             with open(self.dirs_path) as f:
@@ -414,10 +433,19 @@ class AutoLibrary:
     # Uses the empty metadata.db shipped in the app root to create a new library
     def make_new_library(self):
         print("[cwa-auto-library]: No existing library found. Creating new library...")
+        if os.environ.get("CWA_CALIBRE_LIBRARY_DIR", "").strip():
+            location_help = (
+                "Set CWA_CALIBRE_LIBRARY_DIR to a directory this user can write to."
+            )
+        else:
+            location_help = (
+                f"Set 'calibre_library_dir' in {self.dirs_path} to a directory "
+                "this user can write to."
+            )
         self.ensure_dir_exists(
             self.library_dir,
             "library directory",
-            f"Set 'calibre_library_dir' in {self.dirs_path} to a directory this user can write to.",
+            location_help,
         )
         self.metadb_path = os.path.join(self.library_dir, "metadata.db")
         create_metadb(self.metadb_path)

--- a/scripts/convert_library.py
+++ b/scripts/convert_library.py
@@ -168,13 +168,9 @@ class LibraryConverter:
 
 
     def get_dirs(self, dirs_json_path: str) -> tuple[str, str, str]:
-        dirs = {}
-        with open(dirs_json_path, 'r') as f:
-            dirs: dict[str, str] = json.load(f)
-
-        ingest_folder = f"{dirs['ingest_folder']}/"
-        library_dir = f"{dirs['calibre_library_dir']}/"
-        tmp_conversion_dir = f"{dirs['tmp_conversion_dir']}/"
+        ingest_folder = f"{app_paths.ingest_folder(dirs_json_path)}/"
+        library_dir = f"{app_paths.calibre_library_dir(dirs_json_path)}/"
+        tmp_conversion_dir = f"{app_paths.tmp_conversion_dir(dirs_json_path)}/"
 
         return ingest_folder, library_dir, tmp_conversion_dir
 

--- a/scripts/cover_enforcer.py
+++ b/scripts/cover_enforcer.py
@@ -300,9 +300,7 @@ class Book:
 
     def get_calibre_library(self) -> str:
         """Gets Calibre-Library location from dirs.json"""
-        with open(dirs_json, 'r') as f:
-            dirs = json.load(f)
-        return dirs['calibre_library_dir'] # Returns without / on the end
+        return app_paths.calibre_library_dir(dirs_json) # Returns without / on the end
 
 
     def get_time(self) -> str:
@@ -471,9 +469,7 @@ class Enforcer:
 
 
     def get_calibre_library(self) -> str:
-        with open(dirs_json, 'r') as f:
-            dirs = json.load(f)
-        return dirs['calibre_library_dir'] # Returns without / on the end
+        return app_paths.calibre_library_dir(dirs_json) # Returns without / on the end
 
 
     def _restat_format_size_after_modification(self, book_id: str, file_format: str, file_path: str) -> None:

--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -1347,13 +1347,9 @@ class NewBookProcessor:
 
 
     def get_dirs(self, dirs_json_path: str) -> tuple[str, str, str]:
-        dirs = {}
-        with open(dirs_json_path, 'r') as f:
-            dirs: dict[str, str] = json.load(f)
-
-        ingest_folder = f"{dirs['ingest_folder']}/"
-        library_dir = f"{dirs['calibre_library_dir']}/"
-        tmp_conversion_dir = f"{dirs['tmp_conversion_dir']}/"
+        ingest_folder = f"{app_paths.ingest_folder(dirs_json_path)}/"
+        library_dir = f"{app_paths.calibre_library_dir(dirs_json_path)}/"
+        tmp_conversion_dir = f"{app_paths.tmp_conversion_dir(dirs_json_path)}/"
 
         return ingest_folder, library_dir, tmp_conversion_dir
 

--- a/scripts/kindle_epub_fixer.py
+++ b/scripts/kindle_epub_fixer.py
@@ -1243,16 +1243,11 @@ def get_library_location() -> str:
         con.close()
         return split_path
     else:
-        dirs = {}
         # The module-level `dirs_json`, not a fresh app_paths lookup: it is the
         # same value, and it is the seam the rest of this module (and its tests)
-        # already resolve through. Before #1462 this line hardcoded a path that
-        # does not exist outside the container, so it raised and the caller's
-        # `except` branch quietly did the right thing via that global.
-        with open(dirs_json, 'r') as f:
-            dirs: dict[str, str] = json.load(f)
-        library_dir = f"{dirs['calibre_library_dir']}/"
-        return library_dir
+        # already resolve through. app_paths adds the per-key environment and
+        # safe default layers while preserving this function's trailing slash.
+        return f"{app_paths.calibre_library_dir(dirs_json)}/"
 
 # Calibre's own bookkeeping directories inside the library root. Matched by
 # exact name so that a book whose author or title legitimately begins with a

--- a/scripts/library_paths.py
+++ b/scripts/library_paths.py
@@ -1,6 +1,5 @@
 """Resolve the active Calibre library without creating database files."""
 
-import json
 import os
 import sqlite3
 from pathlib import Path
@@ -14,15 +13,7 @@ DEFAULT_LIBRARY_DIR = app_paths.DEFAULT_LIBRARY_DIR
 
 def get_calibre_library_dir(dirs_json_path=None):
     """Return the configured library directory, with the legacy root as fallback."""
-    config_path = dirs_json_path or str(app_paths.dirs_json())
-    try:
-        with open(config_path, "r", encoding="utf-8") as config_file:
-            configured = json.load(config_file).get("calibre_library_dir")
-        if isinstance(configured, str) and configured.strip():
-            return configured
-    except (OSError, ValueError, TypeError):
-        pass
-    return DEFAULT_LIBRARY_DIR
+    return app_paths.calibre_library_dir(dirs_json_path)
 
 
 def get_calibre_metadata_db_path(dirs_json_path=None):

--- a/scripts/set_ownership.sh
+++ b/scripts/set_ownership.sh
@@ -94,6 +94,22 @@ read_configured_dirs() {
     "${CWA_PYTHON}" "${CWA_APP_PATHS}" all
 }
 
+# Defence in depth for the CLI boundary. app_paths owns the validation
+# contract; this check makes a missing, replaced, or broken resolver unable to
+# hand root's recursive chown an empty/relative/traversing path.
+valid_resolved_dir() {
+  local p="$1"
+  [ -n "$p" ] || return 1
+  case "$p" in
+    /*) ;;
+    *) return 1 ;;
+  esac
+  case "$p" in
+    *$'\n'*|*$'\r'*|*/../*|*/..) return 1 ;;
+  esac
+  return 0
+}
+
 # Strip trailing slashes so /config/ and /config compare equal.
 normalise() {
   local p="$1"
@@ -132,7 +148,7 @@ dedupe_paths() {
 
 main() {
   local -a candidates=("${CWA_CONFIG_ROOT}")
-  local dir
+  local dir resolved_dirs resolved_count
 
   # Started as an arbitrary non-root user (`--user`, `--userns=keep-id`):
   # nothing below can succeed. LSIO's init-adduser is skipped on that path, so
@@ -148,12 +164,34 @@ main() {
     return 0
   fi
 
+  if ! valid_resolved_dir "${CWA_CONFIG_ROOT}"; then
+    log "ERROR: CWA_CONFIG_ROOT must be a non-empty absolute path without '..' components; refusing ownership pass"
+    return 1
+  fi
+
+  if ! resolved_dirs="$(read_configured_dirs)"; then
+    log "ERROR: runtime path resolver failed; refusing ownership pass"
+    return 1
+  fi
+  if [ -z "${resolved_dirs}" ]; then
+    log "ERROR: runtime path resolver returned no paths; refusing ownership pass"
+    return 1
+  fi
+
+  resolved_count=0
   while IFS= read -r dir; do
-    if [ -n "$dir" ]; then
-      CWA_RESOLVED_DIRS+=("$dir")
-      candidates+=("$dir")
+    if ! valid_resolved_dir "$dir"; then
+      log "ERROR: runtime path resolver returned unsafe path '${dir}'; refusing ownership pass"
+      return 1
     fi
-  done < <(read_configured_dirs)
+    CWA_RESOLVED_DIRS+=("$dir")
+    candidates+=("$dir")
+    resolved_count=$((resolved_count + 1))
+  done <<< "${resolved_dirs}"
+  if [ "${resolved_count}" -ne 3 ]; then
+    log "ERROR: runtime path resolver returned ${resolved_count} paths instead of 3; refusing ownership pass"
+    return 1
+  fi
 
   local -a requiredDirs=()
   while IFS= read -r dir; do

--- a/scripts/set_ownership.sh
+++ b/scripts/set_ownership.sh
@@ -99,20 +99,37 @@ read_configured_dirs() {
 # hand root's recursive chown an empty/relative/traversing path.
 valid_resolved_dir() {
   local p="$1"
+  p="$(normalise "$p")"
   [ -n "$p" ] || return 1
   case "$p" in
     /*) ;;
     *) return 1 ;;
   esac
   case "$p" in
-    *$'\n'*|*$'\r'*|*/../*|*/..) return 1 ;;
+    "/"|*$'\n'*|*$'\r'*|*/../*|*/..) return 1 ;;
   esac
   return 0
 }
 
-# Strip trailing slashes so /config/ and /config compare equal.
+# Lexically collapse separators and dot components without resolving symlinks.
+# Bash owns this final trust boundary because CWA_CONFIG_ROOT and a replacement
+# resolver can both supply values that did not pass through app_paths.py.
 normalise() {
   local p="$1"
+  local before
+  local double_slash="//"
+  local slash="/"
+  local dot_component="/./"
+
+  while :; do
+    before="$p"
+    p="${p//$double_slash/$slash}"
+    p="${p//$dot_component/$slash}"
+    if [ "$p" != "/" ] && [ "${#p}" -gt 1 ] && [ "${p: -2}" = "/." ]; then
+      p="${p%/.}"
+    fi
+    [ "$p" = "$before" ] && break
+  done
   while [ "${#p}" -gt 1 ] && [ "${p: -1}" = "/" ]; do p="${p%/}"; done
   printf '%s' "$p"
 }

--- a/scripts/set_ownership.sh
+++ b/scripts/set_ownership.sh
@@ -4,7 +4,8 @@
 # Called by the cwa-init s6 unit at every container start.
 #
 # The list is a fixed floor (/config, plus the narrow set of app-tree dirs the
-# runtime user writes) and whatever dirs.json declares. dirs.json ships
+# runtime user writes) and the three paths resolved from environment,
+# dirs.json, or defaults. dirs.json ships
 # calibre_library_dir=/calibre-library and
 # tmp_conversion_dir=/config/.cwa_conversion_tmp, and the old inline version of
 # this logic hardcoded /calibre-library and /config on top of that -- so every
@@ -35,9 +36,9 @@
 # repeated here. The rest of the tree (dirs.json, the code) is written only by
 # root or never, so orphaned build-time ownership is harmless.
 #
-# scripts/auto_library.py also rewrites dirs.json in place at runtime, so a crash
-# mid-write can leave it unparseable -- which must not be able to silently reduce
-# this pass to nothing.
+# scripts/auto_library.py can rewrite dirs.json in place at runtime when the
+# library environment override is unset, so a crash mid-write can leave it
+# unparseable -- which must not be able to silently reduce this pass to nothing.
 #
 # Every path is env-overridable so the logic is testable without a container;
 # see tests/unit/test_set_ownership.py.
@@ -50,7 +51,10 @@ CWA_DIRS_JSON="${CWA_DIRS_JSON:-${CWA_APP_ROOT}/dirs.json}"
 CWA_OWNER_USER="${CWA_OWNER_USER:-abc}"
 CWA_CHOWN="${CWA_CHOWN:-chown}"
 CWA_PYTHON="${CWA_PYTHON:-python3}"
+CWA_SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+CWA_APP_PATHS="${CWA_APP_PATHS:-${CWA_SCRIPT_DIR}/app_paths.py}"
 CWA_UID="${CWA_UID:-$(id -u)}"
+CWA_RESOLVED_DIRS=()
 
 log() { echo "[cwa-init] $*"; }
 
@@ -68,31 +72,26 @@ network_share_mode() {
 
 # Bind-mounted trees we must not touch when they live on a network share.
 share_exempt() {
+  local configured
   case "$1" in
-    "${CWA_CONFIG_ROOT}"|"${CWA_CONFIG_ROOT}"/*|/calibre-library|/calibre-library/*|/cwa-book-ingest|/cwa-book-ingest/*)
+    "${CWA_CONFIG_ROOT}"|"${CWA_CONFIG_ROOT}"/*)
       return 0 ;;
-    *) return 1 ;;
   esac
+  for configured in ${CWA_RESOLVED_DIRS[@]+"${CWA_RESOLVED_DIRS[@]}"}; do
+    configured="$(normalise "$configured")"
+    case "$1" in
+      "$configured"|"$configured"/*) return 0 ;;
+    esac
+  done
+  return 1
 }
 
-# Echo the absolute directories declared in dirs.json, one per line. A missing or
-# unparseable file yields nothing; the caller keeps its own floor.
-read_dirs_json() {
-  [ -f "${CWA_DIRS_JSON}" ] || return 0
-  "${CWA_PYTHON}" - "${CWA_DIRS_JSON}" <<'PY'
-import json
-import sys
-
-try:
-    with open(sys.argv[1], "r", encoding="utf-8") as fh:
-        data = json.load(fh)
-    if isinstance(data, dict):
-        for value in data.values():
-            if isinstance(value, str) and value.startswith("/"):
-                print(value)
-except Exception:
-    pass
-PY
+# Echo the three resolved runtime directories, one per line. app_paths owns
+# per-key environment -> dirs.json -> compiled-default precedence for every
+# scripts/ and shell consumer.
+read_configured_dirs() {
+  CWA_APP_ROOT="${CWA_APP_ROOT}" CWA_DIRS_JSON="${CWA_DIRS_JSON}" \
+    "${CWA_PYTHON}" "${CWA_APP_PATHS}" all
 }
 
 # Strip trailing slashes so /config/ and /config compare equal.
@@ -150,8 +149,11 @@ main() {
   fi
 
   while IFS= read -r dir; do
-    [ -n "$dir" ] && candidates+=("$dir")
-  done < <(read_dirs_json)
+    if [ -n "$dir" ]; then
+      CWA_RESOLVED_DIRS+=("$dir")
+      candidates+=("$dir")
+    fi
+  done < <(read_configured_dirs)
 
   local -a requiredDirs=()
   while IFS= read -r dir; do

--- a/tests/unit/test_1436_nested_library_metadata.py
+++ b/tests/unit/test_1436_nested_library_metadata.py
@@ -99,6 +99,7 @@ def test_checksum_service_polls_and_backfills_nested_library(tmp_path):
     env = os.environ.copy()
     env.update({
         "CWA_DIRS_JSON": str(dirs_json),
+        "CWA_APP_PATHS": str(SCRIPTS_DIR / "app_paths.py"),
         "BACKFILL_ARGS": str(invocation),
         "SQLITE_ARGS": str(sqlite_invocation),
         "PATH": f"{bin_dir}:{env['PATH']}",

--- a/tests/unit/test_1438_undefined_module_globals.py
+++ b/tests/unit/test_1438_undefined_module_globals.py
@@ -142,26 +142,27 @@ def _cps_python_files():
                 yield os.path.join(dirpath, filename)
 
 
-def test_web_module_resolves_dirs_json():
-    """The exact regression: ``DIRS_JSON`` is used in web.py, so it must be bound.
+def test_web_module_resolves_library_location_through_constants():
+    """The exact regression: web.py's library resolver must use a bound SSOT.
 
     Red against the #1438 tree, where the constant was referenced but never
     imported and ``cwa_get_library_location()`` raised ``NameError`` on call.
+    Since #1611, constants owns the guarded per-key resolver as well as the
+    dirs.json path, so web.py delegates instead of binding DIRS_JSON itself.
     """
     path = os.path.join(CPS_ROOT, "web.py")
     with open(path, encoding="utf-8") as handle:
         source = handle.read()
 
-    assert "DIRS_JSON" in source, (
-        "web.py no longer references DIRS_JSON — if the path lookup moved, move "
-        "this test with it rather than deleting the guard."
+    assert "constants.calibre_library_dir()" in source, (
+        "cwa_get_library_location() bypasses cps.constants; it must use the "
+        "shared guarded resolver so environment, dirs.json and default "
+        "precedence cannot diverge."
     )
-    assert "DIRS_JSON" not in _undefined_globals(path), (
-        "cps/web.py uses DIRS_JSON without binding it. cwa_get_library_location() "
-        "will raise NameError when called, and both callers swallow it — "
-        "/health reports 'degraded' 503 forever and the library count renders 0. "
-        "Add `from .constants import DIRS_JSON` (the import cps/cwa_functions.py "
-        "already uses)."
+    assert "constants" not in _undefined_globals(path), (
+        "cps/web.py calls constants.calibre_library_dir() without binding "
+        "constants. Its callers swallow the resulting NameError, so /health "
+        "reports degraded and the library count renders 0."
     )
 
 

--- a/tests/unit/test_1611_path_env_overrides.py
+++ b/tests/unit/test_1611_path_env_overrides.py
@@ -8,7 +8,9 @@
 import importlib
 import json
 import logging
+import os
 from pathlib import Path
+import subprocess
 import sys
 
 import pytest
@@ -163,6 +165,63 @@ def test_cps_and_scripts_resolvers_agree_for_same_env_and_file(
     }
 
 
+@pytest.mark.parametrize("key,env_name,default", PATH_CASES)
+@pytest.mark.parametrize("invalid", ("relative/path", "..", "/safe/../escape"))
+def test_nonblank_invalid_env_paths_fail_on_both_sides(
+    resolvers, monkeypatch, key, env_name, default, invalid
+):
+    app_paths, constants = resolvers
+    monkeypatch.setenv(env_name, invalid)
+
+    with pytest.raises(ValueError, match=env_name):
+        getattr(app_paths, key)()
+    with pytest.raises(ValueError, match=env_name):
+        getattr(constants, key)()
+
+
+@pytest.mark.parametrize("key,env_name,default", PATH_CASES)
+def test_nonblank_invalid_dirs_json_paths_fail_on_both_sides(
+    resolvers, monkeypatch, tmp_path, key, env_name, default
+):
+    app_paths, constants = resolvers
+    dirs_file = _write_dirs(tmp_path / "dirs.json", {key: "../escape"})
+    monkeypatch.setenv("CWA_DIRS_JSON", str(dirs_file))
+    monkeypatch.setattr(constants, "DIRS_JSON", str(dirs_file))
+
+    with pytest.raises(ValueError, match=key):
+        getattr(app_paths, key)()
+    with pytest.raises(ValueError, match=key):
+        getattr(constants, key)()
+
+
+def test_app_paths_cli_rejects_invalid_path_without_partial_stdout(tmp_path):
+    dirs_file = _write_dirs(
+        tmp_path / "dirs.json",
+        {
+            "ingest_folder": "/valid-ingest",
+            "calibre_library_dir": "../escape",
+            "tmp_conversion_dir": "/valid-tmp",
+        },
+    )
+    env = os.environ.copy()
+    env.update({"CWA_DIRS_JSON": str(dirs_file)})
+    for name in PATH_ENV_VARS:
+        env.pop(name, None)
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPTS_DIR / "app_paths.py"), "all"],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode != 0
+    assert result.stdout == ""
+    assert "ERROR" in result.stderr
+    assert "calibre_library_dir" in result.stderr
+
+
 def test_read_site_trailing_separator_shapes_are_preserved(
     resolvers, monkeypatch, tmp_path
 ):
@@ -264,7 +323,7 @@ def test_auto_library_stops_on_discovery_conflicting_with_env_override(
     tmp_path, monkeypatch, capsys
 ):
     writer, original = _auto_library_writer(
-        tmp_path, monkeypatch, "/env-library", "/discovered-library"
+        tmp_path, monkeypatch, "/env-library", "/env-library/Books"
     )
 
     with pytest.raises(SystemExit) as excinfo:
@@ -275,7 +334,160 @@ def test_auto_library_stops_on_discovery_conflicting_with_env_override(
     output = capsys.readouterr().out
     assert "CWA_CALIBRE_LIBRARY_DIR" in output
     assert "/env-library" in output
-    assert "/discovered-library" in output
+    assert "/env-library/Books" in output
+
+
+def _write_executable(path, body):
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+    return path
+
+
+def _isolated_path_env(tmp_path):
+    env = os.environ.copy()
+    for name in ("CWA_DIRS_JSON", "WATCH_FOLDER", *PATH_ENV_VARS):
+        env.pop(name, None)
+    env.update(
+        {
+            "CWA_INGEST_RETRY_QUEUE": str(tmp_path / "retry-queue"),
+            "CWA_INGEST_STATUS_FILE": str(tmp_path / "ingest-status"),
+            "CWA_INGEST_SERVICE_TEST_MODE": "1",
+        }
+    )
+    return env
+
+
+def _cwa_init_ingest_block(tmp_path):
+    source = (S6_DIR / "cwa-init/run").read_text(encoding="utf-8")
+    start = source.index("# Ensure the resolved ingest directory exists")
+    end = source.index("# For Calibre Plugins", start)
+    script = tmp_path / "cwa-init-ingest-block.sh"
+    return _write_executable(script, "#!/bin/bash\n" + source[start:end])
+
+
+def test_cwa_init_skips_custom_ingest_chown_in_network_share_mode(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    chown_log = tmp_path / "chown.log"
+    _write_executable(
+        bin_dir / "chown",
+        '#!/bin/sh\nprintf "%s\\n" "$*" >> "$CWA_TEST_CHOWN_LOG"\n',
+    )
+    custom_ingest = tmp_path / "custom-ingest"
+    env = _isolated_path_env(tmp_path)
+    env.update(
+        {
+            "CWA_APP_PATHS": str(SCRIPTS_DIR / "app_paths.py"),
+            "CWA_INGEST_FOLDER": str(custom_ingest),
+            "NETWORK_SHARE_MODE": "true",
+            "CWA_TEST_CHOWN_LOG": str(chown_log),
+            "PATH": f"{bin_dir}:{env['PATH']}",
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(_cwa_init_ingest_block(tmp_path))],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert custom_ingest.is_dir()
+    assert not chown_log.exists()
+    assert f"skipping chown of {custom_ingest}" in result.stdout
+
+
+def test_ingest_service_resolves_whitespace_env_through_file_fallback(tmp_path):
+    ingest = tmp_path / "from-file"
+    dirs_file = _write_dirs(tmp_path / "dirs.json", {"ingest_folder": str(ingest)})
+    env = _isolated_path_env(tmp_path)
+    env.update(
+        {
+            "CWA_APP_PATHS": str(SCRIPTS_DIR / "app_paths.py"),
+            "CWA_DIRS_JSON": str(dirs_file),
+            "CWA_INGEST_FOLDER": "   ",
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(S6_DIR / "cwa-ingest-service/run")],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert f"Watching folder: {ingest}" in result.stdout
+
+
+@pytest.mark.parametrize("resolver_mode", ("missing", "empty"))
+def test_each_s6_path_caller_fails_closed_on_unusable_resolver_output(
+    tmp_path, resolver_mode
+):
+    if resolver_mode == "missing":
+        app_paths = tmp_path / "missing-app-paths.py"
+    else:
+        app_paths = tmp_path / "empty-app-paths.py"
+        app_paths.write_text("", encoding="utf-8")
+
+    env = _isolated_path_env(tmp_path)
+    env["CWA_APP_PATHS"] = str(app_paths)
+
+    init_result = subprocess.run(
+        ["bash", str(_cwa_init_ingest_block(tmp_path))],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    ingest_result = subprocess.run(
+        ["bash", str(S6_DIR / "cwa-ingest-service/run")],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    bin_dir = tmp_path / "checksum-bin"
+    bin_dir.mkdir()
+    _write_executable(bin_dir / "sleep", "#!/bin/sh\nexit 0\n")
+    _write_executable(bin_dir / "cwa-as-abc", "#!/bin/sh\nexit 0\n")
+    checksum_env = env.copy()
+    checksum_env["PATH"] = f"{bin_dir}:{checksum_env['PATH']}"
+    checksum_result = subprocess.run(
+        ["bash", str(S6_DIR / "cwa-checksum-backfill/run")],
+        env=checksum_env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    for result in (init_result, ingest_result, checksum_result):
+        assert result.returncode != 0, result.stdout
+        assert "ERROR" in result.stdout + result.stderr
+
+
+def test_auto_library_s6_wrapper_propagates_child_failure(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_executable(bin_dir / "python3", "#!/bin/sh\nexit 23\n")
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env.pop("DISABLE_LIBRARY_AUTOMOUNT", None)
+
+    result = subprocess.run(
+        ["bash", str(S6_DIR / "cwa-auto-library/run")],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 23
+    assert "exit code: 23" in result.stdout
 
 
 def test_shell_consumers_delegate_path_resolution_to_app_paths_cli():

--- a/tests/unit/test_1611_path_env_overrides.py
+++ b/tests/unit/test_1611_path_env_overrides.py
@@ -1,0 +1,298 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Regression tests for #1611 — per-key runtime path overrides."""
+
+import importlib
+import json
+import logging
+from pathlib import Path
+import sys
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+S6_DIR = REPO_ROOT / "root/etc/s6-overlay/s6-rc.d"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+PATH_CASES = (
+    ("ingest_folder", "CWA_INGEST_FOLDER", "/cwa-book-ingest"),
+    ("calibre_library_dir", "CWA_CALIBRE_LIBRARY_DIR", "/calibre-library"),
+    ("tmp_conversion_dir", "CWA_TMP_CONVERSION_DIR", "/config/.cwa_conversion_tmp"),
+)
+PATH_ENV_VARS = tuple(case[1] for case in PATH_CASES)
+
+
+@pytest.fixture()
+def resolvers(monkeypatch):
+    """Return fresh scripts and cps resolvers with an isolated environment."""
+    for name in ("CWA_DIRS_JSON", *PATH_ENV_VARS):
+        monkeypatch.delenv(name, raising=False)
+
+    app_paths = importlib.reload(importlib.import_module("app_paths"))
+    from cps import constants
+
+    getattr(constants, "_DIRS_JSON_LOGGED_KEYS", set()).clear()
+    return app_paths, constants
+
+
+def _write_dirs(path, values):
+    path.write_text(json.dumps(values), encoding="utf-8")
+    return path
+
+
+def _answers(module):
+    return {key: getattr(module, key)() for key, _env, _default in PATH_CASES}
+
+
+@pytest.mark.parametrize("key,env_name,default", PATH_CASES)
+def test_each_env_var_overrides_its_file_value_on_both_sides(
+    resolvers, monkeypatch, tmp_path, key, env_name, default
+):
+    app_paths, constants = resolvers
+    values = {case_key: f"/from-file/{case_key}" for case_key, _env, _default in PATH_CASES}
+    dirs_file = _write_dirs(tmp_path / "dirs.json", values)
+    monkeypatch.setenv("CWA_DIRS_JSON", str(dirs_file))
+    monkeypatch.setattr(constants, "DIRS_JSON", str(dirs_file))
+    monkeypatch.setenv(env_name, f"  /from-env/{key}  ")
+
+    assert getattr(app_paths, key)() == f"/from-env/{key}"
+    assert getattr(constants, key)() == f"/from-env/{key}"
+
+    for other_key, _other_env, _other_default in PATH_CASES:
+        if other_key != key:
+            assert getattr(app_paths, other_key)() == values[other_key]
+            assert getattr(constants, other_key)() == values[other_key]
+
+
+def test_env_unset_honours_hand_edited_dirs_json_on_both_sides(
+    resolvers, monkeypatch, tmp_path
+):
+    app_paths, constants = resolvers
+    values = {key: f"/edited/{key}" for key, _env, _default in PATH_CASES}
+    dirs_file = _write_dirs(tmp_path / "dirs.json", values)
+    monkeypatch.setenv("CWA_DIRS_JSON", str(dirs_file))
+    monkeypatch.setattr(constants, "DIRS_JSON", str(dirs_file))
+
+    assert _answers(app_paths) == values
+    assert _answers(constants) == values
+
+
+def test_missing_file_yields_defaults_at_every_python_read_site(
+    resolvers, monkeypatch, tmp_path
+):
+    _app_paths, constants = resolvers
+    missing = tmp_path / "missing-dirs.json"
+    monkeypatch.setenv("CWA_DIRS_JSON", str(missing))
+    monkeypatch.setattr(constants, "DIRS_JSON", str(missing))
+
+    from cps import cwa_functions, web
+    import convert_library
+    import cover_enforcer
+    import ingest_processor
+    import library_paths
+
+    monkeypatch.setattr(cover_enforcer, "dirs_json", str(missing))
+
+    assert web.cwa_get_library_location() == "/calibre-library"
+    assert cwa_functions.get_ingest_dir() == "/cwa-book-ingest"
+    assert cwa_functions.get_tmp_conversion_dir() == "/config/.cwa_conversion_tmp/"
+    expected_dirs = (
+        "/cwa-book-ingest/",
+        "/calibre-library/",
+        "/config/.cwa_conversion_tmp/",
+    )
+    assert convert_library.LibraryConverter.get_dirs(None, str(missing)) == expected_dirs
+    assert ingest_processor.NewBookProcessor.get_dirs(None, str(missing)) == expected_dirs
+    assert cover_enforcer.Book.get_calibre_library(None) == "/calibre-library"
+    assert cover_enforcer.Enforcer.get_calibre_library(None) == "/calibre-library"
+    assert library_paths.get_calibre_library_dir(str(missing)) == "/calibre-library"
+
+
+@pytest.mark.parametrize(
+    "contents",
+    (
+        "not JSON",
+        json.dumps(["not", "an", "object"]),
+        json.dumps({"ingest_folder": None, "calibre_library_dir": None,
+                    "tmp_conversion_dir": None}),
+        json.dumps({"ingest_folder": "", "calibre_library_dir": "   ",
+                    "tmp_conversion_dir": ""}),
+    ),
+    ids=("not-json", "json-list", "null-values", "blank-values"),
+)
+def test_corrupt_or_unusable_file_values_yield_defaults_on_both_sides(
+    resolvers, monkeypatch, tmp_path, contents
+):
+    app_paths, constants = resolvers
+    dirs_file = tmp_path / "dirs.json"
+    dirs_file.write_text(contents, encoding="utf-8")
+    monkeypatch.setenv("CWA_DIRS_JSON", str(dirs_file))
+    monkeypatch.setattr(constants, "DIRS_JSON", str(dirs_file))
+
+    expected = {key: default for key, _env, default in PATH_CASES}
+    assert _answers(app_paths) == expected
+    assert _answers(constants) == expected
+
+
+def test_cps_and_scripts_resolvers_agree_for_same_env_and_file(
+    resolvers, monkeypatch, tmp_path
+):
+    app_paths, constants = resolvers
+    dirs_file = _write_dirs(
+        tmp_path / "dirs.json",
+        {
+            "ingest_folder": "/file-ingest",
+            "calibre_library_dir": "/file-library",
+            "tmp_conversion_dir": "/file-tmp",
+        },
+    )
+    monkeypatch.setenv("CWA_DIRS_JSON", str(dirs_file))
+    monkeypatch.setattr(constants, "DIRS_JSON", str(dirs_file))
+    monkeypatch.setenv("CWA_INGEST_FOLDER", "/env-ingest")
+    monkeypatch.setenv("CWA_TMP_CONVERSION_DIR", "/env-tmp")
+
+    assert _answers(app_paths) == _answers(constants) == {
+        "ingest_folder": "/env-ingest",
+        "calibre_library_dir": "/file-library",
+        "tmp_conversion_dir": "/env-tmp",
+    }
+
+
+def test_read_site_trailing_separator_shapes_are_preserved(
+    resolvers, monkeypatch, tmp_path
+):
+    _app_paths, constants = resolvers
+    dirs_file = _write_dirs(
+        tmp_path / "dirs.json",
+        {
+            "ingest_folder": "/shape-ingest",
+            "calibre_library_dir": "/shape-library",
+            "tmp_conversion_dir": "/shape-tmp",
+        },
+    )
+    monkeypatch.setenv("CWA_DIRS_JSON", str(dirs_file))
+    monkeypatch.setattr(constants, "DIRS_JSON", str(dirs_file))
+
+    from cps import cwa_functions, web
+    import convert_library
+    import cover_enforcer
+    import ingest_processor
+    import library_paths
+
+    monkeypatch.setattr(cover_enforcer, "dirs_json", str(dirs_file))
+
+    assert cwa_functions.get_ingest_dir() == "/shape-ingest"
+    assert web.cwa_get_library_location() == "/shape-library"
+    assert cwa_functions.get_tmp_conversion_dir() == "/shape-tmp/"
+    expected_dirs = ("/shape-ingest/", "/shape-library/", "/shape-tmp/")
+    assert convert_library.LibraryConverter.get_dirs(None, str(dirs_file)) == expected_dirs
+    assert ingest_processor.NewBookProcessor.get_dirs(None, str(dirs_file)) == expected_dirs
+    assert cover_enforcer.Book.get_calibre_library(None) == "/shape-library"
+    assert cover_enforcer.Enforcer.get_calibre_library(None) == "/shape-library"
+    assert library_paths.get_calibre_library_dir(str(dirs_file)) == "/shape-library"
+
+
+def test_file_fallback_is_reported_once_per_key_per_process(
+    resolvers, monkeypatch, tmp_path, caplog, capsys
+):
+    app_paths, constants = resolvers
+    values = {key: f"/logged/{key}" for key, _env, _default in PATH_CASES}
+    dirs_file = _write_dirs(tmp_path / "dirs.json", values)
+    monkeypatch.setenv("CWA_DIRS_JSON", str(dirs_file))
+    monkeypatch.setattr(constants, "DIRS_JSON", str(dirs_file))
+
+    _answers(app_paths)
+    _answers(app_paths)
+    script_lines = [
+        line for line in capsys.readouterr().err.splitlines()
+        if line.startswith("[cwa-paths]")
+    ]
+    assert len(script_lines) == 3
+
+    caplog.set_level(logging.INFO, logger="cps.constants")
+    _answers(constants)
+    _answers(constants)
+    app_records = [r for r in caplog.records if r.name == "cps.constants"]
+    assert len(app_records) == 3
+
+    for key, _env, _default in PATH_CASES:
+        assert sum(key in line and values[key] in line for line in script_lines) == 1
+        assert sum(
+            key in record.getMessage() and values[key] in record.getMessage()
+            for record in app_records
+        ) == 1
+
+
+def _auto_library_writer(tmp_path, monkeypatch, env_value, discovered):
+    import auto_library
+
+    monkeypatch.setenv("CWA_CALIBRE_LIBRARY_DIR", env_value)
+    writer = auto_library.AutoLibrary.__new__(auto_library.AutoLibrary)
+    writer.dirs_path = str(tmp_path / "dirs.json")
+    writer.lib_path = discovered
+    original = {
+        "ingest_folder": "/file-ingest",
+        "calibre_library_dir": "/file-library",
+        "tmp_conversion_dir": "/file-tmp",
+    }
+    Path(writer.dirs_path).write_text(json.dumps(original), encoding="utf-8")
+    return writer, original
+
+
+def test_auto_library_env_override_is_visible_and_leaves_file_untouched(
+    tmp_path, monkeypatch, capsys
+):
+    writer, original = _auto_library_writer(
+        tmp_path, monkeypatch, "/env-library", "/env-library"
+    )
+
+    writer.update_dirs_json()
+
+    assert json.loads(Path(writer.dirs_path).read_text(encoding="utf-8")) == original
+    output = capsys.readouterr().out
+    assert "CWA_CALIBRE_LIBRARY_DIR" in output
+    assert "authoritative" in output
+    assert "unchanged" in output
+
+
+def test_auto_library_stops_on_discovery_conflicting_with_env_override(
+    tmp_path, monkeypatch, capsys
+):
+    writer, original = _auto_library_writer(
+        tmp_path, monkeypatch, "/env-library", "/discovered-library"
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        writer.update_dirs_json()
+
+    assert excinfo.value.code == 1
+    assert json.loads(Path(writer.dirs_path).read_text(encoding="utf-8")) == original
+    output = capsys.readouterr().out
+    assert "CWA_CALIBRE_LIBRARY_DIR" in output
+    assert "/env-library" in output
+    assert "/discovered-library" in output
+
+
+def test_shell_consumers_delegate_path_resolution_to_app_paths_cli():
+    consumers = {
+        REPO_ROOT / "scripts/set_ownership.sh": "all",
+        S6_DIR / "cwa-init/run": "ingest_folder",
+        S6_DIR / "cwa-ingest-service/run": "ingest_folder",
+        S6_DIR / "cwa-checksum-backfill/run": "calibre_library_dir",
+    }
+    for path, command in consumers.items():
+        source = path.read_text(encoding="utf-8")
+        assert "app_paths.py" in source, f"{path.relative_to(REPO_ROOT)} bypasses app_paths"
+        assert command in source, f"{path.relative_to(REPO_ROOT)} does not resolve {command}"
+
+    assert "/app/calibre-web-automated/dirs.json" not in (
+        S6_DIR / "cwa-ingest-service/run"
+    ).read_text(encoding="utf-8")
+    assert "json.load(config_file).get(\"calibre_library_dir\")" not in (
+        S6_DIR / "cwa-checksum-backfill/run"
+    ).read_text(encoding="utf-8")

--- a/tests/unit/test_1611_path_env_overrides.py
+++ b/tests/unit/test_1611_path_env_overrides.py
@@ -27,6 +27,7 @@ PATH_CASES = (
     ("tmp_conversion_dir", "CWA_TMP_CONVERSION_DIR", "/config/.cwa_conversion_tmp"),
 )
 PATH_ENV_VARS = tuple(case[1] for case in PATH_CASES)
+ROOT_EQUIVALENT_PATHS = ("/", "/./", "//", "///./")
 
 
 @pytest.fixture()
@@ -166,7 +167,10 @@ def test_cps_and_scripts_resolvers_agree_for_same_env_and_file(
 
 
 @pytest.mark.parametrize("key,env_name,default", PATH_CASES)
-@pytest.mark.parametrize("invalid", ("relative/path", "..", "/safe/../escape"))
+@pytest.mark.parametrize(
+    "invalid",
+    ("relative/path", "..", "/safe/../escape", *ROOT_EQUIVALENT_PATHS),
+)
 def test_nonblank_invalid_env_paths_fail_on_both_sides(
     resolvers, monkeypatch, key, env_name, default, invalid
 ):
@@ -180,11 +184,12 @@ def test_nonblank_invalid_env_paths_fail_on_both_sides(
 
 
 @pytest.mark.parametrize("key,env_name,default", PATH_CASES)
+@pytest.mark.parametrize("invalid", ("../escape", *ROOT_EQUIVALENT_PATHS))
 def test_nonblank_invalid_dirs_json_paths_fail_on_both_sides(
-    resolvers, monkeypatch, tmp_path, key, env_name, default
+    resolvers, monkeypatch, tmp_path, key, env_name, default, invalid
 ):
     app_paths, constants = resolvers
-    dirs_file = _write_dirs(tmp_path / "dirs.json", {key: "../escape"})
+    dirs_file = _write_dirs(tmp_path / "dirs.json", {key: invalid})
     monkeypatch.setenv("CWA_DIRS_JSON", str(dirs_file))
     monkeypatch.setattr(constants, "DIRS_JSON", str(dirs_file))
 
@@ -194,12 +199,15 @@ def test_nonblank_invalid_dirs_json_paths_fail_on_both_sides(
         getattr(constants, key)()
 
 
-def test_app_paths_cli_rejects_invalid_path_without_partial_stdout(tmp_path):
+@pytest.mark.parametrize("invalid", ("../escape", *ROOT_EQUIVALENT_PATHS))
+def test_app_paths_cli_rejects_invalid_path_without_partial_stdout(
+    tmp_path, invalid
+):
     dirs_file = _write_dirs(
         tmp_path / "dirs.json",
         {
             "ingest_folder": "/valid-ingest",
-            "calibre_library_dir": "../escape",
+            "calibre_library_dir": invalid,
             "tmp_conversion_dir": "/valid-tmp",
         },
     )
@@ -220,6 +228,25 @@ def test_app_paths_cli_rejects_invalid_path_without_partial_stdout(tmp_path):
     assert result.stdout == ""
     assert "ERROR" in result.stderr
     assert "calibre_library_dir" in result.stderr
+
+
+@pytest.mark.parametrize("key,env_name,default", PATH_CASES)
+@pytest.mark.parametrize(
+    "configured,normalised",
+    (
+        ("/safe//path/./", "/safe/path"),
+        ("///safe/path//", "/safe/path"),
+        ("  /safe/./path/  ", "/safe/path"),
+    ),
+)
+def test_safe_runtime_paths_are_lexically_normalised_on_both_sides(
+    resolvers, monkeypatch, key, env_name, default, configured, normalised
+):
+    app_paths, constants = resolvers
+    monkeypatch.setenv(env_name, configured)
+
+    assert getattr(app_paths, key)() == normalised
+    assert getattr(constants, key)() == normalised
 
 
 def test_read_site_trailing_separator_shapes_are_preserved(
@@ -397,6 +424,41 @@ def test_cwa_init_skips_custom_ingest_chown_in_network_share_mode(tmp_path):
     assert custom_ingest.is_dir()
     assert not chown_log.exists()
     assert f"skipping chown of {custom_ingest}" in result.stdout
+
+
+@pytest.mark.parametrize("root_equivalent", ROOT_EQUIVALENT_PATHS)
+def test_cwa_init_rejects_root_equivalent_ingest_before_chown(
+    tmp_path, root_equivalent
+):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    chown_log = tmp_path / "chown.log"
+    _write_executable(
+        bin_dir / "chown",
+        '#!/bin/sh\nprintf "%s\\n" "$*" >> "$CWA_TEST_CHOWN_LOG"\n',
+    )
+    env = _isolated_path_env(tmp_path)
+    env.update(
+        {
+            "CWA_APP_PATHS": str(SCRIPTS_DIR / "app_paths.py"),
+            "CWA_INGEST_FOLDER": root_equivalent,
+            "NETWORK_SHARE_MODE": "false",
+            "CWA_TEST_CHOWN_LOG": str(chown_log),
+            "PATH": f"{bin_dir}:{env['PATH']}",
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(_cwa_init_ingest_block(tmp_path))],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode != 0
+    assert not chown_log.exists()
+    assert "ERROR" in result.stdout + result.stderr
 
 
 def test_ingest_service_resolves_whitespace_env_through_file_fallback(tmp_path):

--- a/tests/unit/test_set_ownership.py
+++ b/tests/unit/test_set_ownership.py
@@ -365,6 +365,27 @@ def test_falsey_network_share_mode_walks_everything(harness: Harness):
     assert str(harness.config_root) in walked
 
 
+def test_network_share_mode_skips_per_key_environment_paths(harness: Harness):
+    """#1611 custom bind targets receive the same no-chown protection."""
+    custom_library = harness.tmp / "custom-library"
+    custom_ingest = harness.tmp / "custom-ingest"
+    custom_tmp = harness.tmp / "custom-conversion"
+    for path in (custom_library, custom_ingest, custom_tmp):
+        path.mkdir()
+
+    harness.run(
+        NETWORK_SHARE_MODE="true",
+        CWA_CALIBRE_LIBRARY_DIR=custom_library,
+        CWA_INGEST_FOLDER=custom_ingest,
+        CWA_TMP_CONVERSION_DIR=custom_tmp,
+    )
+
+    walked = harness.chowned_paths()
+    assert str(custom_library) not in walked
+    assert str(custom_ingest) not in walked
+    assert str(custom_tmp) not in walked
+
+
 # --------------------------------------------------------------------------
 # The init unit must actually call the script
 # --------------------------------------------------------------------------

--- a/tests/unit/test_set_ownership.py
+++ b/tests/unit/test_set_ownership.py
@@ -116,7 +116,7 @@ class Harness:
         env.pop("NETWORK_SHARE_MODE", None)
         env.update({k: str(v) for k, v in env_overrides.items()})
         return subprocess.run(
-            ["bash", str(SET_OWNERSHIP)],
+            ["/bin/bash", str(SET_OWNERSHIP)],
             env=env,
             capture_output=True,
             text=True,
@@ -328,6 +328,34 @@ def test_non_absolute_dirs_json_values_are_ignored(harness: Harness):
     )
     harness.run()
     assert "not-a-path" not in harness.chowned_paths()
+
+
+@pytest.mark.parametrize("invalid", ("..", "relative/path", "/safe/../escape"))
+def test_invalid_runtime_path_fails_before_any_recursive_chown(
+    harness: Harness, invalid: str
+):
+    result = harness.run(CWA_INGEST_FOLDER=invalid)
+
+    assert result.returncode != 0
+    assert harness.chowned_paths() == []
+    assert "ERROR" in result.stdout + result.stderr
+
+
+@pytest.mark.parametrize("resolver_mode", ("missing", "empty"))
+def test_unusable_path_resolver_fails_before_any_recursive_chown(
+    harness: Harness, resolver_mode: str
+):
+    if resolver_mode == "missing":
+        app_paths = harness.tmp / "missing-app-paths.py"
+    else:
+        app_paths = harness.tmp / "empty-app-paths.py"
+        app_paths.write_text("")
+
+    result = harness.run(CWA_APP_PATHS=app_paths)
+
+    assert result.returncode != 0
+    assert harness.chowned_paths() == []
+    assert "ERROR" in result.stdout + result.stderr
 
 
 def test_log_line_names_the_directories(harness: Harness):

--- a/tests/unit/test_set_ownership.py
+++ b/tests/unit/test_set_ownership.py
@@ -41,6 +41,7 @@ pytestmark = pytest.mark.unit
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SET_OWNERSHIP = REPO_ROOT / "scripts" / "set_ownership.sh"
+ROOT_EQUIVALENT_PATHS = ("/", "/./", "//", "///./")
 
 CHOWN_STUB = """#!/bin/sh
 # Records every invocation, one line per call, then succeeds.
@@ -330,11 +331,43 @@ def test_non_absolute_dirs_json_values_are_ignored(harness: Harness):
     assert "not-a-path" not in harness.chowned_paths()
 
 
-@pytest.mark.parametrize("invalid", ("..", "relative/path", "/safe/../escape"))
+@pytest.mark.parametrize(
+    "invalid",
+    ("..", "relative/path", "/safe/../escape", *ROOT_EQUIVALENT_PATHS),
+)
 def test_invalid_runtime_path_fails_before_any_recursive_chown(
     harness: Harness, invalid: str
 ):
     result = harness.run(CWA_INGEST_FOLDER=invalid)
+
+    assert result.returncode != 0
+    assert harness.chowned_paths() == []
+    assert "ERROR" in result.stdout + result.stderr
+
+
+@pytest.mark.parametrize("root_equivalent", ROOT_EQUIVALENT_PATHS)
+def test_root_equivalent_from_replacement_resolver_fails_before_chown(
+    harness: Harness, root_equivalent: str
+):
+    app_paths = harness.tmp / "root-app-paths.py"
+    app_paths.write_text(
+        f'print({root_equivalent!r})\n'
+        'print("/safe-library")\n'
+        'print("/safe-tmp")\n'
+    )
+
+    result = harness.run(CWA_APP_PATHS=app_paths)
+
+    assert result.returncode != 0
+    assert harness.chowned_paths() == []
+    assert "ERROR" in result.stdout + result.stderr
+
+
+@pytest.mark.parametrize("root_equivalent", ROOT_EQUIVALENT_PATHS)
+def test_root_equivalent_config_floor_fails_before_chown(
+    harness: Harness, root_equivalent: str
+):
+    result = harness.run(CWA_CONFIG_ROOT=root_equivalent)
 
     assert result.returncode != 0
     assert harness.chowned_paths() == []


### PR DESCRIPTION
Supersedes #1885 (same work, rebased onto current main after the #1926 revert; the old branch could not be force-pushed through the identity firewall).

## Round 2 — the five review findings, fixed at the root
Resolver contract (shared by `scripts/app_paths.py`, `cps/constants.py`, `scripts/set_ownership.sh` and every s6 caller): strip, lexical POSIX normalisation (no filesystem access), reject `..`, reject anything normalising to `/`, fail closed on empty/failed resolver output.

1. Root-equivalent/relative paths can no longer reach root's `chown -R` (`..`, relative, `/`, `//`, `/./`, `///./` all rejected; OBSERVED by the adversarial re-review).
2. `cwa-init` exempts the *resolved* ingest dir under `NETWORK_SHARE_MODE=true`.
3. `cwa-auto-library` propagates the child's failure status; startup no longer proceeds split-path.
4. `cwa-ingest-service` routes whitespace-only overrides through the resolver.
5. All shell boundaries fail closed on resolver failure.

## Evidence
- Red/green regressions in `tests/unit/test_1611_path_env_overrides.py` + `tests/unit/test_set_ownership.py`: 23 failed / 39 passed before → 62 passed; root-path round: red → 115 passed (×2).
- Independent adversarial review (Sol, fresh thread) on round 1: findings 2–5 RESOLVED, one CRITICAL (root-equivalent) → fixed in round 2 and re-probed locally (`/`, `//`, `/./`, `///./`, `/config/../` rejected; `/x//y` → `/x/y`).
- Full unit suite: 7,035 passed / 105 skipped on round 1. Default Docker layout (dirs.json present, no env) resolves unchanged.
- Security review: passed (this IS the security review — user-controlled paths feeding root `chown -R`).
