### PR TITLE
fix(auth): a local-only account can sign in when LDAP rejects it (#1903)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ is for things you can see or feel when running the app.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Local-only accounts can now sign in through the classic login form when
+  an LDAP directory rejects their credentials.** The fallback accepts only a
+  non-empty stored local password hash, so LDAP-imported accounts remain
+  passwordless locally. LDAP outages, account-creation failures, and successful
+  directory authentication also no longer show a misleading extra "Wrong
+  Username or Password" message. Reported by @justemu
+  ([#1903](https://github.com/new-usemame/Calibre-Web-NextGen/issues/1903)).
+
 ## [v4.1.41] - 2026-08-25
 
 ### Added

--- a/CHANGES-vs-upstream.md
+++ b/CHANGES-vs-upstream.md
@@ -61,6 +61,23 @@ Format: each row is one fork-PR, mapped to its upstream PR or issue (if any), wi
 
 ### Bug fixes
 
+- **Local-only accounts can now use the classic login form in an LDAP
+  deployment when the directory explicitly rejects their credentials** (fork
+  [#1903](https://github.com/new-usemame/Calibre-Web-NextGen/issues/1903),
+  reported by @justemu) — the classic handler previously tried the stored local
+  password only when LDAP was unreachable, so mixed LDAP/local deployments
+  worked backwards: a local-only user could sign in during an outage but not
+  while the directory was healthy. An explicit LDAP rejection now falls back
+  only for an existing non-Guest user with a non-empty stored password hash;
+  LDAP-imported users retain their empty password and cannot pass locally.
+  Genuine failures retain the existing limiter and failed-login activity log.
+  The unconditional trailing error flash is also removed, so rejected
+  credentials produce one error and successful LDAP authentication or an LDAP
+  outage no longer gains a contradictory "Wrong Username or Password" message.
+  Six focused route tests cover valid, empty, wrong, and Guest local-password
+  cases, preserve the server-unreachable fallback, and cover successful LDAP
+  authentication with auto-creation disabled. | SHA `TBD` | release `TBD`.
+
 - **Kobo annotation PATCH parse failures now preserve the device retry instead
   of acknowledging an upload CWNG could not address** (fork #1827) — a
   non-empty non-object body and any non-empty non-list `updatedAnnotations`

--- a/cps/web.py
+++ b/cps/web.py
@@ -2960,6 +2960,16 @@ def login_post():
                 # LDAP unavailable and no local fallback
                 log.info(error)
                 flash(_(u"Could not login: %(message)s", message=error), category="error")
+            elif login_result is False and user and user.password \
+                    and check_password_hash(str(user.password), form['password']) \
+                    and user.name != "Guest":
+                # LDAP rejected the credentials, try the stored local password
+                log.info("Local Fallback Login as: '{}' (LDAP rejected)".format(user.name))
+                return handle_login_user(user,
+                                         remember_me,
+                                         _(u"Local Login as: '%(nickname)s', "
+                                           u"LDAP authentication rejected", nickname=user.name),
+                                         "warning")
             else:
                 # LDAP authentication failed
                 # Use request.remote_addr (already corrected by ProxyFix) instead of raw header
@@ -2983,7 +2993,6 @@ def login_post():
                     log.debug(f"Failed to log failed login attempt: {e}")
                 
                 flash(_(u"Wrong Username or Password"), category="error")
-            flash(_(u"Wrong Username or Password"), category="error")
     else:
         # Use request.remote_addr (already corrected by ProxyFix) instead of raw header
         ip_address = request.remote_addr

--- a/tests/unit/test_1903_ldap_local_fallback.py
+++ b/tests/unit/test_1903_ldap_local_fallback.py
@@ -1,0 +1,193 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import flask
+import pytest
+from werkzeug.security import generate_password_hash
+
+import cps.web
+
+
+pytestmark = pytest.mark.unit
+
+
+class _Anonymous:
+    is_authenticated = False
+
+
+def _translate(message, **values):
+    return message % values if values else message
+
+
+def _app():
+    app = flask.Flask(__name__)
+    app.testing = True
+    app.config["SECRET_KEY"] = "test"
+    app.config["RATELIMIT_ENABLED"] = False
+    app.register_blueprint(cps.web.web)
+    return app
+
+
+def _post_ldap_login(
+    *, stored_password, submitted_password, ldap_result, user_exists=True,
+    user_name="local-user",
+):
+    user = None
+    if user_exists:
+        user = cps.web.ub.User()
+        user.id = 1903
+        user.name = user_name
+        user.password = stored_password
+        user.role = cps.web.constants.ROLE_USER
+
+    db_session = MagicMock()
+    db_session.query.return_value.filter.return_value.first.return_value = user
+
+    ldap = MagicMock()
+    ldap.bind_user.return_value = (ldap_result, "LDAP unavailable")
+
+    activity_log = MagicMock()
+    cwa_db_loader = MagicMock(
+        return_value=SimpleNamespace(CWA_DB=MagicMock(return_value=activity_log))
+    )
+
+    app = _app()
+    with app.test_client() as client, \
+            patch("cps.web.current_user", _Anonymous()), \
+            patch("cps.web.config.config_disable_standard_login", False, create=True), \
+            patch("cps.web.config.config_login_type", cps.web.constants.LOGIN_LDAP, create=True), \
+            patch("cps.web.config.config_ldap_auto_create_users", False, create=True), \
+            patch("cps.web.services.ldap", ldap), \
+            patch("cps.web.ub.session", db_session), \
+            patch("cps.web.limiter.check") as limiter_check, \
+            patch("cps.web.render_login", return_value="login"), \
+            patch("cps.web.handle_login_user", return_value="logged-in") as handle_login_user, \
+            patch("cps.web._", side_effect=_translate), \
+            patch("cps.cwa_db_loader.load_cwa_db", cwa_db_loader):
+        response = client.post(
+            "/login",
+            data={"username": user_name, "password": submitted_password},
+        )
+        flashes = list(flask.session.get("_flashes", ()))
+
+    return SimpleNamespace(
+        response=response,
+        user=user,
+        ldap=ldap,
+        limiter_check=limiter_check,
+        handle_login_user=handle_login_user,
+        activity_log=activity_log,
+        flashes=flashes,
+    )
+
+
+def _wrong_password_flashes(result):
+    return [
+        message
+        for category, message in result.flashes
+        if category == "error" and message == "Wrong Username or Password"
+    ]
+
+
+def test_ldap_rejection_accepts_valid_stored_local_password():
+    result = _post_ldap_login(
+        stored_password=generate_password_hash("local-secret"),
+        submitted_password="local-secret",
+        ldap_result=False,
+    )
+
+    assert result.response.get_data(as_text=True) == "logged-in"
+    result.handle_login_user.assert_called_once()
+    logged_in_user, remember_me, message, category = result.handle_login_user.call_args.args
+    assert logged_in_user is result.user
+    assert remember_me is False
+    assert "local-user" in message
+    assert "LDAP authentication rejected" in message
+    assert category == "warning"
+    result.activity_log.log_activity.assert_not_called()
+    result.limiter_check.assert_called_once_with()
+
+
+def test_ldap_rejection_refuses_empty_stored_password():
+    result = _post_ldap_login(
+        stored_password="",
+        submitted_password="anything",
+        ldap_result=False,
+    )
+
+    result.handle_login_user.assert_not_called()
+    assert len(_wrong_password_flashes(result)) == 1
+    result.activity_log.log_activity.assert_called_once()
+    result.limiter_check.assert_called_once_with()
+
+
+def test_ldap_rejection_refuses_wrong_local_password_with_one_error_flash():
+    result = _post_ldap_login(
+        stored_password=generate_password_hash("local-secret"),
+        submitted_password="wrong-secret",
+        ldap_result=False,
+    )
+
+    result.handle_login_user.assert_not_called()
+    assert len(_wrong_password_flashes(result)) == 1
+    result.activity_log.log_activity.assert_called_once()
+    result.limiter_check.assert_called_once_with()
+
+
+def test_ldap_rejection_still_refuses_guest_with_a_valid_local_hash():
+    result = _post_ldap_login(
+        stored_password=generate_password_hash("guest-secret"),
+        submitted_password="guest-secret",
+        ldap_result=False,
+        user_name="Guest",
+    )
+
+    result.handle_login_user.assert_not_called()
+    assert len(_wrong_password_flashes(result)) == 1
+    result.activity_log.log_activity.assert_called_once()
+    result.limiter_check.assert_called_once_with()
+
+
+def test_ldap_unreachable_keeps_the_existing_local_fallback():
+    result = _post_ldap_login(
+        stored_password=generate_password_hash("local-secret"),
+        submitted_password="local-secret",
+        ldap_result=None,
+    )
+
+    result.handle_login_user.assert_called_once()
+    logged_in_user, remember_me, message, category = result.handle_login_user.call_args.args
+    assert logged_in_user is result.user
+    assert remember_me is False
+    assert message == (
+        "Fallback Login as: 'local-user', "
+        "LDAP Server not reachable, or user not known"
+    )
+    assert category == "warning"
+    result.activity_log.log_activity.assert_not_called()
+    result.limiter_check.assert_called_once_with()
+
+
+def test_successful_ldap_bind_without_auto_create_has_no_wrong_password_flash():
+    result = _post_ldap_login(
+        stored_password=None,
+        submitted_password="directory-secret",
+        ldap_result=True,
+        user_exists=False,
+    )
+
+    result.handle_login_user.assert_not_called()
+    assert (
+        "error",
+        "Authentication successful, but no local account found. "
+        "Please contact your administrator to create your account.",
+    ) in result.flashes
+    assert _wrong_password_flashes(result) == []
+    result.activity_log.log_activity.assert_not_called()
+    result.limiter_check.assert_called_once_with()


### PR DESCRIPTION
## Why

@justemu reported (#1903, Bug 1) that in an LDAP deployment a local-only account cannot sign in
through the classic login form. Confirmed by reading `cps/web.py::login_post()`.

**What the person was trying to do:** run a mixed deployment — some users in the directory, some
local-only — and have both sign in at `/login`.

## Root cause

Inside the `config_login_type == LOGIN_LDAP` branch, the local-password fallback is reachable only
from `login_result is None` (directory unreachable). When `services.ldap.bind_user()` returns
`False` (directory reached, credentials rejected — which is what happens for an account that simply
is not in the directory) control fell straight through to "Wrong Username or Password". A local-only
user could therefore sign in exactly when LDAP was *down*, and not while it was healthy.

A second defect sat in the same block: the final `flash(_("Wrong Username or Password"))` was
outside the `else:`, so it also fired on the "LDAP unreachable" path and on the "LDAP bind succeeded
but no local account / auto-creation disabled" path. A user who authenticated successfully against
the directory was told their password was wrong, and a genuine failure flashed the message twice.

## Fix

- On an explicit LDAP rejection, fall back to the stored local password hash for an existing,
  non-Guest user **whose stored password is non-empty**. `ldap_import_create_user()` creates LDAP
  users with `content.password = ''` (`cps/admin.py:2630`), so directory-sourced accounts can never
  become locally passwordless-authenticable through this path.
- Remove the unconditional trailing flash; each branch now emits exactly its own message.
- Untouched: the successful-LDAP path, the existing `login_result is None` fallback and its wording,
  the non-LDAP path, the per-username rate limiting, and the `LOGIN_FAILED` activity write on the
  genuine-failure branch.

## Validation

Six route-level tests in `tests/unit/test_1903_ldap_local_fallback.py` issue real `POST /login`
requests through the registered blueprint, substituting only `bind_user`'s documented
`True`/`False`/`None` results: LDAP-rejects + valid local hash → logged in; + empty stored password
→ refused; + wrong local password → refused with exactly one error flash; + Guest → refused;
LDAP-unreachable fallback still behaves as before; successful bind with auto-create disabled emits
no wrong-password flash.

Red/green confirmed independently by breaking the fix at its choke point:

- neutering the new `elif` to `elif False:` → `1 failed, 5 passed`
- restoring the unconditional trailing flash → `4 failed, 2 passed`
- unmodified branch → `6 passed`

Adjacent: every `tests/unit` file importing `cps.web` — `301 passed`. Changelog/i18n guard suites —
`129 passed, 1 skipped`. The new string extracts cleanly under `pybabel extract`. Security review of
the diff: no HIGH or MEDIUM findings.

**ASSUMED link, stated plainly:** no live LDAP directory was exercised. The handler's behaviour for
each `bind_user` outcome is OBSERVED at the HTTP route; the on-wire bind that produces those
outcomes is unchanged code and was not re-tested.

## Scope

Bug 1 of #1903 only. Bug 2 (SPA login has no LDAP) is #1893 with @justemu's PR #1894 open against
it; Bug 3 (reverse-proxy identification for `/app/` and `/api/v1/auth/me`) stays open on #1903.

Addresses #1903.
