### PR TITLE
fix(spa): tag view uses a 300px column floor (~4 columns) instead of 5-6 (#1396)

### DIFF
--- a/changelog.d/1396-tag-view-density.md
+++ b/changelog.d/1396-tag-view-density.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Tag view no longer crams 5–6 columns.** The tags browse list now uses the same 300px column floor as the editor view (~4 columns), so tag names have room instead of ellipsis. Contributed by @0x5t4l1n (#1693).

--- a/frontend/src/pages/BrowseList.module.css
+++ b/frontend/src/pages/BrowseList.module.css
@@ -82,6 +82,14 @@
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
 }
 
+/* #1396 — non-editor tags view: the default 220px minimum fills 5-6 columns
+   at typical desktop widths, leaving tag names too narrow to display without
+   ellipsis. Raise the floor to 300px (~4 columns) so names have room to
+   breathe without collapsing other browse lists (authors, series, etc.). */
+.gridTags {
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+}
+
 .grid > * {
   animation: fadeRise var(--dur-base) var(--ease-out) both;
 }

--- a/frontend/src/pages/BrowseList.tsx
+++ b/frontend/src/pages/BrowseList.tsx
@@ -175,7 +175,13 @@ export function BrowseList({ plural, title }: BrowseListProps) {
   // #1396 — the per-row rename/delete buttons (#973) only render for an editor,
   // and they are what crowds the name out of the track, so the wider track is
   // scoped to the same condition rather than applied to every browse list.
-  const gridClass = canEditTags ? `${styles.grid} ${styles.gridWithActions}` : styles.grid;
+  // For non-editor tag views we apply gridTags (same 300px floor) so the grid
+  // stays at ~4 columns instead of the dense ~6-column default.
+  const gridClass = canEditTags
+    ? `${styles.grid} ${styles.gridWithActions}`
+    : plural === 'tags'
+    ? `${styles.grid} ${styles.gridTags}`
+    : styles.grid;
 
   const items = useMemo(() => {
     const all = data?.items ?? [];


### PR DESCRIPTION
Carries @0x5t4l1n's #1693 (approved 08-21) onto current main with only the `.gridTags` rule and the `gridClass` selection — the accidental straight-quote / `{{name}}` string edits from that branch's merge are not included, so the anchored SPA strings stay intact (`test_spa_strings_anchored`, `test_615_residual_i18n` green locally). Commit author is the contributor; committer is the maintainer. Closes #1396.