### PR TITLE
changelog guard: examples/ is documentation, not a shipping path

### DIFF
--- a/scripts/check_changelog_diff.py
+++ b/scripts/check_changelog_diff.py
@@ -20,6 +20,8 @@ NON_SHIPPING_PATH_PREFIXES = (
     # 2026-08-27; #1896 was forced to invent a fragment).
     "cps/translations/",
     "docs/",
+    # Example configuration files document; they do not ship.
+    "examples/",
     "findings/",
     "frontend/e2e/",
     "notes/",

--- a/tests/unit/test_changelog_diff_guard.py
+++ b/tests/unit/test_changelog_diff_guard.py
@@ -196,6 +196,7 @@ def test_other_allowlisted_non_shipping_paths_do_not_require_an_entry():
         "notes/kobo-hardware-run.md",
         "docs/install/compose.md",
         "wiki-src/Contributing.md",
+        "examples/.env.example",
         "tests/unit/test_changelog_diff_guard.py",
         "changelog.d/README.md",
         "scripts/check_changelog_diff.py",


### PR DESCRIPTION
Adds `examples/` to `NON_SHIPPING_PATH_PREFIXES` (same shape as `docs/`, `wiki-src/`, `frontend/e2e/`) so #1913's `examples/.env.example` doesn't need a release-note fragment. Test added to the allowlist case. Unblocks a community PR.