### PR TITLE
fix(ingest): a fulfilment ticket the converter can't accept is no longer a dead end (#984)

### DIFF
--- a/changelog.d/984-ingest-ticket-paths.md
+++ b/changelog.d/984-ingest-ticket-paths.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- **Failed fulfilment tickets are preserved with useful recovery guidance.** ACSM and LCPL uploads
+  now reach the failed backup even when Calibre does not recognize the input format, browser-upload
+  sidecars are cleaned up after failed kepub fulfilment, and raw licence files are never retained as
+  book formats. Reported by @jakejoh.

--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -1525,7 +1525,11 @@ class NewBookProcessor:
         input the failed folder never held the file the user actually dropped
         in, which is the one they would retry (#1094).
         """
-        self.backup(self.filepath, backup_type="failed")
+        if (
+            self.backup(self.filepath, backup_type="failed")
+            and not is_a_book_format(self.input_format)
+        ):
+            _remove_completed_import_manifest(self.filepath)
         if converted_filepath and str(converted_filepath) != str(self.filepath):
             self.backup(str(converted_filepath), backup_type="failed")
 
@@ -2445,7 +2449,11 @@ def main(filepath=None):
                     nbp.add_book_to_library(converted_filepath) # type: ignore
 
                     # If the original format should be retained, also add it as an additional format
-                    if nbp.input_format in nbp.convert_retained_formats and nbp.input_format not in nbp.ingest_ignored_formats:
+                    if (
+                        is_a_book_format(nbp.input_format)
+                        and nbp.input_format in nbp.convert_retained_formats
+                        and nbp.input_format not in nbp.ingest_ignored_formats
+                    ):
                         print(f"[ingest-processor]: Retaining original format ({nbp.input_format}) for {nbp.filename}...", flush=True)
                         # Find the book that was just added to get its ID
                         try:
@@ -2481,7 +2489,10 @@ def main(filepath=None):
                 else:
                     _fail_not_a_book_input(nbp, filepath)
             else:
-                print(f"[ingest-processor]: Cannot convert {nbp.filepath}. {nbp.input_format} is currently unsupported / is not a known ebook format.", flush=True)
+                if is_a_book_format(nbp.input_format):
+                    print(f"[ingest-processor]: Cannot convert {nbp.filepath}. {nbp.input_format} is currently unsupported / is not a known ebook format.", flush=True)
+                else:
+                    _fail_not_a_book_input(nbp, filepath)
 
         return 0
 

--- a/tests/unit/test_1094_failed_conversion_imports_original.py
+++ b/tests/unit/test_1094_failed_conversion_imports_original.py
@@ -515,6 +515,34 @@ class TestKepubFailureAlwaysReturnsAPair:
         nbp.backup = lambda f, backup_type: nbp.backed_up.append((f, backup_type))
         return nbp
 
+    def test_failed_kepub_ticket_conversion_removes_import_sidecar(
+        self, tmp_path
+    ):
+        source = tmp_path / "Library Ticket.acsm"
+        source.write_text("ticket contents")
+        intermediate = tmp_path / "Library Ticket.epub"
+        intermediate.write_text("fulfilled epub")
+        import_manifest = Path(str(source) + ".cwa.json")
+        import_manifest.write_text('{"action": "import"}')
+
+        nbp = object.__new__(ingest_processor.NewBookProcessor)
+        nbp.filepath = str(source)
+        nbp.input_format = "acsm"
+        nbp.backed_up = []
+
+        def _backup(filepath, backup_type):
+            nbp.backed_up.append((filepath, backup_type))
+            return True
+
+        nbp.backup = _backup
+        nbp._backup_failed_kepub_inputs(str(intermediate))
+
+        assert nbp.backed_up == [
+            (str(source), "failed"),
+            (str(intermediate), "failed"),
+        ]
+        assert not import_manifest.exists()
+
     @pytest.mark.parametrize(
         "exc",
         [

--- a/tests/unit/test_984_ticket_fulfilment_without_auto_convert.py
+++ b/tests/unit/test_984_ticket_fulfilment_without_auto_convert.py
@@ -41,6 +41,9 @@ class _FakeProcessor:
         convert_result,
         target_format="epub",
         convert_ignored_formats=(),
+        convert_retained_formats=(),
+        can_convert=True,
+        last_added_book_id=None,
         use_real_converter=False,
     ):
         self.filepath = filepath
@@ -52,7 +55,7 @@ class _FakeProcessor:
         ) + os.sep
         self.ingest_ignored_formats = []
         self.convert_ignored_formats = list(convert_ignored_formats)
-        self.convert_retained_formats = []
+        self.convert_retained_formats = list(convert_retained_formats)
         self.cwa_settings = {
             "ingest_timeout_minutes": 15,
             "auto_backup_conversions": False,
@@ -60,14 +63,15 @@ class _FakeProcessor:
         self.calibre_env = os.environ.copy()
         self.is_target_format = False
         self.auto_convert_on = auto_convert_on
-        self.can_convert = True
-        self.last_added_book_id = None
+        self.can_convert = can_convert
+        self.last_added_book_id = last_added_book_id
         self._convert_result = convert_result
         self._use_real_converter = use_real_converter
         self.imported = []
         self.convert_book_calls = []
         self.convert_to_kepub_calls = 0
         self.backed_up = []
+        self.added_formats = []
 
     def is_file_in_use(self, timeout=None):
         return True
@@ -87,6 +91,9 @@ class _FakeProcessor:
 
     def add_book_to_library(self, filepath, *args, **kwargs):
         self.imported.append(filepath)
+
+    def add_format_to_book(self, book_id, filepath):
+        self.added_formats.append((book_id, filepath))
 
     def backup(self, filepath, backup_type):
         self.backed_up.append((filepath, backup_type))
@@ -108,10 +115,16 @@ def _run_main(
     convert_result,
     target_format="epub",
     convert_ignored_formats=(),
+    convert_retained_formats=(),
+    can_convert=True,
+    last_added_book_id=None,
+    create_import_manifest=False,
     use_real_converter=False,
 ):
     source = tmp_path / f"Library Ticket.{input_format}"
     source.write_text("ticket or book contents")
+    if create_import_manifest:
+        Path(str(source) + ".cwa.json").write_text('{"action": "import"}')
     holder = {}
 
     def _factory(filepath):
@@ -122,6 +135,9 @@ def _run_main(
             convert_result=convert_result,
             target_format=target_format,
             convert_ignored_formats=convert_ignored_formats,
+            convert_retained_formats=convert_retained_formats,
+            can_convert=can_convert,
+            last_added_book_id=last_added_book_id,
             use_real_converter=use_real_converter,
         )
         holder["fake"] = fake
@@ -192,6 +208,47 @@ def test_real_book_is_still_imported_as_is_when_auto_convert_is_off(
     assert fake.convert_book_calls == []
     assert fake.convert_to_kepub_calls == 0
     assert fake.imported == [source]
+
+
+def test_unconvertible_acsm_uses_ticket_failure_flow(
+    monkeypatch, tmp_path, capsys
+):
+    fake, source = _run_main(
+        monkeypatch,
+        tmp_path,
+        input_format="acsm",
+        auto_convert_on=False,
+        convert_result=(False, ""),
+        can_convert=False,
+        create_import_manifest=True,
+    )
+
+    output = capsys.readouterr().out
+    assert fake.convert_book_calls == []
+    assert fake.imported == []
+    assert fake.backed_up == [(source, "failed")]
+    assert not Path(source + ".cwa.json").exists()
+    assert "ACSM_NOTICE:" in output
+    assert "is currently unsupported / is not a known ebook format" not in output
+
+
+def test_successful_fulfilment_never_retains_raw_ticket_as_book_format(
+    monkeypatch, tmp_path
+):
+    converted = str(tmp_path / "Library Ticket.epub")
+    fake, source = _run_main(
+        monkeypatch,
+        tmp_path,
+        input_format="acsm",
+        auto_convert_on=True,
+        convert_result=(True, converted),
+        convert_retained_formats=("acsm",),
+        last_added_book_id=7,
+    )
+
+    assert fake.imported == [converted]
+    assert fake.added_formats == []
+    assert source not in fake.imported
 
 
 def test_failed_ticket_fulfilment_keeps_plugin_reason_and_preserves_original(


### PR DESCRIPTION
## What this fixes

Three defects on the ingest lane's ticket/licence (`.acsm` / `.lcpl`) handling, all in
`scripts/ingest_processor.py`. All three were surfaced by the cross-family review of #1921
and are newly reachable for users running with Auto-Convert **off**.

1. **A fulfilment ticket the converter cannot accept hit a dead end** (this is the part of
   #984 that survived #1921). When `can_convert` is false — e.g. no DeACSM plugin is
   registered, so Calibre never lists `acsm` as an input format — the file fell through to a
   bare `Cannot convert … unsupported / is not a known ebook format` line. It was never backed
   up to the failed folder, its browser-upload sidecar was orphaned, and the guidance that
   tells you to install the plugin never fired. Tickets now take the same
   `_fail_not_a_book_input()` path the other two dispatch sites already use. A genuinely
   unknown *book* format keeps its existing message.
2. **A failed kepub fulfilment orphaned the browser-upload sidecar.** `delete_current_file()`
   removes the original but deliberately skips `*.cwa.json`, so a kepubify failure on a ticket
   left a `.cwa.json` pointing at a file that no longer exists. The sibling `convert_book()`
   failure paths already cleaned it up; the kepub path now does too.
3. **A raw licence file could be attached to the book it fulfilled.** With `acsm` in
   *retained formats*, a successful fulfilment passed the raw ticket to `add_format_to_book()`,
   adding an unopenable licence as a Calibre format. Retention is now guarded by
   `is_a_book_format()`.

## Verification

- Three regression tests, one per defect, each exercising the real `main()` / real method —
  not source pins.
- **Red** proven with the parent production file restored and the new tests in place:
  `3 failed in 0.42s`.
- **Green** on this head: `.venv/bin/python -m pytest tests/unit -k "ingest or acsm or lcpl"`
  → `203 passed, 7 skipped`, run twice.
- `tests/unit/test_s6_ingest_service_shutdown.py` has 3 pre-existing timing failures; the
  identical 3 fail on the parent production file, and neither that test file nor the s6
  service script is touched here.

No new dependencies, no license changes, no external service URLs.

Reported by @jakejoh in #984.


## Manager merge gate — independent verification (2026-08-28)

- **Red, reproduced by the manager rather than taken on report:** reverting all three production
  hunks in a separate worktree at `d22faa07a` gives **3 failed / 76 passed** — exactly one
  failure per claimed defect.
- **Green:** 79 passed with the hunks restored, run twice.
- **Security, manager-inspected:** the only new filesystem write is the pre-existing
  `_remove_completed_import_manifest`, which deletes `<filepath>.cwa.json` only when that file
  parses as JSON with `action == "import"`, and swallows every `OSError`. No new path is built
  from untrusted input; the other two hunks only narrow what gets attached or printed.
- CI green on the head, Integration Tests (Docker) included; E2E skipped by the path filter.
