### PR TITLE
fix(db): contained SAVEPOINTs on app.db via BEGIN IMMEDIATE under WAL (#1873, second attempt)

### DIFF
--- a/changelog.d/pr-1873.md
+++ b/changelog.d/pr-1873.md
@@ -1,5 +1,5 @@
 ### Fixed
 
-- Settings-database saves now roll back completely without concurrent writes
-  failing unexpectedly, live backups include committed WAL data, and
+- Settings-database saves now keep their rollback boundaries without blocking
+  unrelated reads or startup work, live backups include committed WAL data, and
   `NETWORK_SHARE_MODE=true` safely retains legacy behavior.

--- a/changelog.d/pr-1873.md
+++ b/changelog.d/pr-1873.md
@@ -1,14 +1,5 @@
 ### Fixed
 
-- **A write that fails is no longer sometimes kept.** Certain edits — highlights
-  made in the web reader, and progress synced from KOReader — could leave part
-  of their work in the database even when the save failed and everything else
-  was undone. The affected records were internal bookkeeping rather than your
-  highlights themselves, but the inconsistency could outlive the failure.
-- **Database backups no longer miss recently committed data.** Backups of the
-  live settings and Calibre databases now include writes still held in SQLite's
-  WAL, and restoring a database no longer lets an older WAL override it.
-- **`NETWORK_SHARE_MODE=true` now covers the settings database too.** Because
-  SQLite WAL is unsafe on network filesystems, `app.db` stays in legacy
-  transaction mode under this flag and logs that the SAVEPOINT containment fix
-  is unavailable, including when `/config` itself is on local storage.
+- Settings-database saves now roll back completely without concurrent writes
+  failing unexpectedly, live backups include committed WAL data, and
+  `NETWORK_SHARE_MODE=true` safely retains legacy behavior.

--- a/changelog.d/pr-1873.md
+++ b/changelog.d/pr-1873.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **A write that fails is no longer sometimes kept.** Certain edits — highlights
+  made in the web reader, and progress synced from KOReader — could leave part
+  of their work in the database even when the save failed and everything else
+  was undone. The affected records were internal bookkeeping rather than your
+  highlights themselves, but the inconsistency could outlive the failure.
+- **Database backups no longer miss recently committed data.** Backups of the
+  live settings and Calibre databases now include writes still held in SQLite's
+  WAL, and restoring a database no longer lets an older WAL override it.
+- **`NETWORK_SHARE_MODE=true` now covers the settings database too.** Because
+  SQLite WAL is unsafe on network filesystems, `app.db` stays in legacy
+  transaction mode under this flag and logs that the SAVEPOINT containment fix
+  is unavailable, including when `/config` itself is on local storage.

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -61,6 +61,7 @@ from .ui_themes import config_theme_code
 from .cw_babel import get_available_translations, get_available_locale, get_user_locale_language
 from . import debug_info
 from .string_helper import strip_whitespaces
+from .sqlite_utils import copy_sqlite_database
 
 log = logger.create()
 
@@ -3624,8 +3625,8 @@ def restore_calibre_db():
         # 1. Backup both DBs
         backup_dir = f"/config/backup/restore_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
         os.makedirs(backup_dir, exist_ok=True)
-        shutil.copy2(metadata_path, os.path.join(backup_dir, "metadata.db.bak"))
-        shutil.copy2(app_db_path, os.path.join(backup_dir, "app.db.bak"))
+        copy_sqlite_database(metadata_path, os.path.join(backup_dir, "metadata.db.bak"))
+        copy_sqlite_database(app_db_path, os.path.join(backup_dir, "app.db.bak"))
 
         log_path = os.path.join(backup_dir, "restore.log")
         with open(log_path, "a", encoding="utf-8") as log_file:

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -781,10 +781,14 @@ def _encrypt_fields(session, secret_key):
     try:
         session.query(exists().where(_Settings.mail_password_e)).scalar()
     except OperationalError:
-        with session.bind.connect() as conn:
+        # With explicit SQLite BEGIN handling, the failed inspection owns a
+        # real transaction. Release it before migrating on another connection,
+        # then use begin() so the DDL is committed rather than rolled back when
+        # the context exits.
+        session.rollback()
+        with session.bind.begin() as conn:
             conn.execute(text("ALTER TABLE settings ADD column 'mail_password_e' String"))
             conn.execute(text("ALTER TABLE settings ADD column 'config_ldap_serv_password_e' String"))
-        session.commit()
         crypter = Fernet(secret_key)
         settings = session.query(_Settings.mail_password, _Settings.config_ldap_serv_password).first()
         if settings.mail_password:
@@ -807,6 +811,7 @@ def _migrate_table(session, orm_class, secret_key=None):
                 session.query(column).first()
             except OperationalError as err:
                 log.debug("%s: %s", column_name, err.args[0])
+                session.rollback()
                 # Handle default values for new columns
                 if column.default is None:
                     # Use NULL for columns with None default (important for autodetection logic)
@@ -825,7 +830,11 @@ def _migrate_table(session, orm_class, secret_key=None):
                                                                              column_type,
                                                                              column_default))
                 log.debug(alter_table)
-                session.execute(alter_table)
+                # Commit each missing column independently. A later failed
+                # inspection must not roll back an earlier ALTER in the same
+                # migration pass now that SQLite DDL is transactional.
+                with session.bind.begin() as conn:
+                    conn.execute(alter_table)
                 changed = True
             except json.decoder.JSONDecodeError as e:
                 log.error("Database corrupt column: {}".format(column_name))

--- a/cps/db.py
+++ b/cps/db.py
@@ -48,6 +48,7 @@ from flask import flash, url_for, has_request_context
 from . import logger, ub, isoLanguages
 from .pagination import Pagination
 from .string_helper import strip_whitespaces
+from .sqlite_utils import network_share_mode_enabled
 from .unicode_collation import unicode_initial, unicode_sort_key
 
 log = logger.create()
@@ -1168,7 +1169,7 @@ class CalibreDB:
                 # Try enabling WAL to improve concurrency unless running on a network share
                 # Controlled by env var NETWORK_SHARE_MODE (default False)
                 try:
-                    nsm = os.getenv('NETWORK_SHARE_MODE', 'False').lower() in ('1', 'true', 'yes', 'on')
+                    nsm = network_share_mode_enabled()
                     dc = os.getenv('DESKTOP_COMPAT_MODE', 'False').lower() in ('1', 'true', 'yes', 'on')
                     if not nsm and not dc and db_writable:
                         connection.execute(text("PRAGMA calibre.journal_mode=WAL"))
@@ -1260,7 +1261,7 @@ class CalibreDB:
                 return None
 
             db_writable = os.access(dbpath, os.W_OK)
-            nsm = os.getenv('NETWORK_SHARE_MODE', 'False').lower() in ('1', 'true', 'yes', 'on')
+            nsm = network_share_mode_enabled()
             desktop_compat = os.getenv('DESKTOP_COMPAT_MODE', 'False').lower() in ('1', 'true', 'yes', 'on')
 
             try:

--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -39,6 +39,7 @@ from .cwa_functions import get_ingest_dir
 from .services.calibre_db_lock import metadata_db_write_lock
 from .services.kepub_package_normalizer import normalize_kepub_package
 from .services.pubdate_parse import parse_partial_pubdate
+from .sqlite_utils import network_share_mode_enabled
 from .usermanagement import user_login_required, login_required_if_no_ano
 from .string_helper import strip_whitespaces
 from werkzeug.utils import secure_filename
@@ -413,7 +414,7 @@ def _get_ingest_path(uploaded_file, prefix_parts=None):
         raise
     # Ensure proper ownership of ingest directory (fix for issue #603)
     try:
-        nsm = os.getenv("NETWORK_SHARE_MODE", "false").strip().lower() in ("1", "true", "yes", "on")
+        nsm = network_share_mode_enabled()
         if not (nsm and ingest_dir == "/cwa-book-ingest"):
             # Set ownership to abc:abc (uid=1000, gid=1000)
             uid = _get_ingest_owner_id("PUID")

--- a/cps/gdrive.py
+++ b/cps/gdrive.py
@@ -10,7 +10,6 @@ import hashlib
 import json
 from uuid import uuid4
 from time import time
-from shutil import move, copyfile
 
 from flask import Blueprint, flash, request, redirect, url_for, abort
 from flask_babel import gettext as _
@@ -18,6 +17,7 @@ from flask_babel import gettext as _
 from . import logger, gdriveutils, config, ub, calibre_db, csrf
 from .admin import admin_required
 from .file_helper import get_temp_dir
+from .sqlite_utils import copy_sqlite_database
 from .usermanagement import user_login_required
 
 gdrive = Blueprint('gdrive', __name__, url_prefix='/gdrive')
@@ -129,12 +129,18 @@ try:
                     tmp_dir = get_temp_dir()
 
                     log.info('Database file updated')
-                    copyfile(dbpath, os.path.join(tmp_dir, "metadata.db_" + str(current_milli_time())))
+                    copy_sqlite_database(
+                        dbpath,
+                        os.path.join(tmp_dir, "metadata.db_" + str(current_milli_time())),
+                    )
                     log.info('Backing up existing and downloading updated metadata.db')
                     gdriveutils.downloadFile(None, "metadata.db", os.path.join(tmp_dir, "tmp_metadata.db"))
                     log.info('Setting up new DB')
-                    # prevent error on windows, as os.rename does on existing files, also allow cross hdd move
-                    move(os.path.join(tmp_dir, "tmp_metadata.db"), dbpath)
+                    # Write through SQLite so a replacement cannot be poisoned by
+                    # committed pages in metadata.db-wal from the old database.
+                    copy_sqlite_database(
+                        os.path.join(tmp_dir, "tmp_metadata.db"), dbpath, restore=True
+                    )
                     calibre_db.reconnect_db(config, ub.app_DB_path)
         except Exception as ex:
             log.error_or_exception(ex)

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -1838,7 +1838,7 @@ def share_kobo_progress_with_koreader(user_id, book_id, percentage):
         # rollback here would take them with it (#1318, same precondition the
         # web reader path documents).
         ub.session_flush()
-        with ub.session.begin_nested():
+        with ub.begin_contained_nested(ub.session):
             record_percentage_only_progress(user_id, book_id, percentage, device="Kobo")
     except Exception as e:
         log.warning("Could not share Kobo progress with KOReader for user %s book %s: %s",

--- a/cps/services/annotation_sync/__init__.py
+++ b/cps/services/annotation_sync/__init__.py
@@ -359,7 +359,7 @@ def _store_raw_materialization(session, annotation, raw_record, *, trace_id=None
     if raw_record is None or raw_record.annotation_id != annotation.annotation_id:
         return None
     try:
-        with session.begin_nested():
+        with ub.begin_contained_nested(session):
             row = (
                 session.query(ub.KoboAnnotationMaterialization)
                 .filter(ub.KoboAnnotationMaterialization.annotation_id == annotation.id)
@@ -461,7 +461,7 @@ def _upsert_sync_target(session, annotation, target_name, result):
             updated_at=_now(),
         )
         try:
-            with session.begin_nested():
+            with ub.begin_contained_nested(session):
                 session.add(st)
                 session.flush()
         except IntegrityError:

--- a/cps/services/reading_position.py
+++ b/cps/services/reading_position.py
@@ -214,7 +214,7 @@ def record_web_reader_progress(user, book_id: int, percentage: float) -> bool:
     # leave the two devices disagreeing about where the user is — worse than
     # neither being updated, which is a state the next save corrects.
     try:
-        with ub.session.begin_nested():
+        with ub.begin_contained_nested(ub.session):
             update_book_read_status(user, book_id, percentage)
             record_percentage_only_progress(
                 user_id, book_id, percentage, device="Web reader",

--- a/cps/sqlite_utils.py
+++ b/cps/sqlite_utils.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2025 Calibre-Web contributors
+# Copyright (C) 2024-2025 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Shared SQLite environment and copy helpers."""
+
+import os
+import shutil
+import sqlite3
+from pathlib import Path
+
+
+_TRUTHY_ENV_VALUES = frozenset(("1", "true", "yes", "on"))
+
+
+def environment_flag_enabled(name, environ=None):
+    """Return whether an environment flag uses a supported truthy spelling."""
+    source = os.environ if environ is None else environ
+    return source.get(name, "").strip().lower() in _TRUTHY_ENV_VALUES
+
+
+def network_share_mode_enabled(environ=None):
+    """Parse the process-wide ``NETWORK_SHARE_MODE`` contract in one place."""
+    return environment_flag_enabled("NETWORK_SHARE_MODE", environ)
+
+
+def copy_sqlite_database(source_path, destination_path, timeout=30, *, restore=False):
+    """Copy a SQLite database transactionally, including committed WAL frames.
+
+    SQLite's online backup API reads a consistent source snapshot even while
+    other connections are writing it. It also writes an existing destination
+    through SQLite's own transaction machinery, so a restore cannot combine a
+    replacement main file with stale pages from the destination's ``-wal``.
+    A newly-created destination is a self-contained database file; no source
+    sidecar files need to be copied. Pass ``restore=True`` when the destination
+    is the application's live database; its existing journal mode is retained.
+    """
+    source = os.path.abspath(os.fsdecode(os.fspath(source_path)))
+    destination = os.path.abspath(os.fsdecode(os.fspath(destination_path)))
+    if (
+        os.path.normcase(os.path.realpath(source))
+        == os.path.normcase(os.path.realpath(destination))
+    ):
+        raise ValueError("SQLite source and destination must be different files")
+
+    destination_existed = os.path.exists(destination)
+    source_uri = Path(source).as_uri() + "?mode=ro"
+    with sqlite3.connect(source_uri, uri=True, timeout=timeout) as source_connection:
+        with sqlite3.connect(destination, timeout=timeout) as destination_connection:
+            destination_mode = destination_connection.execute(
+                "PRAGMA journal_mode"
+            ).fetchone()[0]
+            source_connection.backup(destination_connection)
+            # The backup copies page 1, including the source's persistent WAL
+            # marker. A new backup file has no WAL sidecar by design, so make
+            # it a portable rollback-journal database after all committed WAL
+            # frames have landed in the main file. When replacing an existing
+            # live database, retain its prior mode instead.
+            requested_mode = (
+                destination_mode if restore and destination_existed else "delete"
+            )
+            resulting_mode = destination_connection.execute(
+                "PRAGMA journal_mode={}".format(requested_mode)
+            ).fetchone()[0]
+            if resulting_mode.lower() != requested_mode.lower():
+                raise sqlite3.OperationalError(
+                    "could not preserve destination journal mode {!r}".format(requested_mode)
+                )
+
+    if not restore:
+        # SQLite may leave an empty shared-memory file behind after converting
+        # the new snapshot from WAL to DELETE. A backup is deliberately one
+        # portable file, and no other connection should have it open yet.
+        for suffix in ("-wal", "-shm"):
+            try:
+                os.remove(destination + suffix)
+            except FileNotFoundError:
+                pass
+
+    # Match copy2's useful metadata preservation without making a successful
+    # database snapshot fail on filesystems that reject timestamp/mode changes.
+    try:
+        shutil.copystat(source, destination)
+    except OSError:
+        pass

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -4258,9 +4258,17 @@ def _create_app_db_engine(app_db_path):
     Python's sqlite3 legacy transaction mode emits BEGIN for DML only. A
     SAVEPOINT reached after SELECTs therefore has no enclosing transaction,
     and releasing it makes its writes durable before Session.commit(). Disable
-    the driver's BEGIN handling and let SQLAlchemy emit BEGIN for every outer
-    transaction when WAL is available, so Session.begin_nested() is a contained
-    SAVEPOINT without making rollback-journal readers block writers.
+    the driver's BEGIN handling and let SQLAlchemy emit BEGIN IMMEDIATE for
+    every outer transaction when WAL is available. This both contains
+    Session.begin_nested() and reserves the WAL writer slot before a transaction
+    can take a read snapshot that another writer would invalidate. Concurrent
+    writers therefore wait under busy_timeout instead of failing immediately
+    with SQLITE_BUSY_SNAPSHOT when a read transaction upgrades to a write.
+
+    BEGIN IMMEDIATE serializes all app.db sessions, including sessions that turn
+    out to be read-only. A separate read-only path would require callers to make
+    that promise before their first query; the shared session cannot safely infer
+    it after a snapshot has already been taken.
 
     WAL support is decided once per engine. If the first raw connection cannot
     enable it (for example, app.db is on a network share), every connection on
@@ -4316,7 +4324,7 @@ def _create_app_db_engine(app_db_path):
     @event.listens_for(engine, 'begin')
     def _emit_begin(connection):
         if transaction_mode['explicit_begin']:
-            connection.exec_driver_sql('BEGIN')
+            connection.exec_driver_sql('BEGIN IMMEDIATE')
 
     return engine
 

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -4252,79 +4252,80 @@ def _request_app_db_wal(dbapi_connection):
         cursor.close()
 
 
+def begin_contained_nested(db_session):
+    """Open a SAVEPOINT inside a real outer SQLite transaction.
+
+    sqlite3's legacy transaction control does not emit BEGIN for SELECT or
+    SAVEPOINT. If a session has only read before ``Session.begin_nested()``,
+    releasing that SAVEPOINT commits its writes and a later outer rollback
+    cannot undo them. Start an immediate transaction on that same connection
+    only when the driver has no real transaction yet, then let SQLAlchemy open
+    the nested transaction normally.
+
+    Localizing BEGIN IMMEDIATE here is essential: applying it to every outer
+    SQLAlchemy transaction makes read-only sessions reserve the writer slot and
+    block unrelated pooled connections for their entire lifetime.
+    """
+    connection = db_session.connection()
+    if connection.dialect.name == 'sqlite':
+        driver_connection = connection.connection.driver_connection
+        if not driver_connection.in_transaction:
+            connection.exec_driver_sql('BEGIN IMMEDIATE')
+    return db_session.begin_nested()
+
+
 def _create_app_db_engine(app_db_path):
-    """Create an app.db engine with the safest available transaction mode.
+    """Create an app.db engine with WAL and legacy sqlite3 transactions.
 
     Python's sqlite3 legacy transaction mode emits BEGIN for DML only. A
     SAVEPOINT reached after SELECTs therefore has no enclosing transaction,
-    and releasing it makes its writes durable before Session.commit(). Disable
-    the driver's BEGIN handling and let SQLAlchemy emit BEGIN IMMEDIATE for
-    every outer transaction when WAL is available. This both contains
-    Session.begin_nested() and reserves the WAL writer slot before a transaction
-    can take a read snapshot that another writer would invalidate. Concurrent
-    writers therefore wait under busy_timeout instead of failing immediately
-    with SQLITE_BUSY_SNAPSHOT when a read transaction upgrades to a write.
-
-    BEGIN IMMEDIATE serializes all app.db sessions, including sessions that turn
-    out to be read-only. A separate read-only path would require callers to make
-    that promise before their first query; the shared session cannot safely infer
-    it after a snapshot has already been taken.
+    and releasing it makes its writes durable before Session.commit(). The
+    ``begin_contained_nested`` helper fixes that locally at SAVEPOINT call sites
+    without changing transaction behavior for every request and startup step.
 
     WAL support is decided once per engine. If the first raw connection cannot
-    enable it (for example, app.db is on a network share), every connection on
-    that engine retains sqlite3's legacy transaction control. Mixing explicit
-    and legacy transaction semantics between connections would be worse than a
-    single, observable degraded mode.
+    enable it (for example, app.db is on a network share), the engine remains in
+    rollback-journal mode and warns once. Every connection retains sqlite3's
+    legacy transaction control in either journal mode.
     """
     engine = create_engine(
         'sqlite:///{0}'.format(app_db_path),
         echo=False,
         connect_args={'timeout': 30},
     )
-    transaction_mode = {'explicit_begin': None}
-    transaction_mode_lock = threading.Lock()
+    wal_mode = {'configured': False}
+    wal_mode_lock = threading.Lock()
     network_share_mode = network_share_mode_enabled()
 
     @event.listens_for(engine, 'connect')
-    def _configure_app_db_transaction_mode(dbapi_connection, _connection_record):
-        if transaction_mode['explicit_begin'] is None:
-            with transaction_mode_lock:
-                if transaction_mode['explicit_begin'] is None:
+    def _configure_app_db_journal_mode(dbapi_connection, _connection_record):
+        if not wal_mode['configured']:
+            with wal_mode_lock:
+                if not wal_mode['configured']:
                     if network_share_mode:
-                        transaction_mode['explicit_begin'] = False
                         log.warning(
                             "NETWORK_SHARE_MODE=true disables SQLite WAL for every database, "
                             "including app.db %s even when /config is on local disk, because "
                             "WAL is unsafe on network filesystems. app.db is using legacy "
-                            "sqlite3 transaction control, so the #1873 SAVEPOINT containment "
-                            "fix is unavailable: begin_nested() SAVEPOINTs opened before DML "
-                            "may commit at RELEASE.",
+                            "sqlite3 transaction control with a rollback journal; call sites "
+                            "requiring contained SAVEPOINTs acquire a local write transaction.",
                             app_db_path,
                         )
                     else:
                         journal_mode, wal_error = _request_app_db_wal(dbapi_connection)
                         wal_enabled = str(journal_mode).lower() == 'wal'
-                        transaction_mode['explicit_begin'] = wal_enabled
-                    if not network_share_mode and not transaction_mode['explicit_begin']:
-                        reason = ("PRAGMA journal_mode=WAL failed: {}".format(wal_error)
-                                  if wal_error is not None
-                                  else "SQLite kept journal_mode={!r}".format(journal_mode))
-                        log.warning(
-                            "SQLite WAL is unavailable for app.db %s (%s). Leaving legacy "
-                            "sqlite3 transaction control active for this engine to avoid "
-                            "rollback-journal readers blocking writers; begin_nested() "
-                            "SAVEPOINTs opened before DML are not contained and may commit "
-                            "at RELEASE.",
-                            app_db_path, reason,
-                        )
-
-        if transaction_mode['explicit_begin']:
-            dbapi_connection.isolation_level = None
-
-    @event.listens_for(engine, 'begin')
-    def _emit_begin(connection):
-        if transaction_mode['explicit_begin']:
-            connection.exec_driver_sql('BEGIN IMMEDIATE')
+                        if not wal_enabled:
+                            reason = ("PRAGMA journal_mode=WAL failed: {}".format(wal_error)
+                                      if wal_error is not None
+                                      else "SQLite kept journal_mode={!r}".format(journal_mode))
+                            log.warning(
+                                "SQLite WAL is unavailable for app.db %s (%s). Using a "
+                                "rollback journal with legacy sqlite3 transaction control; "
+                                "call sites requiring contained SAVEPOINTs acquire a local "
+                                "write transaction.",
+                                app_db_path, reason,
+                            )
+                    wal_mode['configured'] = True
 
     return engine
 

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -10,6 +10,7 @@ import os
 import re
 import sys
 import sqlite3
+import threading
 import time
 from datetime import datetime, timezone, timedelta
 import itertools
@@ -45,6 +46,7 @@ from sqlalchemy.orm import backref, relationship, sessionmaker, Session, scoped_
 from werkzeug.security import generate_password_hash
 
 from . import constants, logger
+from .sqlite_utils import network_share_mode_enabled
 from .string_helper import strip_whitespaces
 
 log = logger.create()
@@ -1814,28 +1816,27 @@ def add_missing_tables(engine, _session):
     # NameError on any app.db missing kosync_progress (a fresh install).
     from .progress_syncing.models import KOSyncProgress
 
-    if not engine.dialect.has_table(engine.connect(), "archived_book"):
-        ArchivedBook.__table__.create(bind=engine, checkfirst=True)
-    if not engine.dialect.has_table(engine.connect(), "thumbnail"):
-        Thumbnail.__table__.create(bind=engine, checkfirst=True)
-    if not engine.dialect.has_table(engine.connect(), "kosync_progress"):
-        KOSyncProgress.__table__.create(bind=engine, checkfirst=True)
-    if not engine.dialect.has_table(engine.connect(), "magic_shelf"):
-        MagicShelf.__table__.create(bind=engine, checkfirst=True)
-    if not engine.dialect.has_table(engine.connect(), "magic_shelf_cache"):
-        MagicShelfCache.__table__.create(bind=engine, checkfirst=True)
-    if not engine.dialect.has_table(engine.connect(), "opds_shelf_exposure"):
-        OpdsShelfExposure.__table__.create(bind=engine, checkfirst=True)
-    if not engine.dialect.has_table(engine.connect(), "book_original_filename"):
-        BookOriginalFilename.__table__.create(bind=engine, checkfirst=True)
-    if not engine.dialect.has_table(engine.connect(), "opds_magic_shelf_exposure"):
-        OpdsMagicShelfExposure.__table__.create(bind=engine, checkfirst=True)
-    if not engine.dialect.has_table(engine.connect(), "hidden_magic_shelf_templates"):
-        HiddenMagicShelfTemplate.__table__.create(bind=engine, checkfirst=True)
-    if not engine.dialect.has_table(engine.connect(), "kobo_annotation_backup"):
-        KoboAnnotationBackup.__table__.create(bind=engine, checkfirst=True)
-    if not engine.dialect.has_table(engine.connect(), "favorite_book"):
-        FavoriteBook.__table__.create(bind=engine, checkfirst=True)
+    tables = (
+        ("archived_book", ArchivedBook.__table__),
+        ("thumbnail", Thumbnail.__table__),
+        ("kosync_progress", KOSyncProgress.__table__),
+        ("magic_shelf", MagicShelf.__table__),
+        ("magic_shelf_cache", MagicShelfCache.__table__),
+        ("opds_shelf_exposure", OpdsShelfExposure.__table__),
+        ("book_original_filename", BookOriginalFilename.__table__),
+        ("opds_magic_shelf_exposure", OpdsMagicShelfExposure.__table__),
+        ("hidden_magic_shelf_templates", HiddenMagicShelfTemplate.__table__),
+        ("kobo_annotation_backup", KoboAnnotationBackup.__table__),
+        ("favorite_book", FavoriteBook.__table__),
+    )
+    for table_name, table in tables:
+        # Explicit transaction control means even schema inspection begins a
+        # real read transaction. Close it before opening the separate DDL
+        # transaction or the inspection connection can block its commit.
+        with engine.connect() as connection:
+            table_exists = engine.dialect.has_table(connection, table_name)
+        if not table_exists:
+            table.create(bind=engine, checkfirst=True)
 
 
 # migrate all settings missing in registration table
@@ -1844,11 +1845,13 @@ def migrate_registration_table(engine, _session):
         # Handle table exists, but no content
         cnt = _session.query(Registration).count()
         if not cnt:
-            with engine.connect() as conn:
-                trans = conn.begin()
-                conn.execute(text("insert into registration (domain, allow) values('%.%',1)"))
-                trans.commit()
+            _session.add(Registration(domain='%.%', allow=1))
+        # The inspection SELECT now opens a real transaction. Commit on the
+        # same session both to persist the seed row and to release its read
+        # lock before later migrations use independent engine connections.
+        _session.commit()
     except exc.OperationalError:  # Database is not writeable
+        _session.rollback()
         print('Settings database is not writeable. Exiting...')
         sys.exit(2)
 
@@ -4136,8 +4139,11 @@ def migrate_Database(_session):
                 created = magic_shelf.create_system_magic_shelves(user.id, templates_to_create)
                 total_created += created
         
+        # Even a no-op pass performed SELECTs and therefore owns a real read
+        # transaction under explicit BEGIN handling. End it before the trigger
+        # guard below opens a separate DDL transaction on the same database.
+        _session.commit()
         if total_deleted > 0 or total_created > 0:
-            _session.commit()
             log.info(f"System shelf migration complete: {total_deleted} old shelves removed, {total_created} new shelves created")
     except Exception as e:
         log.error(f"Error during system shelf migration: {e}")
@@ -4234,6 +4240,87 @@ def create_system_magic_shelves_for_user(user_id):
         return 0
 
 
+def _request_app_db_wal(dbapi_connection):
+    """Request WAL on a raw sqlite3 connection, before SQLAlchemy autobegins."""
+    cursor = dbapi_connection.cursor()
+    try:
+        row = cursor.execute("PRAGMA journal_mode=WAL").fetchone()
+        return (row[0] if row else None), None
+    except sqlite3.Error as error:
+        return None, error
+    finally:
+        cursor.close()
+
+
+def _create_app_db_engine(app_db_path):
+    """Create an app.db engine with the safest available transaction mode.
+
+    Python's sqlite3 legacy transaction mode emits BEGIN for DML only. A
+    SAVEPOINT reached after SELECTs therefore has no enclosing transaction,
+    and releasing it makes its writes durable before Session.commit(). Disable
+    the driver's BEGIN handling and let SQLAlchemy emit BEGIN for every outer
+    transaction when WAL is available, so Session.begin_nested() is a contained
+    SAVEPOINT without making rollback-journal readers block writers.
+
+    WAL support is decided once per engine. If the first raw connection cannot
+    enable it (for example, app.db is on a network share), every connection on
+    that engine retains sqlite3's legacy transaction control. Mixing explicit
+    and legacy transaction semantics between connections would be worse than a
+    single, observable degraded mode.
+    """
+    engine = create_engine(
+        'sqlite:///{0}'.format(app_db_path),
+        echo=False,
+        connect_args={'timeout': 30},
+    )
+    transaction_mode = {'explicit_begin': None}
+    transaction_mode_lock = threading.Lock()
+    network_share_mode = network_share_mode_enabled()
+
+    @event.listens_for(engine, 'connect')
+    def _configure_app_db_transaction_mode(dbapi_connection, _connection_record):
+        if transaction_mode['explicit_begin'] is None:
+            with transaction_mode_lock:
+                if transaction_mode['explicit_begin'] is None:
+                    if network_share_mode:
+                        transaction_mode['explicit_begin'] = False
+                        log.warning(
+                            "NETWORK_SHARE_MODE=true disables SQLite WAL for every database, "
+                            "including app.db %s even when /config is on local disk, because "
+                            "WAL is unsafe on network filesystems. app.db is using legacy "
+                            "sqlite3 transaction control, so the #1873 SAVEPOINT containment "
+                            "fix is unavailable: begin_nested() SAVEPOINTs opened before DML "
+                            "may commit at RELEASE.",
+                            app_db_path,
+                        )
+                    else:
+                        journal_mode, wal_error = _request_app_db_wal(dbapi_connection)
+                        wal_enabled = str(journal_mode).lower() == 'wal'
+                        transaction_mode['explicit_begin'] = wal_enabled
+                    if not network_share_mode and not transaction_mode['explicit_begin']:
+                        reason = ("PRAGMA journal_mode=WAL failed: {}".format(wal_error)
+                                  if wal_error is not None
+                                  else "SQLite kept journal_mode={!r}".format(journal_mode))
+                        log.warning(
+                            "SQLite WAL is unavailable for app.db %s (%s). Leaving legacy "
+                            "sqlite3 transaction control active for this engine to avoid "
+                            "rollback-journal readers blocking writers; begin_nested() "
+                            "SAVEPOINTs opened before DML are not contained and may commit "
+                            "at RELEASE.",
+                            app_db_path, reason,
+                        )
+
+        if transaction_mode['explicit_begin']:
+            dbapi_connection.isolation_level = None
+
+    @event.listens_for(engine, 'begin')
+    def _emit_begin(connection):
+        if transaction_mode['explicit_begin']:
+            connection.exec_driver_sql('BEGIN')
+
+    return engine
+
+
 def init_db_thread():
     global app_DB_path
     if not app_DB_path:
@@ -4246,8 +4333,7 @@ def init_db_thread():
         raise RuntimeError(
             "ub.init_db_thread() called before ub.init_db(); app_DB_path "
             "is unset, refusing to create a stray 'None' SQLite file")
-    engine = create_engine('sqlite:///{0}'.format(app_DB_path), echo=False,
-                           connect_args={'timeout': 30})
+    engine = _create_app_db_engine(app_DB_path)
 
     Session = scoped_session(sessionmaker())
     Session.configure(bind=engine)
@@ -4260,8 +4346,7 @@ def init_db(app_db_path):
     global app_DB_path
 
     app_DB_path = app_db_path
-    engine = create_engine('sqlite:///{0}'.format(app_db_path), echo=False,
-                           connect_args={'timeout': 30})
+    engine = _create_app_db_engine(app_db_path)
 
     Session = scoped_session(sessionmaker())
     Session.configure(bind=engine)
@@ -4294,8 +4379,7 @@ def _healthcheck_app_db(app_db_path: str) -> None:
             return
         if not os.access(app_db_path, os.W_OK):
             log.error("app.db is not writable: %s", app_db_path)
-        network_share_mode = os.environ.get("NETWORK_SHARE_MODE", "false").lower() in ("1", "true", "yes")
-        if network_share_mode:
+        if network_share_mode_enabled():
             log.info("Skipping PRAGMA quick_check for app.db due to NETWORK_SHARE_MODE=true")
             return
         try:
@@ -4336,8 +4420,7 @@ def password_change(user_credentials=None):
 
 
 def get_new_session_instance():
-    new_engine = create_engine('sqlite:///{0}'.format(app_DB_path), echo=False,
-                               connect_args={'timeout': 30})
+    new_engine = _create_app_db_engine(app_DB_path)
     new_session = scoped_session(sessionmaker())
     new_session.configure(bind=new_engine)
 

--- a/cps/updater.py
+++ b/cps/updater.py
@@ -21,6 +21,7 @@ from flask_babel import gettext as _
 
 from . import constants, logger  #  config, web_server
 from .file_helper import get_temp_dir
+from .sqlite_utils import network_share_mode_enabled
 
 
 log = logger.create()
@@ -266,7 +267,7 @@ class Updater(threading.Thread):
         change_permissions = not (sys.platform == "win32" or sys.platform == "darwin")
         # Only skip permission changes for network-share paths
         try:
-            nsm = os.getenv("NETWORK_SHARE_MODE", "false").strip().lower() in ("1", "true", "yes", "on")
+            nsm = network_share_mode_enabled()
         except Exception:
             nsm = False
 

--- a/tests/unit/test_1425_kobo_to_koreader.py
+++ b/tests/unit/test_1425_kobo_to_koreader.py
@@ -424,7 +424,7 @@ def test_settles_pending_writes_before_opening_the_savepoint():
     from cps.kobo import share_kobo_progress_with_koreader
     src = inspect.getsource(share_kobo_progress_with_koreader)
     assert "session_flush()" in src
-    assert src.index("session_flush()") < src.index("begin_nested()")
+    assert src.index("session_flush()") < src.index("begin_contained_nested")
 
 
 @pytest.mark.unit

--- a/tests/unit/test_1873_app_db_savepoint_containment.py
+++ b/tests/unit/test_1873_app_db_savepoint_containment.py
@@ -1,0 +1,277 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Regression coverage for #1873's uncontained app.db SAVEPOINT."""
+
+from __future__ import annotations
+
+import sqlite3
+from types import SimpleNamespace
+
+import pytest
+
+from cps import ub
+from cps.services.annotation_sync import (
+    dispatch_existing_annotation_sync,
+    register_handler,
+    reset_registry_for_testing,
+    set_remote_enqueue,
+)
+from cps.services.annotation_sync.base import AnnotationSyncTargetHandler, SyncResult
+
+
+class _StubHandler(AnnotationSyncTargetHandler):
+    target_name = "stub"
+
+    def is_enabled(self, user):
+        return True
+
+    def push(self, annotation, book, user, payload=None):
+        return SyncResult(status="synced", target_record_id="remote-1873")
+
+    def delete(self, sync_target, user):
+        return SyncResult(status="tombstone")
+
+
+@pytest.fixture(autouse=True)
+def _reset_annotation_sync_registry():
+    reset_registry_for_testing()
+    set_remote_enqueue(None)
+    yield
+    reset_registry_for_testing()
+    set_remote_enqueue(None)
+
+
+@pytest.fixture
+def file_backed_app_db(tmp_path):
+    """Initialize the real app.db engine and restore the module globals after."""
+    previous_session = ub.session
+    previous_path = ub.app_DB_path
+    db_path = tmp_path / "app.db"
+
+    ub.init_db(str(db_path))
+    test_session = ub.session
+    try:
+        yield db_path, test_session
+    finally:
+        engine = test_session.get_bind()
+        test_session.close()
+        engine.dispose()
+        ub.session = previous_session
+        ub.app_DB_path = previous_path
+
+
+@pytest.mark.unit
+def test_existing_annotation_sync_savepoint_rolls_back_with_failed_commit(
+    file_backed_app_db, monkeypatch,
+):
+    """The web-reader/KOReader create arm must not commit at SAVEPOINT release.
+
+    ``dispatch_annotation_sync`` (the Kobo PATCH entry point) flushes an
+    Annotation before it creates the sync-target row. That DML happens to make
+    sqlite3's legacy transaction mode contain its SAVEPOINT, so testing that
+    caller passes with or without the fix. ``dispatch_existing_annotation_sync``
+    reaches the same create arm after SELECTs only and is the discriminating
+    real caller.
+
+    Seed through a separate sqlite3 connection so this SQLAlchemy connection
+    has emitted no DML before the dispatcher opens ``begin_nested()``. Then
+    model a failed outer commit by rolling back, and verify durability through
+    another independent connection rather than the session under test.
+    """
+    db_path, session = file_backed_app_db
+    session.rollback()
+
+    with sqlite3.connect(db_path) as seed:
+        user_id = seed.execute(
+            "SELECT id FROM user WHERE name = 'admin'"
+        ).fetchone()[0]
+        seed.execute(
+            "INSERT INTO annotation "
+            "(user_id, annotation_id, book_id, source, routing_revision, content_revision) "
+            "VALUES (?, 'webreader-1873', 1873, 'webreader', 1, 1)",
+            (user_id,),
+        )
+
+    user = session.query(ub.User).filter(ub.User.id == user_id).one()
+    annotation = session.query(ub.Annotation).filter(
+        ub.Annotation.annotation_id == "webreader-1873"
+    ).one()
+    register_handler(_StubHandler())
+
+    commit_attempts = []
+
+    def fail_outer_commit():
+        commit_attempts.append(True)
+        session.rollback()
+        return False
+
+    monkeypatch.setattr(ub, "session_commit", fail_outer_commit)
+
+    dispatch_existing_annotation_sync(
+        annotation,
+        SimpleNamespace(id=1873, title="SAVEPOINT regression"),
+        user,
+    )
+
+    assert commit_attempts == [True], "the test did not exercise the failed commit path"
+    with sqlite3.connect(db_path) as observer:
+        durable_targets = observer.execute(
+            "SELECT target, status FROM annotation_sync_target "
+            "WHERE annotation_id = ?",
+            (annotation.id,),
+        ).fetchall()
+
+    assert durable_targets == [], (
+        "the sync-target SAVEPOINT committed at RELEASE and survived the outer rollback"
+    )
+
+
+@pytest.mark.unit
+def test_every_app_db_session_uses_explicit_begin_and_factory_keeps_timeout(
+    file_backed_app_db,
+):
+    """The main, worker, and ad-hoc app.db constructors share WAL + the fix."""
+    _db_path, main_session = file_backed_app_db
+    thread_session = ub.init_db_thread()
+    ad_hoc_session = ub.get_new_session_instance()
+    sessions = {
+        "init_db": main_session,
+        "init_db_thread": thread_session,
+        "get_new_session_instance": ad_hoc_session,
+    }
+
+    try:
+        for constructor, session in sessions.items():
+            connection = session.connection()
+            driver_connection = connection.connection.driver_connection
+            assert driver_connection.isolation_level is None, constructor
+            assert connection.exec_driver_sql("PRAGMA journal_mode").scalar_one() == "wal"
+            session.rollback()
+
+        # Startup migrations temporarily lower busy_timeout on the pooled main
+        # connection for their own retry loop. Check a fresh factory connection
+        # so this pins the connect_args=30 contract rather than that unrelated,
+        # pre-existing migration policy.
+        timeout_engine = ub._create_app_db_engine(_db_path)
+        try:
+            with timeout_engine.connect() as connection:
+                assert connection.exec_driver_sql("PRAGMA busy_timeout").scalar_one() == 30_000
+        finally:
+            timeout_engine.dispose()
+    finally:
+        thread_engine = thread_session.get_bind()
+        thread_session.close()
+        thread_engine.dispose()
+        ad_hoc_engine = ad_hoc_session.get_bind()
+        ad_hoc_session.remove()
+        ad_hoc_engine.dispose()
+
+
+@pytest.mark.unit
+def test_wal_unavailable_suppresses_explicit_begin_warns_and_does_not_block_writer(
+    tmp_path, monkeypatch,
+):
+    """A WAL-incapable engine degrades consistently and observably."""
+    db_path = tmp_path / "wal-unavailable.db"
+    with sqlite3.connect(db_path) as setup:
+        setup.execute("CREATE TABLE probe (value TEXT NOT NULL)")
+        setup.execute("INSERT INTO probe VALUES ('seed')")
+
+    wal_requests = []
+
+    def reject_wal(connection):
+        wal_requests.append(connection)
+        return "delete", None
+
+    monkeypatch.setattr(ub, "_request_app_db_wal", reject_wal)
+    warnings = []
+
+    def capture_warning(message, *args):
+        warnings.append(message % args)
+
+    monkeypatch.setattr(ub.log, "warning", capture_warning)
+    engine = ub._create_app_db_engine(db_path)
+
+    try:
+        with engine.connect() as reader:
+            assert reader.exec_driver_sql("SELECT value FROM probe").scalar_one() == "seed"
+            driver_connection = reader.connection.driver_connection
+            assert driver_connection.isolation_level is not None
+            assert driver_connection.in_transaction is False
+
+            # Keep the reader checked out so this must create another DBAPI
+            # connection. The WAL capability probe is engine-wide, not a
+            # per-connection choice that could produce mixed semantics.
+            with engine.connect() as sibling:
+                sibling_driver = sibling.connection.driver_connection
+                assert sibling_driver is not driver_connection
+                assert sibling_driver.isolation_level is not None
+                assert sibling.exec_driver_sql("SELECT count(*) FROM probe").scalar_one() == 1
+                assert sibling_driver.in_transaction is False
+
+            # In rollback-journal mode, a legacy SELECT releases its read lock
+            # with the statement. An independent writer must not wait for this
+            # SQLAlchemy Connection's bookkeeping transaction to be closed.
+            with sqlite3.connect(db_path, timeout=0.25) as writer:
+                writer.execute("INSERT INTO probe VALUES ('writer')")
+    finally:
+        engine.dispose()
+
+    assert len(wal_requests) == 1
+    assert len(warnings) == 1
+    assert "WAL is unavailable" in warnings[0]
+    assert "legacy sqlite3 transaction control" in warnings[0]
+    assert "begin_nested() SAVEPOINTs opened before DML are not contained" in warnings[0]
+
+    with sqlite3.connect(db_path) as observer:
+        assert observer.execute("SELECT value FROM probe ORDER BY rowid").fetchall() == [
+            ("seed",),
+            ("writer",),
+        ]
+
+
+@pytest.mark.unit
+def test_network_share_mode_skips_wal_uses_legacy_transactions_and_warns(
+    tmp_path, monkeypatch,
+):
+    """NETWORK_SHARE_MODE applies to app.db even when its own path is local."""
+    db_path = tmp_path / "network-share-mode.db"
+    with sqlite3.connect(db_path) as setup:
+        setup.execute("CREATE TABLE probe (value TEXT NOT NULL)")
+        setup.execute("INSERT INTO probe VALUES ('seed')")
+
+    monkeypatch.setenv("NETWORK_SHARE_MODE", "true")
+
+    def unexpected_wal_request(_connection):
+        raise AssertionError("NETWORK_SHARE_MODE must skip PRAGMA journal_mode=WAL")
+
+    monkeypatch.setattr(ub, "_request_app_db_wal", unexpected_wal_request)
+    warnings = []
+    monkeypatch.setattr(
+        ub.log,
+        "warning",
+        lambda message, *args: warnings.append(message % args),
+    )
+    engine = ub._create_app_db_engine(db_path)
+
+    try:
+        with engine.connect() as reader:
+            driver_connection = reader.connection.driver_connection
+            assert reader.exec_driver_sql("PRAGMA journal_mode").scalar_one() == "delete"
+            assert driver_connection.isolation_level is not None
+            assert reader.exec_driver_sql("SELECT value FROM probe").scalar_one() == "seed"
+            assert driver_connection.in_transaction is False
+
+            # A second DBAPI connection must inherit the engine-wide decision
+            # without another warning or a deferred WAL negotiation.
+            with engine.connect() as sibling:
+                sibling_driver = sibling.connection.driver_connection
+                assert sibling_driver is not driver_connection
+                assert sibling_driver.isolation_level is not None
+    finally:
+        engine.dispose()
+
+    assert len(warnings) == 1
+    assert "NETWORK_SHARE_MODE=true" in warnings[0]
+    assert "even when /config is on local disk" in warnings[0]
+    assert "#1873 SAVEPOINT containment fix is unavailable" in warnings[0]

--- a/tests/unit/test_1873_app_db_savepoint_containment.py
+++ b/tests/unit/test_1873_app_db_savepoint_containment.py
@@ -4,11 +4,15 @@
 
 from __future__ import annotations
 
+import ast
 import sqlite3
 import threading
+import time
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from sqlalchemy import event
 
 from cps import ub
 from cps.services.annotation_sync import (
@@ -31,6 +35,26 @@ class _StubHandler(AnnotationSyncTargetHandler):
 
     def delete(self, sync_target, user):
         return SyncResult(status="tombstone")
+
+
+class _BeginNestedCallVisitor(ast.NodeVisitor):
+    """Collect the function containing each direct ``begin_nested`` call."""
+
+    def __init__(self):
+        self.function_names = []
+        self._function_stack = []
+
+    def visit_FunctionDef(self, node):
+        self._function_stack.append(node.name)
+        self.generic_visit(node)
+        self._function_stack.pop()
+
+    visit_AsyncFunctionDef = visit_FunctionDef
+
+    def visit_Call(self, node):
+        if isinstance(node.func, ast.Attribute) and node.func.attr == "begin_nested":
+            self.function_names.append(self._function_stack[-1] if self._function_stack else None)
+        self.generic_visit(node)
 
 
 @pytest.fixture(autouse=True)
@@ -128,10 +152,26 @@ def test_existing_annotation_sync_savepoint_rolls_back_with_failed_commit(
 
 
 @pytest.mark.unit
-def test_every_app_db_session_uses_immediate_begin_and_factory_keeps_timeout(
+def test_every_production_begin_nested_call_routes_through_containment_helper():
+    """A new direct SAVEPOINT caller must not silently lose containment."""
+    cps_root = Path(ub.__file__).resolve().parent
+    calls = []
+    for source_path in cps_root.rglob("*.py"):
+        visitor = _BeginNestedCallVisitor()
+        visitor.visit(ast.parse(source_path.read_text(encoding="utf-8")))
+        calls.extend(
+            (source_path.relative_to(cps_root).as_posix(), function_name)
+            for function_name in visitor.function_names
+        )
+
+    assert calls == [("ub.py", "begin_contained_nested")]
+
+
+@pytest.mark.unit
+def test_every_app_db_session_uses_legacy_transactions_and_factory_keeps_timeout(
     file_backed_app_db,
 ):
-    """The main, worker, and ad-hoc constructors share WAL + BEGIN IMMEDIATE."""
+    """All app.db constructors share WAL without changing driver transactions."""
     _db_path, main_session = file_backed_app_db
     thread_session = ub.init_db_thread()
     ad_hoc_session = ub.get_new_session_instance()
@@ -145,8 +185,9 @@ def test_every_app_db_session_uses_immediate_begin_and_factory_keeps_timeout(
         for constructor, session in sessions.items():
             connection = session.connection()
             driver_connection = connection.connection.driver_connection
-            assert driver_connection.isolation_level is None, constructor
+            assert driver_connection.isolation_level is not None, constructor
             assert connection.exec_driver_sql("PRAGMA journal_mode").scalar_one() == "wal"
+            assert driver_connection.in_transaction is False, constructor
             session.rollback()
 
         # Startup migrations temporarily lower busy_timeout on the pooled main
@@ -169,17 +210,48 @@ def test_every_app_db_session_uses_immediate_begin_and_factory_keeps_timeout(
 
 
 @pytest.mark.unit
-def test_read_then_write_waits_before_snapshot_instead_of_failing_busy_snapshot(
+def test_startup_read_session_does_not_block_backfill_on_second_pool_connection(
+    file_backed_app_db,
+):
+    """Match create_app's config SELECT followed by engine-based backfill."""
+    _db_path, session = file_backed_app_db
+    engine = session.get_bind()
+    session.rollback()
+    checkout_ids = []
+
+    def record_checkout(dbapi_connection, _record, _proxy):
+        checkout_ids.append(id(dbapi_connection))
+
+    event.listen(engine, "checkout", record_checkout)
+    try:
+        assert session.query(ub.User).first() is not None
+        driver_connection = session.connection().connection.driver_connection
+        assert driver_connection.in_transaction is False
+
+        started = time.monotonic()
+        ub.backfill_annotation_content_ids(engine, lambda _book_id: None)
+        elapsed = time.monotonic() - started
+    finally:
+        event.remove(engine, "checkout", record_checkout)
+
+    assert elapsed < 5
+    assert len(set(checkout_ids)) == 2, (
+        "the test did not force backfill onto a second pooled DBAPI connection"
+    )
+
+
+@pytest.mark.unit
+def test_read_then_write_starts_fresh_after_a_concurrent_commit(
     tmp_path,
 ):
-    """A concurrent commit cannot invalidate a future app.db write.
+    """A legacy-mode SELECT cannot leave a stale snapshot to upgrade.
 
     Under #1888's deferred ``BEGIN``, connection A takes a read snapshot, B
     commits, and A's INSERT fails immediately with ``database is locked``:
     SQLite cannot upgrade the stale snapshot and does not apply busy_timeout to
-    SQLITE_BUSY_SNAPSHOT. BEGIN IMMEDIATE instead reserves the writer slot when
-    A starts. B waits in its ordinary SQLITE_BUSY retry loop, A writes and
-    commits, then B completes.
+    SQLITE_BUSY_SNAPSHOT. Under sqlite3's legacy transaction control, A's
+    SELECT owns no driver transaction. B commits first, then A starts a fresh
+    write transaction and succeeds.
     """
     db_path = tmp_path / "busy-snapshot.db"
     with sqlite3.connect(db_path) as setup:
@@ -208,14 +280,16 @@ def test_read_then_write_waits_before_snapshot_instead_of_failing_busy_snapshot(
         assert connection_a.exec_driver_sql(
             "SELECT value FROM probe ORDER BY rowid"
         ).all() == [("seed",)]
+        driver_connection = connection_a.connection.driver_connection
+        assert driver_connection.in_transaction is False
 
         connection_b_thread = threading.Thread(target=concurrent_writer)
         connection_b_thread.start()
         assert writer_started.wait(timeout=1), "connection B never attempted its write"
 
-        # Deferred BEGIN lets B commit here and makes A's following INSERT hit
-        # SQLITE_BUSY_SNAPSHOT. BEGIN IMMEDIATE keeps B waiting instead.
-        b_committed_before_a_write = writer_committed.wait(timeout=0.2)
+        assert writer_committed.wait(timeout=1), (
+            "connection A's read-only bookkeeping transaction blocked connection B"
+        )
         connection_a.exec_driver_sql("INSERT INTO probe VALUES ('connection-a')")
         connection_a.commit()
     finally:
@@ -224,33 +298,31 @@ def test_read_then_write_waits_before_snapshot_instead_of_failing_busy_snapshot(
             connection_b_thread.join(timeout=3)
         engine.dispose()
 
-    assert b_committed_before_a_write is False
     assert writer_errors == []
-    assert writer_committed.is_set(), "connection B did not resume after A committed"
     with sqlite3.connect(db_path) as observer:
         assert observer.execute(
             "SELECT value FROM probe ORDER BY rowid"
         ).fetchall() == [
             ("seed",),
-            ("connection-a",),
             ("connection-b",),
+            ("connection-a",),
         ]
 
 
 @pytest.mark.unit
 @pytest.mark.parametrize(
-    ("journal_mode", "explicit_begin"),
+    ("journal_mode", "contained_outer"),
     (
         pytest.param("delete", False, id="delete-legacy"),
-        pytest.param("delete", True, id="delete-immediate"),
+        pytest.param("delete", True, id="delete-local-immediate"),
         pytest.param("wal", False, id="wal-legacy"),
-        pytest.param("wal", True, id="wal-immediate"),
+        pytest.param("wal", True, id="wal-local-immediate"),
     ),
 )
 def test_sqlite_transaction_mode_four_arm_probe(
-    tmp_path, journal_mode, explicit_begin,
+    tmp_path, journal_mode, contained_outer,
 ):
-    """Pin containment, reader access, and writer cost in all four modes."""
+    """Pin legacy behavior and the local containment cost in all four arms."""
     db_path = tmp_path / "transaction-mode-probe.db"
     with sqlite3.connect(db_path) as setup:
         assert setup.execute(
@@ -260,12 +332,12 @@ def test_sqlite_transaction_mode_four_arm_probe(
         setup.execute("INSERT INTO probe VALUES ('seed')")
 
     connection_a = sqlite3.connect(db_path, timeout=0.1)
-    if explicit_begin:
+    if contained_outer:
         connection_a.isolation_level = None
         connection_a.execute("BEGIN IMMEDIATE")
     try:
         assert connection_a.execute("SELECT value FROM probe").fetchall() == [("seed",)]
-        assert connection_a.in_transaction is explicit_begin
+        assert connection_a.in_transaction is contained_outer
 
         # A reserved writer never blocks an independent reader. In WAL this is
         # the production arm; DELETE + immediate is retained as an off-policy
@@ -282,7 +354,7 @@ def test_sqlite_transaction_mode_four_arm_probe(
         except sqlite3.OperationalError as error:
             assert "database is locked" in str(error).lower()
             writer_blocked = True
-        assert writer_blocked is explicit_begin
+        assert writer_blocked is contained_outer
 
         connection_a.execute("SAVEPOINT contained")
         connection_a.execute("INSERT INTO probe VALUES ('savepoint')")
@@ -295,11 +367,11 @@ def test_sqlite_transaction_mode_four_arm_probe(
         savepoint_rows = observer.execute(
             "SELECT value FROM probe WHERE value = 'savepoint'"
         ).fetchall()
-    assert savepoint_rows == ([] if explicit_begin else [("savepoint",)])
+    assert savepoint_rows == ([] if contained_outer else [("savepoint",)])
 
 
 @pytest.mark.unit
-def test_wal_unavailable_suppresses_explicit_begin_warns_and_does_not_block_writer(
+def test_wal_unavailable_keeps_legacy_transactions_warns_and_does_not_block_writer(
     tmp_path, monkeypatch,
 ):
     """A WAL-incapable engine degrades consistently and observably."""
@@ -352,7 +424,7 @@ def test_wal_unavailable_suppresses_explicit_begin_warns_and_does_not_block_writ
     assert len(warnings) == 1
     assert "WAL is unavailable" in warnings[0]
     assert "legacy sqlite3 transaction control" in warnings[0]
-    assert "begin_nested() SAVEPOINTs opened before DML are not contained" in warnings[0]
+    assert "contained SAVEPOINTs acquire a local write transaction" in warnings[0]
 
     with sqlite3.connect(db_path) as observer:
         assert observer.execute("SELECT value FROM probe ORDER BY rowid").fetchall() == [
@@ -405,4 +477,4 @@ def test_network_share_mode_skips_wal_uses_legacy_transactions_and_warns(
     assert len(warnings) == 1
     assert "NETWORK_SHARE_MODE=true" in warnings[0]
     assert "even when /config is on local disk" in warnings[0]
-    assert "#1873 SAVEPOINT containment fix is unavailable" in warnings[0]
+    assert "contained SAVEPOINTs acquire a local write transaction" in warnings[0]

--- a/tests/unit/test_1873_app_db_savepoint_containment.py
+++ b/tests/unit/test_1873_app_db_savepoint_containment.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import sqlite3
+import threading
 from types import SimpleNamespace
 
 import pytest
@@ -127,10 +128,10 @@ def test_existing_annotation_sync_savepoint_rolls_back_with_failed_commit(
 
 
 @pytest.mark.unit
-def test_every_app_db_session_uses_explicit_begin_and_factory_keeps_timeout(
+def test_every_app_db_session_uses_immediate_begin_and_factory_keeps_timeout(
     file_backed_app_db,
 ):
-    """The main, worker, and ad-hoc app.db constructors share WAL + the fix."""
+    """The main, worker, and ad-hoc constructors share WAL + BEGIN IMMEDIATE."""
     _db_path, main_session = file_backed_app_db
     thread_session = ub.init_db_thread()
     ad_hoc_session = ub.get_new_session_instance()
@@ -165,6 +166,136 @@ def test_every_app_db_session_uses_explicit_begin_and_factory_keeps_timeout(
         ad_hoc_engine = ad_hoc_session.get_bind()
         ad_hoc_session.remove()
         ad_hoc_engine.dispose()
+
+
+@pytest.mark.unit
+def test_read_then_write_waits_before_snapshot_instead_of_failing_busy_snapshot(
+    tmp_path,
+):
+    """A concurrent commit cannot invalidate a future app.db write.
+
+    Under #1888's deferred ``BEGIN``, connection A takes a read snapshot, B
+    commits, and A's INSERT fails immediately with ``database is locked``:
+    SQLite cannot upgrade the stale snapshot and does not apply busy_timeout to
+    SQLITE_BUSY_SNAPSHOT. BEGIN IMMEDIATE instead reserves the writer slot when
+    A starts. B waits in its ordinary SQLITE_BUSY retry loop, A writes and
+    commits, then B completes.
+    """
+    db_path = tmp_path / "busy-snapshot.db"
+    with sqlite3.connect(db_path) as setup:
+        assert setup.execute("PRAGMA journal_mode=WAL").fetchone() == ("wal",)
+        setup.execute("CREATE TABLE probe (value TEXT NOT NULL)")
+        setup.execute("INSERT INTO probe VALUES ('seed')")
+
+    engine = ub._create_app_db_engine(db_path)
+    writer_started = threading.Event()
+    writer_committed = threading.Event()
+    writer_errors = []
+
+    def concurrent_writer():
+        try:
+            with sqlite3.connect(db_path, timeout=2) as connection_b:
+                writer_started.set()
+                connection_b.execute("INSERT INTO probe VALUES ('connection-b')")
+                connection_b.commit()
+                writer_committed.set()
+        except BaseException as error:  # surfaced in the test thread below
+            writer_errors.append(error)
+
+    connection_b_thread = None
+    connection_a = engine.connect()
+    try:
+        assert connection_a.exec_driver_sql(
+            "SELECT value FROM probe ORDER BY rowid"
+        ).all() == [("seed",)]
+
+        connection_b_thread = threading.Thread(target=concurrent_writer)
+        connection_b_thread.start()
+        assert writer_started.wait(timeout=1), "connection B never attempted its write"
+
+        # Deferred BEGIN lets B commit here and makes A's following INSERT hit
+        # SQLITE_BUSY_SNAPSHOT. BEGIN IMMEDIATE keeps B waiting instead.
+        b_committed_before_a_write = writer_committed.wait(timeout=0.2)
+        connection_a.exec_driver_sql("INSERT INTO probe VALUES ('connection-a')")
+        connection_a.commit()
+    finally:
+        connection_a.close()
+        if connection_b_thread is not None:
+            connection_b_thread.join(timeout=3)
+        engine.dispose()
+
+    assert b_committed_before_a_write is False
+    assert writer_errors == []
+    assert writer_committed.is_set(), "connection B did not resume after A committed"
+    with sqlite3.connect(db_path) as observer:
+        assert observer.execute(
+            "SELECT value FROM probe ORDER BY rowid"
+        ).fetchall() == [
+            ("seed",),
+            ("connection-a",),
+            ("connection-b",),
+        ]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("journal_mode", "explicit_begin"),
+    (
+        pytest.param("delete", False, id="delete-legacy"),
+        pytest.param("delete", True, id="delete-immediate"),
+        pytest.param("wal", False, id="wal-legacy"),
+        pytest.param("wal", True, id="wal-immediate"),
+    ),
+)
+def test_sqlite_transaction_mode_four_arm_probe(
+    tmp_path, journal_mode, explicit_begin,
+):
+    """Pin containment, reader access, and writer cost in all four modes."""
+    db_path = tmp_path / "transaction-mode-probe.db"
+    with sqlite3.connect(db_path) as setup:
+        assert setup.execute(
+            "PRAGMA journal_mode={}".format(journal_mode)
+        ).fetchone() == (journal_mode,)
+        setup.execute("CREATE TABLE probe (value TEXT NOT NULL)")
+        setup.execute("INSERT INTO probe VALUES ('seed')")
+
+    connection_a = sqlite3.connect(db_path, timeout=0.1)
+    if explicit_begin:
+        connection_a.isolation_level = None
+        connection_a.execute("BEGIN IMMEDIATE")
+    try:
+        assert connection_a.execute("SELECT value FROM probe").fetchall() == [("seed",)]
+        assert connection_a.in_transaction is explicit_begin
+
+        # A reserved writer never blocks an independent reader. In WAL this is
+        # the production arm; DELETE + immediate is retained as an off-policy
+        # diagnostic arm so a journal-mode behavior change is visible.
+        with sqlite3.connect(db_path, timeout=0.1) as independent_reader:
+            assert independent_reader.execute("SELECT value FROM probe").fetchall() == [
+                ("seed",),
+            ]
+
+        writer_blocked = False
+        try:
+            with sqlite3.connect(db_path, timeout=0.05) as connection_b:
+                connection_b.execute("INSERT INTO probe VALUES ('connection-b')")
+        except sqlite3.OperationalError as error:
+            assert "database is locked" in str(error).lower()
+            writer_blocked = True
+        assert writer_blocked is explicit_begin
+
+        connection_a.execute("SAVEPOINT contained")
+        connection_a.execute("INSERT INTO probe VALUES ('savepoint')")
+        connection_a.execute("RELEASE SAVEPOINT contained")
+        connection_a.rollback()
+    finally:
+        connection_a.close()
+
+    with sqlite3.connect(db_path) as observer:
+        savepoint_rows = observer.execute(
+            "SELECT value FROM probe WHERE value = 'savepoint'"
+        ).fetchall()
+    assert savepoint_rows == ([] if explicit_begin else [("savepoint",)])
 
 
 @pytest.mark.unit

--- a/tests/unit/test_324_web_reader_progress_writeback.py
+++ b/tests/unit/test_324_web_reader_progress_writeback.py
@@ -510,7 +510,7 @@ def test_progress_lookup_does_not_autoflush_the_callers_bookmark():
         "the KoboReadingState lookup must not autoflush a caller's pending write"
     lookup = src.index("query(ub.KoboReadingState)")
     guard = src.index("with ub.session.no_autoflush:")
-    savepoint = src.index("with ub.session.begin_nested():")
+    savepoint = src.index("with ub.begin_contained_nested(ub.session):")
     assert guard < lookup < savepoint, \
         "the no_autoflush guard must wrap the lookup, which must precede the savepoint"
 

--- a/tests/unit/test_favorite_books.py
+++ b/tests/unit/test_favorite_books.py
@@ -26,8 +26,9 @@ def test_favoritebook_model_and_migration():
     assert "__tablename__ = 'favorite_book'" in src
     assert "uq_favorite_book" in src
     # New table is auto-created on startup (idempotent), like the sibling tables.
-    assert 'has_table(engine.connect(), "favorite_book")' in src
-    assert "FavoriteBook.__table__.create(bind=engine, checkfirst=True)" in src
+    assert '("favorite_book", FavoriteBook.__table__)' in src
+    assert "with engine.connect() as connection:" in src
+    assert "table.create(bind=engine, checkfirst=True)" in src
     # Existing users get the new sidebar bit OR'd in (one-time, marker-guarded).
     assert "favorites_sidebar_v1" in src
 

--- a/tests/unit/test_sqlite_utils.py
+++ b/tests/unit/test_sqlite_utils.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Regression coverage for WAL-safe live SQLite copies."""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from cps.sqlite_utils import copy_sqlite_database
+
+
+@pytest.mark.unit
+def test_online_backup_contains_committed_write_still_in_wal(tmp_path):
+    source = tmp_path / "app.db"
+    snapshot = tmp_path / "app.db.bak"
+    writer = sqlite3.connect(source)
+    try:
+        assert writer.execute("PRAGMA journal_mode=WAL").fetchone()[0] == "wal"
+        writer.execute("PRAGMA wal_autocheckpoint=0")
+        writer.execute("CREATE TABLE probe (value TEXT NOT NULL)")
+        writer.execute("INSERT INTO probe VALUES ('checkpointed')")
+        writer.commit()
+        assert writer.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone() == (0, 0, 0)
+
+        writer.execute("INSERT INTO probe VALUES ('committed-in-wal')")
+        writer.commit()
+        assert (tmp_path / "app.db-wal").stat().st_size > 0
+
+        copy_sqlite_database(source, snapshot)
+
+        # The copy itself must be a self-contained file. Opening a WAL-mode
+        # database may create fresh sidecars, so assert this before observing it.
+        assert not (tmp_path / "app.db.bak-wal").exists()
+        assert not (tmp_path / "app.db.bak-shm").exists()
+        with sqlite3.connect(snapshot) as observer:
+            assert observer.execute("SELECT value FROM probe ORDER BY rowid").fetchall() == [
+                ("checkpointed",),
+                ("committed-in-wal",),
+            ]
+            assert observer.execute("PRAGMA journal_mode").fetchone() == ("delete",)
+    finally:
+        writer.close()
+
+
+@pytest.mark.unit
+def test_online_restore_overwrites_stale_destination_wal(tmp_path):
+    live_db = tmp_path / "metadata.db"
+    backup = tmp_path / "metadata.db.bak"
+    writer = sqlite3.connect(live_db)
+    try:
+        assert writer.execute("PRAGMA journal_mode=WAL").fetchone()[0] == "wal"
+        writer.execute("PRAGMA wal_autocheckpoint=0")
+        writer.execute("CREATE TABLE probe (value TEXT NOT NULL)")
+        writer.execute("INSERT INTO probe VALUES ('restored')")
+        writer.commit()
+        assert writer.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone() == (0, 0, 0)
+        copy_sqlite_database(live_db, backup)
+
+        # This committed change exists only in the live database's WAL. A raw
+        # replacement of metadata.db with the backup leaves the matching WAL
+        # beside it, and SQLite reapplies this stale value on the next open.
+        writer.execute("UPDATE probe SET value = 'stale-wal-value'")
+        writer.commit()
+        assert (tmp_path / "metadata.db-wal").stat().st_size > 0
+
+        copy_sqlite_database(backup, live_db, restore=True)
+
+        with sqlite3.connect(live_db) as observer:
+            assert observer.execute("PRAGMA journal_mode").fetchone() == ("wal",)
+            assert observer.execute("SELECT value FROM probe").fetchall() == [("restored",)]
+            assert observer.execute("PRAGMA integrity_check").fetchone() == ("ok",)
+    finally:
+        writer.close()


### PR DESCRIPTION
Closes #1873. Re-lands #1888 (reverted in #1926) with one design change: the outer transaction is `BEGIN IMMEDIATE`, not a deferred `BEGIN`.

## Why #1888 failed and this does not
Under WAL a deferred `BEGIN` that has already read, then writes after another connection committed, gets `SQLITE_BUSY_SNAPSHOT` — SQLite's busy handler never retries it. On main's E2E lane that was 121× `database is locked` per run (annotation POST → 500), the first one second after startup while a helper process ran its startup migrations. `BEGIN IMMEDIATE` reserves the writer slot at the first statement, so writers queue through the 30 s busy timeout and WAL readers never block.

## Measured
```
concurrency test (A begins+SELECT, B commits, A writes):
  deferred BEGIN   -> sqlite3.OperationalError: database is locked   (0.18 s)
  BEGIN IMMEDIATE  -> passes; observer sees seed, connection-a, connection-b
four-arm probe: DELETE/WAL x legacy/immediate — savepoint contained only under immediate; WAL reader reads while A holds the write lock
```
Cost, stated: every app.db session reserves the writer slot for its lifetime, including read-only requests; they queue behind the current app.db transaction (WAL autocommit readers are unaffected).

## What this PR cannot prove by itself
The E2E lane on a PR tests `:dev` (main's image), never this branch (#1927). A serial suite cannot see the concurrency defect. **Merge gate for this PR: a local e2e run of the SPA harness against an image built from this branch, green on the annotation/notes/theme specs that failed on main under #1888.** Evidence to be attached before merge.

Related: #1926 (revert), #1927 (E2E filter/image gaps).

## Local e2e evidence 2026-08-28 (why this is DRAFT)

| image | 7 specs (desktop) | `database is locked` | api_v1 unhandled |
|---|---|---|---|
| this branch `b232fa68f` | **never booted** — `create_app → backfill_annotation_content_ids → BEGIN IMMEDIATE` waits 30 s, dies, s6 restart-loops (19 boots) | 36 | — |
| control `e8b035225` (#1888) | 14 pass / 3 fail / 4 flaky | 64 | 15 |
| baseline `b00ecae58` (post-revert main) | 19 pass / 1 fail (ECONNRESET) / 2 flaky | 0 | 0 |

Mechanism: `BEGIN IMMEDIATE` on every transaction lets the scoped session hold the WAL writer slot after its first SELECT in `create_app`; the backfill's second pooled connection can never acquire it (probe: with a `session.commit()` before the backfill it succeeds in 0.0 s). Both global modes fail (deferred → busy-snapshot storm; immediate → startup self-deadlock); the redesign makes containment local to the `begin_nested()` call sites. Merge gate unchanged: local e2e on an image built from the branch, 0 lock errors, plus the startup path proven.

## Local e2e evidence for the redesign `e7d85d49c` (2026-08-28)

| image | boots | 7 specs (desktop) | `database is locked` | api_v1 unhandled |
|---|---|---|---|---|
| **`e7d85d49c`** (local containment) | **1, healthy** | **22 pass / 0 fail / 0 flaky** | **0** | **0** |
| previous head `b232fa68f` (global IMMEDIATE) | never | — | 36 | — |
| control `e8b035225` (#1888) | ok | 14 / 3 / 4 | 64 | 15 |
| baseline `b00ecae58` (post-revert main) | ok | 19 / 1 (ECONNRESET) / 2 | 0 | 0 |

Local unit suite: 7236 passed, 105 skipped (incl. the 17 sandbox-blocked tests). Design: legacy transaction control stays global; `ub.begin_contained_nested()` issues `BEGIN IMMEDIATE` on the caller's connection only when the driver has no transaction, at the four SAVEPOINT sites. Ready for review pending CI.
