### PR TITLE
fix(kobo): answer owned books' annotation GET and PATCH locally instead of proxying to Kobo (#1923)

### DIFF
--- a/changelog.d/issue-1923.md
+++ b/changelog.d/issue-1923.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Kobo highlights for books owned by your Calibre-Web library now stay private and survive re-downloads because annotation uploads and downloads for those books are answered by Calibre-Web instead of being sent through Kobo's cloud.**

--- a/changelog.d/issue-1923.md
+++ b/changelog.d/issue-1923.md
@@ -1,3 +1,3 @@
 ### Fixed
 
-- **Kobo highlights for books owned by your Calibre-Web library now stay private and survive re-downloads because annotation uploads and downloads for those books are answered by Calibre-Web instead of being sent through Kobo's cloud.**
+- **Kobo annotation downloads for books in your Calibre-Web library are now answered locally only after Calibre-Web has a complete authoritative set; unseeded, ineligible, and paginated collections continue through Kobo so partial local data cannot replace device highlights.**

--- a/changelog.d/issue-1923.md
+++ b/changelog.d/issue-1923.md
@@ -1,3 +1,3 @@
 ### Fixed
 
-- **Kobo annotation downloads for books in your Calibre-Web library are now answered locally only after Calibre-Web has a complete authoritative set; unseeded, ineligible, and paginated collections continue through Kobo so partial local data cannot replace device highlights.**
+- **Kobo annotation uploads and downloads are answered locally only for books whose annotation set Calibre-Web has fully seeded; other books continue through Kobo so partial server data cannot replace device highlights.**

--- a/cps/readingservices.py
+++ b/cps/readingservices.py
@@ -449,24 +449,72 @@ def _owned_annotation_patch_ack(capture_session, ownership, entitlement_id):
     return response
 
 
-def _owned_annotation_get_response(capture_session, ownership, entitlement_id):
-    """Always return the complete local set; If-None-Match never yields 304."""
-    from cps.services.kobo_annotation_authority import render_owned_annotations
+def _owned_annotation_page_limit():
+    """Return the requested one-page bound, or ``None`` to force the proxy."""
+    try:
+        values = request.args.getlist("limit")
+        if not values:
+            return 100
+        if len(values) != 1:
+            return None
+        page_limit = int(values[0])
+        if page_limit < 1 or page_limit > 100:
+            return None
+        return page_limit
+    except (TypeError, ValueError, OverflowError):
+        return None
 
-    body, etag = render_owned_annotations(
-        user_id=current_user.id,
-        book_id=ownership.id,
-        entitlement_id=entitlement_id,
-        log=log,
-    )
-    _record_annotation_decision(
-        capture_session, ownership, "answered_locally", entitlement_id,
-    )
-    response = make_response(body, 200)
-    response.headers["Content-Type"] = "application/json"
-    response.headers["Content-Length"] = str(len(body))
-    response.headers["ETag"] = etag
-    return response
+
+def _owned_annotation_get_response(capture_session, ownership, entitlement_id):
+    """Return one complete eligible local page, otherwise proxy unchanged."""
+    try:
+        from cps.services.kobo_annotation_authority import (
+            local_get_is_eligible,
+            render_owned_annotations,
+        )
+
+        page_limit = _owned_annotation_page_limit()
+        has_cursor = request.args.get("pageOffsetToken") is not None
+        if has_cursor or not local_get_is_eligible(
+            settings=config,
+            user=current_user,
+            book_id=ownership.id,
+            entitlement_id=entitlement_id,
+            page_limit=page_limit,
+            log=log,
+        ):
+            return _proxy_annotation_request(
+                capture_session, ownership, entitlement_id,
+            )
+
+        rendered = render_owned_annotations(
+            user_id=current_user.id,
+            book_id=ownership.id,
+            entitlement_id=entitlement_id,
+            page_limit=page_limit,
+            log=log,
+        )
+        if rendered is None:
+            return _proxy_annotation_request(
+                capture_session, ownership, entitlement_id,
+            )
+        body, etag = rendered
+        _record_annotation_decision(
+            capture_session, ownership, "answered_locally", entitlement_id,
+        )
+        response = make_response(body, 200)
+        response.headers["Content-Type"] = "application/json"
+        response.headers["Content-Length"] = str(len(body))
+        response.headers["ETag"] = etag
+        return response
+    except Exception:
+        log.exception(
+            "Owned Kobo annotation GET local authority failed; proxying "
+            "entitlement=%s", entitlement_id,
+        )
+        return _proxy_annotation_request(
+            capture_session, ownership, entitlement_id,
+        )
 
 
 def _stage_patch_for_recovery(raw_body, entitlement_id):

--- a/cps/readingservices.py
+++ b/cps/readingservices.py
@@ -415,6 +415,60 @@ def _capture_ownership_label(ownership):
     return "owned"
 
 
+def _record_annotation_decision(capture_session, ownership, action, entitlement_id):
+    """Best-effort exchange-capture decision for one annotation request."""
+    if capture_session is None:
+        return
+    capture_session.add_decision(
+        stage="local_authority",
+        index=0,
+        content_id=entitlement_id,
+        ownership=_capture_ownership_label(ownership),
+        authority_status=_capture_authority_status(ownership),
+        action=action,
+    )
+
+
+def _proxy_annotation_request(capture_session, ownership, entitlement_id):
+    _record_annotation_decision(
+        capture_session, ownership, "proxied", entitlement_id,
+    )
+    if capture_session is None:
+        return proxy_to_kobo_reading_services()
+    return proxy_to_kobo_reading_services(capture_session=capture_session)
+
+
+def _owned_annotation_patch_ack(capture_session, ownership, entitlement_id):
+    """The bare 204 shape Nickel receives from Kobo on a successful PATCH."""
+    _record_annotation_decision(
+        capture_session, ownership, "answered_locally", entitlement_id,
+    )
+    response = make_response(b"", 204)
+    response.headers["Content-Type"] = "text/html"
+    response.headers["Content-Length"] = "0"
+    return response
+
+
+def _owned_annotation_get_response(capture_session, ownership, entitlement_id):
+    """Always return the complete local set; If-None-Match never yields 304."""
+    from cps.services.kobo_annotation_authority import render_owned_annotations
+
+    body, etag = render_owned_annotations(
+        user_id=current_user.id,
+        book_id=ownership.id,
+        entitlement_id=entitlement_id,
+        log=log,
+    )
+    _record_annotation_decision(
+        capture_session, ownership, "answered_locally", entitlement_id,
+    )
+    response = make_response(body, 200)
+    response.headers["Content-Type"] = "application/json"
+    response.headers["Content-Length"] = str(len(body))
+    response.headers["ETag"] = etag
+    return response
+
+
 def _stage_patch_for_recovery(raw_body, entitlement_id):
     """Bounded off-hub durable stage; never change route success."""
     try:
@@ -635,14 +689,16 @@ def _dispatch_kobo_annotation_deletes(annotation_sync, deleted, entitlement_id, 
             "Ignoring deletedAnnotationIds for entitlement %s: expected a list",
             entitlement_id,
         )
+        return True
     elif deleted:
         # Nickel can only name annotations Kobo created: CWNG has no annotation
         # writeback to Kobo. If F-3b565b implements writeback, this provenance
         # authority must be revisited.
-        annotation_sync.dispatch_annotation_deletes(
+        return annotation_sync.dispatch_annotation_deletes(
             deleted, current_user, book_id=book.id,
             deletable_sources={"kobo"},
         )
+    return True
 
 
 @csrf.exempt
@@ -651,7 +707,8 @@ def _dispatch_kobo_annotation_deletes(annotation_sync, deleted, entitlement_id, 
 def handle_annotations(entitlement_id):
     """Handle annotation requests for a specific book.
 
-    GET: proxied directly to Kobo.
+    GET: owned books are answered from CWNG's complete visible set; unowned
+    books retain the byte-transparent Kobo proxy.
     PATCH: intercept — persist locally (source='kobo'), then dispatch through
     each registered + enabled annotation_sync handler (Hardcover today; future
     Readwise / Notion / etc.). All DB writes happen in the dispatcher; this
@@ -669,7 +726,8 @@ def handle_annotations(entitlement_id):
         # The capture needs the bytes earlier than that, so the guard has to
         # move with it -- but it must NOT become a blanket 503: a 503 on the
         # annotations GET is one of the three measured answers that makes Nickel
-        # empty the book's local annotation set. Refuse the PATCH, proxy the GET.
+        # empty the book's local annotation set. Refuse the PATCH, proxy the GET
+        # only when ownership is not known locally.
         log.exception(
             "Could not read the annotation request body for entitlement %s",
             entitlement_id,
@@ -678,6 +736,9 @@ def handle_annotations(entitlement_id):
             return make_response(
                 jsonify({"error": "Annotation capture temporarily unavailable"}), 503,
             )
+        ownership = resolve_entitlement_ownership(entitlement_id)
+        if ownership is not None and ownership is not OWNERSHIP_UNKNOWN:
+            return _owned_annotation_get_response(None, ownership, entitlement_id)
         return proxy_to_kobo_reading_services()
     capture_session = _begin_exchange_capture(
         "annotations_patch" if request.method == "PATCH" else "annotations_get",
@@ -685,6 +746,15 @@ def handle_annotations(entitlement_id):
         authentication="authenticated",
         user_id=getattr(current_user, "id", None),
     )
+    if request.method == "GET":
+        ownership = resolve_entitlement_ownership(entitlement_id)
+        if ownership is not None and ownership is not OWNERSHIP_UNKNOWN:
+            return _owned_annotation_get_response(
+                capture_session, ownership, entitlement_id,
+            )
+        return _proxy_annotation_request(capture_session, ownership, entitlement_id)
+
+    book = None
     if request.method == "PATCH":
         patch_spool_ticket = _stage_patch_for_recovery(raw_body, entitlement_id)
         # The conservative default is replayable. Every post-stage exit crosses
@@ -805,9 +875,20 @@ def handle_annotations(entitlement_id):
                             503,
                         )
                 if not deterministic_update_rejection:
-                    _dispatch_kobo_annotation_deletes(
+                    deletes_persisted = _dispatch_kobo_annotation_deletes(
                         annotation_sync, deleted, entitlement_id, book,
                     )
+                    if deletes_persisted is False:
+                        log.error(
+                            "Kobo annotation deletes were not fully persisted for "
+                            "user_id=%s book_id=%s; refusing to acknowledge them",
+                            getattr(current_user, "id", None), book.id,
+                        )
+                        patch_spool_outcome = "dispatch_refused"
+                        return make_response(
+                            jsonify({"error": "Annotation capture temporarily unavailable"}),
+                            503,
+                        )
             patch_spool_outcome = "dispatch_completed"
         except Exception:
             log.exception("Error processing PATCH annotations")
@@ -816,12 +897,9 @@ def handle_annotations(entitlement_id):
             )
         finally:
             _mark_patch_spool_outcome(patch_spool_ticket, patch_spool_outcome)
-    # Proxy both GET + PATCH. Do not refuse GET: hardware testing showed that a
-    # 503 (or a hung request) makes Nickel empty its local annotations. The safe
-    # containment point is checkforchanges, before Nickel decides to GET.
-    if capture_session is None:
-        return proxy_to_kobo_reading_services()
-    return proxy_to_kobo_reading_services(capture_session=capture_session)
+    if book is not None:
+        return _owned_annotation_patch_ack(capture_session, book, entitlement_id)
+    return _proxy_annotation_request(capture_session, book, entitlement_id)
 
 
 @csrf.exempt

--- a/cps/readingservices.py
+++ b/cps/readingservices.py
@@ -449,6 +449,30 @@ def _owned_annotation_patch_ack(capture_session, ownership, entitlement_id):
     return response
 
 
+def _owned_patch_is_local_authority(ownership, entitlement_id):
+    """Use the exact same complete-set proof as the owned GET."""
+    try:
+        from cps.services.kobo_annotation_authority import local_get_is_eligible
+        return local_get_is_eligible(
+            settings=config,
+            user=current_user,
+            book_id=ownership.id,
+            entitlement_id=entitlement_id,
+            page_limit=100,
+            device_id=getattr(g, "annotation_origin_device_id", None),
+            log=log,
+        )
+    except Exception:
+        # A gate failure must preserve the pre-authority PATCH path.  Proxying
+        # keeps feeding Kobo's copy; locally acknowledging would split the two
+        # verbs and could make the next replacement-set GET destructive.
+        log.exception(
+            "Kobo PATCH authority gate failed; proxying user_id=%s book_id=%s",
+            getattr(current_user, "id", None), getattr(ownership, "id", None),
+        )
+        return False
+
+
 def _owned_annotation_page_limit():
     """Return the requested one-page bound, or ``None`` to force the proxy."""
     try:
@@ -481,6 +505,7 @@ def _owned_annotation_get_response(capture_session, ownership, entitlement_id):
             book_id=ownership.id,
             entitlement_id=entitlement_id,
             page_limit=page_limit,
+            device_id=getattr(g, "annotation_origin_device_id", None),
             log=log,
         ):
             return _proxy_annotation_request(
@@ -492,6 +517,7 @@ def _owned_annotation_get_response(capture_session, ownership, entitlement_id):
             book_id=ownership.id,
             entitlement_id=entitlement_id,
             page_limit=page_limit,
+            device_id=getattr(g, "annotation_origin_device_id", None),
             log=log,
         )
         if rendered is None:
@@ -755,12 +781,13 @@ def _dispatch_kobo_annotation_deletes(annotation_sync, deleted, entitlement_id, 
 def handle_annotations(entitlement_id):
     """Handle annotation requests for a specific book.
 
-    GET: owned books are answered from CWNG's complete visible set; unowned
-    books retain the byte-transparent Kobo proxy.
-    PATCH: intercept — persist locally (source='kobo'), then dispatch through
+    GET: fully seeded owned books are answered from CWNG's complete visible
+    set; unseeded and unowned books retain the byte-transparent Kobo proxy.
+    PATCH: persist locally (source='kobo'), then dispatch through
     each registered + enabled annotation_sync handler (Hardcover today; future
     Readwise / Notion / etc.). All DB writes happen in the dispatcher; this
-    handler is a thin orchestrator.
+    handler is a thin orchestrator. Fully seeded owned books are acknowledged
+    locally; unseeded books continue upstream so Kobo's copy is not starved.
 
     The exact PATCH body is durably staged before parsing and dispatch so an
     interrupted local capture can be replayed server-side. Local persistence is
@@ -945,7 +972,7 @@ def handle_annotations(entitlement_id):
             )
         finally:
             _mark_patch_spool_outcome(patch_spool_ticket, patch_spool_outcome)
-    if book is not None:
+    if book is not None and _owned_patch_is_local_authority(book, entitlement_id):
         return _owned_annotation_patch_ack(capture_session, book, entitlement_id)
     return _proxy_annotation_request(capture_session, book, entitlement_id)
 

--- a/cps/services/kobo_annotation_authority.py
+++ b/cps/services/kobo_annotation_authority.py
@@ -21,10 +21,16 @@ containing every row's identity and text is safer than a 5xx that is perfectly
 honest about a rendering or state-persistence failure.  Book-state persistence
 is consequently advisory, and row rendering has a last-resort wire mapping.
 
-This renderer is used only when the complete current set fits in the requested
-page.  The route proxies larger sets to Kobo until CWNG implements the immutable
-snapshot + cursor contract; a local response can therefore honestly terminate
-with ``nextPageOffsetToken`` set to null.
+This renderer is used only after Stage 0 proves that the authenticated device's
+complete set was accepted and the book state is ``authoritative`` (the stored
+spelling of "fully seeded").  GET and PATCH use the same proof gate: until that
+proof exists, both continue through Kobo so a partial local set cannot replace
+the device set and new uploads continue feeding Kobo's more-complete copy.
+
+The complete current set must also fit in the requested page.  The route proxies
+larger sets to Kobo until CWNG implements the immutable snapshot + cursor
+contract; a local response can therefore honestly terminate with
+``nextPageOffsetToken`` set to null.
 """
 
 from __future__ import annotations
@@ -32,6 +38,7 @@ from __future__ import annotations
 import hashlib
 import json
 import math
+import threading
 import uuid
 from datetime import datetime, timezone
 
@@ -46,6 +53,9 @@ from cps.services.kobo_annotation_capture import project_exact_materialization
 _KOBO_WIRE_COLORS = frozenset(KOBO_BOOKMARK_COLOR_HEX.values())
 _EPOCH = "1970-01-01T00:00:00.000Z"
 _BOOK_STATE_CONTENT_ID_LIMIT = 64
+_LOCAL_PAGE_CAPACITY = 100
+_SKIP_LOGGED_BOOKS = set()
+_SKIP_LOG_LOCK = threading.Lock()
 
 
 def _blob(value):
@@ -331,55 +341,138 @@ def _state_for_content(user_id, normalized_content_id):
     )
 
 
-def local_get_is_eligible(*, settings, user, book_id, entitlement_id, page_limit, log):
-    """Fail closed unless CWNG can return one complete, authoritative page."""
+def _log_authority_skip_once(log, *, user_id, book_id, reason):
+    """Log one structural INFO per user/book for this process lifetime."""
+    key = (user_id, book_id)
+    with _SKIP_LOG_LOCK:
+        if key in _SKIP_LOGGED_BOOKS:
+            return
+        _SKIP_LOGGED_BOOKS.add(key)
+    try:
+        log.info(
+            "Kobo local annotation authority skipped user_id=%s book_id=%s "
+            "reason=%s",
+            user_id, book_id, reason,
+        )
+    except Exception:
+        pass
+
+
+def reset_skip_log_for_testing():
+    with _SKIP_LOG_LOCK:
+        _SKIP_LOGGED_BOOKS.clear()
+
+
+def _accepted_device_annotation_count(book_state_id, device_id):
+    """Return the latest accepted complete-seed count for this device/book."""
+    if not isinstance(device_id, int) or isinstance(device_id, bool):
+        return None
+    capture = (
+        ub.session.query(ub.KoboAnnotationSeedCapture)
+        .filter(
+            ub.KoboAnnotationSeedCapture.book_state_id == book_state_id,
+            ub.KoboAnnotationSeedCapture.device_id == device_id,
+            ub.KoboAnnotationSeedCapture.result == "accepted",
+            ub.KoboAnnotationSeedCapture.completed_at.isnot(None),
+            ub.KoboAnnotationSeedCapture.annotation_count.isnot(None),
+        )
+        .order_by(
+            ub.KoboAnnotationSeedCapture.completed_at.desc(),
+            ub.KoboAnnotationSeedCapture.id.desc(),
+        )
+        .first()
+    )
+    count = getattr(capture, "annotation_count", None)
+    if not isinstance(count, int) or isinstance(count, bool) or count < 0:
+        return None
+    return count
+
+
+def _visible_annotation_count(user_id, book_id):
+    return (
+        ub.session.query(ub.Annotation.id)
+        .filter(
+            ub.Annotation.user_id == user_id,
+            ub.Annotation.book_id == book_id,
+            (
+                ub.Annotation.hidden.is_(None)
+                | (ub.Annotation.hidden == False)  # noqa: E712
+            ),
+        )
+        .count()
+    )
+
+
+def local_get_is_eligible(*, settings, user, book_id, entitlement_id,
+                          page_limit, device_id, log):
+    """Gate both GET and PATCH on one proven, locally serveable seed.
+
+    ``authority_status='authoritative'`` is Stage 0's stored spelling for a
+    fully seeded book.  It is not sufficient by itself: an accepted complete
+    seed count must exist for this exact device/book, the local visible set may
+    not be smaller than that declaration, and the entire set must fit in the
+    one-page implementation.  PATCH uses the same function with a limit of 100
+    so it can never stop feeding Kobo while GET still needs Kobo as authority.
+    """
+    user_id = getattr(user, "id", None)
+    reason = None
     try:
         if not isinstance(page_limit, int) or isinstance(page_limit, bool):
-            return False
-        if page_limit < 1 or page_limit > 100:
-            return False
+            reason = "page_limit_invalid"
+        elif page_limit < 1 or page_limit > _LOCAL_PAGE_CAPACITY:
+            reason = "page_limit_unsupported"
 
         from cps.services import kobo_annotation_stage0
 
-        schema_ready = kobo_annotation_stage0.schema_capable(ub.session.get_bind())
-        state = _state_for_book(user.id, book_id)
-        if not kobo_annotation_stage0.gates_allow(
-            settings, user, state, schema_ready=schema_ready,
+        state = None
+        if reason is None:
+            schema_ready = kobo_annotation_stage0.schema_capable(
+                ub.session.get_bind(),
+            )
+            state = _state_for_book(user_id, book_id)
+            reason = kobo_annotation_stage0.gate_failure_reason(
+                settings, user, state, schema_ready=schema_ready,
+            )
+        if reason is None and (
+            _normalized_entitlement_id(state.content_id)
+            != _normalized_entitlement_id(entitlement_id)
         ):
-            return False
-        if _normalized_entitlement_id(state.content_id) != _normalized_entitlement_id(
-            entitlement_id,
-        ):
-            return False
+            reason = "content_id_mismatch"
 
-        # Cursor snapshots are deliberately outside this branch. Read at most
-        # one id beyond the requested page so an over-limit set fails closed to
-        # Kobo without loading or rendering the complete collection locally.
-        visible_ids = (
-            ub.session.query(ub.Annotation.id)
-            .filter(
-                ub.Annotation.user_id == user.id,
-                ub.Annotation.book_id == book_id,
-                (
-                    ub.Annotation.hidden.is_(None)
-                    | (ub.Annotation.hidden == False)  # noqa: E712
-                ),
-            )
-            .limit(page_limit + 1)
-            .all()
-        )
-        return len(visible_ids) <= page_limit
-    except Exception:
+        declared_count = None
+        if reason is None:
+            declared_count = _accepted_device_annotation_count(state.id, device_id)
+            if declared_count is None:
+                reason = "accepted_device_seed_count_missing"
+
+        visible_count = None
+        if reason is None:
+            visible_count = _visible_annotation_count(user_id, book_id)
+            if visible_count < declared_count:
+                reason = "local_count_below_device_seed"
+            elif visible_count > _LOCAL_PAGE_CAPACITY:
+                reason = "local_set_requires_pagination"
+            elif visible_count > page_limit:
+                reason = "requested_page_too_small"
+    except Exception as error:
         _safe_rollback()
-        try:
-            log.warning(
-                "Owned Kobo annotation GET eligibility failed; proxying "
-                "user_id=%s book_id=%s",
-                getattr(user, "id", None), book_id, exc_info=True,
-            )
-        except Exception:
-            pass
+        reason = _failure_reason("authority_gate", error)
+
+    if reason is not None:
+        _log_authority_skip_once(
+            log, user_id=user_id, book_id=book_id, reason=reason,
+        )
         return False
+    return True
+
+
+def _render_count_is_safe(*, user_id, book_id, device_id, row_count):
+    """Recheck the accepted count at render time to close the query race."""
+    state = _state_for_book(user_id, book_id)
+    if state is None or state.authority_status != "authoritative":
+        return False
+    declared_count = _accepted_device_annotation_count(state.id, device_id)
+    return declared_count is not None and row_count >= declared_count
 
 
 def _book_state(user_id, book_id, entitlement_id):
@@ -543,9 +636,15 @@ def _log_degraded(log, *, user_id, book_id, visible_count, reasons):
         pass
 
 
-def _emergency_render(*, user_id, book_id, entitlement_id, page_limit, log, reason):
+def _emergency_render(*, user_id, book_id, entitlement_id, page_limit,
+                      device_id, log, reason):
     rows, query_reason = _emergency_rows(user_id, book_id, page_limit)
     if len(rows) > page_limit:
+        return None
+    if not _render_count_is_safe(
+        user_id=user_id, book_id=book_id, device_id=device_id,
+        row_count=len(rows),
+    ):
         return None
     reasons = [reason]
     if query_reason is not None:
@@ -583,11 +682,17 @@ def _emergency_render(*, user_id, book_id, entitlement_id, page_limit, log, reas
     return body, etag
 
 
-def _render_owned_annotations(*, user_id, book_id, entitlement_id, page_limit, log):
+def _render_owned_annotations(*, user_id, book_id, entitlement_id, page_limit,
+                              device_id, log):
     objects = []
     reasons = []
     rows = _annotation_rows(user_id, book_id, page_limit)
     if len(rows) > page_limit:
+        return None
+    if not _render_count_is_safe(
+        user_id=user_id, book_id=book_id, device_id=device_id,
+        row_count=len(rows),
+    ):
         return None
     for annotation, materialization in rows:
         try:
@@ -649,7 +754,8 @@ def _render_owned_annotations(*, user_id, book_id, entitlement_id, page_limit, l
     return body, etag
 
 
-def render_owned_annotations(*, user_id, book_id, entitlement_id, page_limit, log):
+def render_owned_annotations(*, user_id, book_id, entitlement_id, page_limit,
+                             device_id, log):
     """Return a complete local page, or ``None`` when the set is too large."""
     try:
         return _render_owned_annotations(
@@ -657,6 +763,7 @@ def render_owned_annotations(*, user_id, book_id, entitlement_id, page_limit, lo
             book_id=book_id,
             entitlement_id=entitlement_id,
             page_limit=page_limit,
+            device_id=device_id,
             log=log,
         )
     except Exception as error:
@@ -669,6 +776,7 @@ def render_owned_annotations(*, user_id, book_id, entitlement_id, page_limit, lo
             book_id=book_id,
             entitlement_id=entitlement_id,
             page_limit=page_limit,
+            device_id=device_id,
             log=log,
             reason=_failure_reason("render", error),
         )

--- a/cps/services/kobo_annotation_authority.py
+++ b/cps/services/kobo_annotation_authority.py
@@ -9,6 +9,18 @@ is represented in the returned array.  Exact Kobo materializations win.  When
 one is absent or stale, the generic columns are mapped conservatively; an
 imperfect mapping is logged and included, never silently omitted.
 
+``KoboAnnotationMaterialization.serveable`` is intentionally not consulted for
+``provenance='kobo_patch'`` here.  That flag answers whether a delta is safe to
+promote into an independently authoritative/cloud-seeded set; it does not make
+the authenticated user's own, byte-exact upload unsafe to replay to that same
+user.  Refusing it here would replace a device row with less faithful columns.
+
+An owned annotations GET must also never become an error response.  Nickel has
+been observed treating an error as an empty replacement set, so a degraded 200
+containing every row's identity and text is safer than a 5xx that is perfectly
+honest about a rendering or state-persistence failure.  Book-state persistence
+is consequently advisory, and row rendering has a last-resort wire mapping.
+
 Pagination is deliberately unnecessary here.  The complete current set is
 returned in one response (therefore at least Nickel's measured ``limit=100``),
 and ``nextPageOffsetToken`` is always null.
@@ -22,6 +34,8 @@ import math
 import uuid
 from datetime import datetime, timezone
 
+from sqlalchemy.exc import IntegrityError
+
 from cps import ub
 from cps.services.annotation_colors import KOBO_BOOKMARK_COLOR_HEX, to_storage_color
 from cps.services.annotation_types import to_storage_type
@@ -30,6 +44,7 @@ from cps.services.kobo_annotation_capture import project_exact_materialization
 
 _KOBO_WIRE_COLORS = frozenset(KOBO_BOOKMARK_COLOR_HEX.values())
 _EPOCH = "1970-01-01T00:00:00.000Z"
+_BOOK_STATE_CONTENT_ID_LIMIT = 64
 
 
 def _blob(value):
@@ -228,8 +243,71 @@ def _annotation_rows(user_id, book_id):
     )
 
 
-def _book_state(user_id, book_id, entitlement_id):
-    state = (
+def _simple_annotation_rows(user_id, book_id):
+    """Read visible rows without the optional materialization join."""
+    return [
+        (annotation, None)
+        for annotation in (
+            ub.session.query(ub.Annotation)
+            .filter(
+                ub.Annotation.user_id == user_id,
+                ub.Annotation.book_id == book_id,
+                (
+                    ub.Annotation.hidden.is_(None)
+                    | (ub.Annotation.hidden == False)  # noqa: E712
+                ),
+            )
+            .order_by(ub.Annotation.annotation_id.collate("BINARY").asc())
+            .all()
+        )
+    ]
+
+
+def _normalized_entitlement_id(entitlement_id):
+    """Mirror ``resolve_entitlement_ownership``'s safe lookup spelling."""
+    if not isinstance(entitlement_id, str):
+        return ""
+    return entitlement_id.strip().strip("{}").strip().casefold()
+
+
+def _safe_rollback():
+    try:
+        ub.session.rollback()
+    except Exception:
+        pass
+
+
+def _failure_reason(stage, error):
+    # Exception messages can contain annotation text or raw SQL parameters.
+    # The class is enough to diagnose the failed stage without logging either.
+    return f"{stage}_{type(error).__name__}"
+
+
+def _transient_generation(user_id, book_id, normalized_content_id):
+    # JSON's ASCII escaping keeps even malformed Unicode out of uuid5's UTF-8
+    # encoder, so an unusable request id cannot defeat the emergency ETag.
+    seed = json.dumps(
+        ["cwng:kobo-annotations", user_id, book_id, normalized_content_id],
+        ensure_ascii=True, separators=(",", ":"), default=str,
+    )
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, seed))
+
+
+def _transient_etag(user_id, book_id, normalized_content_id, digest):
+    # When state cannot be persisted, make both the generation and revision a
+    # function of stable request identity + returned bytes.  The same degraded
+    # set gets the same ETag and any set change necessarily changes both the
+    # digest suffix and numeric revision (subject only to SHA-256 collision).
+    revision = int(digest, 16) or 1
+    return 'W/"CWNG:{}:{}:{}"'.format(
+        _transient_generation(user_id, book_id, normalized_content_id),
+        revision,
+        digest[:16],
+    )
+
+
+def _state_for_book(user_id, book_id):
+    return (
         ub.session.query(ub.KoboAnnotationBookState)
         .filter(
             ub.KoboAnnotationBookState.user_id == user_id,
@@ -237,71 +315,300 @@ def _book_state(user_id, book_id, entitlement_id):
         )
         .first()
     )
-    if state is None:
-        state = ub.KoboAnnotationBookState(
-            user_id=user_id,
-            book_id=book_id,
-            content_id=entitlement_id,
-            authority_status="unseeded",
-            authority_revision=0,
-            generation_id=str(uuid.uuid4()),
-            opaque_content_status="unknown",
+
+
+def _state_for_content(user_id, normalized_content_id):
+    return (
+        ub.session.query(ub.KoboAnnotationBookState)
+        .filter(
+            ub.KoboAnnotationBookState.user_id == user_id,
+            ub.KoboAnnotationBookState.content_id == normalized_content_id,
         )
-        ub.session.add(state)
-        ub.session.flush()
+        .first()
+    )
+
+
+def _book_state(user_id, book_id, entitlement_id):
+    """Race-safe best-effort state lookup/create; never raise to the GET."""
+    normalized_content_id = _normalized_entitlement_id(entitlement_id)
+    if (
+        not normalized_content_id
+        or len(normalized_content_id) > _BOOK_STATE_CONTENT_ID_LIMIT
+    ):
+        return None, normalized_content_id, "book_state_content_id_unusable"
+
     try:
-        if str(uuid.UUID(state.generation_id)) != state.generation_id:
-            raise ValueError("non-canonical generation id")
-    except (ValueError, TypeError, AttributeError):
-        state.generation_id = str(uuid.uuid4())
-    return state
+        state = _state_for_book(user_id, book_id)
+        if state is None:
+            # Detect the other unique key before attempting the INSERT.  A row
+            # for another book is inconsistent state, not ours to claim.
+            content_state = _state_for_content(user_id, normalized_content_id)
+            if content_state is not None:
+                if content_state.book_id == book_id:
+                    state = content_state
+                else:
+                    return None, normalized_content_id, \
+                        "book_state_content_conflict"
 
+        if state is None:
+            candidate = ub.KoboAnnotationBookState(
+                user_id=user_id,
+                book_id=book_id,
+                content_id=normalized_content_id,
+                authority_status="unseeded",
+                authority_revision=0,
+                generation_id=str(uuid.uuid4()),
+                opaque_content_status="unknown",
+            )
+            try:
+                # The SAVEPOINT confines a losing concurrent INSERT.  A bare
+                # rollback here could discard unrelated request state.
+                with ub.session.begin_nested():
+                    ub.session.add(candidate)
+                    ub.session.flush()
+            except IntegrityError:
+                # The winner may have matched either unique key.  Re-read both;
+                # if it is not visible yet, use a deterministic transient ETag.
+                state = _state_for_book(user_id, book_id)
+                if state is None:
+                    state = _state_for_content(user_id, normalized_content_id)
+                    if state is not None and state.book_id != book_id:
+                        state = None
+                if state is None:
+                    return None, normalized_content_id, \
+                        "book_state_insert_IntegrityError"
+            except Exception as error:
+                return None, normalized_content_id, _failure_reason(
+                    "book_state_insert", error,
+                )
+            else:
+                state = candidate
 
-def render_owned_annotations(*, user_id, book_id, entitlement_id, log):
-    """Return the complete envelope bytes and its CWNG revision ETag."""
-    objects = []
-    imperfect = []
-    for annotation, materialization in _annotation_rows(user_id, book_id):
-        raw = _exact_raw(annotation, materialization)
-        if raw is not None:
-            objects.append(raw)
-            continue
-        mapped, faithful, reason = _fallback_object(annotation, entitlement_id)
-        if not faithful:
-            imperfect.append((annotation.annotation_id, reason))
-        objects.append(json.dumps(
-            mapped, ensure_ascii=False, separators=(",", ":"),
-        ).encode("utf-8"))
-
-    if imperfect:
-        log.error(
-            "Owned Kobo annotation GET included %d loss-preserving column "
-            "fallback(s) user_id=%s book_id=%s reasons=%s",
-            len(imperfect), user_id, book_id,
-            [(annotation_id, reason) for annotation_id, reason in imperfect],
+        try:
+            if str(uuid.UUID(state.generation_id)) != state.generation_id:
+                raise ValueError("non-canonical generation id")
+        except (ValueError, TypeError, AttributeError):
+            # Deterministic repair also remains stable if its commit fails.
+            state.generation_id = _transient_generation(
+                user_id, book_id, normalized_content_id,
+            )
+        return state, normalized_content_id, None
+    except Exception as error:
+        _safe_rollback()
+        return None, normalized_content_id, _failure_reason(
+            "book_state_lookup", error,
         )
+
+
+def _safe_string(annotation, attribute, default=""):
+    try:
+        value = getattr(annotation, attribute)
+    except Exception:
+        return default
+    if value is None:
+        return default
+    if isinstance(value, str):
+        return value
+    try:
+        return str(value)
+    except Exception:
+        return default
+
+
+def _emergency_object(annotation, entitlement_id):
+    """Minimal Kobo-like object that preserves a row's identity and text."""
+    native_type = _safe_string(annotation, "annotation_type", "note").casefold()
+    if native_type not in {"highlight", "dogear", "note"}:
+        native_type = "note"
+    timestamp = None
+    for attribute in ("client_modified_at", "server_modified_at", "created_at"):
+        try:
+            timestamp = _utc_timestamp(getattr(annotation, attribute))
+        except Exception:
+            timestamp = None
+        if timestamp is not None:
+            break
+    try:
+        span = _span(annotation, entitlement_id, dogear=native_type == "dogear")
+    except Exception:
+        span = None
+
+    result = {
+        "clientLastModifiedUtc": timestamp or _EPOCH,
+        "context": _safe_string(annotation, "context_string"),
+        "highlightedText": _safe_string(annotation, "highlighted_text"),
+        "id": _safe_string(annotation, "annotation_id"),
+        "location": {"span": span} if span is not None else {},
+        "type": native_type,
+    }
+    note_text = _safe_string(annotation, "note_text", default="")
+    if native_type != "dogear":
+        result["attachments"] = {}
+    if note_text or native_type == "note":
+        result["noteText"] = note_text
+    color = _safe_string(annotation, "highlight_color", default="")
+    if color and native_type != "dogear":
+        result["highlightColor"] = color
+    return result
+
+
+def _encode_object(value):
+    try:
+        return json.dumps(
+            value, ensure_ascii=False, separators=(",", ":"),
+        ).encode("utf-8")
+    except Exception:
+        # Escaping non-ASCII also handles malformed/unpaired Unicode while
+        # preserving the JSON string's code points for a best-effort replay.
+        return json.dumps(
+            value, ensure_ascii=True, separators=(",", ":"), default=str,
+        ).encode("ascii")
+
+
+def _emergency_rows(user_id, book_id):
+    try:
+        return _simple_annotation_rows(user_id, book_id), None
+    except Exception as error:
+        _safe_rollback()
+        return [], _failure_reason("emergency_row_query", error)
+
+
+def _log_degraded(log, *, user_id, book_id, visible_count, reasons):
+    if not reasons:
+        return
+    try:
+        log.error(
+            "Owned Kobo annotation GET degraded user_id=%s book_id=%s "
+            "visible_count=%d reason_count=%d reasons=%s",
+            user_id, book_id, visible_count, len(reasons),
+            sorted(set(reasons)),
+        )
+    except Exception:
+        # Logging must not be allowed to convert the loss-preventing 200 to a
+        # device-wiping error response.
+        pass
+
+
+def _emergency_render(*, user_id, book_id, entitlement_id, log, reason):
+    rows, query_reason = _emergency_rows(user_id, book_id)
+    reasons = [reason]
+    if query_reason is not None:
+        reasons.append(query_reason)
+    objects = []
+    for annotation, _materialization in rows:
+        try:
+            objects.append(_encode_object(_emergency_object(annotation, entitlement_id)))
+        except Exception as error:
+            # Keep one member per visible row even if an exotic ORM value also
+            # defeats the emergency mapper.  Identity/text getters are each
+            # isolated so this object cannot inherit the original exception.
+            objects.append(_encode_object({
+                "attachments": {},
+                "clientLastModifiedUtc": _EPOCH,
+                "context": "",
+                "highlightedText": _safe_string(annotation, "highlighted_text"),
+                "id": _safe_string(annotation, "annotation_id"),
+                "location": {},
+                "type": "note",
+                "noteText": _safe_string(annotation, "note_text"),
+            }))
+            reasons.append(_failure_reason("emergency_row_render", error))
+    body = b'{"annotations":[' + b",".join(objects) \
+        + b'],"nextPageOffsetToken":null}'
+    digest = hashlib.sha256(body).hexdigest()
+    normalized_content_id = _normalized_entitlement_id(entitlement_id)
+    etag = _transient_etag(
+        user_id, book_id, normalized_content_id, digest,
+    )
+    _log_degraded(
+        log, user_id=user_id, book_id=book_id,
+        visible_count=len(rows), reasons=reasons,
+    )
+    return body, etag
+
+
+def _render_owned_annotations(*, user_id, book_id, entitlement_id, log):
+    objects = []
+    reasons = []
+    rows = _annotation_rows(user_id, book_id)
+    for annotation, materialization in rows:
+        try:
+            raw = _exact_raw(annotation, materialization)
+            if raw is not None:
+                objects.append(raw)
+                continue
+            mapped, faithful, reason = _fallback_object(annotation, entitlement_id)
+            if not faithful:
+                reasons.append(f"column_fallback:{reason}")
+            objects.append(_encode_object(mapped))
+        except Exception as error:
+            # A single malformed row or serializer bug cannot abort a
+            # replacement-set GET.  Preserve at least its id and user text.
+            objects.append(_encode_object(_emergency_object(annotation, entitlement_id)))
+            reasons.append(_failure_reason("row_render", error))
 
     body = b'{"annotations":[' + b",".join(objects) \
         + b'],"nextPageOffsetToken":null}'
     digest = hashlib.sha256(body).hexdigest()
-    state = _book_state(user_id, book_id, entitlement_id)
-    if state.set_digest != digest:
-        state.authority_revision = (state.authority_revision or 0) + 1
-        state.set_digest = digest
-        state.last_mutation_at = datetime.now(timezone.utc)
-    revision = max(1, state.authority_revision or 0)
-    state.authority_revision = revision
-    etag = 'W/"CWNG:{}:{}:{}"'.format(
-        state.generation_id, revision, digest[:16],
+    state, normalized_content_id, state_reason = _book_state(
+        user_id, book_id, entitlement_id,
     )
-    state.current_etag = etag
-    state.etag_kind = "cwng_revision"
-    if ub.session_commit() is False:
-        # The device's replacement-set safety is more important than caching.
-        # Serve the complete set with this request's computed token even when
-        # persisting the token failed; the next GET will still receive 200.
-        log.error(
-            "Could not persist owned Kobo annotation ETag user_id=%s book_id=%s",
-            user_id, book_id,
+    if state_reason is not None:
+        reasons.append(state_reason)
+
+    if state is None:
+        etag = _transient_etag(
+            user_id, book_id, normalized_content_id, digest,
         )
+    else:
+        try:
+            if state.set_digest != digest:
+                state.authority_revision = (state.authority_revision or 0) + 1
+                state.set_digest = digest
+                state.last_mutation_at = datetime.now(timezone.utc)
+            revision = max(1, state.authority_revision or 0)
+            state.authority_revision = revision
+            etag = 'W/"CWNG:{}:{}:{}"'.format(
+                state.generation_id, revision, digest[:16],
+            )
+            state.current_etag = etag
+            state.etag_kind = "cwng_revision"
+            # Commit directly so this boundary owns the one sanitized error
+            # log. ``ub.session_commit`` logs before returning False, which
+            # would duplicate the degraded-response record below.
+            ub.session.commit()
+        except Exception as error:
+            _safe_rollback()
+            reasons.append(_failure_reason("book_state_commit", error))
+            etag = _transient_etag(
+                user_id, book_id, normalized_content_id, digest,
+            )
+
+    _log_degraded(
+        log, user_id=user_id, book_id=book_id,
+        visible_count=len(rows), reasons=reasons,
+    )
     return body, etag
+
+
+def render_owned_annotations(*, user_id, book_id, entitlement_id, log):
+    """Return a complete 200 envelope and ETag, including after exceptions."""
+    try:
+        return _render_owned_annotations(
+            user_id=user_id,
+            book_id=book_id,
+            entitlement_id=entitlement_id,
+            log=log,
+        )
+    except Exception as error:
+        # A failed joined query may leave SQLAlchemy's transaction unusable.
+        # Reset that read transaction before retrying the simpler row query;
+        # otherwise the emergency path could unnecessarily lose every row.
+        _safe_rollback()
+        return _emergency_render(
+            user_id=user_id,
+            book_id=book_id,
+            entitlement_id=entitlement_id,
+            log=log,
+            reason=_failure_reason("render", error),
+        )

--- a/cps/services/kobo_annotation_authority.py
+++ b/cps/services/kobo_annotation_authority.py
@@ -1,0 +1,307 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Render CWNG's complete owned-book annotation set for Kobo Nickel.
+
+Owned annotation GETs are replacement-set operations on the device: a partial,
+empty-on-error, or non-success response can destroy Nickel's local rows.  This
+module therefore has one non-negotiable invariant: every visible database row
+is represented in the returned array.  Exact Kobo materializations win.  When
+one is absent or stale, the generic columns are mapped conservatively; an
+imperfect mapping is logged and included, never silently omitted.
+
+Pagination is deliberately unnecessary here.  The complete current set is
+returned in one response (therefore at least Nickel's measured ``limit=100``),
+and ``nextPageOffsetToken`` is always null.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import uuid
+from datetime import datetime, timezone
+
+from cps import ub
+from cps.services.annotation_colors import KOBO_BOOKMARK_COLOR_HEX, to_storage_color
+from cps.services.annotation_types import to_storage_type
+from cps.services.kobo_annotation_capture import project_exact_materialization
+
+
+_KOBO_WIRE_COLORS = frozenset(KOBO_BOOKMARK_COLOR_HEX.values())
+_EPOCH = "1970-01-01T00:00:00.000Z"
+
+
+def _blob(value):
+    if isinstance(value, memoryview):
+        return value.tobytes()
+    return value if isinstance(value, bytes) else None
+
+
+def _utc_timestamp(value):
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    else:
+        value = value.astimezone(timezone.utc)
+    return value.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def _chapter_filename(annotation, entitlement_id):
+    content_id = annotation.content_id
+    if not isinstance(content_id, str) or "!!" not in content_id:
+        return None
+    book_part, chapter = content_id.split("!!", 1)
+    if not chapter:
+        return None
+    if book_part.strip().strip("{}").casefold() != entitlement_id.strip().strip("{}").casefold():
+        return None
+    return chapter
+
+
+def _span(annotation, entitlement_id, *, dogear=False):
+    chapter = _chapter_filename(annotation, entitlement_id)
+    progress = annotation.chapter_progress
+    start_path = annotation.start_container_path
+    end_path = annotation.end_container_path
+    start_offset = annotation.start_offset
+    end_offset = annotation.end_offset
+    if (
+        chapter is None
+        or isinstance(progress, bool)
+        or not isinstance(progress, (int, float))
+        or not math.isfinite(progress)
+        or not 0 <= progress <= 1
+        or not isinstance(start_path, str)
+        or not start_path
+        or not isinstance(end_path, str)
+        or not end_path
+        or isinstance(start_offset, bool)
+        or not isinstance(start_offset, int)
+        or start_offset < 0
+        or isinstance(end_offset, bool)
+        or not isinstance(end_offset, int)
+        or end_offset < 0
+        or (start_path == end_path and start_offset > end_offset)
+    ):
+        return None
+    span = {
+        "chapterFilename": chapter,
+        "chapterProgress": progress,
+        "endChar": end_offset,
+        "endPath": end_path,
+        "startChar": start_offset,
+        "startPath": start_path,
+    }
+    if dogear:
+        # The measured dogear shape contains chapterTitle.  The generic schema
+        # predates that field, so an empty title is the only honest value when
+        # no raw Kobo object survived; the positional identity is still exact.
+        span["chapterTitle"] = ""
+    return span
+
+
+def _exact_raw(annotation, materialization):
+    if materialization is None:
+        return None
+    # A generic-column edit advances content_revision without rewriting the
+    # Kobo sidecar.  Replaying that stale object would resurrect the old edit.
+    if materialization.materialization_revision != annotation.content_revision:
+        return None
+    raw_object = _blob(materialization.raw_annotation_json)
+    raw_location = _blob(materialization.raw_location_json)
+    if raw_object is None or raw_location is None:
+        return None
+    if hashlib.sha256(raw_object).hexdigest() != materialization.payload_sha256:
+        return None
+    try:
+        projected = project_exact_materialization(raw_object, raw_location)
+        parsed = json.loads(projected)
+    except Exception:
+        return None
+    if not isinstance(parsed, dict) or parsed.get("id") != annotation.annotation_id:
+        return None
+    return projected
+
+
+def _fallback_object(annotation, entitlement_id):
+    """Return ``(object, faithful, reason)`` without ever dropping the row."""
+    reasons = []
+    native_type = to_storage_type(annotation.annotation_type)
+    if native_type not in {"highlight", "dogear", "note"}:
+        reasons.append("unknown_annotation_type")
+        native_type = native_type or "note"
+
+    dogear = native_type == "dogear"
+    span = _span(annotation, entitlement_id, dogear=dogear)
+    if span is None:
+        reasons.append("incomplete_kobo_location")
+
+    timestamp = (
+        _utc_timestamp(annotation.client_modified_at)
+        or _utc_timestamp(annotation.server_modified_at)
+        or _utc_timestamp(annotation.created_at)
+    )
+    if timestamp is None:
+        reasons.append("missing_timestamp")
+        timestamp = _EPOCH
+
+    common = {
+        "clientLastModifiedUtc": timestamp,
+        "context": annotation.context_string or "",
+        "highlightedText": annotation.highlighted_text or "",
+        "id": annotation.annotation_id,
+        "location": {"span": span} if span is not None else {},
+        "type": native_type,
+    }
+    if dogear:
+        # Generic Annotation rows do not retain chapterTitle.  Keep the exact
+        # field set and positional identity, but report the missing value rather
+        # than pretending the empty placeholder is byte-faithful.
+        reasons.append("dogear_chapter_title_unavailable")
+        if common["highlightedText"]:
+            reasons.append("dogear_has_highlighted_text")
+        if annotation.highlight_color is not None:
+            reasons.append("dogear_has_color")
+        if annotation.note_text not in (None, ""):
+            # Preserve content even though tonight's measured dogear did not
+            # carry this member.
+            common["noteText"] = annotation.note_text
+            reasons.append("dogear_has_note")
+        return common, not reasons, ",".join(reasons)
+
+    result = {
+        "attachments": {},
+        "clientLastModifiedUtc": common["clientLastModifiedUtc"],
+        "context": common["context"],
+        "highlightedText": common["highlightedText"],
+        "id": common["id"],
+        "location": common["location"],
+        "type": common["type"],
+    }
+    if annotation.note_text is not None:
+        result["noteText"] = annotation.note_text
+
+    if native_type == "note":
+        # Native notes exist in the measured device DB, but no column-built note
+        # object has yet been accepted on Nickel's wire.  It is still included
+        # so its id and text cannot disappear from a replacement set.
+        reasons.append("note_wire_shape_unproven")
+
+    color = to_storage_color(annotation.highlight_color)
+    if color in _KOBO_WIRE_COLORS:
+        result["highlightColor"] = color
+    elif native_type == "highlight":
+        # Keep a future/foreign token rather than inventing a measured colour.
+        # Nickel may understand a newer palette even when this version does not.
+        result["highlightColor"] = color
+        reasons.append("unrecognized_or_missing_highlight_color")
+    elif color is not None:
+        result["highlightColor"] = color
+        reasons.append("note_has_unproven_color")
+
+    if native_type == "highlight" and not common["highlightedText"]:
+        reasons.append("highlight_text_empty")
+    if native_type == "note" and annotation.note_text in (None, ""):
+        reasons.append("note_text_empty")
+    return result, not reasons, ",".join(reasons)
+
+
+def _annotation_rows(user_id, book_id):
+    return (
+        ub.session.query(ub.Annotation, ub.KoboAnnotationMaterialization)
+        .outerjoin(
+            ub.KoboAnnotationMaterialization,
+            ub.KoboAnnotationMaterialization.annotation_id == ub.Annotation.id,
+        )
+        .filter(
+            ub.Annotation.user_id == user_id,
+            ub.Annotation.book_id == book_id,
+            (
+                ub.Annotation.hidden.is_(None)
+                | (ub.Annotation.hidden == False)  # noqa: E712 - SQLAlchemy expression
+            ),
+        )
+        .order_by(ub.Annotation.annotation_id.collate("BINARY").asc())
+        .all()
+    )
+
+
+def _book_state(user_id, book_id, entitlement_id):
+    state = (
+        ub.session.query(ub.KoboAnnotationBookState)
+        .filter(
+            ub.KoboAnnotationBookState.user_id == user_id,
+            ub.KoboAnnotationBookState.book_id == book_id,
+        )
+        .first()
+    )
+    if state is None:
+        state = ub.KoboAnnotationBookState(
+            user_id=user_id,
+            book_id=book_id,
+            content_id=entitlement_id,
+            authority_status="unseeded",
+            authority_revision=0,
+            generation_id=str(uuid.uuid4()),
+            opaque_content_status="unknown",
+        )
+        ub.session.add(state)
+        ub.session.flush()
+    try:
+        if str(uuid.UUID(state.generation_id)) != state.generation_id:
+            raise ValueError("non-canonical generation id")
+    except (ValueError, TypeError, AttributeError):
+        state.generation_id = str(uuid.uuid4())
+    return state
+
+
+def render_owned_annotations(*, user_id, book_id, entitlement_id, log):
+    """Return the complete envelope bytes and its CWNG revision ETag."""
+    objects = []
+    imperfect = []
+    for annotation, materialization in _annotation_rows(user_id, book_id):
+        raw = _exact_raw(annotation, materialization)
+        if raw is not None:
+            objects.append(raw)
+            continue
+        mapped, faithful, reason = _fallback_object(annotation, entitlement_id)
+        if not faithful:
+            imperfect.append((annotation.annotation_id, reason))
+        objects.append(json.dumps(
+            mapped, ensure_ascii=False, separators=(",", ":"),
+        ).encode("utf-8"))
+
+    if imperfect:
+        log.error(
+            "Owned Kobo annotation GET included %d loss-preserving column "
+            "fallback(s) user_id=%s book_id=%s reasons=%s",
+            len(imperfect), user_id, book_id,
+            [(annotation_id, reason) for annotation_id, reason in imperfect],
+        )
+
+    body = b'{"annotations":[' + b",".join(objects) \
+        + b'],"nextPageOffsetToken":null}'
+    digest = hashlib.sha256(body).hexdigest()
+    state = _book_state(user_id, book_id, entitlement_id)
+    if state.set_digest != digest:
+        state.authority_revision = (state.authority_revision or 0) + 1
+        state.set_digest = digest
+        state.last_mutation_at = datetime.now(timezone.utc)
+    revision = max(1, state.authority_revision or 0)
+    state.authority_revision = revision
+    etag = 'W/"CWNG:{}:{}:{}"'.format(
+        state.generation_id, revision, digest[:16],
+    )
+    state.current_etag = etag
+    state.etag_kind = "cwng_revision"
+    if ub.session_commit() is False:
+        # The device's replacement-set safety is more important than caching.
+        # Serve the complete set with this request's computed token even when
+        # persisting the token failed; the next GET will still receive 200.
+        log.error(
+            "Could not persist owned Kobo annotation ETag user_id=%s book_id=%s",
+            user_id, book_id,
+        )
+    return body, etag

--- a/cps/services/kobo_annotation_authority.py
+++ b/cps/services/kobo_annotation_authority.py
@@ -21,9 +21,10 @@ containing every row's identity and text is safer than a 5xx that is perfectly
 honest about a rendering or state-persistence failure.  Book-state persistence
 is consequently advisory, and row rendering has a last-resort wire mapping.
 
-Pagination is deliberately unnecessary here.  The complete current set is
-returned in one response (therefore at least Nickel's measured ``limit=100``),
-and ``nextPageOffsetToken`` is always null.
+This renderer is used only when the complete current set fits in the requested
+page.  The route proxies larger sets to Kobo until CWNG implements the immutable
+snapshot + cursor contract; a local response can therefore honestly terminate
+with ``nextPageOffsetToken`` set to null.
 """
 
 from __future__ import annotations
@@ -223,7 +224,7 @@ def _fallback_object(annotation, entitlement_id):
     return result, not reasons, ",".join(reasons)
 
 
-def _annotation_rows(user_id, book_id):
+def _annotation_rows(user_id, book_id, page_limit):
     return (
         ub.session.query(ub.Annotation, ub.KoboAnnotationMaterialization)
         .outerjoin(
@@ -239,11 +240,12 @@ def _annotation_rows(user_id, book_id):
             ),
         )
         .order_by(ub.Annotation.annotation_id.collate("BINARY").asc())
+        .limit(page_limit + 1)
         .all()
     )
 
 
-def _simple_annotation_rows(user_id, book_id):
+def _simple_annotation_rows(user_id, book_id, page_limit):
     """Read visible rows without the optional materialization join."""
     return [
         (annotation, None)
@@ -258,6 +260,7 @@ def _simple_annotation_rows(user_id, book_id):
                 ),
             )
             .order_by(ub.Annotation.annotation_id.collate("BINARY").asc())
+            .limit(page_limit + 1)
             .all()
         )
     ]
@@ -326,6 +329,57 @@ def _state_for_content(user_id, normalized_content_id):
         )
         .first()
     )
+
+
+def local_get_is_eligible(*, settings, user, book_id, entitlement_id, page_limit, log):
+    """Fail closed unless CWNG can return one complete, authoritative page."""
+    try:
+        if not isinstance(page_limit, int) or isinstance(page_limit, bool):
+            return False
+        if page_limit < 1 or page_limit > 100:
+            return False
+
+        from cps.services import kobo_annotation_stage0
+
+        schema_ready = kobo_annotation_stage0.schema_capable(ub.session.get_bind())
+        state = _state_for_book(user.id, book_id)
+        if not kobo_annotation_stage0.gates_allow(
+            settings, user, state, schema_ready=schema_ready,
+        ):
+            return False
+        if _normalized_entitlement_id(state.content_id) != _normalized_entitlement_id(
+            entitlement_id,
+        ):
+            return False
+
+        # Cursor snapshots are deliberately outside this branch. Read at most
+        # one id beyond the requested page so an over-limit set fails closed to
+        # Kobo without loading or rendering the complete collection locally.
+        visible_ids = (
+            ub.session.query(ub.Annotation.id)
+            .filter(
+                ub.Annotation.user_id == user.id,
+                ub.Annotation.book_id == book_id,
+                (
+                    ub.Annotation.hidden.is_(None)
+                    | (ub.Annotation.hidden == False)  # noqa: E712
+                ),
+            )
+            .limit(page_limit + 1)
+            .all()
+        )
+        return len(visible_ids) <= page_limit
+    except Exception:
+        _safe_rollback()
+        try:
+            log.warning(
+                "Owned Kobo annotation GET eligibility failed; proxying "
+                "user_id=%s book_id=%s",
+                getattr(user, "id", None), book_id, exc_info=True,
+            )
+        except Exception:
+            pass
+        return False
 
 
 def _book_state(user_id, book_id, entitlement_id):
@@ -465,9 +519,9 @@ def _encode_object(value):
         ).encode("ascii")
 
 
-def _emergency_rows(user_id, book_id):
+def _emergency_rows(user_id, book_id, page_limit):
     try:
-        return _simple_annotation_rows(user_id, book_id), None
+        return _simple_annotation_rows(user_id, book_id, page_limit), None
     except Exception as error:
         _safe_rollback()
         return [], _failure_reason("emergency_row_query", error)
@@ -489,8 +543,10 @@ def _log_degraded(log, *, user_id, book_id, visible_count, reasons):
         pass
 
 
-def _emergency_render(*, user_id, book_id, entitlement_id, log, reason):
-    rows, query_reason = _emergency_rows(user_id, book_id)
+def _emergency_render(*, user_id, book_id, entitlement_id, page_limit, log, reason):
+    rows, query_reason = _emergency_rows(user_id, book_id, page_limit)
+    if len(rows) > page_limit:
+        return None
     reasons = [reason]
     if query_reason is not None:
         reasons.append(query_reason)
@@ -527,10 +583,12 @@ def _emergency_render(*, user_id, book_id, entitlement_id, log, reason):
     return body, etag
 
 
-def _render_owned_annotations(*, user_id, book_id, entitlement_id, log):
+def _render_owned_annotations(*, user_id, book_id, entitlement_id, page_limit, log):
     objects = []
     reasons = []
-    rows = _annotation_rows(user_id, book_id)
+    rows = _annotation_rows(user_id, book_id, page_limit)
+    if len(rows) > page_limit:
+        return None
     for annotation, materialization in rows:
         try:
             raw = _exact_raw(annotation, materialization)
@@ -591,13 +649,14 @@ def _render_owned_annotations(*, user_id, book_id, entitlement_id, log):
     return body, etag
 
 
-def render_owned_annotations(*, user_id, book_id, entitlement_id, log):
-    """Return a complete 200 envelope and ETag, including after exceptions."""
+def render_owned_annotations(*, user_id, book_id, entitlement_id, page_limit, log):
+    """Return a complete local page, or ``None`` when the set is too large."""
     try:
         return _render_owned_annotations(
             user_id=user_id,
             book_id=book_id,
             entitlement_id=entitlement_id,
+            page_limit=page_limit,
             log=log,
         )
     except Exception as error:
@@ -609,6 +668,7 @@ def render_owned_annotations(*, user_id, book_id, entitlement_id, log):
             user_id=user_id,
             book_id=book_id,
             entitlement_id=entitlement_id,
+            page_limit=page_limit,
             log=log,
             reason=_failure_reason("render", error),
         )

--- a/cps/services/kobo_annotation_authority.py
+++ b/cps/services/kobo_annotation_authority.py
@@ -363,7 +363,7 @@ def _book_state(user_id, book_id, entitlement_id):
             try:
                 # The SAVEPOINT confines a losing concurrent INSERT.  A bare
                 # rollback here could discard unrelated request state.
-                with ub.session.begin_nested():
+                with ub.begin_contained_nested(ub.session):
                     ub.session.add(candidate)
                     ub.session.flush()
             except IntegrityError:

--- a/cps/services/kobo_annotation_stage0.py
+++ b/cps/services/kobo_annotation_stage0.py
@@ -121,7 +121,7 @@ def emergency_override_disables(environ=None) -> bool:
 
 
 def gates_allow(settings, user, book_state, *, schema_ready) -> bool:
-    """Evaluate the future route gate; Stage 0 does not call this from routes."""
+    """Evaluate the local Kobo annotation wire-authority gate."""
     if emergency_override_disables():
         return False
     if not schema_ready:

--- a/cps/services/kobo_annotation_stage0.py
+++ b/cps/services/kobo_annotation_stage0.py
@@ -120,14 +120,26 @@ def emergency_override_disables(environ=None) -> bool:
     return value is not None and value.strip().lower() in {"0", "false", "off", "no"}
 
 
+def gate_failure_reason(settings, user, book_state, *, schema_ready):
+    """Return a privacy-safe reason code, or ``None`` when gates pass."""
+    if emergency_override_disables():
+        return "emergency_override"
+    if not schema_ready:
+        return "schema_incomplete"
+    if not bool(getattr(settings, "config_kobo_two_way_annotation_sync", False)):
+        return "instance_gate_disabled"
+    if not bool(getattr(user, "kobo_two_way_annotation_sync", False)):
+        return "user_gate_disabled"
+    status = getattr(book_state, "authority_status", None)
+    if status != "authoritative":
+        if status in {"unseeded", "seeding", "quarantined", "disabled"}:
+            return f"authority_status_{status}"
+        return "authority_state_missing_or_invalid"
+    return None
+
+
 def gates_allow(settings, user, book_state, *, schema_ready) -> bool:
     """Evaluate the local Kobo annotation wire-authority gate."""
-    if emergency_override_disables():
-        return False
-    if not schema_ready:
-        return False
-    if not bool(getattr(settings, "config_kobo_two_way_annotation_sync", False)):
-        return False
-    if not bool(getattr(user, "kobo_two_way_annotation_sync", False)):
-        return False
-    return getattr(book_state, "authority_status", None) == "authoritative"
+    return gate_failure_reason(
+        settings, user, book_state, schema_ready=schema_ready,
+    ) is None

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -41,7 +41,7 @@ surfaces; reverse dependents cannot be discovered by that traversal and must be 
 prefixes. The whole `cps/api/` blueprint tree is therefore protected explicitly: its registration in
 `cps/main.py` points toward the handlers, opposite to the import direction walked by the classifier. The
 two-level cutoff only bounds each root's dependency fan-out—it is not what excludes reverse dependents.
-At this revision the derived set is 149 of 215 local Python modules. Measured at `origin/main`
+At this revision the derived set is 149 of 216 local Python modules. Measured at `origin/main`
 `e6298e0d560b`, the previous and expanded policies each fired on 26 of the latest 100 first-parent commits;
 protecting `cps/api/` added zero historical gate runs in that sample.
 

--- a/tests/unit/test_1660_kobo_checkforchanges_filter.py
+++ b/tests/unit/test_1660_kobo_checkforchanges_filter.py
@@ -269,12 +269,9 @@ def test_upstream_auth_failure_with_json_list_is_propagated(app, monkeypatch, st
     assert response.get_json() == [OWNED]
 
 
-def test_annotation_get_proxies_even_for_owned_content(app, monkeypatch):
+def test_annotation_get_for_unowned_content_still_proxies(app, monkeypatch):
     sentinel = object()
-    monkeypatch.setattr(
-        rs, "resolve_entitlement_ownership",
-        lambda _content_id: pytest.fail("annotation GET must not expose ownership"),
-    )
+    monkeypatch.setattr(rs, "resolve_entitlement_ownership", lambda _content_id: None)
     monkeypatch.setattr(rs, "proxy_to_kobo_reading_services", lambda: sentinel)
     with app.test_request_context(
         f"/api/v3/content/{OWNED}/annotations?limit=100", method="GET",
@@ -336,10 +333,9 @@ def test_empty_patch_for_unowned_content_still_proxies(app, monkeypatch):
         assert _view(rs.handle_annotations)(OWNED) is sentinel
 
 
-def test_patch_captures_updated_annotations_before_proxying(app, monkeypatch):
+def test_owned_patch_captures_updated_annotations_then_answers_locally(app, monkeypatch):
     from cps.services import annotation_sync
 
-    sentinel = object()
     book = SimpleNamespace(id=347, title="Flatland", identifiers=[])
     user = SimpleNamespace(id=7, name="test-user", is_authenticated=True)
     dispatched = []
@@ -351,13 +347,19 @@ def test_patch_captures_updated_annotations_before_proxying(app, monkeypatch):
         annotation_sync, "dispatch_annotation_sync",
         lambda *args, **kwargs: dispatched.append((args, kwargs)),
     )
-    monkeypatch.setattr(rs, "proxy_to_kobo_reading_services", lambda: sentinel)
+    monkeypatch.setattr(
+        rs, "proxy_to_kobo_reading_services",
+        lambda: pytest.fail("owned PATCH must not contact Kobo"),
+    )
     with app.test_request_context(
         f"/api/v3/content/{OWNED}/annotations", method="PATCH",
         json={"updatedAnnotations": [annotation]},
     ):
-        assert _view(rs.handle_annotations)(OWNED) is sentinel
+        response = _view(rs.handle_annotations)(OWNED)
 
+    assert response.status_code == 204
+    assert response.get_data() == b""
+    assert response.headers["Content-Length"] == "0"
     assert dispatched == [(([annotation], book, user), {"origin_device_id": None})]
 
 
@@ -388,10 +390,9 @@ def test_patch_persistence_failure_is_not_acknowledged_upstream(
     assert "not fully persisted" in caplog.text
 
 
-def test_patch_declares_kobo_delete_authority_before_proxying(app, monkeypatch):
+def test_owned_patch_declares_kobo_delete_authority_then_answers_locally(app, monkeypatch):
     from cps.services import annotation_sync
 
-    sentinel = object()
     book = SimpleNamespace(id=347, title="Flatland", identifiers=[])
     user = SimpleNamespace(id=7, name="test-user", is_authenticated=True)
     dispatched = []
@@ -402,18 +403,52 @@ def test_patch_declares_kobo_delete_authority_before_proxying(app, monkeypatch):
         annotation_sync, "dispatch_annotation_deletes",
         lambda *args, **kwargs: dispatched.append((args, kwargs)),
     )
-    monkeypatch.setattr(rs, "proxy_to_kobo_reading_services", lambda: sentinel)
+    monkeypatch.setattr(
+        rs, "proxy_to_kobo_reading_services",
+        lambda: pytest.fail("owned PATCH must not contact Kobo"),
+    )
 
     with app.test_request_context(
         f"/api/v3/content/{OWNED}/annotations", method="PATCH",
         json={"deletedAnnotationIds": ["annotation-1"]},
     ):
-        assert _view(rs.handle_annotations)(OWNED) is sentinel
+        response = _view(rs.handle_annotations)(OWNED)
 
+    assert response.status_code == 204
     assert dispatched == [(
         (["annotation-1"], user),
         {"book_id": book.id, "deletable_sources": {"kobo"}},
     )]
+
+
+def test_owned_patch_delete_commit_failure_is_refused_not_proxied(app, monkeypatch):
+    from cps.services import annotation_sync
+
+    book = SimpleNamespace(id=347, title="Flatland", identifiers=[])
+    monkeypatch.setattr(rs, "resolve_entitlement_ownership", lambda _content_id: book)
+    monkeypatch.setattr(rs, "log_annotation_data", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(rs, "_stage_patch_for_recovery", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        rs, "current_user", SimpleNamespace(id=7, name="reader", is_authenticated=True),
+    )
+    monkeypatch.setattr(
+        annotation_sync, "dispatch_annotation_deletes", lambda *_args, **_kwargs: False,
+    )
+    monkeypatch.setattr(
+        rs, "proxy_to_kobo_reading_services",
+        lambda: pytest.fail("failed local delete must not be acknowledged upstream"),
+    )
+
+    with app.test_request_context(
+        f"/api/v3/content/{OWNED}/annotations", method="PATCH",
+        json={"deletedAnnotationIds": ["annotation-1"]},
+    ):
+        response = _view(rs.handle_annotations)(OWNED)
+
+    assert response.status_code == 503
+    assert response.get_json() == {
+        "error": "Annotation capture temporarily unavailable",
+    }
 
 
 def test_patch_ownership_unknown_is_visible_and_not_proxied(app, monkeypatch, caplog):
@@ -521,7 +556,7 @@ def test_patch_non_list_annotation_batch_reaches_dispatcher_and_is_refused(
     assert "not fully persisted" in caplog.text
 
 
-def test_null_update_batch_preserves_deletes_and_upstream_proxy(
+def test_owned_null_update_batch_preserves_deletes_and_answers_locally(
     app, monkeypatch,
 ):
     from cps.services import annotation_sync
@@ -546,9 +581,8 @@ def test_null_update_batch_preserves_deletes_and_upstream_proxy(
         lambda *args, **kwargs: deleted.append((args, kwargs)),
     )
     monkeypatch.setattr(
-        rs,
-        "proxy_to_kobo_reading_services",
-        lambda: make_response(jsonify({"upstream": "accepted"}), 207),
+        rs, "proxy_to_kobo_reading_services",
+        lambda: pytest.fail("owned PATCH must not contact Kobo"),
     )
 
     with app.test_request_context(
@@ -562,7 +596,7 @@ def test_null_update_batch_preserves_deletes_and_upstream_proxy(
     ):
         response = _view(rs.handle_annotations)(OWNED)
 
-    assert response.status_code == 207
+    assert response.status_code == 204
     assert deleted == [(
         (["ghost-annotation-1"], user),
         {"book_id": book.id, "deletable_sources": {"kobo"}},
@@ -574,7 +608,6 @@ def test_valid_json_annotation_batch_is_parsed_without_json_content_type(
 ):
     from cps.services import annotation_sync
 
-    sentinel = object()
     book = SimpleNamespace(id=347, title="Flatland", identifiers=[])
     user = SimpleNamespace(id=7, name="test-user", is_authenticated=True)
     annotation = {"id": "annotation-1", "type": "highlight"}
@@ -588,7 +621,10 @@ def test_valid_json_annotation_batch_is_parsed_without_json_content_type(
         "dispatch_annotation_sync",
         lambda *args, **kwargs: dispatched.append((args, kwargs)) or True,
     )
-    monkeypatch.setattr(rs, "proxy_to_kobo_reading_services", lambda: sentinel)
+    monkeypatch.setattr(
+        rs, "proxy_to_kobo_reading_services",
+        lambda: pytest.fail("owned PATCH must not contact Kobo"),
+    )
 
     with app.test_request_context(
         f"/api/v3/content/{OWNED}/annotations",
@@ -596,8 +632,9 @@ def test_valid_json_annotation_batch_is_parsed_without_json_content_type(
         data=json.dumps({"updatedAnnotations": [annotation]}).encode(),
         content_type="text/plain",
     ):
-        assert _view(rs.handle_annotations)(OWNED) is sentinel
+        response = _view(rs.handle_annotations)(OWNED)
 
+    assert response.status_code == 204
     [(args, kwargs)] = dispatched
     assert args == ([annotation], book, user)
     assert kwargs["origin_device_id"] is None
@@ -606,7 +643,6 @@ def test_valid_json_annotation_batch_is_parsed_without_json_content_type(
 def test_valid_update_and_delete_batch_preserves_dispatch_order(app, monkeypatch):
     from cps.services import annotation_sync
 
-    sentinel = object()
     book = SimpleNamespace(id=347, title="Flatland", identifiers=[])
     events = []
     monkeypatch.setattr(rs, "resolve_entitlement_ownership", lambda _content_id: book)
@@ -625,7 +661,10 @@ def test_valid_update_and_delete_batch_preserves_dispatch_order(app, monkeypatch
         "dispatch_annotation_deletes",
         lambda *_args, **_kwargs: events.append("delete"),
     )
-    monkeypatch.setattr(rs, "proxy_to_kobo_reading_services", lambda: sentinel)
+    monkeypatch.setattr(
+        rs, "proxy_to_kobo_reading_services",
+        lambda: pytest.fail("owned PATCH must not contact Kobo"),
+    )
 
     with app.test_request_context(
         f"/api/v3/content/{OWNED}/annotations",
@@ -635,8 +674,9 @@ def test_valid_update_and_delete_batch_preserves_dispatch_order(app, monkeypatch
             "deletedAnnotationIds": ["annotation-1"],
         },
     ):
-        assert _view(rs.handle_annotations)(OWNED) is sentinel
+        response = _view(rs.handle_annotations)(OWNED)
 
+    assert response.status_code == 204
     assert events == ["update", "delete"]
 
 
@@ -762,17 +802,19 @@ def test_registered_annotation_patch_route_returns_retryable_refusal(
         b'{"updatedAnnotations":[],"deletedAnnotationIds":[]}',
     ],
 )
-def test_empty_and_object_noop_patch_bodies_still_proxy(
+def test_owned_empty_and_object_noop_patch_bodies_answer_locally(
     app, monkeypatch, raw_body,
 ):
-    sentinel = object()
     monkeypatch.setattr(
         rs, "resolve_entitlement_ownership",
         lambda _content_id: SimpleNamespace(id=347, title="Flatland", identifiers=[]),
     )
     monkeypatch.setattr(rs, "log_annotation_data", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(rs, "_stage_patch_for_recovery", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(rs, "proxy_to_kobo_reading_services", lambda: sentinel)
+    monkeypatch.setattr(
+        rs, "proxy_to_kobo_reading_services",
+        lambda: pytest.fail("owned PATCH must not contact Kobo"),
+    )
     monkeypatch.setattr(
         rs, "current_user", SimpleNamespace(id=7, name="test-user", is_authenticated=True),
     )
@@ -781,4 +823,7 @@ def test_empty_and_object_noop_patch_bodies_still_proxy(
         f"/api/v3/content/{OWNED}/annotations", method="PATCH",
         data=raw_body, content_type="application/json",
     ):
-        assert _view(rs.handle_annotations)(OWNED) is sentinel
+        response = _view(rs.handle_annotations)(OWNED)
+
+    assert response.status_code == 204
+    assert response.get_data() == b""

--- a/tests/unit/test_1660_kobo_checkforchanges_filter.py
+++ b/tests/unit/test_1660_kobo_checkforchanges_filter.py
@@ -22,6 +22,14 @@ def app():
     return Flask(__name__)
 
 
+@pytest.fixture(autouse=True)
+def _pre_1923_patch_tests_use_seeded_authority(monkeypatch):
+    """Keep this module focused on capture/refusal, not the Stage-0 gate."""
+    monkeypatch.setattr(
+        rs, "_owned_patch_is_local_authority", lambda *_args, **_kwargs: True,
+    )
+
+
 def _request_entries(*content_ids):
     return [{"ContentId": content_id, "etag": f"etag-{content_id}"}
             for content_id in content_ids]

--- a/tests/unit/test_1923_owned_annotations_local_authority.py
+++ b/tests/unit/test_1923_owned_annotations_local_authority.py
@@ -240,6 +240,35 @@ def test_owned_get_returns_more_than_device_limit_as_one_honest_page(
     assert payload["nextPageOffsetToken"] is None
 
 
+def test_book_state_insert_uses_contained_savepoint_on_active_session(
+    session, monkeypatch,
+):
+    active_connection = session.connection()
+    original_begin_contained_nested = ub.begin_contained_nested
+    containment_calls = []
+
+    def track_contained_nested(db_session):
+        connection = db_session.connection()
+        nested = original_begin_contained_nested(db_session)
+        containment_calls.append((
+            db_session is session,
+            connection is active_connection,
+            connection.connection.driver_connection.in_transaction,
+        ))
+        return nested
+
+    monkeypatch.setattr(ub, "begin_contained_nested", track_contained_nested)
+
+    state, normalized_content_id, failure = authority._book_state(
+        USER_ID, BOOK_ID, OWNED,
+    )
+
+    assert failure is None
+    assert normalized_content_id == OWNED
+    assert state in session
+    assert containment_calls == [(True, True, True)]
+
+
 def test_owned_get_survives_normalized_book_state_insert_integrity_error(
     app, session, monkeypatch,
 ):

--- a/tests/unit/test_1923_owned_annotations_local_authority.py
+++ b/tests/unit/test_1923_owned_annotations_local_authority.py
@@ -7,11 +7,11 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from types import SimpleNamespace
 
 import pytest
-from flask import Flask, make_response
+from flask import Flask, g, make_response
 from sqlalchemy import create_engine
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
@@ -25,6 +25,7 @@ from cps.services.kobo_annotation_capture import extract_object_member_value
 OWNED = "9e5251ad-d530-4e58-9121-8b8336099fdd"
 BOOK_ID = 347
 USER_ID = 7
+DEVICE_ID = 91
 
 
 @pytest.fixture
@@ -57,6 +58,7 @@ def app(monkeypatch):
         lambda _engine: True,
     )
     monkeypatch.setattr(rs, "_begin_exchange_capture", lambda *_a, **_k: None)
+    authority.reset_skip_log_for_testing()
     return application
 
 
@@ -85,14 +87,14 @@ def _annotation(annotation_id, annotation_type="highlight", **overrides):
     return ub.Annotation(**values)
 
 
-def _owned(monkeypatch, session):
+def _owned(monkeypatch, session, annotation_count):
     book = SimpleNamespace(id=BOOK_ID, uuid=OWNED, title="Flatland", identifiers=[])
     monkeypatch.setattr(rs, "resolve_entitlement_ownership", lambda _content_id: book)
     monkeypatch.setattr(
         rs, "proxy_to_kobo_reading_services",
         lambda **_kwargs: pytest.fail("owned annotations request contacted Kobo"),
     )
-    session.add(ub.KoboAnnotationBookState(
+    state = ub.KoboAnnotationBookState(
         user_id=USER_ID,
         book_id=BOOK_ID,
         content_id=OWNED,
@@ -100,6 +102,17 @@ def _owned(monkeypatch, session):
         authority_revision=1,
         generation_id="00000000-0000-0000-0000-000000000001",
         opaque_content_status="absent",
+        seeded_at=datetime(2026, 8, 28, tzinfo=timezone.utc),
+    )
+    session.add(state)
+    session.flush()
+    session.add(ub.KoboAnnotationSeedCapture(
+        book_state_id=state.id,
+        device_id=DEVICE_ID,
+        completed_at=datetime(2026, 8, 28, tzinfo=timezone.utc),
+        annotation_count=annotation_count,
+        page_count=1,
+        result="accepted",
     ))
     return book
 
@@ -167,7 +180,7 @@ def test_owned_patch_ack_has_measured_response_shape(app):
 def test_owned_get_is_full_200_raw_exact_if_none_match_ignored_and_etag_moves(
     app, session, monkeypatch,
 ):
-    _owned(monkeypatch, session)
+    _owned(monkeypatch, session, 3)
     raw = (
         b'{ "type" : "highlight", "id" : "a-raw", '
         b'"clientLastModifiedUtc" : "2026-08-28T05:00:00Z", '
@@ -201,6 +214,7 @@ def test_owned_get_is_full_200_raw_exact_if_none_match_ignored_and_etag_moves(
         f"/api/v3/content/{OWNED}/annotations?limit=100", method="GET",
         headers={"If-None-Match": 'W/"CWNG:ignored:1:ignored"'},
     ):
+        g.annotation_origin_device_id = DEVICE_ID
         first = rs.handle_annotations.__wrapped__(OWNED)
 
     assert first.status_code == 200
@@ -220,6 +234,7 @@ def test_owned_get_is_full_200_raw_exact_if_none_match_ignored_and_etag_moves(
         f"/api/v3/content/{OWNED}/annotations?limit=100", method="GET",
         headers={"If-None-Match": first_etag},
     ):
+        g.annotation_origin_device_id = DEVICE_ID
         matched = rs.handle_annotations.__wrapped__(OWNED)
 
     assert matched.status_code == 200
@@ -232,6 +247,7 @@ def test_owned_get_is_full_200_raw_exact_if_none_match_ignored_and_etag_moves(
     with app.test_request_context(
         f"/api/v3/content/{OWNED}/annotations?limit=100", method="GET",
     ):
+        g.annotation_origin_device_id = DEVICE_ID
         changed = rs.handle_annotations.__wrapped__(OWNED)
 
     assert changed.status_code == 200
@@ -246,7 +262,7 @@ def test_owned_get_over_limit_proxies_instead_of_violating_page_contract(
 ):
     book = SimpleNamespace(id=BOOK_ID, uuid=OWNED, title="Flatland", identifiers=[])
     monkeypatch.setattr(rs, "resolve_entitlement_ownership", lambda _content_id: book)
-    session.add(ub.KoboAnnotationBookState(
+    state = ub.KoboAnnotationBookState(
         user_id=USER_ID,
         book_id=BOOK_ID,
         content_id=OWNED,
@@ -254,6 +270,13 @@ def test_owned_get_over_limit_proxies_instead_of_violating_page_contract(
         authority_revision=1,
         generation_id="00000000-0000-0000-0000-000000000001",
         opaque_content_status="absent",
+    )
+    session.add(state)
+    session.flush()
+    session.add(ub.KoboAnnotationSeedCapture(
+        book_state_id=state.id, device_id=DEVICE_ID,
+        completed_at=datetime(2026, 8, 28, tzinfo=timezone.utc),
+        annotation_count=101, page_count=2, result="accepted",
     ))
     session.add_all([_annotation(f"row-{index:03d}") for index in range(101)])
     session.commit()
@@ -269,6 +292,7 @@ def test_owned_get_over_limit_proxies_instead_of_violating_page_contract(
     with app.test_request_context(
         f"/api/v3/content/{OWNED}/annotations?limit=100", method="GET",
     ):
+        g.annotation_origin_device_id = DEVICE_ID
         response = rs.handle_annotations.__wrapped__(OWNED)
 
     assert response.status_code == 206
@@ -281,6 +305,7 @@ def test_renderer_rechecks_limit_after_eligibility_probe(app, session, monkeypat
     book = SimpleNamespace(id=BOOK_ID, uuid=OWNED, title="Flatland", identifiers=[])
     monkeypatch.setattr(rs, "resolve_entitlement_ownership", lambda _content_id: book)
     monkeypatch.setattr(authority, "local_get_is_eligible", lambda **_kwargs: True)
+    monkeypatch.setattr(authority, "_render_count_is_safe", lambda **_kwargs: True)
     session.add_all([_annotation(f"race-row-{index:03d}") for index in range(101)])
     session.commit()
 
@@ -334,6 +359,189 @@ def test_owned_unseeded_get_proxies_without_serving_partial_local_set(
     assert response.status_code == 200
     assert response.get_data() == upstream_body
     assert response.headers["ETag"] == 'W/"kobo-cloud"'
+
+
+def test_owned_unseeded_patch_is_persisted_then_proxied(app, session, monkeypatch):
+    book = SimpleNamespace(id=BOOK_ID, uuid=OWNED, title="Flatland", identifiers=[])
+    monkeypatch.setattr(rs, "resolve_entitlement_ownership", lambda _content_id: book)
+    monkeypatch.setattr(rs, "_stage_patch_for_recovery", lambda *_a, **_k: None)
+    session.add(ub.KoboAnnotationBookState(
+        user_id=USER_ID, book_id=BOOK_ID, content_id=OWNED,
+        authority_status="unseeded", authority_revision=0,
+        generation_id="00000000-0000-0000-0000-000000000001",
+        opaque_content_status="unknown",
+    ))
+    session.commit()
+    dispatched = []
+    monkeypatch.setattr(
+        "cps.services.annotation_sync.dispatch_annotation_sync",
+        lambda rows, *_a, **_k: dispatched.extend(rows) or True,
+    )
+    upstream_body = b'{"upstream":"patch-preserved"}'
+    proxy_calls = []
+    monkeypatch.setattr(
+        rs, "proxy_to_kobo_reading_services",
+        lambda **_kwargs: proxy_calls.append(True) or make_response(upstream_body, 202),
+    )
+    payload = {"updatedAnnotations": [{
+        "id": "unseeded-upload", "type": "highlight",
+        "highlightedText": "must still reach Kobo", "location": {"span": {}},
+    }]}
+
+    with app.test_request_context(
+        f"/api/v3/content/{OWNED}/annotations", method="PATCH", json=payload,
+    ):
+        g.annotation_origin_device_id = DEVICE_ID
+        response = rs.handle_annotations.__wrapped__(OWNED)
+
+    assert [row["id"] for row in dispatched] == ["unseeded-upload"]
+    assert proxy_calls == [True]
+    assert response.status_code == 202
+    assert response.get_data() == upstream_body
+
+
+def test_owned_seeded_patch_is_answered_locally(app, session, monkeypatch):
+    _owned(monkeypatch, session, 0)
+    monkeypatch.setattr(rs, "_stage_patch_for_recovery", lambda *_a, **_k: None)
+
+    with app.test_request_context(
+        f"/api/v3/content/{OWNED}/annotations", method="PATCH", json={},
+    ):
+        g.annotation_origin_device_id = DEVICE_ID
+        response = rs.handle_annotations.__wrapped__(OWNED)
+
+    assert response.status_code == 204
+    assert response.get_data() == b""
+    assert response.headers["Content-Length"] == "0"
+
+
+def test_owned_unseeded_raw_materialization_still_proxies_get(
+    app, session, monkeypatch,
+):
+    book = SimpleNamespace(id=BOOK_ID, uuid=OWNED, title="Flatland", identifiers=[])
+    monkeypatch.setattr(rs, "resolve_entitlement_ownership", lambda _content_id: book)
+    state = ub.KoboAnnotationBookState(
+        user_id=USER_ID, book_id=BOOK_ID, content_id=OWNED,
+        authority_status="unseeded", authority_revision=0,
+        generation_id="00000000-0000-0000-0000-000000000001",
+        opaque_content_status="unknown",
+    )
+    row = _annotation("raw-but-unseeded")
+    session.add_all([state, row])
+    session.flush()
+    raw = b'{"id":"raw-but-unseeded","type":"highlight","highlightedText":"partial"}'
+    session.add(ub.KoboAnnotationMaterialization(
+        annotation_id=row.id, raw_annotation_json=raw,
+        raw_location_json=b"null",
+        raw_client_modified_utc="2026-08-28T05:00:00Z",
+        payload_sha256=hashlib.sha256(raw).hexdigest(),
+        materialization_revision=1, provenance="kobo_patch",
+        attachments_state="missing", serveable=False,
+    ))
+    session.commit()
+    upstream_body = b'{"annotations":[{"id":"cloud-complete"}]}'
+    proxy_calls = []
+    monkeypatch.setattr(
+        rs, "proxy_to_kobo_reading_services",
+        lambda **_kwargs: proxy_calls.append(True) or make_response(upstream_body, 200),
+    )
+
+    with app.test_request_context(
+        f"/api/v3/content/{OWNED}/annotations?limit=100", method="GET",
+    ):
+        g.annotation_origin_device_id = DEVICE_ID
+        response = rs.handle_annotations.__wrapped__(OWNED)
+
+    assert proxy_calls == [True]
+    assert response.get_data() == upstream_body
+
+
+def test_device_seed_count_guard_keeps_both_verbs_upstream(
+    app, session, monkeypatch,
+):
+    _owned(monkeypatch, session, 3)
+    session.add_all([_annotation("only-a"), _annotation("only-b")])
+    session.commit()
+    monkeypatch.setattr(rs, "_stage_patch_for_recovery", lambda *_a, **_k: None)
+    proxy_methods = []
+    monkeypatch.setattr(
+        rs, "proxy_to_kobo_reading_services",
+        lambda **_kwargs: proxy_methods.append(rs.request.method)
+        or make_response(b'{"upstream":true}', 200),
+    )
+
+    for method in ("GET", "PATCH"):
+        with app.test_request_context(
+            f"/api/v3/content/{OWNED}/annotations?limit=100",
+            method=method, json={} if method == "PATCH" else None,
+        ):
+            g.annotation_origin_device_id = DEVICE_ID
+            response = rs.handle_annotations.__wrapped__(OWNED)
+        assert response.status_code == 200
+
+    assert proxy_methods == ["GET", "PATCH"]
+
+
+def test_authoritative_without_device_seed_count_keeps_both_verbs_upstream(
+    app, session, monkeypatch,
+):
+    book = SimpleNamespace(id=BOOK_ID, uuid=OWNED, title="Flatland", identifiers=[])
+    monkeypatch.setattr(rs, "resolve_entitlement_ownership", lambda _content_id: book)
+    monkeypatch.setattr(rs, "_stage_patch_for_recovery", lambda *_a, **_k: None)
+    session.add(ub.KoboAnnotationBookState(
+        user_id=USER_ID, book_id=BOOK_ID, content_id=OWNED,
+        authority_status="authoritative", authority_revision=1,
+        generation_id="00000000-0000-0000-0000-000000000001",
+        opaque_content_status="absent",
+        seeded_at=datetime(2026, 8, 28, tzinfo=timezone.utc),
+    ))
+    session.commit()
+    proxy_methods = []
+    monkeypatch.setattr(
+        rs, "proxy_to_kobo_reading_services",
+        lambda **_kwargs: proxy_methods.append(rs.request.method)
+        or make_response(b'{"upstream":true}', 200),
+    )
+
+    for method in ("GET", "PATCH"):
+        with app.test_request_context(
+            f"/api/v3/content/{OWNED}/annotations?limit=100",
+            method=method, json={} if method == "PATCH" else None,
+        ):
+            g.annotation_origin_device_id = DEVICE_ID
+            response = rs.handle_annotations.__wrapped__(OWNED)
+        assert response.status_code == 200
+
+    assert proxy_methods == ["GET", "PATCH"]
+
+
+def test_authority_skip_logs_once_per_book_with_structural_reason(
+    app, session, monkeypatch,
+):
+    state = ub.KoboAnnotationBookState(
+        user_id=USER_ID, book_id=BOOK_ID, content_id=OWNED,
+        authority_status="unseeded", authority_revision=0,
+        generation_id="00000000-0000-0000-0000-000000000001",
+        opaque_content_status="unknown",
+    )
+    session.add(state)
+    session.commit()
+    records = []
+    structural_log = SimpleNamespace(
+        info=lambda *args: records.append(args),
+    )
+    user = SimpleNamespace(id=USER_ID, kobo_two_way_annotation_sync=True)
+    settings = SimpleNamespace(config_kobo_two_way_annotation_sync=True)
+
+    for _attempt in range(2):
+        assert authority.local_get_is_eligible(
+            settings=settings, user=user, book_id=BOOK_ID,
+            entitlement_id=OWNED, page_limit=100, device_id=DEVICE_ID,
+            log=structural_log,
+        ) is False
+
+    assert len(records) == 1
+    assert records[0][-1] == "authority_status_unseeded"
 
 
 def test_owned_unseeded_get_forwards_upstream_failure_unchanged(
@@ -411,6 +619,7 @@ def test_owned_get_survives_normalized_book_state_insert_integrity_error(
         lambda **_kwargs: pytest.fail("renderer containment must not contact Kobo"),
     )
     monkeypatch.setattr(authority, "local_get_is_eligible", lambda **_kwargs: True)
+    monkeypatch.setattr(authority, "_render_count_is_safe", lambda **_kwargs: True)
     session.add_all([
         _annotation("state-race-a", highlighted_text="private state text A"),
         _annotation("state-race-b", highlighted_text="private state text B"),
@@ -478,7 +687,7 @@ def test_owned_get_survives_normalized_book_state_insert_integrity_error(
 def test_owned_get_row_render_exception_keeps_every_identity_and_text(
     app, session, monkeypatch,
 ):
-    _owned(monkeypatch, session)
+    _owned(monkeypatch, session, 2)
     session.add_all([
         _annotation("render-a", highlighted_text="private render text A"),
         _annotation("render-b", highlighted_text="private render text B"),
@@ -499,6 +708,7 @@ def test_owned_get_row_render_exception_keeps_every_identity_and_text(
     with app.test_request_context(
         f"/api/v3/content/{OWNED}/annotations?limit=100", method="GET",
     ):
+        g.annotation_origin_device_id = DEVICE_ID
         response = rs.handle_annotations.__wrapped__(OWNED)
 
     payload = response.get_json()

--- a/tests/unit/test_1923_owned_annotations_local_authority.py
+++ b/tests/unit/test_1923_owned_annotations_local_authority.py
@@ -1,0 +1,239 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Owned Kobo annotation requests are answered by CWNG on the wire (#1923)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from cps import ub
+import cps.readingservices as rs
+from cps.services import kobo_annotation_authority as authority
+from cps.services.kobo_annotation_capture import extract_object_member_value
+
+
+OWNED = "9e5251ad-d530-4e58-9121-8b8336099fdd"
+BOOK_ID = 347
+USER_ID = 7
+
+
+@pytest.fixture
+def session(monkeypatch):
+    engine = create_engine("sqlite:///:memory:", future=True)
+    ub.Base.metadata.create_all(engine)
+    database = sessionmaker(bind=engine, future=True)()
+    monkeypatch.setattr(ub, "session", database)
+    monkeypatch.setattr(ub, "session_commit", lambda: database.commit() or True)
+    yield database
+    database.close()
+    engine.dispose()
+
+
+@pytest.fixture
+def app(monkeypatch):
+    application = Flask(__name__)
+    monkeypatch.setattr(
+        rs, "current_user",
+        SimpleNamespace(id=USER_ID, name="reader", is_authenticated=True),
+    )
+    monkeypatch.setattr(rs, "_begin_exchange_capture", lambda *_a, **_k: None)
+    return application
+
+
+def _annotation(annotation_id, annotation_type="highlight", **overrides):
+    values = {
+        "user_id": USER_ID,
+        "book_id": BOOK_ID,
+        "annotation_id": annotation_id,
+        "source": "kobo",
+        "annotation_type": annotation_type,
+        "highlighted_text": "measured passage" if annotation_type == "highlight" else "",
+        "highlight_color": "#F6F3B3" if annotation_type == "highlight" else None,
+        "note_text": None,
+        "content_id": f"{OWNED}!!OEBPS/chapter.xhtml",
+        "chapter_progress": 0.25,
+        "start_container_path": "p/1",
+        "end_container_path": "p/1",
+        "start_offset": 2,
+        "end_offset": 18,
+        "context_string": "surrounding context",
+        "client_modified_at": datetime(2026, 8, 28, 5, 0, 0),
+        "hidden": False,
+        "content_revision": 1,
+    }
+    values.update(overrides)
+    return ub.Annotation(**values)
+
+
+def _owned(monkeypatch):
+    book = SimpleNamespace(id=BOOK_ID, uuid=OWNED, title="Flatland", identifiers=[])
+    monkeypatch.setattr(rs, "resolve_entitlement_ownership", lambda _content_id: book)
+    monkeypatch.setattr(
+        rs, "proxy_to_kobo_reading_services",
+        lambda **_kwargs: pytest.fail("owned annotations request contacted Kobo"),
+    )
+    return book
+
+
+def test_fallback_field_sets_match_measured_highlight_and_dogear_shapes():
+    highlight, exact_highlight, _reason = authority._fallback_object(
+        _annotation("highlight-1"), OWNED,
+    )
+    dogear, exact_dogear, dogear_reason = authority._fallback_object(
+        _annotation("dogear-1", "dogear"), OWNED,
+    )
+
+    assert exact_highlight is True
+    assert set(highlight) == {
+        "attachments", "clientLastModifiedUtc", "context", "highlightColor",
+        "highlightedText", "id", "location", "type",
+    }
+    assert set(highlight["location"]["span"]) == {
+        "chapterFilename", "chapterProgress", "endChar", "endPath",
+        "startChar", "startPath",
+    }
+    assert exact_dogear is False
+    assert dogear_reason == "dogear_chapter_title_unavailable"
+    assert set(dogear) == {
+        "clientLastModifiedUtc", "context", "highlightedText", "id",
+        "location", "type",
+    }
+    assert set(dogear["location"]["span"]) == {
+        "chapterFilename", "chapterProgress", "chapterTitle", "endChar",
+        "endPath", "startChar", "startPath",
+    }
+    assert "attachments" not in dogear
+    assert "highlightColor" not in dogear
+
+
+def test_note_column_fallback_preserves_note_text_and_identity():
+    note, faithful, reason = authority._fallback_object(
+        _annotation(
+            "note-1", "note", highlighted_text="", note_text="Do not lose this note",
+            highlight_color=None,
+        ),
+        OWNED,
+    )
+
+    assert faithful is False
+    assert reason == "note_wire_shape_unproven"
+    assert note["id"] == "note-1"
+    assert note["type"] == "note"
+    assert note["noteText"] == "Do not lose this note"
+    assert note["location"]["span"]["chapterFilename"] == "OEBPS/chapter.xhtml"
+
+
+def test_owned_patch_ack_has_measured_response_shape(app):
+    with app.test_request_context(f"/annotations/{OWNED}", method="PATCH"):
+        response = rs._owned_annotation_patch_ack(
+            None, SimpleNamespace(id=BOOK_ID), OWNED,
+        )
+
+    assert response.status_code == 204
+    assert response.get_data() == b""
+    assert response.headers["Content-Type"] == "text/html"
+    assert response.headers["Content-Length"] == "0"
+
+
+def test_owned_get_is_full_200_raw_exact_if_none_match_ignored_and_etag_moves(
+    app, session, monkeypatch,
+):
+    _owned(monkeypatch)
+    raw = (
+        b'{ "type" : "highlight", "id" : "a-raw", '
+        b'"clientLastModifiedUtc" : "2026-08-28T05:00:00Z", '
+        b'"context" : "raw context", "highlightedText" : "raw text", '
+        b'"highlightColor" : "#E8AFCF", "attachments" : {}, '
+        b'"location" : {"span":{"chapterFilename":"OEBPS/raw.xhtml",'
+        b'"chapterProgress":0.5,"endChar":9,"endPath":"p/2",'
+        b'"startChar":1,"startPath":"p/2"}} }'
+    )
+    raw_row = _annotation("a-raw", highlighted_text="parsed copy", highlight_color="#E8AFCF")
+    mapped_row = _annotation("b-mapped")
+    legacy_visible_row = _annotation("c-legacy-null", hidden=None)
+    hidden_row = _annotation("d-hidden", hidden=True)
+    session.add_all([raw_row, mapped_row, legacy_visible_row, hidden_row])
+    session.flush()
+    raw_location = extract_object_member_value(raw, "location")
+    session.add(ub.KoboAnnotationMaterialization(
+        annotation_id=raw_row.id,
+        raw_annotation_json=raw,
+        raw_location_json=raw_location,
+        raw_client_modified_utc="2026-08-28T05:00:00Z",
+        payload_sha256=hashlib.sha256(raw).hexdigest(),
+        materialization_revision=1,
+        provenance="kobo_patch",
+        attachments_state="empty",
+        serveable=False,
+    ))
+    session.commit()
+
+    with app.test_request_context(
+        f"/api/v3/content/{OWNED}/annotations?limit=100", method="GET",
+        headers={"If-None-Match": 'W/"CWNG:ignored:1:ignored"'},
+    ):
+        first = rs.handle_annotations.__wrapped__(OWNED)
+
+    assert first.status_code == 200
+    assert first.headers["Content-Type"] == "application/json"
+    assert first.get_data().count(raw) == 1
+    first_payload = json.loads(first.get_data())
+    assert [row["id"] for row in first_payload["annotations"]] == [
+        "a-raw", "b-mapped", "c-legacy-null",
+    ]
+    assert first_payload["nextPageOffsetToken"] is None
+    assert re.fullmatch(
+        r'W/"CWNG:[0-9a-f-]{36}:1:[0-9a-f]{16}"', first.headers["ETag"],
+    )
+    first_etag = first.headers["ETag"]
+
+    with app.test_request_context(
+        f"/api/v3/content/{OWNED}/annotations?limit=100", method="GET",
+        headers={"If-None-Match": first_etag},
+    ):
+        matched = rs.handle_annotations.__wrapped__(OWNED)
+
+    assert matched.status_code == 200
+    assert matched.get_data() == first.get_data()
+    assert matched.headers["ETag"] == first_etag
+
+    mapped_row.highlighted_text = "changed set"
+    mapped_row.content_revision += 1
+    session.commit()
+    with app.test_request_context(
+        f"/api/v3/content/{OWNED}/annotations?limit=100", method="GET",
+    ):
+        changed = rs.handle_annotations.__wrapped__(OWNED)
+
+    assert changed.status_code == 200
+    assert changed.headers["ETag"] != first_etag
+    assert re.fullmatch(
+        r'W/"CWNG:[0-9a-f-]{36}:2:[0-9a-f]{16}"', changed.headers["ETag"],
+    )
+
+
+def test_owned_get_returns_more_than_device_limit_as_one_honest_page(
+    app, session, monkeypatch,
+):
+    _owned(monkeypatch)
+    session.add_all([_annotation(f"row-{index:03d}") for index in range(101)])
+    session.commit()
+
+    with app.test_request_context(
+        f"/api/v3/content/{OWNED}/annotations?limit=100", method="GET",
+    ):
+        response = rs.handle_annotations.__wrapped__(OWNED)
+
+    payload = response.get_json()
+    assert response.status_code == 200
+    assert len(payload["annotations"]) == 101
+    assert payload["nextPageOffsetToken"] is None

--- a/tests/unit/test_1923_owned_annotations_local_authority.py
+++ b/tests/unit/test_1923_owned_annotations_local_authority.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from types import SimpleNamespace
 
 import pytest
-from flask import Flask
+from flask import Flask, make_response
 from sqlalchemy import create_engine
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
@@ -44,7 +44,17 @@ def app(monkeypatch):
     application = Flask(__name__)
     monkeypatch.setattr(
         rs, "current_user",
-        SimpleNamespace(id=USER_ID, name="reader", is_authenticated=True),
+        SimpleNamespace(
+            id=USER_ID, name="reader", is_authenticated=True,
+            kobo_two_way_annotation_sync=True,
+        ),
+    )
+    monkeypatch.setattr(
+        rs.config, "config_kobo_two_way_annotation_sync", True, raising=False,
+    )
+    monkeypatch.setattr(
+        "cps.services.kobo_annotation_stage0.schema_capable",
+        lambda _engine: True,
     )
     monkeypatch.setattr(rs, "_begin_exchange_capture", lambda *_a, **_k: None)
     return application
@@ -75,13 +85,22 @@ def _annotation(annotation_id, annotation_type="highlight", **overrides):
     return ub.Annotation(**values)
 
 
-def _owned(monkeypatch):
+def _owned(monkeypatch, session):
     book = SimpleNamespace(id=BOOK_ID, uuid=OWNED, title="Flatland", identifiers=[])
     monkeypatch.setattr(rs, "resolve_entitlement_ownership", lambda _content_id: book)
     monkeypatch.setattr(
         rs, "proxy_to_kobo_reading_services",
         lambda **_kwargs: pytest.fail("owned annotations request contacted Kobo"),
     )
+    session.add(ub.KoboAnnotationBookState(
+        user_id=USER_ID,
+        book_id=BOOK_ID,
+        content_id=OWNED,
+        authority_status="authoritative",
+        authority_revision=1,
+        generation_id="00000000-0000-0000-0000-000000000001",
+        opaque_content_status="absent",
+    ))
     return book
 
 
@@ -148,7 +167,7 @@ def test_owned_patch_ack_has_measured_response_shape(app):
 def test_owned_get_is_full_200_raw_exact_if_none_match_ignored_and_etag_moves(
     app, session, monkeypatch,
 ):
-    _owned(monkeypatch)
+    _owned(monkeypatch, session)
     raw = (
         b'{ "type" : "highlight", "id" : "a-raw", '
         b'"clientLastModifiedUtc" : "2026-08-28T05:00:00Z", '
@@ -193,7 +212,7 @@ def test_owned_get_is_full_200_raw_exact_if_none_match_ignored_and_etag_moves(
     ]
     assert first_payload["nextPageOffsetToken"] is None
     assert re.fullmatch(
-        r'W/"CWNG:[0-9a-f-]{36}:1:[0-9a-f]{16}"', first.headers["ETag"],
+        r'W/"CWNG:[0-9a-f-]{36}:2:[0-9a-f]{16}"', first.headers["ETag"],
     )
     first_etag = first.headers["ETag"]
 
@@ -218,26 +237,139 @@ def test_owned_get_is_full_200_raw_exact_if_none_match_ignored_and_etag_moves(
     assert changed.status_code == 200
     assert changed.headers["ETag"] != first_etag
     assert re.fullmatch(
-        r'W/"CWNG:[0-9a-f-]{36}:2:[0-9a-f]{16}"', changed.headers["ETag"],
+        r'W/"CWNG:[0-9a-f-]{36}:3:[0-9a-f]{16}"', changed.headers["ETag"],
     )
 
 
-def test_owned_get_returns_more_than_device_limit_as_one_honest_page(
+def test_owned_get_over_limit_proxies_instead_of_violating_page_contract(
     app, session, monkeypatch,
 ):
-    _owned(monkeypatch)
+    book = SimpleNamespace(id=BOOK_ID, uuid=OWNED, title="Flatland", identifiers=[])
+    monkeypatch.setattr(rs, "resolve_entitlement_ownership", lambda _content_id: book)
+    session.add(ub.KoboAnnotationBookState(
+        user_id=USER_ID,
+        book_id=BOOK_ID,
+        content_id=OWNED,
+        authority_status="authoritative",
+        authority_revision=1,
+        generation_id="00000000-0000-0000-0000-000000000001",
+        opaque_content_status="absent",
+    ))
     session.add_all([_annotation(f"row-{index:03d}") for index in range(101)])
     session.commit()
+
+    upstream_body = b'{"upstream":"paginated"}'
+    monkeypatch.setattr(
+        rs, "proxy_to_kobo_reading_services",
+        lambda **_kwargs: make_response(
+            upstream_body, 206, {"X-Upstream-Pagination": "preserved"},
+        ),
+    )
 
     with app.test_request_context(
         f"/api/v3/content/{OWNED}/annotations?limit=100", method="GET",
     ):
         response = rs.handle_annotations.__wrapped__(OWNED)
 
-    payload = response.get_json()
+    assert response.status_code == 206
+    assert response.get_data() == upstream_body
+    assert response.headers["X-Upstream-Pagination"] == "preserved"
+
+
+def test_renderer_rechecks_limit_after_eligibility_probe(app, session, monkeypatch):
+    """A concurrent 101st row cannot slip between eligibility and rendering."""
+    book = SimpleNamespace(id=BOOK_ID, uuid=OWNED, title="Flatland", identifiers=[])
+    monkeypatch.setattr(rs, "resolve_entitlement_ownership", lambda _content_id: book)
+    monkeypatch.setattr(authority, "local_get_is_eligible", lambda **_kwargs: True)
+    session.add_all([_annotation(f"race-row-{index:03d}") for index in range(101)])
+    session.commit()
+
+    upstream_body = b'{"upstream":"race-safe"}'
+    monkeypatch.setattr(
+        rs, "proxy_to_kobo_reading_services",
+        lambda **_kwargs: make_response(upstream_body, 207),
+    )
+
+    with app.test_request_context(
+        f"/api/v3/content/{OWNED}/annotations?limit=100", method="GET",
+    ):
+        response = rs.handle_annotations.__wrapped__(OWNED)
+
+    assert response.status_code == 207
+    assert response.get_data() == upstream_body
+
+
+def test_owned_unseeded_get_proxies_without_serving_partial_local_set(
+    app, session, monkeypatch,
+):
+    book = SimpleNamespace(id=BOOK_ID, uuid=OWNED, title="Flatland", identifiers=[])
+    monkeypatch.setattr(rs, "resolve_entitlement_ownership", lambda _content_id: book)
+    session.add_all([
+        ub.KoboAnnotationBookState(
+            user_id=USER_ID,
+            book_id=BOOK_ID,
+            content_id=OWNED,
+            authority_status="unseeded",
+            authority_revision=0,
+            generation_id="00000000-0000-0000-0000-000000000001",
+            opaque_content_status="unknown",
+        ),
+        _annotation("local-partial", highlighted_text="not a complete set"),
+    ])
+    session.commit()
+
+    upstream_body = b'{"annotations":[{"id":"cloud-complete"}]}'
+    monkeypatch.setattr(
+        rs, "proxy_to_kobo_reading_services",
+        lambda **_kwargs: make_response(
+            upstream_body, 200, {"ETag": 'W/"kobo-cloud"'},
+        ),
+    )
+
+    with app.test_request_context(
+        f"/api/v3/content/{OWNED}/annotations?limit=100", method="GET",
+    ):
+        response = rs.handle_annotations.__wrapped__(OWNED)
+
     assert response.status_code == 200
-    assert len(payload["annotations"]) == 101
-    assert payload["nextPageOffsetToken"] is None
+    assert response.get_data() == upstream_body
+    assert response.headers["ETag"] == 'W/"kobo-cloud"'
+
+
+def test_owned_unseeded_get_forwards_upstream_failure_unchanged(
+    app, session, monkeypatch,
+):
+    book = SimpleNamespace(id=BOOK_ID, uuid=OWNED, title="Flatland", identifiers=[])
+    monkeypatch.setattr(rs, "resolve_entitlement_ownership", lambda _content_id: book)
+    session.add(ub.KoboAnnotationBookState(
+        user_id=USER_ID,
+        book_id=BOOK_ID,
+        content_id=OWNED,
+        authority_status="unseeded",
+        authority_revision=0,
+        generation_id="00000000-0000-0000-0000-000000000001",
+        opaque_content_status="unknown",
+    ))
+    session.commit()
+
+    upstream_body = b'{"error":"upstream unavailable"}'
+    monkeypatch.setattr(
+        rs, "proxy_to_kobo_reading_services",
+        lambda **_kwargs: make_response(
+            upstream_body, 503,
+            {"Retry-After": "17", "X-Upstream-Failure": "preserved"},
+        ),
+    )
+
+    with app.test_request_context(
+        f"/api/v3/content/{OWNED}/annotations?limit=100", method="GET",
+    ):
+        response = rs.handle_annotations.__wrapped__(OWNED)
+
+    assert response.status_code == 503
+    assert response.get_data() == upstream_body
+    assert response.headers["Retry-After"] == "17"
+    assert response.headers["X-Upstream-Failure"] == "preserved"
 
 
 def test_book_state_insert_uses_contained_savepoint_on_active_session(
@@ -272,7 +404,13 @@ def test_book_state_insert_uses_contained_savepoint_on_active_session(
 def test_owned_get_survives_normalized_book_state_insert_integrity_error(
     app, session, monkeypatch,
 ):
-    _owned(monkeypatch)
+    book = SimpleNamespace(id=BOOK_ID, uuid=OWNED, title="Flatland", identifiers=[])
+    monkeypatch.setattr(rs, "resolve_entitlement_ownership", lambda _content_id: book)
+    monkeypatch.setattr(
+        rs, "proxy_to_kobo_reading_services",
+        lambda **_kwargs: pytest.fail("renderer containment must not contact Kobo"),
+    )
+    monkeypatch.setattr(authority, "local_get_is_eligible", lambda **_kwargs: True)
     session.add_all([
         _annotation("state-race-a", highlighted_text="private state text A"),
         _annotation("state-race-b", highlighted_text="private state text B"),
@@ -340,7 +478,7 @@ def test_owned_get_survives_normalized_book_state_insert_integrity_error(
 def test_owned_get_row_render_exception_keeps_every_identity_and_text(
     app, session, monkeypatch,
 ):
-    _owned(monkeypatch)
+    _owned(monkeypatch, session)
     session.add_all([
         _annotation("render-a", highlighted_text="private render text A"),
         _annotation("render-b", highlighted_text="private render text B"),

--- a/tests/unit/test_1923_owned_annotations_local_authority.py
+++ b/tests/unit/test_1923_owned_annotations_local_authority.py
@@ -13,6 +13,7 @@ from types import SimpleNamespace
 import pytest
 from flask import Flask
 from sqlalchemy import create_engine
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
 
 from cps import ub
@@ -237,3 +238,111 @@ def test_owned_get_returns_more_than_device_limit_as_one_honest_page(
     assert response.status_code == 200
     assert len(payload["annotations"]) == 101
     assert payload["nextPageOffsetToken"] is None
+
+
+def test_owned_get_survives_normalized_book_state_insert_integrity_error(
+    app, session, monkeypatch,
+):
+    _owned(monkeypatch)
+    session.add_all([
+        _annotation("state-race-a", highlighted_text="private state text A"),
+        _annotation("state-race-b", highlighted_text="private state text B"),
+    ])
+    session.commit()
+
+    original_flush = session.flush
+    inserted_content_ids = []
+
+    def fail_book_state_flush(*args, **kwargs):
+        pending = [
+            row for row in session.new
+            if isinstance(row, ub.KoboAnnotationBookState)
+        ]
+        if pending:
+            inserted_content_ids.extend(row.content_id for row in pending)
+            raise IntegrityError("simulated race", {}, RuntimeError("duplicate"))
+        return original_flush(*args, **kwargs)
+
+    monkeypatch.setattr(session, "flush", fail_book_state_flush)
+    errors = []
+    monkeypatch.setattr(rs.log, "error", lambda *args, **kwargs: errors.append(args))
+    decorated_entitlement = f" {{ {OWNED.upper()} }} "
+
+    with app.test_request_context(
+        f"/api/v3/content/{OWNED}/annotations?limit=100", method="GET",
+    ):
+        response = rs.handle_annotations.__wrapped__(decorated_entitlement)
+
+    payload = response.get_json()
+    assert response.status_code == 200
+    assert [row["id"] for row in payload["annotations"]] == [
+        "state-race-a", "state-race-b",
+    ]
+    assert [row["highlightedText"] for row in payload["annotations"]] == [
+        "private state text A", "private state text B",
+    ]
+    assert re.fullmatch(
+        r'W/"CWNG:[0-9a-f-]{36}:[0-9]+:[0-9a-f]{16}"',
+        response.headers["ETag"],
+    )
+    first_etag = response.headers["ETag"]
+    first_body = response.get_data()
+    assert inserted_content_ids == [OWNED]
+    assert len(errors) == 1
+    assert errors[0][3] == 2
+    assert "book_state" in repr(errors[0])
+    assert "private state text" not in repr(errors[0])
+
+    errors.clear()
+    with app.test_request_context(
+        f"/api/v3/content/{OWNED}/annotations?limit=100", method="GET",
+    ):
+        repeated = rs.handle_annotations.__wrapped__(decorated_entitlement)
+
+    assert repeated.status_code == 200
+    assert repeated.get_data() == first_body
+    assert repeated.headers["ETag"] == first_etag
+    assert inserted_content_ids == [OWNED, OWNED]
+    assert len(errors) == 1
+    assert errors[0][3] == 2
+    assert "private state text" not in repr(errors[0])
+
+
+def test_owned_get_row_render_exception_keeps_every_identity_and_text(
+    app, session, monkeypatch,
+):
+    _owned(monkeypatch)
+    session.add_all([
+        _annotation("render-a", highlighted_text="private render text A"),
+        _annotation("render-b", highlighted_text="private render text B"),
+    ])
+    session.commit()
+
+    original_fallback = authority._fallback_object
+
+    def fail_one_row(annotation, entitlement_id):
+        if annotation.annotation_id == "render-a":
+            raise RuntimeError("must not log private render text A")
+        return original_fallback(annotation, entitlement_id)
+
+    monkeypatch.setattr(authority, "_fallback_object", fail_one_row)
+    errors = []
+    monkeypatch.setattr(rs.log, "error", lambda *args, **kwargs: errors.append(args))
+
+    with app.test_request_context(
+        f"/api/v3/content/{OWNED}/annotations?limit=100", method="GET",
+    ):
+        response = rs.handle_annotations.__wrapped__(OWNED)
+
+    payload = response.get_json()
+    assert response.status_code == 200
+    assert [row["id"] for row in payload["annotations"]] == [
+        "render-a", "render-b",
+    ]
+    assert [row["highlightedText"] for row in payload["annotations"]] == [
+        "private render text A", "private render text B",
+    ]
+    assert len(errors) == 1
+    assert errors[0][3] == 2
+    assert "row_render_RuntimeError" in repr(errors[0])
+    assert "private render text" not in repr(errors[0])

--- a/tests/unit/test_f5c1146_kobo_patch_recovery_spool.py
+++ b/tests/unit/test_f5c1146_kobo_patch_recovery_spool.py
@@ -1192,6 +1192,13 @@ def test_unreadable_patch_body_still_refuses_but_unreadable_get_body_does_not(
     """
     _root(monkeypatch, tmp_path)
     app = _app(monkeypatch, dispatch=lambda *_a, **_k: None)
+    upstream_body = b'{"upstream":"preserved"}'
+    monkeypatch.setattr(
+        rs, "proxy_to_kobo_reading_services",
+        lambda **_kwargs: app.response_class(
+            upstream_body, status=207, headers={"X-Upstream": "same"},
+        ),
+    )
 
     def _unreadable(self, *args, **kwargs):
         del self, args, kwargs
@@ -1205,7 +1212,9 @@ def test_unreadable_patch_body_still_refuses_but_unreadable_get_body_does_not(
     assert patch_response.status_code == 503
 
     get_response = app.test_client().get(f"/annotations/{BOOK_UUID}")
-    assert get_response.status_code != 503
+    assert get_response.status_code == 207
+    assert get_response.get_data() == upstream_body
+    assert get_response.headers["X-Upstream"] == "same"
 
 
 @pytest.mark.unit

--- a/tests/unit/test_f5c1146_kobo_patch_recovery_spool.py
+++ b/tests/unit/test_f5c1146_kobo_patch_recovery_spool.py
@@ -154,9 +154,7 @@ def _app(monkeypatch, *, dispatch):
     )
     monkeypatch.setattr(
         rs, "proxy_to_kobo_reading_services",
-        lambda **_kwargs: app.response_class(
-            b'{"upstream":"accepted"}', status=207, headers={"X-Upstream": "same"},
-        ),
+        lambda **_kwargs: pytest.fail("owned PATCH must not contact Kobo"),
     )
     return app
 
@@ -178,8 +176,8 @@ def test_patch_spool_is_durable_before_parse_and_dispatch(monkeypatch, tmp_path)
         f"/annotations/{BOOK_UUID}", data=RAW_PATCH, content_type="application/json",
     )
 
-    assert response.status_code == 207
-    assert response.get_data() == b'{"upstream":"accepted"}'
+    assert response.status_code == 204
+    assert response.get_data() == b""
     [(path, record)] = _records(spool, root)
     assert record["body"] == RAW_PATCH
     assert record["body_sha256"] == spool.sha256_bytes(RAW_PATCH)
@@ -295,8 +293,8 @@ def test_spool_failure_cannot_change_patch_response_or_dispatch(monkeypatch, tmp
         f"/annotations/{BOOK_UUID}", data=RAW_PATCH, content_type="application/json",
     )
 
-    assert response.status_code == 207
-    assert response.get_data() == b'{"upstream":"accepted"}'
+    assert response.status_code == 204
+    assert response.get_data() == b""
     assert len(dispatched) == 1
 
 

--- a/tests/unit/test_f5c1146_kobo_patch_recovery_spool.py
+++ b/tests/unit/test_f5c1146_kobo_patch_recovery_spool.py
@@ -150,6 +150,9 @@ def _app(monkeypatch, *, dispatch):
     monkeypatch.setattr(rs, "resolve_entitlement_ownership", lambda _content_id: book)
     monkeypatch.setattr(rs, "log_annotation_data", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
+        rs, "_owned_patch_is_local_authority", lambda *_args, **_kwargs: True,
+    )
+    monkeypatch.setattr(
         "cps.services.annotation_sync.dispatch_annotation_sync", dispatch,
     )
     monkeypatch.setattr(

--- a/tests/unit/test_kobo_annotation_stage0.py
+++ b/tests/unit/test_kobo_annotation_stage0.py
@@ -33,6 +33,16 @@ OLD_ANNOTATION_COLUMNS = (
 )
 
 
+@pytest.fixture(autouse=True)
+def _stage0_route_tests_assume_completed_seed(monkeypatch):
+    """Stage-0 route tests predate and are orthogonal to the authority gate."""
+    import cps.readingservices as readingservices
+    monkeypatch.setattr(
+        readingservices, "_owned_patch_is_local_authority",
+        lambda *_args, **_kwargs: True,
+    )
+
+
 def _create_gate_tables(conn, *, user_gate=False, settings_gate=False):
     conn.execute(text(
         "CREATE TABLE user (id INTEGER PRIMARY KEY, name VARCHAR(64)"

--- a/tests/unit/test_kobo_annotation_stage0.py
+++ b/tests/unit/test_kobo_annotation_stage0.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Stage 0 contract for Kobo two-way annotation sync.
 
-Stage 0 is deliberately passive: it adds durable evidence and opt-ins, while
-the existing reading-services proxy remains the only response owner.
+Stage 0 is deliberately passive: it adds durable evidence and opt-ins.  The
+later owned-book wire-authority route consumes that evidence independently.
 """
 
 from __future__ import annotations
@@ -15,7 +15,7 @@ from datetime import datetime, timezone
 from types import SimpleNamespace
 
 import pytest
-from flask import Flask, make_response
+from flask import Flask
 from sqlalchemy import create_engine, inspect, text
 from sqlalchemy.orm import sessionmaker
 
@@ -527,13 +527,12 @@ def test_dispatch_persists_raw_sidecar_without_rewriting_parsed_location(monkeyp
 
 
 @pytest.mark.unit
-def test_patch_raw_capture_failure_logs_but_keeps_proxy_bytes_and_response(caplog, monkeypatch):
+def test_patch_raw_capture_failure_logs_but_keeps_local_ack_and_dispatch(caplog, monkeypatch):
     import cps.readingservices as rs
 
     app = Flask(__name__)
     forwarded = []
     dispatched = []
-    response_body = b' {"upstream":"unchanged"} '
 
     monkeypatch.setattr(rs, "resolve_entitlement_ownership", lambda _content_id: SimpleNamespace(id=348))
     monkeypatch.setattr(rs, "log_annotation_data", lambda *_args, **_kwargs: None)
@@ -544,7 +543,7 @@ def test_patch_raw_capture_failure_logs_but_keeps_proxy_bytes_and_response(caplo
     monkeypatch.setattr(
         rs, "proxy_to_kobo_reading_services",
         lambda **_kwargs: forwarded.append(rs.request.get_data()) or
-        make_response(response_body, 207, {"X-Upstream": "same"}),
+        pytest.fail("owned PATCH must not contact Kobo"),
     )
     rejected_capture_bodies = (
         b'{"updatedAnnotations":[{"id":"ann-1","location":null}]}',
@@ -565,10 +564,9 @@ def test_patch_raw_capture_failure_logs_but_keeps_proxy_bytes_and_response(caplo
             response = rs.handle_annotations.__wrapped__("book")
 
         assert dispatched
-        assert forwarded == [rejected_body]
-        assert response.status_code == 207
-        assert response.get_data() == response_body
-        assert response.headers["X-Upstream"] == "same"
+        assert forwarded == []
+        assert response.status_code == 204
+        assert response.get_data() == b""
         assert "raw lexical capture failed" in caplog.text.lower()
 
     forwarded.clear()
@@ -578,10 +576,9 @@ def test_patch_raw_capture_failure_logs_but_keeps_proxy_bytes_and_response(caplo
         data=RAW_PATCH, content_type="application/json",
     ):
         response = rs.handle_annotations.__wrapped__("book")
-    assert forwarded == [RAW_PATCH]
-    assert response.status_code == 207
-    assert response.get_data() == response_body
-    assert response.headers["X-Upstream"] == "same"
+    assert forwarded == []
+    assert response.status_code == 204
+    assert response.get_data() == b""
     raw_records = dispatched[0][1]["raw_materializations"]
     assert raw_records[0].raw_annotation_json in RAW_PATCH
     assert raw_records[0].raw_location_json == RAW_LOCATION

--- a/tests/unit/test_kobo_iso_clock_overflow.py
+++ b/tests/unit/test_kobo_iso_clock_overflow.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from types import SimpleNamespace
 
 import pytest
-from flask import Flask, make_response
+from flask import Flask
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -57,13 +57,12 @@ def test_kobo_reading_state_clock_parser_rejects_both_utc_overflows(clock):
 def test_live_patch_stores_the_highlight_without_the_rejected_clock(
     annotation_session, monkeypatch, clock
 ):
-    """The upstream-success response must correspond to a durable local row."""
+    """The local-success response must correspond to a durable local row."""
     from cps import readingservices
 
     session, user = annotation_session
     book = SimpleNamespace(id=347, title="The Clock", uuid=BOOK_UUID)
     app = Flask(__name__)
-    upstream_body = b'{"upstream":"accepted"}'
     monkeypatch.setattr(readingservices, "current_user", user)
     monkeypatch.setattr(
         readingservices,
@@ -74,7 +73,7 @@ def test_live_patch_stores_the_highlight_without_the_rejected_clock(
     monkeypatch.setattr(
         readingservices,
         "proxy_to_kobo_reading_services",
-        lambda: make_response(upstream_body, 207),
+        lambda: pytest.fail("owned PATCH must not contact Kobo"),
     )
     payload = {
         "updatedAnnotations": [{
@@ -94,8 +93,8 @@ def test_live_patch_stores_the_highlight_without_the_rejected_clock(
     ):
         response = readingservices.handle_annotations.__wrapped__(BOOK_UUID)
 
-    assert response.status_code == 207
-    assert response.get_data() == upstream_body
+    assert response.status_code == 204
+    assert response.get_data() == b""
     row = session.query(ub.Annotation).one()
     assert row.highlighted_text == "This highlight must survive the rejected clock."
     assert row.client_modified_at is None

--- a/tests/unit/test_kobo_iso_clock_overflow.py
+++ b/tests/unit/test_kobo_iso_clock_overflow.py
@@ -71,6 +71,10 @@ def test_live_patch_stores_the_highlight_without_the_rejected_clock(
     )
     monkeypatch.setattr(readingservices, "log_annotation_data", lambda *_args: None)
     monkeypatch.setattr(
+        readingservices, "_owned_patch_is_local_authority",
+        lambda *_args, **_kwargs: True,
+    )
+    monkeypatch.setattr(
         readingservices,
         "proxy_to_kobo_reading_services",
         lambda: pytest.fail("owned PATCH must not contact Kobo"),

--- a/tests/unit/test_kobo_reading_services_exchange_capture.py
+++ b/tests/unit/test_kobo_reading_services_exchange_capture.py
@@ -533,9 +533,13 @@ def test_owned_annotations_capture_records_local_answer_without_upstream_leg(
 
     monkeypatch.setattr(rs, "current_user", SimpleNamespace(id=7, is_authenticated=True))
     monkeypatch.setattr(rs, "resolve_entitlement_ownership", lambda _content_id: book)
-    monkeypatch.setattr(rs, "_capture_authority_status", lambda _ownership: "unseeded")
+    monkeypatch.setattr(rs, "_capture_authority_status", lambda _ownership: "authoritative")
     monkeypatch.setattr(rs, "_stage_patch_for_recovery", lambda *_args: None)
     monkeypatch.setattr(rs, "log_annotation_data", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        "cps.services.kobo_annotation_authority.local_get_is_eligible",
+        lambda **_kwargs: True,
+    )
     monkeypatch.setattr(
         rs, "proxy_to_kobo_reading_services",
         lambda **_kwargs: pytest.fail("owned request must not create an upstream leg"),
@@ -563,7 +567,7 @@ def test_owned_annotations_capture_records_local_answer_without_upstream_leg(
         "index": 0,
         "content_id": OWNED,
         "ownership": "owned",
-        "authority_status": "unseeded",
+        "authority_status": "authoritative",
         "action": "answered_locally",
     }]
     assert record["device_response"]["status"] == expected_status

--- a/tests/unit/test_kobo_reading_services_exchange_capture.py
+++ b/tests/unit/test_kobo_reading_services_exchange_capture.py
@@ -510,3 +510,60 @@ def test_annotations_get_and_patch_capture_both_proxy_legs_and_device_response(
     assert record["upstream_response"]["body"]["data"].encode() == upstream_body
     assert record["device_response"]["body"]["data"].encode() == upstream_body
     assert "secret" not in json.dumps(record).lower()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("method", "request_body", "expected_status"),
+    [
+        ("GET", b"", 200),
+        ("PATCH", b"{}", 204),
+    ],
+)
+def test_owned_annotations_capture_records_local_answer_without_upstream_leg(
+    monkeypatch, tmp_path, method, request_body, expected_status,
+):
+    _capture, root = _enable(monkeypatch, tmp_path)
+    app = Flask(__name__)
+    book = SimpleNamespace(id=347, title="Flatland", identifiers=[])
+
+    @app.route("/annotations/<content_id>", methods=["GET", "PATCH"])
+    def annotations(content_id):
+        return rs.handle_annotations.__wrapped__(content_id)
+
+    monkeypatch.setattr(rs, "current_user", SimpleNamespace(id=7, is_authenticated=True))
+    monkeypatch.setattr(rs, "resolve_entitlement_ownership", lambda _content_id: book)
+    monkeypatch.setattr(rs, "_capture_authority_status", lambda _ownership: "unseeded")
+    monkeypatch.setattr(rs, "_stage_patch_for_recovery", lambda *_args: None)
+    monkeypatch.setattr(rs, "log_annotation_data", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        rs, "proxy_to_kobo_reading_services",
+        lambda **_kwargs: pytest.fail("owned request must not create an upstream leg"),
+    )
+    monkeypatch.setattr(
+        "cps.services.kobo_annotation_authority.render_owned_annotations",
+        lambda **_kwargs: (
+            b'{"annotations":[],"nextPageOffsetToken":null}',
+            'W/"CWNG:00000000-0000-0000-0000-000000000000:1:0000000000000000"',
+        ),
+    )
+
+    response = app.test_client().open(
+        f"/annotations/{OWNED}?limit=100", method=method, data=request_body,
+        content_type="application/json",
+    )
+
+    assert response.status_code == expected_status
+    [record] = _records(root)
+    assert record["upstream_request"] is None
+    assert record["upstream_response"] is None
+    assert record["upstream_error"] is None
+    assert record["decisions"] == [{
+        "stage": "local_authority",
+        "index": 0,
+        "content_id": OWNED,
+        "ownership": "owned",
+        "authority_status": "unseeded",
+        "action": "answered_locally",
+    }]
+    assert record["device_response"]["status"] == expected_status


### PR DESCRIPTION
Answers owned books' Kobo annotation `GET` and `PATCH` from our own store instead of proxying them to Kobo (#1923), so annotations on sideloaded/owned titles stay local, stay private, and survive a re-download.

## Cross-family review found two blocking defects; both are fixed here

An independent review of `e59bd1237` returned **DO-NOT-MERGE**, and both findings were confirmed against the code and against this repo's own design notes before acting on them.

1. **Highlight loss on an unseeded or ineligible owned book.** The GET handler served the local set with `200` for *any* owned book, and created the book state as `authority_status="unseeded"` on the way. Because a successful GET replaces Nickel's entire set (measured — `notes/KOBO-HIGHLIGHT-LOSS-ROOT-CAUSE-2026-08-15.md`), a book whose local store was empty, partial or stale would have silently destroyed the device's highlights. `kobo_annotation_stage0.gates_allow` already existed and was never consulted.
2. **Pagination contract discarded.** Every visible row was loaded and `nextPageOffsetToken` was hardcoded to `null`, ignoring `limit`. The measured device requests `limit=100` and follows the token until it is null.

`567dad6b6` makes local authority **fail closed**. CWNG answers locally only when the schema is capable, the instance opt-in and the user opt-in are both on, an existing `(user, book)` state is `authoritative`, its normalized content id matches the request, and the complete visible set fits inside the requested page. Unseeded, missing-state, disabled, ineligible, malformed-`limit`, continuation-token and unexpected-exception cases all proxy to Kobo unchanged, and an upstream failure on that path is forwarded unchanged rather than converted into a local `200`. Over-limit sets proxy rather than violating the wire contract; the immutable snapshot + cursor design (§6.2) is deliberately left to a later change. The renderer re-checks the bound after the eligibility probe, so a second device adding the 101st row mid-request cannot slip an over-limit page out.

## Evidence

- Red/green, run independently of the authoring leg: bypassing `local_get_is_eligible` → **2 failed, 9 passed**; disabling the renderer's page bound → **1 failed, 10 passed**; restored → **148 passed** across the seven touched unit files. Both defences are separately load-bearing.
- Earlier evidence on this branch stands: 5 tests fail against the pre-fix proxying behaviour; `test_book_state_insert_uses_contained_savepoint_on_active_session` proves the new SAVEPOINT is routed through `ub.begin_contained_nested` (#1936); `/security-review` over the auth, ownership, user-scoping, injection and capture surfaces found nothing high-confidence.
- No dependency, license, schema or external-service change.

## Not yet done — why this is still `needs-review`

- Practical verification for the corrective commit was observed at the real Flask request-context level, not through a live container HTTP flow.
- Hardware verification on a real device (create and read back an annotation on an owned book) is still outstanding.
- Over-limit collections and continuation pages proxy; CWNG does not yet implement local cursors.

## Gate added 2026-08-28 (`2779606b2`) — HOLD lifted to "inert until seeded"
Local authority (GET **and** PATCH, switched together) now requires the Stage-0 book state to be `authoritative` **and** an accepted seed capture for the requesting device whose annotation count the local visible set meets, within one page. Every other book keeps the exact status quo (proxy both verbs) with one structural INFO reason per user/book/process. Raw materializations never imply completeness. Effect today: no real book qualifies, so nothing changes on the wire until #1942 seeds a book; the Clara probe will be seeded for the hardware verification.


## Manager merge gate — independent verification (2026-08-28)

Run by the manager against `6d6edb6b4` in a separate worktree, not by the authoring leg.

- **Green:** 143 passed across the six touched unit files (`repo/.venv/bin/python -m pytest`).
- **Red, mutation at the safety choke point:** forcing `local_get_is_eligible` to return `True`
  → **4 failed / 92 passed**, including `test_owned_unseeded_patch_is_persisted_then_proxied`
  and both device-seed-count guards. The gate is load-bearing and behaviourally pinned.
- **Red, second mutation:** failing open the `authority_status == "authoritative"` requirement
  inside `gate_failure_reason` → 1 failed / 38 passed; the accepted-seed-count layer still
  refuses. The defence is genuinely layered rather than a single check.
- **Blast radius — OBSERVED, not assumed:** no code in `cps/` ever writes
  `authority_status='authoritative'` (the opt-out API only ever writes `'disabled'`; the column
  defaults to `'unseeded'`), and nothing constructs a `KoboAnnotationSeedCapture` row at all.
  Both gate flags also default to 0. **No real book can reach the local path today**, so every
  book keeps the existing byte-transparent Kobo proxy on both verbs. That is what makes this
  mergeable ahead of the hardware verification.
- **Security surface, manager-inspected:** every new query is `user_id`-scoped, ownership goes
  through the existing `resolve_entitlement_ownership`, the content id is re-checked for
  equality, all access is ORM (no string SQL), and there is no new route, subprocess,
  filesystem path, dependency, licence change or external URL.
- **Known coverage gap, filed rather than fixed:** `_render_count_is_safe` is not pinned —
  forcing it to `True` leaves the suite fully green. It is a redundant race-closer sitting
  behind an already-proven gate, so this is a test-coverage finding, not a live defect.

Still outstanding and unchanged: hardware verification on a real device, and local cursors for
over-limit collections (those sets proxy).
