### PR TITLE
env vars: examples/.env.example is the enforced single source of truth (follow-up to #1913)

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,8 @@ After Shelfmark starts, open it and pick **Settings → Security → Authenticat
 
 ### Network shares (NFS, SMB, ZFS)
 
+See [`examples/.env.example`](examples/.env.example) for the complete environment-variable reference and defaults.
+
 If `/config` or `/calibre-library` lives on a network share, set:
 
 ```yaml

--- a/changelog.d/env-vars-ssot.md
+++ b/changelog.d/env-vars-ssot.md
@@ -1,0 +1,6 @@
+### Changed
+
+- **Environment settings now have one complete, drift-checked reference.**
+  `examples/.env.example` documents every supported application, service, and test
+  variable, and automated tests keep it synchronized with the code. Initiated by
+  @Thovi98.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     image: ghcr.io/new-usemame/calibre-web-nextgen:latest
     container_name: calibre-web-nextgen
     environment:
+      # See examples/.env.example for the complete environment-variable reference and defaults.
       # Only change these if you know what you're doing
       - PUID=1000
       - PGID=1000

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -1,40 +1,314 @@
-# APP_MODE can be production, development or test
+# Application mode: production, development, or test. Default: production.
+# Change only for a development or test process.
 APP_MODE=production
+# Node/Vite mode. Default: production; change only for frontend development or tests.
 NODE_ENV=production
 
+# Container timezone. Default: UTC; set to a valid IANA zone for local timestamps.
 TZ=UTC
+# Application listen port. Default: 8083; change the published port and health checks with it.
 CWA_PORT_OVERRIDE=8083
 
-# A HARDCOVER_TOKEN is needed to enable Hardcover auto-fetch. It can be set via following environment variable or by configuring it in the Basic Configuration.
-# You can find your Hadcover token at https://hardcover.app/account/api.
+# A HARDCOVER_TOKEN is needed to enable Hardcover auto-fetch. Default: unset.
+# Set it here, via HARDCOVER_TOKEN_FILE, or in Basic Configuration.
+# You can find your Hardcover token at https://hardcover.app/account/api.
 # Users still have to configure their own Hardcover token if they want to track their readings to Hardcover.app
 # HARDCOVER_TOKEN=eyJhbGciOiJIUzI1NiI...
 
 # Always set NETWORK_SHARE_MODE=true when running CWA on NFS/SMB shares to prevent database corruption and permission errors.
 NETWORK_SHARE_MODE=false
 
+# File-watcher backend. Default: inotify (or automatic polling on network shares/Docker Desktop).
+# Set to poll to force polling on any filesystem.
 # CWA_WATCH_MODE=poll
-# DISABLE_LIBRARY_AUTOMOUNT=
+# Skip automatic Calibre-library detection/mounting. Default: false.
+# Set true/yes/1 when the library mount is managed entirely outside CWNG.
+# DISABLE_LIBRARY_AUTOMOUNT=false
 
-# Change following if CWNG is running behind multiple proxies (e.g., Cloudflare Tunnel + reverse proxy)
+# Trusted reverse-proxy hops. Default: 1.
+# Change this if CWNG is running behind multiple proxies (e.g., Cloudflare Tunnel + reverse proxy).
 # TRUSTED_PROXY_COUNT=1
 
-# Path where CWNG is installed
+# Path where CWNG is installed. Default: the parent of scripts/app_paths.py.
+# Set when a packager separates the installed application tree from this layout.
 # CWA_APP_ROOT=
 
-# application's configured state directory — the same place ``app.db`` lives 
+# Application's configured state directory — the same place app.db lives.
+# The container default is /config; this packager template places it below the install directory.
 CALIBRE_DBPATH=__INSTALL_DIR__/config
 
-# Same as CALIBRE_DBPATH unless changed
+# Interpolation helper for the paths below; CWNG itself reads CALIBRE_DBPATH.
 CONFIG_DIR=${CALIBRE_DBPATH}
 
-# Path where the Calibre config and plugins can be found
-CALIBRE_CONFIG_DIRECTORY=${CONFIG_DIR}/.config/calibre
-# Enable Calibre configuration loading
+# Calibre's own config directory is set per child process when user plugins are enabled.
+# Do not set this globally unless every Calibre subprocess should load that configuration.
+# CALIBRE_CONFIG_DIRECTORY=${CONFIG_DIR}/.config/calibre
+# Enable Calibre user-plugin loading. Default: false.
+# Set true only after mounting plugins under /config/.config/calibre/plugins.
 CWA_CALIBRE_USER_PLUGINS=false
 
+# Ingest directory. Default: /cwa-book-ingest; set when the container mount target differs.
 CWA_INGEST_FOLDER=/cwa-book-ingest
+# Calibre library directory. Default: /calibre-library; set when the mount target differs.
 CWA_CALIBRE_LIBRARY_DIR=/calibre-library
+# Conversion scratch directory. Built-in default: /config/.cwa_conversion_tmp.
+# This template follows a customized CALIBRE_DBPATH instead.
 CWA_TMP_CONVERSION_DIR=${CONFIG_DIR}/.cwa_conversion_tmp
 
+# Directory for the cross-process metadata.db advisory lock. Default: /config.
+# Keep it on a local filesystem even when the Calibre library is on a network share.
 CWA_METADATA_LOCK_DIR=${CONFIG_DIR}
+
+# User and group IDs applied to library and ingest files in the container. Defaults: 1000/1000.
+# Set these to the host account that owns the bind-mounted directories.
+# PUID=1000
+# PGID=1000
+
+# Cache directory for thumbnails and other generated application data.
+# Default: <application root>/cps/cache. Set only when generated cache data belongs elsewhere.
+# CACHE_DIR=
+
+# Prefix added to the Flask session and remember-cookie names. Default: empty.
+# Set this when multiple CWNG instances share one browser hostname.
+# COOKIE_PREFIX=
+
+# Force secure-only session cookies. Default: false; HTTPS/OAuth settings can also force this on.
+# Set true when TLS terminates upstream but the application cannot infer it.
+# SESSION_COOKIE_SECURE=false
+
+# Flask session-signing key. Default: the persistent key stored in app.db.
+# Set only when deployment policy requires an externally managed stable key.
+# SECRET_KEY=
+
+# Enable Flask debug-dependent behavior. Default: unset/off.
+# Set only for local development; any non-empty value enables the checked paths.
+# FLASK_DEBUG=
+
+# Require strict TLS certificate verification for OAuth. Default: 1 (enabled).
+# Set to false/0 only for a deliberately self-signed development OAuth endpoint.
+# OAUTH_SSL_STRICT=1
+
+# Allow SMTP TLS without certificate or hostname verification. Default: false.
+# Set only for a mail server whose certificate cannot be validated normally.
+# SMTP_ALLOW_UNVERIFIED_SSL=false
+
+# HTML token used by Google Search Console site verification. Default: empty.
+# Set when this instance's public site has been registered with Google Search Console.
+# GOOGLE_SITE_VERIFICATION=
+
+# Public reconnect endpoint and localhost-cover access mirror the -r and -l CLI switches.
+# Defaults: unset/off. Set to a non-empty value only when the corresponding behavior is needed.
+# CALIBRE_RECONNECT=
+# CALIBRE_LOCALHOST=
+
+# Listen on a Unix-domain socket instead of the configured TCP address. Default: unset.
+# Set to an absolute socket path for a local reverse proxy on non-Windows hosts.
+# CALIBRE_UNIX_SOCKET=
+
+# Reverse-proxy fallback values used when the matching forwarded headers are absent.
+# Defaults: empty. Set only for a proxy that cannot send X-Script-Name/X-Scheme/X-Forwarded-Host.
+# PROXY_SCRIPT_NAME=/calibre
+# PROXY_SCHEME=https
+# PROXY_HOST=books.example.com
+# PROXY_PORT=443
+
+# Additional browser origins accepted by the SPA API's origin check, comma-separated.
+# Default: empty. Set only when a proxy rewrites Host without forwarding the public host.
+# CWNG_TRUSTED_ORIGINS=https://books.example.com,https://books.lan:8443
+
+# Serve the NextGen SPA. Default: enabled; empty/0/false/no/off disables it.
+# Set false only to hide the SPA while retaining the classic interface.
+# CWNG_SPA=true
+
+# Allow Calibre desktop to coexist with CWNG by using per-request DB connections.
+# Default: false. Set true only when Calibre desktop opens the same library intermittently.
+# DESKTOP_COMPAT_MODE=false
+
+# Installed-version stamp used for User-Agent and update comparisons.
+# Default: package metadata, then v0.0.0 in an unstamped source checkout. Images set this internally.
+# CWA_INSTALLED_VERSION=
+
+# GitHub repository queried by the in-app update checker. Default: new-usemame/Calibre-Web-NextGen.
+# Set for a downstream fork that publishes its own releases.
+# CWA_RELEASE_REPO=new-usemame/Calibre-Web-NextGen
+
+# Absolute application-database path. Default: <CALIBRE_DBPATH>/app.db.
+# Set only when app.db must live separately from the configured state directory.
+# CWA_APP_DB_PATH=
+
+# Directory containing cwa.db, the enforcement/settings database.
+# Default: CALIBRE_DBPATH, with a compatibility fallback to /config when appropriate.
+# CWA_DB_PATH=
+
+# Path to dirs.json. Default: <CWA_APP_ROOT>/dirs.json; relative paths anchor to CWA_APP_ROOT.
+# Set for packagers that keep runtime path configuration outside the application tree.
+# CWA_DIRS_JSON=
+
+# Service account names used when scripts chown generated files. Defaults: abc/abc.
+# Set for nonstandard container images; missing accounts cause ownership changes to be skipped.
+# CWA_SERVICE_USER=abc
+# CWA_SERVICE_GROUP=abc
+
+# Internal path to the shared Python runtime-path resolver used by s6 services.
+# Default: /app/calibre-web-automated/scripts/app_paths.py. Packager/debug override only.
+# CWA_APP_PATHS=/app/calibre-web-automated/scripts/app_paths.py
+
+# Legacy ingest-watcher path override. Default: unset; CWA_INGEST_FOLDER is authoritative.
+# Keep unset for new deployments; it exists only for compatibility with older service setups.
+# WATCH_FOLDER=
+
+# Persistent metadata-change log and temporary export directories.
+# Defaults: /config paths in the container; Python source installs derive them from CALIBRE_DBPATH.
+# Set only when these writer/watcher paths must be relocated together.
+# CWA_METADATA_CHANGE_LOGS_DIR=${CONFIG_DIR}/metadata_change_logs
+# CWA_METADATA_TEMP_DIR=${CONFIG_DIR}/metadata_temp
+
+# Metadata-change dispatcher timing, in seconds. Defaults: 1.0 debounce and 15.0 cooldown.
+# Tune only for unusually slow storage or unusually bursty filesystem notifications.
+# CWA_DETECTOR_DEBOUNCE=1.0
+# CWA_DETECTOR_COOLDOWN=15.0
+
+# Enable DEBUG logging for all metadata providers. Default: unset/off.
+# Set to 1/true/yes while diagnosing provider searches.
+# CWA_METADATA_DEBUG=false
+
+# DNB cover validation mode: skip, head, or get. Default: skip.
+# The probe timeout applies to head/get checks and defaults to 4 seconds.
+# CWA_DNB_COVER_VALIDATION=skip
+# CWA_DNB_COVER_PROBE_TIMEOUT=4
+
+# Cover-picker timeout, worker count, and per-provider candidate cap.
+# Timeout defaults to 12 seconds for provider searches and 4 seconds for URL validation;
+# workers default to 5 and candidates to 30. Set one timeout to override both call paths.
+# CWA_COVER_PICKER_TIMEOUT=12
+# CWA_COVER_PICKER_WORKERS=5
+# CWA_COVER_PICKER_MAX_CANDIDATES=30
+
+# Maximum downloaded cover size in bytes. Default: 15728640 (15 MiB), unless the DB setting differs.
+# Set to enforce a process-wide byte limit for cover URL validation and downloads.
+# CWA_COVER_DOWNLOAD_MAX_BYTES=15728640
+
+# High-resolution cover booster controls. Defaults: enabled, 4-second lookups, 8 workers,
+# 30 records per request, and Amazon's public image CDN enabled.
+# CWA_COVER_BOOST=true
+# CWA_COVER_BOOST_TIMEOUT=4
+# CWA_COVER_BOOST_WORKERS=8
+# CWA_COVER_BOOST_MAX=30
+# CWA_COVER_BOOST_AMAZON_CDN=true
+
+# Base thumbnail height; medium and large thumbnails use 2x and 4x this value.
+# Default: 420 pixels. Lower it only to reduce generated-thumbnail storage and work.
+# CWA_THUMBNAIL_BASE_HEIGHT=420
+
+# Cover-preview cache cap and sweeper schedule. Defaults: 1024 MiB, 120-second startup delay,
+# and 3600 seconds between sweeps. Tune for storage pressure or deployment startup load.
+# CWA_PREVIEW_CACHE_MAX_MB=1024
+# CWA_PREVIEW_CACHE_INITIAL_DELAY=120
+# CWA_PREVIEW_CACHE_SWEEP_INTERVAL=3600
+
+# Maximum time for calibredb export while embedding metadata. Default: 90 seconds.
+# Non-positive or malformed values fall back to 90.
+# CWA_EMBED_TIMEOUT=90
+
+# Maximum wait for a post-ingest duplicate full scan. Default: 7200 seconds.
+# Increase only for very large libraries whose full scan legitimately takes longer.
+# CWA_DUPLICATE_FULL_SCAN_WAIT_TIMEOUT_SECONDS=7200
+
+# In-process conversion deadline in seconds. Default: unset/unbounded for direct runs.
+# The ingest s6 service normally calculates this below its hard watchdog; manual override only.
+# CWA_CONVERSION_DEADLINE_SECONDS=
+
+# Ingest watcher stability checks: total probes, consecutive equal-size probes, and interval.
+# Defaults: 6 checks, 2 consecutive matches, 0.5 seconds. Tune for slow network copies.
+# CWA_INGEST_STABLE_CHECKS=6
+# CWA_INGEST_STABLE_CONSEC_MATCH=2
+# CWA_INGEST_STABLE_INTERVAL=0.5
+
+# Maximum number of pending paths retained in the ingest retry queue. Default: 50.
+# Raise only when burst imports should retain more failed/deferred paths.
+# CWA_INGEST_MAX_QUEUE_SIZE=50
+
+# Persistent ingest retry queue and status files.
+# Defaults: /config/cwa_ingest_retry_queue and /config/cwa_ingest_status.
+# CWA_INGEST_RETRY_QUEUE=/config/cwa_ingest_retry_queue
+# CWA_INGEST_STATUS_FILE=/config/cwa_ingest_status
+
+# Temporary marker directories used to deduplicate ingest filesystem events.
+# Defaults: /tmp/cwa_ingest_processing, /tmp/cwa_ingest_recent, with a 120-second recent-event TTL.
+# CWA_INGEST_PROCESSING_DIR=/tmp/cwa_ingest_processing
+# CWA_INGEST_RECENT_DIR=/tmp/cwa_ingest_recent
+# CWA_INGEST_RECENT_EVENT_TTL=120
+
+# Batch coordination markers and quiet period.
+# Defaults: dirty and active under /config, last-success under /tmp, and 5 quiet seconds.
+# CWA_INGEST_BATCH_DIRTY_FILE=/config/cwa_ingest_batch_dirty
+# CWA_INGEST_BATCH_ACTIVE_FILE=/config/cwa_ingest_batch_active
+# CWA_INGEST_BATCH_LAST_SUCCESS_FILE=/tmp/cwa_ingest_batch_last_success
+# CWA_INGEST_BATCH_QUIET_SECONDS=5
+
+# Override the ingest processor and post-batch commands. Defaults: CWNG's bundled Python commands.
+# Test/packager hooks only; each value must name an executable command.
+# CWA_INGEST_PROCESSOR_CMD=
+# CWA_INGEST_POST_BATCH_CMD=
+
+# Internal ingest-service test hooks. Defaults: disabled/unset; never set in deployments.
+# TEST_STAGE pauses at a named PID-publication stage until the RELEASE path exists and touches READY.
+# CWA_INGEST_SERVICE_TEST_MODE=0
+# CWA_INGEST_PID_PUBLICATION_TEST_STAGE=
+# CWA_INGEST_PID_PUBLICATION_TEST_READY=
+# CWA_INGEST_PID_PUBLICATION_TEST_RELEASE=
+
+# Optional personal ComicVine API key, or a file containing it (Docker-secrets style).
+# Defaults: admin-configured key, then COMICVINE_API_KEY, then the file, then shared provider quota.
+# COMICVINE_API_KEY=
+# COMICVINE_API_KEY_FILE=
+
+# Optional file containing the Hardcover token (Docker-secrets style).
+# The admin-configured value wins, followed by HARDCOVER_TOKEN, then this file.
+# HARDCOVER_TOKEN_FILE=
+
+# Override Hardcover synchronization independently of the saved setting.
+# Default: unset (use the database setting). Accepted values: true/false, 1/0, yes/no, on/off.
+# HARDCOVER_SYNC_ENABLED=
+
+# Hardcover GraphQL endpoint. Default: https://api.hardcover.app/v1/graphql.
+# Set only for integration tests against a compatible mock service.
+# HARDCOVER_API_ENDPOINT=https://api.hardcover.app/v1/graphql
+
+# Optional Kobo metadata-provider cookie. CWA_KOBO_COOKIE wins over the legacy KOBO_COOKIE.
+# Default: unset; set only when the provider requires an authenticated cookie.
+# CWA_KOBO_COOKIE=
+# KOBO_COOKIE=
+
+# Emergency kill switch for Kobo two-way annotations. Default: unset (normal saved gates apply).
+# Set to 0/false/off/no to force-disable the feature; other values do not force-enable it.
+# CWNG_KOBO_TWO_WAY_ANNOTATIONS=
+
+# Private Kobo Reading Services diagnostic capture. Default: disabled.
+# Enabling requires this exact acknowledgement and records private reading exchanges for 7 days.
+# CWNG_KOBO_READING_SERVICES_CAPTURE=I_UNDERSTAND_THIS_CAPTURES_PRIVATE_READING_DATA
+
+# Override the autopilot tier-policy config path. Default: .github/policy/tier-policy.config.
+# CI/test automation only; ordinary application deployments do not need it.
+# CWNG_TIER_POLICY_CONFIG=
+
+# GitHub API token used by scripts/generate_contributors.py. Default: unset.
+# Set when generating contributor data where anonymous GitHub rate limits are insufficient.
+# GITHUB_TOKEN=
+
+# Manual browser-probe target and credentials. Defaults: localhost:8086, cwng84test, no password.
+# Developer test harnesses only; CWN_TEST_PW is required by those manual probes.
+# CWN_TEST_BASE=http://localhost:8086
+# CWN_TEST_USER=cwng84test
+# CWN_TEST_PW=
+
+# Playwright SPA target, optional reverse-proxy-subpath target, and login credentials.
+# Defaults: localhost:8086, no subpath target, admin/admin123. Test environments only.
+# E2E_BASE_URL=http://localhost:8086
+# E2E_SUBPATH_URL=
+# E2E_USER=admin
+# E2E_PASS=admin123
+
+# Route the user-notices E2E page through the current Vite source server.
+# Default: unset/off. Set to a non-empty value only for that focused local test rig.
+# E2E_CURRENT_SOURCE=

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -258,6 +258,10 @@ CWA_METADATA_LOCK_DIR=${CONFIG_DIR}
 # CWA_INGEST_PID_PUBLICATION_TEST_READY=
 # CWA_INGEST_PID_PUBLICATION_TEST_RELEASE=
 
+# Internal React Query unit-test branch selector. Default: unset/current behavior.
+# Set to 1 only to reproduce the pre-fix refetch-on-focus regression in the frontend unit test.
+# QUERY_CLIENT_TEST_PRE_FIX=1
+
 # Optional personal ComicVine API key, or a file containing it (Docker-secrets style).
 # Defaults: admin-configured key, then COMICVINE_API_KEY, then the file, then shared provider quota.
 # COMICVINE_API_KEY=

--- a/tests/unit/test_env_example_is_the_ssot.py
+++ b/tests/unit/test_env_example_is_the_ssot.py
@@ -1,21 +1,23 @@
 """Keep ``examples/.env.example`` in sync with environment-variable reads.
 
-Parsing is deliberately static and narrow enough to avoid treating arbitrary mappings as
-the process environment:
+The scan includes Python and frontend test trees: test-only launch controls are part of
+the SSOT just like deployment controls. Parsing uses these deliberately reviewable seams:
 
-* Python: ``os.environ[KEY]``, ``os.environ.get(KEY)``, ``os.getenv(KEY)``,
-  ``from os import getenv`` aliases, and the small helper-wrapper list below.
-* s6: uppercase ``$VAR``/``${VAR}`` expansions and ``printcontenv VAR`` in the
-  extensionless files below ``root/etc/s6-overlay``. Uppercase variables assigned by
-  the same script are locals, except ``VAR=${VAR:-default}``, which reads inherited
-  configuration while assigning its local default. ``WATCH_FOLDER`` is an explicit
-  compatibility input in the ingest service even though that service conditionally
-  assigns the same name after checking the inherited value.
-* frontend: explicit ``process.env.KEY`` reads in JavaScript/TypeScript sources.
+* Python under ``cps/`` and ``scripts/``: the AST tracks names bound to ``os``,
+  ``os.environ``, or ``os.getenv`` in every lexical scope. String-keyed mapping reads,
+  ``get``/``setdefault``/``pop`` calls, and membership tests are collected. A dynamic
+  key is an error unless it is inside one of the reviewed helper implementations below.
+* s6 shell below ``root/etc/s6-overlay``: uppercase ``$VAR``/``${VAR}`` expansions and
+  ``printcontenv VAR`` are scanned in source order. A reference before the first
+  assignment in that file is inherited; references only after an assignment are local.
+* JavaScript/TypeScript below ``frontend/``: a comment/string-aware tokenizer collects
+  ``process.env.KEY``, literal ``process.env["KEY"]``/``['KEY']``, and object
+  destructuring from ``process.env``. A computed bracket key or rest destructure is an
+  unresolved read and fails with its file and line.
 
 Dynamic Python reads must go through a helper named in ``PYTHON_ENV_HELPERS``. A new
 wrapper therefore fails this test until its call seam is reviewed and declared here;
-that is intentional, because silently ignoring a dynamic lookup would defeat the SSOT.
+silently ignoring a dynamic lookup would defeat the SSOT.
 """
 
 from __future__ import annotations
@@ -23,6 +25,7 @@ from __future__ import annotations
 import ast
 import re
 from pathlib import Path
+from typing import NamedTuple
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -52,82 +55,99 @@ DYNAMIC_PYTHON_READERS = frozenset(
     }
 )
 
-# These names are intentionally outside the deployment SSOT. Keep this list short:
-# each exception must identify the external runtime/tool that owns the value.
+# These names are intentionally outside the deployment SSOT. Each is owned by an
+# external runtime/tool rather than accepted as CWNG configuration.
 SSOT_EXCEPTIONS = {
-    "CALIBRE_CONFIG_DIRECTORY": (
-        "written by CWNG only into opted-in Calibre child processes, then consumed "
-        "by Calibre rather than read from CWNG's launch environment"
-    ),
-    "CI": "provided and interpreted by the CI/Playwright toolchain",
-    "CONFIG_DIR": (
-        "an examples/.env.example interpolation helper, not a CWNG process input"
-    ),
+    "CALIBRE_CONFIG_DIRECTORY": "written by CWNG for Calibre child processes; Calibre owns and consumes it",
+    "CI": "provided and interpreted by the CI and Playwright runtimes",
+    "CONFIG_DIR": "Compose interpolation helper; CWNG reads the resulting CALIBRE_DBPATH instead",
     "LISTEN_FDS": "provided by systemd's socket-activation protocol",
-    "NODE_ENV": "interpreted implicitly by the Node/Vite toolchain",
-    "QUERY_CLIENT_TEST_PRE_FIX": "an internal frontend unit-test branch selector",
+    "NODE_ENV": "provided and interpreted by the Node and Vite runtimes",
     "SECRET": "injected transiently by the operator's secret broker into measurement tools",
 }
-
-SHELL_ENV_COMPAT_READS = frozenset({"WATCH_FOLDER"})
 
 EXAMPLE_ASSIGNMENT = re.compile(r"^\s*#?\s*([A-Z][A-Z0-9_]*)\s*=", re.MULTILINE)
 SHELL_REFERENCE = re.compile(r"\$(?:\{([A-Z][A-Z0-9_]*)[^}]*\}|([A-Z][A-Z0-9_]*))")
 SHELL_ASSIGNMENT = re.compile(r"(?<![A-Za-z0-9_])([A-Z][A-Z0-9_]*)\s*=")
 PRINTCONTENV = re.compile(r"\bprintcontenv\s+([A-Z][A-Z0-9_]*)\b")
-FRONTEND_ENV = re.compile(r"\bprocess\.env\.([A-Z][A-Z0-9_]*)\b")
 
 
 def _relative(path: Path) -> str:
-    return path.relative_to(ROOT).as_posix()
+    try:
+        return path.relative_to(ROOT).as_posix()
+    except ValueError:
+        return path.as_posix()
 
 
-def _module_string_constants(tree: ast.Module) -> dict[str, str]:
-    constants: dict[str, str] = {}
-    for statement in tree.body:
-        if isinstance(statement, ast.Assign):
-            targets = statement.targets
-            value = statement.value
-        elif isinstance(statement, ast.AnnAssign):
-            targets = (statement.target,)
-            value = statement.value
-        else:
-            continue
-        if not isinstance(value, ast.Constant) or not isinstance(value.value, str):
-            continue
-        for target in targets:
-            if isinstance(target, ast.Name):
-                constants[target.id] = value.value
-    return constants
+class _Binding(NamedTuple):
+    kind: str
+    value: str | None = None
+
+
+UNKNOWN = _Binding("unknown")
+OS_MODULE = _Binding("os")
+OS_ENVIRON = _Binding("environ")
+OS_GETENV = _Binding("getenv")
 
 
 class _PythonEnvVisitor(ast.NodeVisitor):
-    def __init__(self, path: Path, tree: ast.Module) -> None:
+    """Resolve process-environment aliases while walking each lexical scope."""
+
+    _ENVIRON_METHODS = frozenset(
+        {"get", "setdefault", "pop", "__getitem__", "__contains__"}
+    )
+
+    def __init__(self, path: Path) -> None:
         self.path = path
         self.relative_path = _relative(path)
-        self.constants = _module_string_constants(tree)
-        self.os_aliases = {"os"}
-        self.getenv_aliases: set[str] = set()
+        self.scopes: list[dict[str, _Binding]] = [{}]
         self.function_stack: list[str] = []
         self.reads: dict[str, set[str]] = {}
         self.unresolved: list[str] = []
 
-        for statement in tree.body:
-            if isinstance(statement, ast.Import):
-                for alias in statement.names:
-                    if alias.name == "os":
-                        self.os_aliases.add(alias.asname or alias.name)
-            elif isinstance(statement, ast.ImportFrom) and statement.module == "os":
-                for alias in statement.names:
-                    if alias.name == "getenv":
-                        self.getenv_aliases.add(alias.asname or alias.name)
+    def _lookup(self, name: str) -> _Binding:
+        for scope in reversed(self.scopes):
+            if name in scope:
+                return scope[name]
+        return UNKNOWN
+
+    def _bind(self, target: ast.AST, binding: _Binding) -> None:
+        if isinstance(target, ast.Name):
+            self.scopes[-1][target.id] = binding
+        elif isinstance(target, (ast.Tuple, ast.List)):
+            for element in target.elts:
+                self._bind(element, UNKNOWN)
+
+    def _expression_binding(self, node: ast.AST | None) -> _Binding:
+        if isinstance(node, ast.Name):
+            return self._lookup(node.id)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return _Binding("string", node.value)
+        if isinstance(node, ast.Attribute):
+            owner = self._expression_binding(node.value)
+            if owner.kind == "os" and node.attr == "environ":
+                return OS_ENVIRON
+            if owner.kind == "os" and node.attr == "getenv":
+                return OS_GETENV
+        if isinstance(node, ast.IfExp):
+            body = self._expression_binding(node.body)
+            otherwise = self._expression_binding(node.orelse)
+            if body == otherwise:
+                return body
+            # A value that may be os.environ remains an environment mapping even
+            # when tests can inject a replacement mapping through the other arm.
+            if "environ" in {body.kind, otherwise.kind}:
+                return OS_ENVIRON
+        return UNKNOWN
 
     def _resolve_key(self, node: ast.AST) -> str | None:
-        if isinstance(node, ast.Constant) and isinstance(node.value, str):
-            return node.value
-        if isinstance(node, ast.Name):
-            return self.constants.get(node.id)
+        binding = self._expression_binding(node)
+        if binding.kind == "string":
+            return binding.value
         return None
+
+    def _current_function(self) -> str:
+        return self.function_stack[-1] if self.function_stack else "<module>"
 
     def _record(self, node: ast.AST, key_node: ast.AST, seam: str) -> None:
         key = self._resolve_key(key_node)
@@ -135,80 +155,140 @@ class _PythonEnvVisitor(ast.NodeVisitor):
         if key is not None:
             self.reads.setdefault(key, set()).add(location)
             return
-        current_function = (
-            self.function_stack[-1] if self.function_stack else "<module>"
-        )
-        if (self.relative_path, current_function) in DYNAMIC_PYTHON_READERS:
+        if (self.relative_path, self._current_function()) in DYNAMIC_PYTHON_READERS:
             return
         self.unresolved.append(
             f"{location} uses dynamic {seam} key {ast.unparse(key_node)!r}"
         )
 
-    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+    def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        for default in (*node.args.defaults, *node.args.kw_defaults):
+            if default is not None:
+                self.visit(default)
+        if node.returns is not None:
+            self.visit(node.returns)
+
         self.function_stack.append(node.name)
-        self.generic_visit(node)
+        self.scopes.append({})
+        arguments = (
+            *node.args.posonlyargs,
+            *node.args.args,
+            *node.args.kwonlyargs,
+        )
+        for argument in arguments:
+            self.scopes[-1][argument.arg] = UNKNOWN
+        if node.args.vararg is not None:
+            self.scopes[-1][node.args.vararg.arg] = UNKNOWN
+        if node.args.kwarg is not None:
+            self.scopes[-1][node.args.kwarg.arg] = UNKNOWN
+        for statement in node.body:
+            self.visit(statement)
+        self.scopes.pop()
         self.function_stack.pop()
 
-    visit_AsyncFunctionDef = visit_FunctionDef
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_function(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_function(node)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        for base in node.bases:
+            self.visit(base)
+        for keyword in node.keywords:
+            self.visit(keyword)
+        self.scopes.append({})
+        for statement in node.body:
+            self.visit(statement)
+        self.scopes.pop()
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            bound_name = alias.asname or alias.name.split(".", 1)[0]
+            self.scopes[-1][bound_name] = OS_MODULE if alias.name == "os" else UNKNOWN
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        for alias in node.names:
+            bound_name = alias.asname or alias.name
+            binding = UNKNOWN
+            if node.module == "os" and alias.name == "environ":
+                binding = OS_ENVIRON
+            elif node.module == "os" and alias.name == "getenv":
+                binding = OS_GETENV
+            self.scopes[-1][bound_name] = binding
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        self.visit(node.value)
+        binding = self._expression_binding(node.value)
+        for target in node.targets:
+            self._bind(target, binding)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        if node.annotation is not None:
+            self.visit(node.annotation)
+        if node.value is not None:
+            self.visit(node.value)
+            binding = self._expression_binding(node.value)
+        else:
+            binding = UNKNOWN
+        self._bind(node.target, binding)
+
+    def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
+        self.visit(node.value)
+        self._bind(node.target, self._expression_binding(node.value))
 
     def visit_Call(self, node: ast.Call) -> None:
         if node.args:
-            function = node.func
-            if (
-                isinstance(function, ast.Attribute)
-                and function.attr == "getenv"
-                and isinstance(function.value, ast.Name)
-                and function.value.id in self.os_aliases
-            ):
+            function_binding = self._expression_binding(node.func)
+            if function_binding.kind == "getenv":
                 self._record(node, node.args[0], "os.getenv")
-            elif isinstance(function, ast.Name) and function.id in self.getenv_aliases:
-                self._record(node, node.args[0], "os.getenv alias")
             elif (
-                isinstance(function, ast.Attribute)
-                and function.attr == "get"
-                and isinstance(function.value, ast.Attribute)
-                and function.value.attr == "environ"
-                and isinstance(function.value.value, ast.Name)
-                and function.value.value.id in self.os_aliases
+                isinstance(node.func, ast.Attribute)
+                and node.func.attr in self._ENVIRON_METHODS
+                and self._expression_binding(node.func.value).kind == "environ"
             ):
-                self._record(node, node.args[0], "os.environ.get")
-            elif (
-                isinstance(function, ast.Attribute)
-                and function.attr == "get"
-                and isinstance(function.value, ast.Name)
-                and function.value.id in {"environ", "_dirs_environ", "source"}
-                and (self.relative_path, self.function_stack[-1])
-                in {
-                    ("cps/constants.py", "_configured_dir"),
-                    (
-                        "cps/services/kobo_annotation_stage0.py",
-                        "emergency_override_disables",
-                    ),
-                    ("cps/services/kobo_exchange_capture.py", "enabled"),
-                    ("cps/sqlite_utils.py", "environment_flag_enabled"),
-                }
-            ):
-                self._record(node, node.args[0], f"{function.value.id}.get")
-            elif isinstance(function, ast.Name) and function.id in PYTHON_ENV_HELPERS:
-                argument_index, paths = PYTHON_ENV_HELPERS[function.id]
+                self._record(node, node.args[0], f"os.environ.{node.func.attr}")
+            elif isinstance(node.func, ast.Name) and node.func.id in PYTHON_ENV_HELPERS:
+                argument_index, paths = PYTHON_ENV_HELPERS[node.func.id]
                 if self.relative_path in paths and len(node.args) > argument_index:
                     self._record(
                         node,
                         node.args[argument_index],
-                        f"{function.id} helper",
+                        f"{node.func.id} helper",
                     )
         self.generic_visit(node)
 
     def visit_Subscript(self, node: ast.Subscript) -> None:
         if (
-            isinstance(node.ctx, ast.Load)
-            and isinstance(node.value, ast.Attribute)
-            and node.value.attr == "environ"
-            and isinstance(node.value.value, ast.Name)
-            and node.value.value.id in self.os_aliases
+            isinstance(node.ctx, (ast.Load, ast.Del))
+            and self._expression_binding(node.value).kind == "environ"
         ):
             self._record(node, node.slice, "os.environ[]")
         self.generic_visit(node)
+
+    def visit_Compare(self, node: ast.Compare) -> None:
+        left = node.left
+        for operator, comparator in zip(node.ops, node.comparators, strict=True):
+            if (
+                isinstance(operator, (ast.In, ast.NotIn))
+                and self._expression_binding(comparator).kind == "environ"
+            ):
+                self._record(node, left, "os.environ membership")
+            left = comparator
+        self.generic_visit(node)
+
+
+def _python_env_reads_from_source(
+    path: Path, source: str
+) -> tuple[dict[str, set[str]], list[str]]:
+    tree = ast.parse(source, filename=str(path))
+    visitor = _PythonEnvVisitor(path)
+    visitor.visit(tree)
+    return visitor.reads, visitor.unresolved
 
 
 def _python_env_reads() -> tuple[dict[str, set[str]], list[str]]:
@@ -216,13 +296,29 @@ def _python_env_reads() -> tuple[dict[str, set[str]], list[str]]:
     unresolved: list[str] = []
     for source_root in PYTHON_ROOTS:
         for path in sorted(source_root.rglob("*.py")):
-            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-            visitor = _PythonEnvVisitor(path, tree)
-            visitor.visit(tree)
-            unresolved.extend(visitor.unresolved)
-            for key, locations in visitor.reads.items():
+            found, source_unresolved = _python_env_reads_from_source(
+                path, path.read_text(encoding="utf-8")
+            )
+            unresolved.extend(source_unresolved)
+            for key, locations in found.items():
                 reads.setdefault(key, set()).update(locations)
     return reads, unresolved
+
+
+def _shell_env_reads_from_source(path: Path, source: str) -> dict[str, set[str]]:
+    reads: dict[str, set[str]] = {}
+    assigned: set[str] = set()
+    for lineno, line in enumerate(source.splitlines(), 1):
+        if line.lstrip().startswith("#"):
+            continue
+        names = {
+            match.group(1) or match.group(2) for match in SHELL_REFERENCE.finditer(line)
+        }
+        names.update(match.group(1) for match in PRINTCONTENV.finditer(line))
+        for name in names - assigned:
+            reads.setdefault(name, set()).add(f"{_relative(path)}:{lineno}")
+        assigned.update(match.group(1) for match in SHELL_ASSIGNMENT.finditer(line))
+    return reads
 
 
 def _shell_env_reads() -> dict[str, set[str]]:
@@ -231,43 +327,209 @@ def _shell_env_reads() -> dict[str, set[str]]:
         candidate for candidate in S6_ROOT.rglob("*") if candidate.is_file()
     ):
         try:
-            lines = path.read_text(encoding="utf-8").splitlines()
+            found = _shell_env_reads_from_source(path, path.read_text(encoding="utf-8"))
         except UnicodeDecodeError:
             continue
-
-        active_lines = [line for line in lines if not line.lstrip().startswith("#")]
-        assignments = {
-            match.group(1)
-            for line in active_lines
-            for match in SHELL_ASSIGNMENT.finditer(line)
-        }
-        for lineno, line in enumerate(lines, 1):
-            if line.lstrip().startswith("#"):
-                continue
-            assigned_on_line = {
-                match.group(1) for match in SHELL_ASSIGNMENT.finditer(line)
-            }
-            names = {
-                match.group(1) or match.group(2)
-                for match in SHELL_REFERENCE.finditer(line)
-            }
-            names.update(match.group(1) for match in PRINTCONTENV.finditer(line))
-            for name in names:
-                # A self-reference while assigning (FOO=${FOO:-x}) consumes the
-                # inherited environment. Other variables assigned in this script
-                # are local implementation details, even when referenced earlier.
-                if (
-                    name in assignments
-                    and name not in assigned_on_line
-                    and name not in SHELL_ENV_COMPAT_READS
-                ):
-                    continue
-                reads.setdefault(name, set()).add(f"{_relative(path)}:{lineno}")
+        for key, locations in found.items():
+            reads.setdefault(key, set()).update(locations)
     return reads
 
 
-def _frontend_env_reads() -> dict[str, set[str]]:
+class _JsToken(NamedTuple):
+    kind: str
+    value: str
+    line: int
+
+
+def _javascript_tokens(source: str) -> list[_JsToken]:
+    """Tokenize only the JS/TS lexical forms needed for process.env reads."""
+
+    tokens: list[_JsToken] = []
+    index = 0
+    line = 1
+    while index < len(source):
+        character = source[index]
+        if character.isspace():
+            line += character == "\n"
+            index += 1
+            continue
+        if source.startswith("//", index):
+            newline = source.find("\n", index + 2)
+            if newline == -1:
+                break
+            index = newline
+            continue
+        if source.startswith("/*", index):
+            end = source.find("*/", index + 2)
+            if end == -1:
+                line += source[index:].count("\n")
+                break
+            line += source[index : end + 2].count("\n")
+            index = end + 2
+            continue
+        if character in {"'", '"', "`"}:
+            quote = character
+            token_line = line
+            index += 1
+            value: list[str] = []
+            while index < len(source):
+                character = source[index]
+                if character == "\\" and index + 1 < len(source):
+                    escaped = source[index + 1]
+                    line += escaped == "\n"
+                    value.append(escaped)
+                    index += 2
+                    continue
+                if character == quote:
+                    index += 1
+                    break
+                line += character == "\n"
+                value.append(character)
+                index += 1
+            tokens.append(
+                _JsToken(
+                    "string" if quote != "`" else "template",
+                    "".join(value),
+                    token_line,
+                )
+            )
+            continue
+        if character.isalpha() or character in {"_", "$"}:
+            token_line = line
+            end = index + 1
+            while end < len(source) and (
+                source[end].isalnum() or source[end] in {"_", "$"}
+            ):
+                end += 1
+            tokens.append(_JsToken("identifier", source[index:end], token_line))
+            index = end
+            continue
+        if source.startswith("...", index):
+            tokens.append(_JsToken("punctuation", "...", line))
+            index += 3
+            continue
+        tokens.append(_JsToken("punctuation", character, line))
+        index += 1
+    return tokens
+
+
+def _matching_open_brace(tokens: list[_JsToken], close_index: int) -> int | None:
+    depth = 0
+    for index in range(close_index, -1, -1):
+        if tokens[index].value == "}":
+            depth += 1
+        elif tokens[index].value == "{":
+            depth -= 1
+            if depth == 0:
+                return index
+    return None
+
+
+def _record_frontend_destructure(
+    path: Path,
+    tokens: list[_JsToken],
+    open_index: int,
+    close_index: int,
+    reads: dict[str, set[str]],
+    unresolved: list[str],
+) -> None:
+    at_property = True
+    nested = 0
+    index = open_index + 1
+    while index < close_index:
+        token = tokens[index]
+        if nested:
+            if token.value in {"{", "[", "("}:
+                nested += 1
+            elif token.value in {"}", "]", ")"}:
+                nested -= 1
+            index += 1
+            continue
+        if token.value == ",":
+            at_property = True
+            index += 1
+            continue
+        if not at_property:
+            if token.value in {"{", "[", "("}:
+                nested = 1
+            index += 1
+            continue
+        if token.value == "...":
+            unresolved.append(
+                f"{_relative(path)}:{token.line} uses dynamic process.env rest destructuring"
+            )
+            at_property = False
+        elif token.value == "[":
+            unresolved.append(
+                f"{_relative(path)}:{token.line} uses dynamic process.env destructuring key"
+            )
+            nested = 1
+            at_property = False
+        elif token.kind in {"identifier", "string"}:
+            reads.setdefault(token.value, set()).add(f"{_relative(path)}:{token.line}")
+            at_property = False
+        else:
+            at_property = False
+        index += 1
+
+
+def _frontend_env_reads_from_source(
+    path: Path, source: str
+) -> tuple[dict[str, set[str]], list[str]]:
     reads: dict[str, set[str]] = {}
+    unresolved: list[str] = []
+    tokens = _javascript_tokens(source)
+    index = 0
+    while index + 2 < len(tokens):
+        if not (
+            tokens[index].kind == "identifier"
+            and tokens[index].value == "process"
+            and tokens[index + 1].value == "."
+            and tokens[index + 2].kind == "identifier"
+            and tokens[index + 2].value == "env"
+        ):
+            index += 1
+            continue
+
+        end = index + 3
+        if end + 1 < len(tokens) and tokens[end].value == ".":
+            key = tokens[end + 1]
+            if key.kind == "identifier":
+                reads.setdefault(key.value, set()).add(f"{_relative(path)}:{key.line}")
+        elif end < len(tokens) and tokens[end].value == "[":
+            if (
+                end + 2 < len(tokens)
+                and tokens[end + 1].kind == "string"
+                and tokens[end + 2].value == "]"
+            ):
+                key = tokens[end + 1]
+                reads.setdefault(key.value, set()).add(f"{_relative(path)}:{key.line}")
+            else:
+                unresolved.append(
+                    f"{_relative(path)}:{tokens[end].line} uses dynamic process.env bracket key"
+                )
+        elif (
+            index >= 2
+            and tokens[index - 1].value == "="
+            and tokens[index - 2].value == "}"
+        ):
+            open_index = _matching_open_brace(tokens, index - 2)
+            if open_index is not None:
+                _record_frontend_destructure(
+                    path,
+                    tokens,
+                    open_index,
+                    index - 2,
+                    reads,
+                    unresolved,
+                )
+        index = end
+    return reads, unresolved
+
+
+def _frontend_env_reads() -> tuple[dict[str, set[str]], list[str]]:
+    reads: dict[str, set[str]] = {}
+    unresolved: list[str] = []
     extensions = frozenset({".cjs", ".js", ".jsx", ".mjs", ".ts", ".tsx"})
     for path in sorted(FRONTEND_ROOT.rglob("*")):
         if (
@@ -276,12 +538,13 @@ def _frontend_env_reads() -> dict[str, set[str]]:
             or "node_modules" in path.parts
         ):
             continue
-        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
-            for match in FRONTEND_ENV.finditer(line):
-                reads.setdefault(match.group(1), set()).add(
-                    f"{_relative(path)}:{lineno}"
-                )
-    return reads
+        found, source_unresolved = _frontend_env_reads_from_source(
+            path, path.read_text(encoding="utf-8")
+        )
+        unresolved.extend(source_unresolved)
+        for key, locations in found.items():
+            reads.setdefault(key, set()).update(locations)
+    return reads, unresolved
 
 
 def _merge_reads(*inventories: dict[str, set[str]]) -> dict[str, set[str]]:
@@ -299,18 +562,9 @@ def _format_keys(keys: set[str], reads: dict[str, set[str]]) -> str:
     )
 
 
-def test_env_example_is_the_single_source_of_truth() -> None:
-    python_reads, unresolved = _python_env_reads()
-    assert not unresolved, (
-        "Environment reads with dynamic keys need a reviewed helper seam:\n"
-        + "\n".join(f"  - {entry}" for entry in unresolved)
-    )
-
-    reads = _merge_reads(python_reads, _shell_env_reads(), _frontend_env_reads())
-    documented_list = EXAMPLE_ASSIGNMENT.findall(EXAMPLE.read_text(encoding="utf-8"))
+def _ssot_failures(reads: dict[str, set[str]], documented_list: list[str]) -> list[str]:
     duplicates = {key for key in documented_list if documented_list.count(key) > 1}
     documented = set(documented_list)
-
     missing = set(reads) - documented - set(SSOT_EXCEPTIONS)
     unused = documented - set(reads) - set(SSOT_EXCEPTIONS)
 
@@ -330,4 +584,130 @@ def test_env_example_is_the_single_source_of_truth() -> None:
             "Keys in examples/.env.example with no in-scope reader:\n"
             + _format_keys(unused, reads)
         )
+    return failures
+
+
+def test_reported_bypass_probes_are_named_as_missing() -> None:
+    python_reads, python_unresolved = _python_env_reads_from_source(
+        ROOT / "scripts" / "ssot_python_probe.py",
+        """
+def probe():
+    import os as operating_system
+    return operating_system.environ.get("CWA_FAKE_LOCAL_ALIAS")
+""",
+    )
+    frontend_reads, frontend_unresolved = _frontend_env_reads_from_source(
+        ROOT / "frontend" / "ssot_frontend_probe.ts",
+        'process.env["CWA_FAKE_FRONTEND_BRACKET"];\n'
+        "const { CWA_FAKE_FRONTEND_DESTRUCTURED } = process.env;\n",
+    )
+    shell_reads = _shell_env_reads_from_source(
+        ROOT / "root" / "etc" / "s6-overlay" / "ssot_shell_probe",
+        'echo "${CWA_FAKE_SH_INHERITED}"\nCWA_FAKE_SH_INHERITED=local\n',
+    )
+
+    assert python_unresolved == []
+    assert frontend_unresolved == []
+    reads = _merge_reads(python_reads, frontend_reads, shell_reads)
+    failure = "\n\n".join(_ssot_failures(reads, []))
+    for key in {
+        "CWA_FAKE_FRONTEND_BRACKET",
+        "CWA_FAKE_FRONTEND_DESTRUCTURED",
+        "CWA_FAKE_LOCAL_ALIAS",
+        "CWA_FAKE_SH_INHERITED",
+    }:
+        assert key in failure
+
+
+def test_python_ast_covers_aliases_mapping_operations_and_dynamic_keys() -> None:
+    reads, unresolved = _python_env_reads_from_source(
+        ROOT / "scripts" / "ssot_python_forms.py",
+        """
+import os
+from os import environ as imported_env
+from os import getenv as imported_getenv
+
+MODULE_KEY = "CWA_MODULE_CONSTANT"
+env = os.environ
+env.setdefault("CWA_SETDEFAULT", "value")
+env.pop("CWA_POP", None)
+present = "CWA_MEMBERSHIP" in imported_env
+value = env[MODULE_KEY]
+other = imported_getenv("CWA_IMPORTED_GETENV")
+
+def local_alias(dynamic_key):
+    import os as operating_system
+    local_env = operating_system.environ
+    local_env.get("CWA_LOCAL_GET")
+    return local_env[dynamic_key]
+""",
+    )
+
+    assert set(reads) == {
+        "CWA_IMPORTED_GETENV",
+        "CWA_LOCAL_GET",
+        "CWA_MEMBERSHIP",
+        "CWA_MODULE_CONSTANT",
+        "CWA_POP",
+        "CWA_SETDEFAULT",
+    }
+    assert len(unresolved) == 1
+    assert "scripts/ssot_python_forms.py:18" in unresolved[0]
+    assert "dynamic os.environ[] key 'dynamic_key'" in unresolved[0]
+
+
+def test_frontend_tokenizer_covers_supported_forms_without_comment_noise() -> None:
+    reads, unresolved = _frontend_env_reads_from_source(
+        ROOT / "frontend" / "ssot_frontend_forms.ts",
+        """
+process.env.CWA_DOT;
+process.env["CWA_DOUBLE_QUOTED"];
+process.env['CWA_SINGLE_QUOTED'];
+const { CWA_SHORT, CWA_SOURCE: localName, CWA_DEFAULT = false } = process.env;
+// process.env.CWA_COMMENT
+const text = "process.env.CWA_STRING";
+process.env[key];
+const { ...remaining } = process.env;
+""",
+    )
+
+    assert set(reads) == {
+        "CWA_DEFAULT",
+        "CWA_DOT",
+        "CWA_DOUBLE_QUOTED",
+        "CWA_SHORT",
+        "CWA_SINGLE_QUOTED",
+        "CWA_SOURCE",
+    }
+    assert len(unresolved) == 2
+    assert all("frontend/ssot_frontend_forms.ts:" in item for item in unresolved)
+
+
+def test_shell_scan_uses_first_occurrence_order() -> None:
+    reads = _shell_env_reads_from_source(
+        ROOT / "root" / "etc" / "s6-overlay" / "ssot_shell_forms",
+        """
+echo "$CWA_BEFORE"
+CWA_BEFORE=local
+CWA_LOCAL=local
+echo "$CWA_LOCAL"
+CWA_SELF=${CWA_SELF:-default}
+""",
+    )
+
+    assert set(reads) == {"CWA_BEFORE", "CWA_SELF"}
+
+
+def test_env_example_is_the_single_source_of_truth() -> None:
+    python_reads, python_unresolved = _python_env_reads()
+    frontend_reads, frontend_unresolved = _frontend_env_reads()
+    unresolved = python_unresolved + frontend_unresolved
+    assert not unresolved, (
+        "Environment reads with unresolved dynamic keys need a reviewed static seam:\n"
+        + "\n".join(f"  - {entry}" for entry in unresolved)
+    )
+
+    reads = _merge_reads(python_reads, _shell_env_reads(), frontend_reads)
+    documented_list = EXAMPLE_ASSIGNMENT.findall(EXAMPLE.read_text(encoding="utf-8"))
+    failures = _ssot_failures(reads, documented_list)
     assert not failures, "\n\n".join(failures)

--- a/tests/unit/test_env_example_is_the_ssot.py
+++ b/tests/unit/test_env_example_is_the_ssot.py
@@ -1,0 +1,333 @@
+"""Keep ``examples/.env.example`` in sync with environment-variable reads.
+
+Parsing is deliberately static and narrow enough to avoid treating arbitrary mappings as
+the process environment:
+
+* Python: ``os.environ[KEY]``, ``os.environ.get(KEY)``, ``os.getenv(KEY)``,
+  ``from os import getenv`` aliases, and the small helper-wrapper list below.
+* s6: uppercase ``$VAR``/``${VAR}`` expansions and ``printcontenv VAR`` in the
+  extensionless files below ``root/etc/s6-overlay``. Uppercase variables assigned by
+  the same script are locals, except ``VAR=${VAR:-default}``, which reads inherited
+  configuration while assigning its local default. ``WATCH_FOLDER`` is an explicit
+  compatibility input in the ingest service even though that service conditionally
+  assigns the same name after checking the inherited value.
+* frontend: explicit ``process.env.KEY`` reads in JavaScript/TypeScript sources.
+
+Dynamic Python reads must go through a helper named in ``PYTHON_ENV_HELPERS``. A new
+wrapper therefore fails this test until its call seam is reviewed and declared here;
+that is intentional, because silently ignoring a dynamic lookup would defeat the SSOT.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+EXAMPLE = ROOT / "examples" / ".env.example"
+PYTHON_ROOTS = (ROOT / "cps", ROOT / "scripts")
+S6_ROOT = ROOT / "root" / "etc" / "s6-overlay"
+FRONTEND_ROOT = ROOT / "frontend"
+
+# name -> (argument index containing the environment key, files defining/calling it)
+PYTHON_ENV_HELPERS = {
+    "_configured_dir": (1, frozenset({"cps/constants.py", "scripts/app_paths.py"})),
+    "_env_path": (0, frozenset({"scripts/app_paths.py"})),
+    "_get_ingest_owner_id": (0, frozenset({"cps/editbooks.py"})),
+    "environment_flag_enabled": (0, frozenset({"cps/sqlite_utils.py"})),
+}
+
+# Dynamic process-environment reads implemented by the helpers above. The source call
+# is ignored only inside these exact functions; their statically named call sites are
+# collected through PYTHON_ENV_HELPERS.
+DYNAMIC_PYTHON_READERS = frozenset(
+    {
+        ("cps/constants.py", "_configured_dir"),
+        ("cps/editbooks.py", "_get_ingest_owner_id"),
+        ("cps/sqlite_utils.py", "environment_flag_enabled"),
+        ("scripts/app_paths.py", "_configured_dir"),
+        ("scripts/app_paths.py", "_env_path"),
+    }
+)
+
+# These names are intentionally outside the deployment SSOT. Keep this list short:
+# each exception must identify the external runtime/tool that owns the value.
+SSOT_EXCEPTIONS = {
+    "CALIBRE_CONFIG_DIRECTORY": (
+        "written by CWNG only into opted-in Calibre child processes, then consumed "
+        "by Calibre rather than read from CWNG's launch environment"
+    ),
+    "CI": "provided and interpreted by the CI/Playwright toolchain",
+    "CONFIG_DIR": (
+        "an examples/.env.example interpolation helper, not a CWNG process input"
+    ),
+    "LISTEN_FDS": "provided by systemd's socket-activation protocol",
+    "NODE_ENV": "interpreted implicitly by the Node/Vite toolchain",
+    "QUERY_CLIENT_TEST_PRE_FIX": "an internal frontend unit-test branch selector",
+    "SECRET": "injected transiently by the operator's secret broker into measurement tools",
+}
+
+SHELL_ENV_COMPAT_READS = frozenset({"WATCH_FOLDER"})
+
+EXAMPLE_ASSIGNMENT = re.compile(r"^\s*#?\s*([A-Z][A-Z0-9_]*)\s*=", re.MULTILINE)
+SHELL_REFERENCE = re.compile(r"\$(?:\{([A-Z][A-Z0-9_]*)[^}]*\}|([A-Z][A-Z0-9_]*))")
+SHELL_ASSIGNMENT = re.compile(r"(?<![A-Za-z0-9_])([A-Z][A-Z0-9_]*)\s*=")
+PRINTCONTENV = re.compile(r"\bprintcontenv\s+([A-Z][A-Z0-9_]*)\b")
+FRONTEND_ENV = re.compile(r"\bprocess\.env\.([A-Z][A-Z0-9_]*)\b")
+
+
+def _relative(path: Path) -> str:
+    return path.relative_to(ROOT).as_posix()
+
+
+def _module_string_constants(tree: ast.Module) -> dict[str, str]:
+    constants: dict[str, str] = {}
+    for statement in tree.body:
+        if isinstance(statement, ast.Assign):
+            targets = statement.targets
+            value = statement.value
+        elif isinstance(statement, ast.AnnAssign):
+            targets = (statement.target,)
+            value = statement.value
+        else:
+            continue
+        if not isinstance(value, ast.Constant) or not isinstance(value.value, str):
+            continue
+        for target in targets:
+            if isinstance(target, ast.Name):
+                constants[target.id] = value.value
+    return constants
+
+
+class _PythonEnvVisitor(ast.NodeVisitor):
+    def __init__(self, path: Path, tree: ast.Module) -> None:
+        self.path = path
+        self.relative_path = _relative(path)
+        self.constants = _module_string_constants(tree)
+        self.os_aliases = {"os"}
+        self.getenv_aliases: set[str] = set()
+        self.function_stack: list[str] = []
+        self.reads: dict[str, set[str]] = {}
+        self.unresolved: list[str] = []
+
+        for statement in tree.body:
+            if isinstance(statement, ast.Import):
+                for alias in statement.names:
+                    if alias.name == "os":
+                        self.os_aliases.add(alias.asname or alias.name)
+            elif isinstance(statement, ast.ImportFrom) and statement.module == "os":
+                for alias in statement.names:
+                    if alias.name == "getenv":
+                        self.getenv_aliases.add(alias.asname or alias.name)
+
+    def _resolve_key(self, node: ast.AST) -> str | None:
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return node.value
+        if isinstance(node, ast.Name):
+            return self.constants.get(node.id)
+        return None
+
+    def _record(self, node: ast.AST, key_node: ast.AST, seam: str) -> None:
+        key = self._resolve_key(key_node)
+        location = f"{self.relative_path}:{node.lineno}"
+        if key is not None:
+            self.reads.setdefault(key, set()).add(location)
+            return
+        current_function = (
+            self.function_stack[-1] if self.function_stack else "<module>"
+        )
+        if (self.relative_path, current_function) in DYNAMIC_PYTHON_READERS:
+            return
+        self.unresolved.append(
+            f"{location} uses dynamic {seam} key {ast.unparse(key_node)!r}"
+        )
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self.function_stack.append(node.name)
+        self.generic_visit(node)
+        self.function_stack.pop()
+
+    visit_AsyncFunctionDef = visit_FunctionDef
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if node.args:
+            function = node.func
+            if (
+                isinstance(function, ast.Attribute)
+                and function.attr == "getenv"
+                and isinstance(function.value, ast.Name)
+                and function.value.id in self.os_aliases
+            ):
+                self._record(node, node.args[0], "os.getenv")
+            elif isinstance(function, ast.Name) and function.id in self.getenv_aliases:
+                self._record(node, node.args[0], "os.getenv alias")
+            elif (
+                isinstance(function, ast.Attribute)
+                and function.attr == "get"
+                and isinstance(function.value, ast.Attribute)
+                and function.value.attr == "environ"
+                and isinstance(function.value.value, ast.Name)
+                and function.value.value.id in self.os_aliases
+            ):
+                self._record(node, node.args[0], "os.environ.get")
+            elif (
+                isinstance(function, ast.Attribute)
+                and function.attr == "get"
+                and isinstance(function.value, ast.Name)
+                and function.value.id in {"environ", "_dirs_environ", "source"}
+                and (self.relative_path, self.function_stack[-1])
+                in {
+                    ("cps/constants.py", "_configured_dir"),
+                    (
+                        "cps/services/kobo_annotation_stage0.py",
+                        "emergency_override_disables",
+                    ),
+                    ("cps/services/kobo_exchange_capture.py", "enabled"),
+                    ("cps/sqlite_utils.py", "environment_flag_enabled"),
+                }
+            ):
+                self._record(node, node.args[0], f"{function.value.id}.get")
+            elif isinstance(function, ast.Name) and function.id in PYTHON_ENV_HELPERS:
+                argument_index, paths = PYTHON_ENV_HELPERS[function.id]
+                if self.relative_path in paths and len(node.args) > argument_index:
+                    self._record(
+                        node,
+                        node.args[argument_index],
+                        f"{function.id} helper",
+                    )
+        self.generic_visit(node)
+
+    def visit_Subscript(self, node: ast.Subscript) -> None:
+        if (
+            isinstance(node.ctx, ast.Load)
+            and isinstance(node.value, ast.Attribute)
+            and node.value.attr == "environ"
+            and isinstance(node.value.value, ast.Name)
+            and node.value.value.id in self.os_aliases
+        ):
+            self._record(node, node.slice, "os.environ[]")
+        self.generic_visit(node)
+
+
+def _python_env_reads() -> tuple[dict[str, set[str]], list[str]]:
+    reads: dict[str, set[str]] = {}
+    unresolved: list[str] = []
+    for source_root in PYTHON_ROOTS:
+        for path in sorted(source_root.rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            visitor = _PythonEnvVisitor(path, tree)
+            visitor.visit(tree)
+            unresolved.extend(visitor.unresolved)
+            for key, locations in visitor.reads.items():
+                reads.setdefault(key, set()).update(locations)
+    return reads, unresolved
+
+
+def _shell_env_reads() -> dict[str, set[str]]:
+    reads: dict[str, set[str]] = {}
+    for path in sorted(
+        candidate for candidate in S6_ROOT.rglob("*") if candidate.is_file()
+    ):
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except UnicodeDecodeError:
+            continue
+
+        active_lines = [line for line in lines if not line.lstrip().startswith("#")]
+        assignments = {
+            match.group(1)
+            for line in active_lines
+            for match in SHELL_ASSIGNMENT.finditer(line)
+        }
+        for lineno, line in enumerate(lines, 1):
+            if line.lstrip().startswith("#"):
+                continue
+            assigned_on_line = {
+                match.group(1) for match in SHELL_ASSIGNMENT.finditer(line)
+            }
+            names = {
+                match.group(1) or match.group(2)
+                for match in SHELL_REFERENCE.finditer(line)
+            }
+            names.update(match.group(1) for match in PRINTCONTENV.finditer(line))
+            for name in names:
+                # A self-reference while assigning (FOO=${FOO:-x}) consumes the
+                # inherited environment. Other variables assigned in this script
+                # are local implementation details, even when referenced earlier.
+                if (
+                    name in assignments
+                    and name not in assigned_on_line
+                    and name not in SHELL_ENV_COMPAT_READS
+                ):
+                    continue
+                reads.setdefault(name, set()).add(f"{_relative(path)}:{lineno}")
+    return reads
+
+
+def _frontend_env_reads() -> dict[str, set[str]]:
+    reads: dict[str, set[str]] = {}
+    extensions = frozenset({".cjs", ".js", ".jsx", ".mjs", ".ts", ".tsx"})
+    for path in sorted(FRONTEND_ROOT.rglob("*")):
+        if (
+            not path.is_file()
+            or path.suffix not in extensions
+            or "node_modules" in path.parts
+        ):
+            continue
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            for match in FRONTEND_ENV.finditer(line):
+                reads.setdefault(match.group(1), set()).add(
+                    f"{_relative(path)}:{lineno}"
+                )
+    return reads
+
+
+def _merge_reads(*inventories: dict[str, set[str]]) -> dict[str, set[str]]:
+    merged: dict[str, set[str]] = {}
+    for inventory in inventories:
+        for key, locations in inventory.items():
+            merged.setdefault(key, set()).update(locations)
+    return merged
+
+
+def _format_keys(keys: set[str], reads: dict[str, set[str]]) -> str:
+    return "\n".join(
+        f"  - {key}: {', '.join(sorted(reads.get(key, {'no in-scope reader'})))}"
+        for key in sorted(keys)
+    )
+
+
+def test_env_example_is_the_single_source_of_truth() -> None:
+    python_reads, unresolved = _python_env_reads()
+    assert not unresolved, (
+        "Environment reads with dynamic keys need a reviewed helper seam:\n"
+        + "\n".join(f"  - {entry}" for entry in unresolved)
+    )
+
+    reads = _merge_reads(python_reads, _shell_env_reads(), _frontend_env_reads())
+    documented_list = EXAMPLE_ASSIGNMENT.findall(EXAMPLE.read_text(encoding="utf-8"))
+    duplicates = {key for key in documented_list if documented_list.count(key) > 1}
+    documented = set(documented_list)
+
+    missing = set(reads) - documented - set(SSOT_EXCEPTIONS)
+    unused = documented - set(reads) - set(SSOT_EXCEPTIONS)
+
+    failures = []
+    if duplicates:
+        failures.append(
+            "Duplicate keys in examples/.env.example:\n"
+            + _format_keys(duplicates, reads)
+        )
+    if missing:
+        failures.append(
+            "Keys read by code but missing from examples/.env.example:\n"
+            + _format_keys(missing, reads)
+        )
+    if unused:
+        failures.append(
+            "Keys in examples/.env.example with no in-scope reader:\n"
+            + _format_keys(unused, reads)
+        )
+    assert not failures, "\n\n".join(failures)


### PR DESCRIPTION
## What
`examples/.env.example` (from #1913, thanks @Thovi98) becomes the enforced single source of truth for environment variables:
- `tests/unit/test_env_example_is_the_ssot.py` fails naming every key the code reads (Python via `ast` incl. aliased/local imports, `environ[...]`/`.get`/`.setdefault`/`.pop`/membership; frontend `process.env.X`, `process.env["X"]`, destructuring; s6 shell `$VAR`/`${VAR}`/`printcontenv` counted when read before any assignment) that is missing from the file, and every documented key nothing reads; dynamic keys are unresolved failures with file:line. Six justified exceptions.
- The file grows from 18 to 109 documented keys, each with what it does / default / when to set it, derived from the code at the cited lines (no invented semantics — 12/12 random checks by an independent reviewer matched).
- One pointer line each in README (network-share section) and docker-compose.yml.

## Evidence
- Red: guard against the 18-key file names 89 missing keys → green ×2 after filling; ~1.2 s wall.
- Independent adversarial review (Sol, fresh thread) round 1: DO-NOT-MERGE — three read shapes bypassed the guard (local alias, bracket notation, shell read-before-assign) + one inconsistent exception. Round 2 fixed all four; the three probes now fail with file:line, re-run independently by the manager in a scratch copy.
- No dependencies, licences or external URLs; security review not required.
