### PR TITLE
fix(ci): the E2E lane could not see the change it was gating

### DIFF
--- a/.github/workflows/docker-image-build-dev.yml
+++ b/.github/workflows/docker-image-build-dev.yml
@@ -33,7 +33,10 @@ on:
 
 concurrency:
   group: dev-image-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # Superseded PR heads may cancel their own unpublished verification build.
+  # Main/manual runs publish load-bearing artifacts and must serialize: a
+  # later neutral commit cannot cancel the relevant build it needs to alias.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # GITHUB_TOKEN is read-only on packages by default. Builds push to
 # ghcr.io/new-usemame/calibre-web-nextgen, so packages:write is
@@ -50,45 +53,87 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
-      full_build: ${{ steps.classify.outputs.full_build }}
-      alias_image: ${{ steps.classify.outputs.alias_image }}
+      full_build: ${{ steps.gate.outputs.full_build }}
+      alias_image: ${{ steps.gate.outputs.alias_image }}
+      image_source: ${{ steps.gate.outputs.image_source }}
     steps:
       - name: Checkout subject
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          ref: ${{ inputs.ref || github.event.pull_request.head.sha || github.ref }}
+          ref: ${{ inputs.ref || github.event.pull_request.head.sha || github.sha }}
 
-      - name: Classify
-        id: classify
+      - name: Classify paths with the trusted base implementation
+        id: detect
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          IS_FORK: ${{ github.event.pull_request.head.repo.fork == true }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "full_build=true" >> "$GITHUB_OUTPUT"
-            echo "alias_image=false" >> "$GITHUB_OUTPUT"
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            printf 'frontend=false\nbuild=true\nconcurrency=true\nimage=true\n' >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           files="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}" 2>/dev/null \
             || git diff --name-only "${BASE_SHA}" "${HEAD_SHA}")"
           printf '%s\n' "$files"
-          printf '%s\n' "$files" \
-            | python3 scripts/ci_path_classification.py --github-output "$GITHUB_OUTPUT"
-          concurrency="$(awk -F= '$1 == "concurrency" { value=$2 } END { print value }' "$GITHUB_OUTPUT")"
-          image="$(awk -F= '$1 == "image" { value=$2 } END { print value }' "$GITHUB_OUTPUT")"
 
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            [[ "$concurrency" == "true" && "$IS_FORK" != "true" ]] \
+          classifier_root="$GITHUB_WORKSPACE"
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            # A PR must not edit the policy that decides whether its own hard
+            # gate runs. Execute the base commit's classifier against the base
+            # tree. This classifier's introducing PR fails closed into every
+            # lane because its base has no trusted implementation yet.
+            classifier_ref="$BASE_SHA"
+            if ! git cat-file -e "$classifier_ref:scripts/ci_path_classification.py"; then
+              echo "::warning::Base has no path classifier; enabling every image gate"
+              printf 'frontend=true\nbuild=true\nconcurrency=true\nimage=true\n' >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            classifier_root="$RUNNER_TEMP/base-path-classifier"
+            mkdir -p "$classifier_root"
+            git archive "$classifier_ref" cps scripts/ci_path_classification.py \
+              | tar -x -C "$classifier_root"
+          fi
+          printf '%s\n' "$files" \
+            | python3 "$classifier_root/scripts/ci_path_classification.py" \
+                --repo-root "$classifier_root" --github-output "$GITHUB_OUTPUT"
+
+      - name: Decide build and alias work
+        id: gate
+        env:
+          CONCURRENCY: ${{ steps.detect.outputs.concurrency }}
+          IMAGE: ${{ steps.detect.outputs.image }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork == true }}
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            {
+              echo "full_build=true"
+              echo "alias_image=false"
+              echo "image_source="
+            } >> "$GITHUB_OUTPUT"
+          elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            [[ "$CONCURRENCY" == "true" && "$IS_FORK" != "true" ]] \
               && full_build=true || full_build=false
-            echo "full_build=$full_build" >> "$GITHUB_OUTPUT"
-            echo "alias_image=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "full_build=$full_build"
+              echo "alias_image=false"
+              echo "image_source="
+            } >> "$GITHUB_OUTPUT"
           else
-            echo "full_build=$image" >> "$GITHUB_OUTPUT"
-            [[ "$image" == "true" ]] && alias=false || alias=true
-            echo "alias_image=$alias" >> "$GITHUB_OUTPUT"
+            [[ "$IMAGE" == "true" ]] && alias=false || alias=true
+            if [[ "$alias" == "true" ]]; then
+              source="$(python3 scripts/ci_path_classification.py \
+                --latest-image-commit "$HEAD_SHA")"
+            else
+              source=""
+            fi
+            {
+              echo "full_build=$IMAGE"
+              echo "alias_image=$alias"
+              echo "image_source=$source"
+            } >> "$GITHUB_OUTPUT"
           fi
 
   # --------------------------------------------------------------------------------
@@ -125,7 +170,7 @@ jobs:
       - name: Set build ref
         env:
           INPUT_REF: ${{ inputs.ref }}
-          SUBJECT_REF: ${{ github.event.pull_request.head.sha || github.ref }}
+          SUBJECT_REF: ${{ github.event.pull_request.head.sha || github.sha }}
           INPUT_BRANCH: ${{ inputs.branch }}
           SUBJECT_BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
@@ -277,7 +322,7 @@ jobs:
       - name: Set build ref
         env:
           INPUT_REF: ${{ inputs.ref }}
-          SUBJECT_REF: ${{ github.event.pull_request.head.sha || github.ref }}
+          SUBJECT_REF: ${{ github.event.pull_request.head.sha || github.sha }}
           INPUT_BRANCH: ${{ inputs.branch }}
           SUBJECT_BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
@@ -441,7 +486,7 @@ jobs:
       - name: Set build ref
         env:
           INPUT_REF: ${{ inputs.ref }}
-          SUBJECT_REF: ${{ github.event.pull_request.head.sha || github.ref }}
+          SUBJECT_REF: ${{ github.event.pull_request.head.sha || github.sha }}
           INPUT_BRANCH: ${{ inputs.branch }}
           SUBJECT_BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
@@ -579,6 +624,12 @@ jobs:
     needs: classify
     if: needs.classify.outputs.alias_image == 'true'
     steps:
+      - name: Checkout exact subject
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ github.sha }}
+
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:
@@ -592,8 +643,9 @@ jobs:
           driver: docker
 
       - name: Publish immutable commit alias
+        env:
+          IMAGE_SOURCE: ${{ needs.classify.outputs.image_source }}
+          SUBJECT_SHA: ${{ github.sha }}
         run: |
           base="ghcr.io/${{ github.repository_owner }}/$(echo '${{ github.event.repository.name }}' | tr '[:upper:]' '[:lower:]')"
-          docker buildx imagetools create \
-            -t "$base:sha-${{ github.sha }}" \
-            "$base:dev"
+          bash scripts/alias-e2e-image.sh "$base" "$IMAGE_SOURCE" "$SUBJECT_SHA"

--- a/.github/workflows/docker-image-build-dev.yml
+++ b/.github/workflows/docker-image-build-dev.yml
@@ -15,11 +15,11 @@ on:
   # tests-only changes skip the build — they can't change the image behavior.
   push:
     branches: [main]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'tests/**'
-      - '.github/**'
+  # A cheap classifier runs on every PR, but only same-repository PRs whose
+  # architectural concurrency closure changed build. Forks never receive a
+  # package-write job, and ordinary PRs pay only for checkout + classification.
+  pull_request:
+    branches: [main, dev]
   workflow_dispatch:
     inputs:
       ref:
@@ -31,6 +31,10 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: dev-image-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # GITHUB_TOKEN is read-only on packages by default. Builds push to
 # ghcr.io/new-usemame/calibre-web-nextgen, so packages:write is
 # required. Without it the build silently failed at the GHCR push step
@@ -41,6 +45,52 @@ permissions:
   contents: read
   packages: write
 jobs:
+  classify:
+    name: Classify image work
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      full_build: ${{ steps.classify.outputs.full_build }}
+      alias_image: ${{ steps.classify.outputs.alias_image }}
+    steps:
+      - name: Checkout subject
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.ref || github.event.pull_request.head.sha || github.ref }}
+
+      - name: Classify
+        id: classify
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork == true }}
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "full_build=true" >> "$GITHUB_OUTPUT"
+            echo "alias_image=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          files="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}" 2>/dev/null \
+            || git diff --name-only "${BASE_SHA}" "${HEAD_SHA}")"
+          printf '%s\n' "$files"
+          printf '%s\n' "$files" \
+            | python3 scripts/ci_path_classification.py --github-output "$GITHUB_OUTPUT"
+          concurrency="$(awk -F= '$1 == "concurrency" { value=$2 } END { print value }' "$GITHUB_OUTPUT")"
+          image="$(awk -F= '$1 == "image" { value=$2 } END { print value }' "$GITHUB_OUTPUT")"
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            [[ "$concurrency" == "true" && "$IS_FORK" != "true" ]] \
+              && full_build=true || full_build=false
+            echo "full_build=$full_build" >> "$GITHUB_OUTPUT"
+            echo "alias_image=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "full_build=$image" >> "$GITHUB_OUTPUT"
+            [[ "$image" == "true" ]] && alias=false || alias=true
+            echo "alias_image=$alias" >> "$GITHUB_OUTPUT"
+          fi
+
   # --------------------------------------------------------------------------------
   # JOB 0: Ensure the python-build-standalone GHCR mirror exists before building.
   # The image build COPYs Python from ghcr.io/new-usemame/pbs-cache instead of the
@@ -50,12 +100,14 @@ jobs:
   # --------------------------------------------------------------------------------
   ensure-mirror:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    timeout-minutes: 15
+    needs: classify
+    if: needs.classify.outputs.full_build == 'true'
     steps:
       - name: Checkout (read Python pin from Dockerfile)
         uses: actions/checkout@v7
         with:
-          ref: ${{ (github.event_name == 'workflow_dispatch' && inputs.ref) || github.ref }}
+          ref: ${{ inputs.ref || github.event.pull_request.head.sha || github.ref }}
       - name: Ensure python-build-standalone mirror exists
         env:
           GHCR_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
@@ -66,21 +118,27 @@ jobs:
   # --------------------------------------------------------------------------------
   build-amd64:
     runs-on: ubuntu-latest
-    needs: ensure-mirror
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    timeout-minutes: 60
+    needs: [classify, ensure-mirror]
+    if: needs.classify.outputs.full_build == 'true'
     steps:
       - name: Set build ref
+        env:
+          INPUT_REF: ${{ inputs.ref }}
+          SUBJECT_REF: ${{ github.event.pull_request.head.sha || github.ref }}
+          INPUT_BRANCH: ${{ inputs.branch }}
+          SUBJECT_BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.ref }}" ]; then
-            echo "BUILD_REF=${{ inputs.ref }}" >> $GITHUB_ENV
+          if [ -n "$INPUT_REF" ]; then
+            echo "BUILD_REF=$INPUT_REF" >> "$GITHUB_ENV"
           else
-            echo "BUILD_REF=${{ github.ref }}" >> $GITHUB_ENV
+            echo "BUILD_REF=$SUBJECT_REF" >> "$GITHUB_ENV"
           fi
 
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.branch }}" ]; then
-            echo "BRANCH_NAME=${{ inputs.branch }}" >> $GITHUB_ENV
+          if [ -n "$INPUT_BRANCH" ]; then
+            echo "BRANCH_NAME=$INPUT_BRANCH" >> "$GITHUB_ENV"
           else
-            echo "BRANCH_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
+            echo "BRANCH_NAME=$SUBJECT_BRANCH" >> "$GITHUB_ENV"
           fi
 
       - name: Checkout correct ref
@@ -106,7 +164,7 @@ jobs:
       - name: DockerHub Login
         # Skipped on the standalone fork where DOCKERHUB secrets aren't set.
         # Operator opts in by setting repo variable DOCKERHUB_PUSH_ENABLED='true'.
-        if: vars.DOCKERHUB_PUSH_ENABLED == 'true'
+        if: vars.DOCKERHUB_PUSH_ENABLED == 'true' && github.event_name != 'pull_request'
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -148,7 +206,7 @@ jobs:
       - name: Compose docker outputs (GHCR always; DockerHub when opted-in)
         run: |
           GHCR_LINE="type=image,name=ghcr.io/${{ github.repository_owner }}/${{ env.LOWER_REPO_NAME }},push-by-digest=true,name-canonical=true,push=true"
-          if [ "${{ vars.DOCKERHUB_PUSH_ENABLED }}" = "true" ]; then
+          if [ "${{ vars.DOCKERHUB_PUSH_ENABLED }}" = "true" ] && [ "${{ github.event_name }}" != "pull_request" ]; then
             DH_LINE="type=image,name=${{ secrets.DOCKERHUB_USERNAME }}/calibre-web-automated,push-by-digest=true,name-canonical=true,push=true"
             printf 'DOCKER_BUILD_OUTPUTS<<EOF\n%s\n%s\nEOF\n' "$DH_LINE" "$GHCR_LINE" >> "$GITHUB_ENV"
           else
@@ -205,21 +263,27 @@ jobs:
     # repo is also a meaningful attack surface (any PR can execute on
     # operator hardware), so GitHub-hosted is the safer default.
     runs-on: ubuntu-24.04-arm
-    needs: ensure-mirror
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    timeout-minutes: 60
+    needs: [classify, ensure-mirror]
+    if: needs.classify.outputs.full_build == 'true'
     steps:
       - name: Set build ref
+        env:
+          INPUT_REF: ${{ inputs.ref }}
+          SUBJECT_REF: ${{ github.event.pull_request.head.sha || github.ref }}
+          INPUT_BRANCH: ${{ inputs.branch }}
+          SUBJECT_BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.ref }}" ]; then
-            echo "BUILD_REF=${{ inputs.ref }}" >> $GITHUB_ENV
+          if [ -n "$INPUT_REF" ]; then
+            echo "BUILD_REF=$INPUT_REF" >> "$GITHUB_ENV"
           else
-            echo "BUILD_REF=${{ github.ref }}" >> $GITHUB_ENV
+            echo "BUILD_REF=$SUBJECT_REF" >> "$GITHUB_ENV"
           fi
 
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.branch }}" ]; then
-            echo "BRANCH_NAME=${{ inputs.branch }}" >> $GITHUB_ENV
+          if [ -n "$INPUT_BRANCH" ]; then
+            echo "BRANCH_NAME=$INPUT_BRANCH" >> "$GITHUB_ENV"
           else
-            echo "BRANCH_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
+            echo "BRANCH_NAME=$SUBJECT_BRANCH" >> "$GITHUB_ENV"
           fi
 
       - name: Checkout correct ref
@@ -245,7 +309,7 @@ jobs:
       - name: DockerHub Login
         # Skipped on the standalone fork where DOCKERHUB secrets aren't set.
         # Operator opts in by setting repo variable DOCKERHUB_PUSH_ENABLED='true'.
-        if: vars.DOCKERHUB_PUSH_ENABLED == 'true'
+        if: vars.DOCKERHUB_PUSH_ENABLED == 'true' && github.event_name != 'pull_request'
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -287,7 +351,7 @@ jobs:
       - name: Compose docker outputs (GHCR always; DockerHub when opted-in)
         run: |
           GHCR_LINE="type=image,name=ghcr.io/${{ github.repository_owner }}/${{ env.LOWER_REPO_NAME }},push-by-digest=true,name-canonical=true,push=true"
-          if [ "${{ vars.DOCKERHUB_PUSH_ENABLED }}" = "true" ]; then
+          if [ "${{ vars.DOCKERHUB_PUSH_ENABLED }}" = "true" ] && [ "${{ github.event_name }}" != "pull_request" ]; then
             DH_LINE="type=image,name=${{ secrets.DOCKERHUB_USERNAME }}/calibre-web-automated,push-by-digest=true,name-canonical=true,push=true"
             printf 'DOCKER_BUILD_OUTPUTS<<EOF\n%s\n%s\nEOF\n' "$DH_LINE" "$GHCR_LINE" >> "$GITHUB_ENV"
           else
@@ -355,22 +419,28 @@ jobs:
   # --------------------------------------------------------------------------------
   merge:
     runs-on: ubuntu-latest
-    needs: [build-amd64, build-arm]
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    timeout-minutes: 15
+    needs: [classify, build-amd64, build-arm]
+    if: needs.classify.outputs.full_build == 'true'
     steps:
       # --- 1. Calculate Variables ---
       - name: Set build ref
+        env:
+          INPUT_REF: ${{ inputs.ref }}
+          SUBJECT_REF: ${{ github.event.pull_request.head.sha || github.ref }}
+          INPUT_BRANCH: ${{ inputs.branch }}
+          SUBJECT_BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.ref }}" ]; then
-            echo "BUILD_REF=${{ inputs.ref }}" >> $GITHUB_ENV
+          if [ -n "$INPUT_REF" ]; then
+            echo "BUILD_REF=$INPUT_REF" >> "$GITHUB_ENV"
           else
-            echo "BUILD_REF=${{ github.ref }}" >> $GITHUB_ENV
+            echo "BUILD_REF=$SUBJECT_REF" >> "$GITHUB_ENV"
           fi
 
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.branch }}" ]; then
-            echo "BRANCH_NAME=${{ inputs.branch }}" >> $GITHUB_ENV
+          if [ -n "$INPUT_BRANCH" ]; then
+            echo "BRANCH_NAME=$INPUT_BRANCH" >> "$GITHUB_ENV"
           else
-            echo "BRANCH_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
+            echo "BRANCH_NAME=$SUBJECT_BRANCH" >> "$GITHUB_ENV"
           fi
 
       - name: Checkout correct ref
@@ -396,12 +466,13 @@ jobs:
           # We use the build number that was passed to the build jobs
           # Note: We append the build number to the 'dev' prefix to keep them grouped
           echo "UNIQUE_TAG=dev-${{ vars.CURRENT_DEV_BUILD_NUM }}" >> $GITHUB_ENV
+          echo "COMMIT_TAG=sha-$(git rev-parse HEAD)" >> $GITHUB_ENV
 
       # --- 2. Logins ---
       - name: DockerHub Login
         # Skipped on the standalone fork where DOCKERHUB secrets aren't set.
         # Operator opts in by setting repo variable DOCKERHUB_PUSH_ENABLED='true'.
-        if: vars.DOCKERHUB_PUSH_ENABLED == 'true'
+        if: vars.DOCKERHUB_PUSH_ENABLED == 'true' && github.event_name != 'pull_request'
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -440,7 +511,7 @@ jobs:
         working-directory: /tmp/digests
         run: |
           # 1. Push to DockerHub (only when DOCKERHUB_PUSH_ENABLED) — both tags
-          if [ "${{ vars.DOCKERHUB_PUSH_ENABLED }}" = "true" ]; then
+          if [ "${{ vars.DOCKERHUB_PUSH_ENABLED }}" = "true" ] && [ "${{ github.event_name }}" != "pull_request" ]; then
             docker buildx imagetools create \
               -t ${{ secrets.DOCKERHUB_USERNAME }}/calibre-web-automated:${{ env.FLOAT_TAG }} \
               -t ${{ secrets.DOCKERHUB_USERNAME }}/calibre-web-automated:${{ env.UNIQUE_TAG }} \
@@ -449,11 +520,15 @@ jobs:
             echo "DOCKERHUB_PUSH_ENABLED is not 'true' — skipping DockerHub manifest push (GHCR-only mode)."
           fi
 
-          # 2. Push to GHCR (Both Tags) — always
-          docker buildx imagetools create \
-            -t ghcr.io/${{ github.repository_owner }}/${{ env.LOWER_REPO_NAME }}:${{ env.FLOAT_TAG }} \
-            -t ghcr.io/${{ github.repository_owner }}/${{ env.LOWER_REPO_NAME }}:${{ env.UNIQUE_TAG }} \
-            $(printf 'ghcr.io/${{ github.repository_owner }}/${{ env.LOWER_REPO_NAME }}@sha256:%s ' *)
+          # 2. GHCR always gets an immutable commit tag. Main/manual builds also
+          # advance the delivery-channel tags; PR verification builds must not.
+          base="ghcr.io/${{ github.repository_owner }}/${{ env.LOWER_REPO_NAME }}"
+          tags=(-t "$base:${{ env.COMMIT_TAG }}")
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            tags+=(-t "$base:${{ env.FLOAT_TAG }}" -t "$base:${{ env.UNIQUE_TAG }}")
+          fi
+          docker buildx imagetools create "${tags[@]}" \
+            $(printf "$base@sha256:%s " *)
 
       # --- 4. Increment Build Number (Last Step) ---
       # Inherited from upstream CWA. Bumps repo variable CURRENT_DEV_BUILD_NUM
@@ -464,9 +539,40 @@ jobs:
       # secret, and fail-soft: a hiccup in this purely-bookkeeping step must
       # never mark an otherwise-successful build red.
       - name: Increment dev build number
+        if: github.event_name != 'pull_request'
         uses: action-pack/increment@v2
         id: increment
         continue-on-error: true
         with:
           name: 'CURRENT_DEV_BUILD_NUM'
           token: ${{ secrets.GH_PAT || secrets.DEV_BUILD_NUM_INCREMENTOR_TOKEN }}
+
+  # Image-neutral main commits (docs/tests/workflow policy) deliberately do not
+  # rebuild or advance :dev. They still need an immutable subject identifier so
+  # Test Suite can prove which backend it exercised. Copying the existing
+  # manifest to sha-<commit> is registry-only and does not restart the canary.
+  alias-image-neutral-commit:
+    name: Alias unchanged image to commit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: classify
+    if: needs.classify.outputs.alias_image == 'true'
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx (registry-only)
+        uses: docker/setup-buildx-action@v4
+        with:
+          driver: docker
+
+      - name: Publish immutable commit alias
+        run: |
+          base="ghcr.io/${{ github.repository_owner }}/$(echo '${{ github.event.repository.name }}' | tr '[:upper:]' '[:lower:]')"
+          docker buildx imagetools create \
+            -t "$base:sha-${{ github.sha }}" \
+            "$base:dev"

--- a/.github/workflows/docker-image-build-dev.yml
+++ b/.github/workflows/docker-image-build-dev.yml
@@ -153,10 +153,17 @@ jobs:
       - name: Determine Docker Image Tag
         id: tag
         run: |
-          if [[ "${{ env.BRANCH_NAME }}" == "main" ]]; then
+          # Use $BRANCH_NAME, never a GitHub expression here: an expression is
+          # substituted into the script TEXT before the shell parses it, so a
+          # branch name containing $( ) would execute. Reading it from the
+          # environment cannot execute. github.head_ref is attacker-controlled
+          # on a fork PR; the fork gate on this job is what makes that
+          # unreachable today, and this line is what keeps it unreachable if
+          # anyone ever relaxes the gate.
+          if [[ "$BRANCH_NAME" == "main" ]]; then
             echo "IMAGE_TAG=dev" >> $GITHUB_ENV
           else
-            sanitized_branch=$(echo "${{ env.BRANCH_NAME }}" | sed 's/[^a-zA-Z0-9.-]/-/g')
+            sanitized_branch=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9.-]/-/g')
             echo "IMAGE_TAG=dev-${sanitized_branch}" >> $GITHUB_ENV
           fi
 
@@ -298,10 +305,17 @@ jobs:
       - name: Determine Docker Image Tag
         id: tag
         run: |
-          if [[ "${{ env.BRANCH_NAME }}" == "main" ]]; then
+          # Use $BRANCH_NAME, never a GitHub expression here: an expression is
+          # substituted into the script TEXT before the shell parses it, so a
+          # branch name containing $( ) would execute. Reading it from the
+          # environment cannot execute. github.head_ref is attacker-controlled
+          # on a fork PR; the fork gate on this job is what makes that
+          # unreachable today, and this line is what keeps it unreachable if
+          # anyone ever relaxes the gate.
+          if [[ "$BRANCH_NAME" == "main" ]]; then
             echo "IMAGE_TAG=dev" >> $GITHUB_ENV
           else
-            sanitized_branch=$(echo "${{ env.BRANCH_NAME }}" | sed 's/[^a-zA-Z0-9.-]/-/g')
+            sanitized_branch=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9.-]/-/g')
             echo "IMAGE_TAG=dev-${sanitized_branch}" >> $GITHUB_ENV
           fi
 
@@ -455,10 +469,17 @@ jobs:
         id: tag
         run: |
           # 1. Determine the "Floating" Tag (e.g., 'dev' or 'dev-featurebranch')
-          if [[ "${{ env.BRANCH_NAME }}" == "main" ]]; then
+          # Use $BRANCH_NAME, never a GitHub expression here: an expression is
+          # substituted into the script TEXT before the shell parses it, so a
+          # branch name containing $( ) would execute. Reading it from the
+          # environment cannot execute. github.head_ref is attacker-controlled
+          # on a fork PR; the fork gate on this job is what makes that
+          # unreachable today, and this line is what keeps it unreachable if
+          # anyone ever relaxes the gate.
+          if [[ "$BRANCH_NAME" == "main" ]]; then
             echo "FLOAT_TAG=dev" >> $GITHUB_ENV
           else
-            sanitized_branch=$(echo "${{ env.BRANCH_NAME }}" | sed 's/[^a-zA-Z0-9.-]/-/g')
+            sanitized_branch=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9.-]/-/g')
             echo "FLOAT_TAG=dev-${sanitized_branch}" >> $GITHUB_ENV
           fi
           

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -428,12 +428,23 @@ jobs:
           # busy main does not make every PR look like it touched everything.
           files="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}" || git diff --name-only "${BASE_SHA}" "${HEAD_SHA}")"
           echo "$files"
-          # One implementation serves this job and the dev-image workflow.
-          # Concurrency classification starts from engine/request entry points
-          # and follows their Python imports, so extracting a new helper cannot
-          # silently remove it from the gate (Class 9b).
+          # A PR cannot certify that its own gate is unnecessary by narrowing
+          # this script. Execute the base commit's classifier against the base
+          # tree. The introducing PR has no trusted base implementation, so it
+          # fails closed into every expensive gate instead of self-certifying.
+          classifier_ref="$BASE_SHA"
+          if ! git cat-file -e "$classifier_ref:scripts/ci_path_classification.py"; then
+            echo "::warning::Base has no path classifier; enabling every path-derived gate"
+            printf 'frontend=true\nbuild=true\nconcurrency=true\nimage=true\n' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          classifier_root="$RUNNER_TEMP/base-path-classifier"
+          mkdir -p "$classifier_root"
+          git archive "$classifier_ref" cps scripts/ci_path_classification.py \
+            | tar -x -C "$classifier_root"
           printf '%s\n' "$files" \
-            | python3 scripts/ci_path_classification.py --github-output "$GITHUB_OUTPUT"
+            | python3 "$classifier_root/scripts/ci_path_classification.py" \
+                --repo-root "$classifier_root" --github-output "$GITHUB_OUTPUT"
 
   # ============================================================================
   # JOB 3: E2E Tests (Full Stack)
@@ -454,9 +465,10 @@ jobs:
     # verification system, frontend/e2e/) is the "earn the release" gate;
     # /CWNG_verify runs the same harness on-demand in dev. Tag runs test the
     # tag's own GHCR image (requires `on.push.tags` above — a `branches:`-only
-    # push trigger never delivers tag events). The dev-branch condition is
-    # forward wiring: no dev branch exists today, so per-merge canary coverage
-    # is a follow-up (workflow_run after the :dev image build).
+    # push trigger never delivers tag events). The dev-branch condition is an
+    # explicit fail-fast tripwire: the dev-image workflow does not build dev
+    # pushes, so this job names that unsupported pairing instead of waiting for
+    # a sha tag no producer will publish.
     # GATING (promoted 2026-07-31, #1130). This was advisory on every PR, and
     # the promotion condition written here — "once several tag runs are green"
     # — has been met: the harness step is green on 9 consecutive runs that
@@ -490,8 +502,11 @@ jobs:
         (needs.changed_paths.outputs.concurrency == 'true' && github.event.pull_request.head.repo.fork != true)
       ))
       )
-    # Tag runs may wait up to ~40 min for the GHCR release build to publish
-    # the image (see the pull loop below) before the ~15 min harness run.
+    # Awaited builds may consume their full 15m mirror + 60m architecture +
+    # 15m manifest budgets. Main image runs also serialize, so a neutral commit
+    # can wait behind the relevant build whose manifest it will honestly alias.
+    # Leave 60m after the 120m resolver budget for setup and Playwright's two
+    # retries of a roughly 15m suite.
     #
     # Advisory ONLY for fork PRs now. A fork's runner gets no repo secrets, and
     # the resolve/pull/overlay path above has never been exercised from one —
@@ -502,7 +517,7 @@ jobs:
     # result is still surfaced; only the block is deferred. Promote (drop the
     # fork clause) once a real fork run shows the path works.
     continue-on-error: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true }}
-    timeout-minutes: 75
+    timeout-minutes: 180
     permissions:
       contents: read
       packages: read   # pull the private pbs-cache mirror images the Dockerfile COPYs from
@@ -511,6 +526,13 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Refuse unsupported dev-branch image wait
+        if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+        run: |
+          echo "::error::Automatic dev-branch E2E has no matching dev-image producer."
+          echo "Run the dev-image workflow for this commit, then dispatch Test Suite with run_e2e=true."
+          exit 1
 
       - name: Set up Node.js
         uses: actions/setup-node@v7
@@ -534,7 +556,7 @@ jobs:
           image="ghcr.io/new-usemame/calibre-web-nextgen"
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             tag="$GITHUB_REF_NAME"
-            attempts=80
+            attempts=240
           elif [[ "${{ github.event_name }}" == "pull_request" \
                   && "${{ needs.changed_paths.outputs.concurrency }}" != "true" ]]; then
             # Frontend-only PRs (including forks) still overlay their own SPA on
@@ -542,12 +564,18 @@ jobs:
             # immediately; capability probes own routes it may not have.
             tag=dev
             attempts=1
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            # Manual runs are an assertion that the operator has already
+            # dispatched the dev build for this ref. Waiting two hours cannot
+            # create a tag whose producer was never started.
+            tag="sha-$SUBJECT_SHA"
+            attempts=1
           else
             # Main pushes and concurrency-shaped same-repo PRs are paired with
             # docker-image-build-dev.yml. Wait for this exact commit tag. No
             # :dev fallback is allowed: an absent subject cannot earn a verdict.
             tag="sha-$SUBJECT_SHA"
-            attempts=80
+            attempts=240
           fi
           resolved="$(bash scripts/resolve-e2e-image.sh "$image" "$tag" "$attempts" 30)"
           echo "image=$resolved" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -405,6 +405,7 @@ jobs:
     outputs:
       frontend: ${{ steps.detect.outputs.frontend }}
       build: ${{ steps.detect.outputs.build }}
+      concurrency: ${{ steps.detect.outputs.concurrency }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -427,60 +428,12 @@ jobs:
           # busy main does not make every PR look like it touched everything.
           files="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}" || git diff --name-only "${BASE_SHA}" "${HEAD_SHA}")"
           echo "$files"
-          # tests.yml itself counts: the e2e job's container setup and seed steps
-          # live in this file, so a PR that changes how the harness is fixtured
-          # could not otherwise be validated by the harness. That is how a broken
-          # seed (config_remote_login left at its default False, so every
-          # magic-link spec 403'd) stayed invisible — the fix for a red e2e gate
-          # would not have run the e2e gate.
-          if echo "$files" | grep -qE '^(frontend/|cps/static/app/|\.github/workflows/tests\.yml$)'; then
-            echo "frontend=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "frontend=false" >> "$GITHUB_OUTPUT"
-          fi
-          # Build-definition changes: things that alter the IMAGE, and so
-          # can only be validated by building and booting it.
-          #   Dockerfile          pins CALIBRE_RELEASE / PYTHON_VERSION /
-          #                       KEPUBIFY_RELEASE — the binaries every
-          #                       conversion and ingest actually runs on.
-          #   *requirements*.txt  the Python side. Note the pattern must
-          #                       also catch optional-requirements.txt,
-          #                       which the image pip-installs alongside
-          #                       requirements.txt; a leading-anchored
-          #                       `requirements` would silently miss it.
-          #   root/               copied to / at build time — the s6
-          #                       service definitions that decide whether
-          #                       the container boots at all.
-          # integration-tests is the ONLY job that builds the image and
-          # exercises that flow, so these must turn it on regardless of
-          # tier label. Before this, a Calibre version bump could merge
-          # with the image never built (#1261).
-          # tests/docker/ and tests/integration/ are included for the same
-          # reason tests.yml counts as frontend-relevant above: a PR that
-          # changes a harness must be validated by the harness it changes.
-          #   cps/**.py          the application the image exists to run. A
-          #                      pure-Python change can stop the container
-          #                      booting just as dead as a bad Dockerfile,
-          #                      and integration-tests is still the ONLY job
-          #                      that boots it. #1438 removed a hardcoded
-          #                      path in cps/web.py without importing the
-          #                      constant that replaced it: import-time was
-          #                      fine, every unit test was green, and the
-          #                      container went permanently unhealthy. It
-          #                      touched no Dockerfile, carried no tier-2
-          #                      label, so Integration Tests was advisory,
-          #                      went red, and the summary reported success.
-          #                      Scoped to .py on purpose: cps/translations/
-          #                      *.po are tier-1 auto-merge PRs and a broken
-          #                      catalogue is already a hard failure in Fast
-          #                      Tests (test_translations_compile.py), so
-          #                      routing them through a full image build
-          #                      would buy nothing and stall every locale PR.
-          if echo "$files" | grep -qE '^(Dockerfile$|[^/]*requirements[^/]*\.txt$|root/|cps/.*\.py$|scripts/.*\.py$|tests/(docker|integration)/|\.github/workflows/tests\.yml$)'; then
-            echo "build=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "build=false" >> "$GITHUB_OUTPUT"
-          fi
+          # One implementation serves this job and the dev-image workflow.
+          # Concurrency classification starts from engine/request entry points
+          # and follows their Python imports, so extracting a new helper cannot
+          # silently remove it from the gate (Class 9b).
+          printf '%s\n' "$files" \
+            | python3 scripts/ci_path_classification.py --github-output "$GITHUB_OUTPUT"
 
   # ============================================================================
   # JOB 3: E2E Tests (Full Stack)
@@ -532,7 +485,10 @@ jobs:
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       github.ref == 'refs/heads/dev' ||
       (github.event_name == 'workflow_dispatch' && inputs.run_e2e) ||
-      (github.event_name == 'pull_request' && needs.changed_paths.outputs.frontend == 'true')
+      (github.event_name == 'pull_request' && (
+        needs.changed_paths.outputs.frontend == 'true' ||
+        (needs.changed_paths.outputs.concurrency == 'true' && github.event.pull_request.head.repo.fork != true)
+      ))
       )
     # Tag runs may wait up to ~40 min for the GHCR release build to publish
     # the image (see the pull loop below) before the ~15 min harness run.
@@ -553,6 +509,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v7
@@ -570,35 +528,37 @@ jobs:
 
       - name: Resolve image to test
         id: img
+        env:
+          SUBJECT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
-          # Test the image users actually get (Class 2/4: verify the shipped
-          # artifact, not a locally-rebuilt one). Version tag → that tag's image;
-          # otherwise → the :dev canary. Avoids the from-source build, which
-          # cold-pulls the private pbs-cache mirror and is fragile in CI.
+          image="ghcr.io/new-usemame/calibre-web-nextgen"
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            echo "image=ghcr.io/new-usemame/calibre-web-nextgen:${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+            tag="$GITHUB_REF_NAME"
+            attempts=80
+          elif [[ "${{ github.event_name }}" == "pull_request" \
+                  && "${{ needs.changed_paths.outputs.concurrency }}" != "true" ]]; then
+            # Frontend-only PRs (including forks) still overlay their own SPA on
+            # the currently published backend. Freeze that backend to a digest
+            # immediately; capability probes own routes it may not have.
+            tag=dev
+            attempts=1
           else
-            # PRs land here too: :dev supplies the API, and the overlay step
-            # below replaces its SPA with the one built from this PR (#953).
-            echo "image=ghcr.io/new-usemame/calibre-web-nextgen:dev" >> "$GITHUB_OUTPUT"
+            # Main pushes and concurrency-shaped same-repo PRs are paired with
+            # docker-image-build-dev.yml. Wait for this exact commit tag. No
+            # :dev fallback is allowed: an absent subject cannot earn a verdict.
+            tag="sha-$SUBJECT_SHA"
+            attempts=80
           fi
+          resolved="$(bash scripts/resolve-e2e-image.sh "$image" "$tag" "$attempts" 30)"
+          echo "image=$resolved" >> "$GITHUB_OUTPUT"
 
       - name: Start container (SPA enabled)
         env:
           IMAGE: ${{ steps.img.outputs.image }}
         run: |
-          echo "Testing image: $IMAGE"
-          # On tag pushes this job races the GHCR release build, which publishes
-          # the tag's image 15–35 min after the tag lands (v4.0.169 lesson) —
-          # poll instead of failing on the first pull. :dev / dispatch runs hit
-          # an already-published image and pull on the first attempt.
-          for i in $(seq 1 80); do
-            docker pull "$IMAGE" && break
-            echo "image not pullable yet (attempt $i/80); retrying in 30s..."
-            sleep 30
-          done
-          if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
-            echo "::error::$IMAGE never became pullable — check the GHCR build for this ref"
+          echo "Testing immutable image: $IMAGE"
+          if ! docker pull "$IMAGE"; then
+            echo "::error::$IMAGE resolved but could not be pulled"
             exit 1
           fi
           mkdir -p /tmp/cwn/config /tmp/cwn/ingest
@@ -854,54 +814,15 @@ jobs:
           npm ci
           npx playwright install --with-deps chromium
 
-      # Without this the container serves whatever SPA the pulled image already
-      # had, and the suite says nothing about the commit under test.
-      #
-      # This ran on `pull_request` only, which quietly made the main-push leg
-      # added in #1557 test THE WRONG CODE. The image resolves to `:dev` for any
-      # non-tag ref, and `:dev` for the head commit is built by a separate
-      # workflow that RACES this job — measured on the 2026-08-12 main push:
-      #
-      #     21:32:22  e2e pulls ghcr.io/...:dev
-      #     21:32:28  build-amd64 for the head commit STARTS
-      #     21:34:22  build-amd64 finishes — the :dev holding that commit first
-      #               exists here, two minutes after it was pulled
-      #
-      # So the container under test predated the head commit by one merge, and
-      # the overlay that would have corrected it was skipped. Every result was
-      # attributed to a commit that was not in the artifact. That is worse than a
-      # cancelled run: a cancelled run verifies nothing, this verified the wrong
-      # thing while looking identical from outside — same green tick, same step
-      # count. Step count proves the suite RAN; it cannot prove WHAT it ran
-      # against.
-      #
-      # Running the overlay on a main push too makes the SPA under test the head
-      # commit's, which is the same contract a PR already gets.
-      #
-      # The `dev` leg has the SAME defect and is arguably worse:
-      # docker-image-build-dev.yml triggers on `push: branches: [main]`, so
-      # `:dev` is built from MAIN. A push to `dev` therefore pulled an image
-      # built from a DIFFERENT BRANCH and ran dev's specs against it. Covered
-      # here too.
-      #
-      # After this, the overlay pins artifact identity on every ref that resolves
-      # to `:dev` — PR, main push, dev push. Tags are the only case that skips
-      # it, and correctly so: there the image IS the tag, which is already
-      # pinned. That makes "did the overlay run" a usable second instrument
-      # alongside step count — steps prove the suite RAN, the overlay proves
-      # WHAT it ran against.
-      #
-      # ⚠️ Stated rather than glossed: the API in the container is still `:dev`,
-      # i.e. one merge behind. This leg is an SPA gate, not a full-stack one (it
-      # says so above), so a backend regression on main is still invisible until
-      # the next push. Pinning the head commit's own image DIGEST is the complete
-      # fix; it needs this job to wait on the image build, which is a bigger
-      # change than this one.
+      # Frontend-only PRs intentionally reuse a digest-pinned :dev backend to
+      # avoid a full multi-arch build for a static-bundle change. Overlay their
+      # own bundle/templates. Main and concurrency-shaped PRs already boot the
+      # triggering commit's sha-tagged image and must remain byte-for-byte that
+      # artifact; overlaying them would weaken the image identity proof.
       - name: Overlay the SPA bundle under test into the container
         if: >-
-          github.event_name == 'pull_request' ||
-          (github.event_name == 'push' &&
-           (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'))
+          github.event_name == 'pull_request' &&
+          needs.changed_paths.outputs.concurrency != 'true'
         working-directory: frontend
         run: |
           npm ci
@@ -1010,6 +931,9 @@ jobs:
           # fork carve-out mirrors the e2e job's own continue-on-error, so the
           # two cannot disagree about what is being gated.
           IS_FRONTEND_PR: ${{ needs.changed_paths.outputs.frontend == 'true' && github.event.pull_request.head.repo.fork != true }}
+          # Concurrency/engine-shaped PRs are a hard full-stack gate. Their E2E
+          # job waits for the PR head's own sha-tagged image before starting.
+          IS_CONCURRENCY_PR: ${{ needs.changed_paths.outputs.concurrency == 'true' && github.event.pull_request.head.repo.fork != true }}
           # Every push to main runs and gates on the SPA e2e suite. Keep this
           # event-scoped so workflow_dispatch continues to honor run_e2e.
           IS_MAIN_PUSH: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
@@ -1021,6 +945,7 @@ jobs:
           echo "Is tier-2 PR:      $IS_TIER2_PR"
           echo "Is build PR:       $IS_BUILD_PR"
           echo "Is frontend PR:    $IS_FRONTEND_PR"
+          echo "Is concurrency PR: $IS_CONCURRENCY_PR"
           echo "Is main push:      $IS_MAIN_PUSH"
 
           # A required summary must positively prove that every hard-gated lane
@@ -1115,6 +1040,16 @@ jobs:
               exit 1
             fi
             echo "⛔ E2E tests failed - do not release! (advisory; not a frontend PR)"
+          fi
+
+          # A concurrency-shaped PR is meaningful only if the full-stack lane
+          # positively completed against its own commit image. Failure,
+          # cancellation, or a skipped job all mean no trustworthy verdict.
+          if [[ "$IS_CONCURRENCY_PR" == "true" \
+                && "${{ needs.e2e-tests.result }}" != "success" ]]; then
+            echo "❌ Full-stack E2E did not succeed on a concurrency-shaped PR."
+            echo "   Actual result: ${{ needs.e2e-tests.result }}"
+            exit 1
           fi
 
           echo "✅ Test suite completed"

--- a/changelog.d/1927-e2e-gate.md
+++ b/changelog.d/1927-e2e-gate.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- **Backend concurrency changes can no longer merge behind a frontend-only test gate.** CI now runs the
+  full browser suite against the triggering commit's immutable container digest when database-engine or
+  concurrent request-handling code changes, instead of accidentally testing the previous `:dev` image.

--- a/findings/items/F-50a97d.json
+++ b/findings/items/F-50a97d.json
@@ -1,0 +1,11 @@
+{
+  "area": "ci",
+  "body": "The commit-pinned E2E gate (#1927) waits up to 240 x 30s for the triggering commit's `sha-<commit>`\nimage tag. That budget is deliberately larger than the producer pipeline's configured critical path\n(95 minutes), so a slow build cannot red-light an innocent PR.\n\nThe gap: the resolver has no signal from the paired build run. If that run FAILS early, the resolver\nstill sleeps out its whole budget before refusing, so a broken build costs ~2 hours of wall-clock\nbefore the hard red appears. The verdict is correct - it refuses rather than testing the wrong image -\nbut the latency is bad enough that people will be tempted to bypass the gate, which is how a good gate\ngets switched off.\n\nFix shape: poll the paired dev-image run's conclusion alongside the tag, and abort early with a\ndistinct message when that run reaches a terminal failure. Keep the long budget for \"still building\";\nshorten only \"will never arrive\".\n\nDeliberately NOT done in the #1927 PR: it is a behaviour change with its own failure mode (a\nmis-identified paired run would abort a legitimate wait), and that PR was already large. Raised by the\nindependent pre-merge re-review of PR #1941.",
+  "created": "2026-08-28",
+  "id": "F-50a97d",
+  "refs": [],
+  "severity": "chore",
+  "source": "audit",
+  "status": "open",
+  "title": "E2E resolver waits its full ~2h budget even when the paired dev-image build has already failed"
+}

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -37,9 +37,13 @@ stated reason because the dev-image workflow currently produces push images for 
 
 The concurrency set is an intentionally bounded architectural approximation. Local imports are followed
 downward from explicit request/engine roots, including the high-write `cps/web.py` and `cps/kobo.py`
-surfaces; reverse dependents cannot be discovered by that traversal and must be added as roots. The
+surfaces; reverse dependents cannot be discovered by that traversal and must be added as roots or package
+prefixes. The whole `cps/api/` blueprint tree is therefore protected explicitly: its registration in
+`cps/main.py` points toward the handlers, opposite to the import direction walked by the classifier. The
 two-level cutoff only bounds each root's dependency fan-out—it is not what excludes reverse dependents.
-At this revision the derived set is 110 of 215 local Python modules.
+At this revision the derived set is 149 of 215 local Python modules. Measured at `origin/main`
+`e6298e0d560b`, the previous and expanded policies each fired on 26 of the latest 100 first-parent commits;
+protecting `cps/api/` added zero historical gate runs in that sample.
 
 ## What it covers (projects = matrix axes)
 

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -23,6 +23,13 @@ Env knobs: `E2E_BASE_URL` (default `http://localhost:8086`), `E2E_USER`/`E2E_PAS
 `admin`/`admin123`), `E2E_SUBPATH_URL` (set to the `cwn-nginx-571` rig `http://localhost:8087` to run the
 reverse-proxy project).
 
+In CI, a same-repository PR whose concurrency/engine dependency closure changed runs this suite as a
+hard gate against `sha-<PR head>` — the dev-image workflow builds that exact commit and the test workflow
+waits for, then pins, its manifest digest. Frontend-only PRs retain the cheaper SPA-overlay route. To run
+the lane outside its automatic path classes, use **Actions → Test Suite → Run workflow** with `run_e2e`
+enabled. If that ref has no `sha-<commit>` dev image, dispatch **Build & Push - Dev - Split Strategy** for
+the same ref first; the test job fails rather than falling back to a different backend.
+
 ## What it covers (projects = matrix axes)
 
 | Project | Axis | Guards |
@@ -48,3 +55,52 @@ Grow the a11y gate via the `CWNG_a11y` skill.
   allowlist, not a growing one. A quarantined violation is a named debt, never a silenced red.
 - **Theme axis** is not live yet (the SPA ships a single dark theme). Add a theme project when `tokens.css`
   gains a light/other `:root` block.
+
+### Backend capability probes
+
+A frontend/full-stack PR can run on a frontend-only or fork lane whose digest-pinned backend predates a
+new route. Use `requireRouteCapability` from `e2e/capabilities.ts` in `beforeEach` to probe route presence
+with Flask's automatic `OPTIONS` response and skip with an explicit, self-retiring reason:
+
+```ts
+await requireRouteCapability(page.request, {
+  method: 'DELETE',
+  path: '/api/v1/widgets/1',
+  name: 'widget deletion',
+  pinnedBy: 'tests/unit/test_widgets.py::test_delete_route_is_registered',
+});
+```
+
+The probe is presence-only: never send a real payload or interpret a handler body in the helper. A present
+but incorrect route must run and fail the real spec. Every probe must name an independent Fast Tests test
+that pins route registration on every PR; otherwise the skip would create a silent coverage hole.
+Use a feature-specific mutation method (`POST`, `PUT`, `PATCH`, or `DELETE`), not `GET`/`HEAD`: the classic
+UI catch-all advertises read methods for unknown paths, so treating those as a presence signal would be a
+false positive. The helper rejects that ambiguous probe shape loudly.
+
+### A second user in one spec
+
+Import `test` and `expect` from `e2e/fixtures.ts` only in a spec that needs multiple users. Requesting the
+`secondaryUser` fixture creates a unique non-admin viewer through the running container's real admin API,
+logs it into a separate browser context through the production auth endpoint, confirms that session in the
+SPA, and deletes it after the test:
+
+```ts
+import { test, expect } from './fixtures';
+
+test('personal state is isolated', async ({ page, secondaryUser }) => {
+  // `page` is the unchanged primary admin session; each request context owns
+  // its browser context's independent cookie jar.
+  const adminMe = await page.request.get('/api/v1/auth/me').then((r) => r.json());
+  const otherMe = await secondaryUser.page.request.get('/api/v1/auth/me').then((r) => r.json());
+  expect(adminMe.name).not.toBe(otherMe.name);
+  expect(adminMe.role.admin).toBe(true);
+  expect(otherMe.role.admin).toBe(false);
+});
+```
+
+The fixture is test-scoped and lazy, so the existing suite creates no extra users and keeps using
+`e2e/.auth/state.json` unchanged. Parallel workers receive different usernames and contexts. Multi-user
+specs must mutate only per-user resources (personal shelves, hidden/read state, annotations) or use an
+already-dedicated book lane and restore it; creating a second account does not make shared catalog writes
+safe while the suite is `fullyParallel` with two CI workers.

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -27,8 +27,19 @@ In CI, a same-repository PR whose concurrency/engine dependency closure changed 
 hard gate against `sha-<PR head>` — the dev-image workflow builds that exact commit and the test workflow
 waits for, then pins, its manifest digest. Frontend-only PRs retain the cheaper SPA-overlay route. To run
 the lane outside its automatic path classes, use **Actions → Test Suite → Run workflow** with `run_e2e`
-enabled. If that ref has no `sha-<commit>` dev image, dispatch **Build & Push - Dev - Split Strategy** for
-the same ref first; the test job fails rather than falling back to a different backend.
+enabled. This is a two-dispatch escape hatch for an old ref: first dispatch **Build & Push - Dev - Split
+Strategy** with both `ref=<old ref>` and a non-main `branch=` value, then dispatch **Test Suite** for the
+same ref with `run_e2e` enabled. Omitting `branch=` while dispatching from `main` advances the floating
+`:dev` channel to that old build; the immutable `sha-<commit>` tag needed by E2E is published either way.
+Manual E2E fails immediately when that tag was not prepared, rather than waiting for a producer that was
+never started or falling back to another backend. Automatic `dev`-branch E2E likewise fails fast with a
+stated reason because the dev-image workflow currently produces push images for `main`, not `dev`.
+
+The concurrency set is an intentionally bounded architectural approximation. Local imports are followed
+downward from explicit request/engine roots, including the high-write `cps/web.py` and `cps/kobo.py`
+surfaces; reverse dependents cannot be discovered by that traversal and must be added as roots. The
+two-level cutoff only bounds each root's dependency fan-out—it is not what excludes reverse dependents.
+At this revision the derived set is 110 of 215 local Python modules.
 
 ## What it covers (projects = matrix axes)
 

--- a/frontend/e2e/capabilities.ts
+++ b/frontend/e2e/capabilities.ts
@@ -1,0 +1,58 @@
+import { test, type APIRequestContext } from '@playwright/test';
+
+export interface RouteCapability {
+  method: string;
+  path: string;
+  /** Human-readable feature/route name used in the skip report. */
+  name: string;
+  /** Every-PR test that pins route registration independently of E2E. */
+  pinnedBy: string;
+}
+
+/**
+ * Ask Flask whether a route+method is registered.
+ *
+ * This is deliberately a PRESENCE probe only. It never sends a feature
+ * payload and never interprets a response body, so a present-but-broken route
+ * still runs the real spec and fails on correctness. Flask's automatic OPTIONS
+ * response is the contract: its Allow header lists methods for the matched
+ * rule without invoking the handler.
+ */
+export async function hasRouteCapability(
+  request: APIRequestContext,
+  capability: Pick<RouteCapability, 'method' | 'path'>,
+): Promise<boolean> {
+  const method = capability.method.toUpperCase();
+  if (method === 'GET' || method === 'HEAD' || method === 'OPTIONS') {
+    throw new Error(
+      `Route capability probes cannot safely use ${method}: the classic UI catch-all advertises GET, HEAD, and OPTIONS for unknown paths. `
+      + 'Probe a feature-specific mutation route so absence cannot be mistaken for presence.',
+    );
+  }
+  const response = await request.fetch(capability.path, {
+    method: 'OPTIONS',
+    failOnStatusCode: false,
+  });
+  if (response.status() === 404) return false;
+  const allowed = new Set(
+    (response.headers()['allow'] ?? '')
+      .split(',')
+      .map((method) => method.trim().toUpperCase())
+      .filter(Boolean),
+  );
+  return allowed.has(method);
+}
+
+/** Skip this spec, with a self-retiring reason, when the backend predates it. */
+export async function requireRouteCapability(
+  request: APIRequestContext,
+  capability: RouteCapability,
+): Promise<void> {
+  const present = await hasRouteCapability(request, capability);
+  test.skip(
+    !present,
+    `${capability.name} is absent from this lane's backend (${capability.method.toUpperCase()} ${capability.path}). `
+      + `This probes presence only; route registration is pinned on every PR by ${capability.pinnedBy}. `
+      + 'The skip retires itself as soon as the image contains the route.',
+  );
+}

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -1,0 +1,102 @@
+import {
+  test as base,
+  expect,
+  type BrowserContext,
+  type Page,
+} from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+
+export interface SecondaryUserSession {
+  id: number;
+  username: string;
+  password: string;
+  context: BrowserContext;
+  page: Page;
+}
+
+type MultiUserFixtures = {
+  /**
+   * A unique, non-admin viewer in a separate browser context.
+   *
+   * Creation and deletion use the primary admin's authenticated API session;
+   * login uses the production auth endpoint in its own browser context. The
+   * fixture is test-scoped, so existing specs pay nothing and parallel workers
+   * never share this account.
+   */
+  secondaryUser: SecondaryUserSession;
+};
+
+async function csrfToken(page: Page): Promise<string> {
+  const response = await page.request.get('/api/v1/auth/csrf');
+  expect(response.ok(), 'CSRF endpoint must answer while arranging the secondary user').toBeTruthy();
+  return ((await response.json()) as { csrf_token: string }).csrf_token;
+}
+
+export const test = base.extend<MultiUserFixtures>({
+  secondaryUser: [async ({ page: adminPage, browser, baseURL }, use, testInfo) => {
+    const suffix = randomUUID().replaceAll('-', '').slice(0, 12);
+    const project = testInfo.project.name.replace(/[^a-z0-9]/gi, '-').slice(0, 12);
+    const username = `e2e-${project}-${testInfo.workerIndex}-${suffix}`;
+    // Keep every policy class deterministic. A UUID slice can (rarely) contain
+    // only digits, which made the old generated password probabilistically
+    // fail instances requiring a lowercase character.
+    const password = `Aa7!zY9@${suffix}`;
+    const created = await adminPage.request.post('/api/v1/admin/users', {
+      headers: { 'X-CSRFToken': await csrfToken(adminPage) },
+      data: {
+        name: username,
+        email: `${username}@example.test`,
+        password,
+        roles: {
+          admin: false,
+          viewer: true,
+          download: true,
+          upload: false,
+          edit: false,
+          edit_shelfs: false,
+          delete_books: false,
+        },
+      },
+    });
+    expect(created.status(), await created.text()).toBe(201);
+    const { id } = (await created.json()) as { id: number };
+
+    let context: BrowserContext | undefined;
+    try {
+      context = await browser.newContext({ baseURL });
+      const secondaryPage = await context.newPage();
+      // BrowserContext.request shares this context's cookie jar. Calling the
+      // real login endpoint here creates an independent browser session without
+      // repeating the global setup's slower UI-login coverage in every test.
+      const secondaryCsrf = await context.request.get('/api/v1/auth/csrf');
+      expect(secondaryCsrf.ok()).toBeTruthy();
+      const loginResponse = await context.request.post('/api/v1/auth/login', {
+        headers: {
+          'X-CSRFToken': ((await secondaryCsrf.json()) as { csrf_token: string }).csrf_token,
+        },
+        data: { username, password, remember: false },
+      });
+      expect(loginResponse.ok(), await loginResponse.text()).toBeTruthy();
+      await secondaryPage.goto('/app');
+      await expect(secondaryPage.getByRole('button', { name: `Account: ${username}` })).toBeVisible();
+      const meResponse = await secondaryPage.request.get('/api/v1/auth/me');
+      expect(meResponse.ok(), 'secondary browser session should be authenticated').toBeTruthy();
+      const me = (await meResponse.json()) as {
+        name: string;
+        role: { admin: boolean };
+      };
+      expect(me.name).toBe(username);
+      expect(me.role.admin).toBe(false);
+
+      await use({ id, username, password, context, page: secondaryPage });
+    } finally {
+      await context?.close().catch(() => undefined);
+      const deleted = await adminPage.request.post(`/api/v1/admin/users/${id}/delete`, {
+        headers: { 'X-CSRFToken': await csrfToken(adminPage) },
+      });
+      expect(deleted.status(), await deleted.text()).toBe(204);
+    }
+  }, { timeout: 15_000 }],
+});
+
+export { expect } from '@playwright/test';

--- a/frontend/e2e/hidden-books.spec.ts
+++ b/frontend/e2e/hidden-books.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect, Page } from '@playwright/test';
+import { test, expect } from './fixtures';
+import type { Page } from '@playwright/test';
 import { assertNoHorizontalOverflow, collectPageErrors, assertNoPageErrors } from './utils';
 
 test.describe.configure({ mode: 'serial' });
@@ -151,40 +152,21 @@ test('hidden+archived remains recoverable through Show hidden, while Archived ke
   }
 });
 
-test('hiding is per-user and a non-delete user still receives Hide', async ({ page, playwright, baseURL }) => {
+test('hiding is per-user and a non-delete user still receives Hide', async ({ page, secondaryUser }) => {
   await page.goto('/app');
   const book = await firstBook(page);
   test.skip(!book, 'seed has no books');
   const headers = await csrfHeaders(page);
-  const username = `hidden-e2e-${Date.now()}`;
-  const password = 'CWNG-hidden-E2E-42!';
-  const created = await page.request.post('/api/v1/admin/users', {
-    headers,
-    data: {
-      name: username,
-      email: `${username}@example.test`,
-      password,
-      roles: { viewer: true, download: true, delete_books: false },
-    },
-  });
-  expect(created.ok(), await created.text()).toBeTruthy();
-  const other = await playwright.request.newContext({ baseURL });
 
   try {
     await page.goto(`/app/book/${book!.id}`);
     await page.getByTestId('hide-book-toggle').click();
 
-    const otherCsrf = await other.get('/api/v1/auth/csrf').then((r) => r.json());
-    const login = await other.post('/api/v1/auth/login', {
-      headers: { 'X-CSRFToken': otherCsrf.csrf_token },
-      data: { username, password },
-    });
-    expect(login.ok(), await login.text()).toBe(true);
-    const me = await other.get('/api/v1/auth/me').then((r) => r.json());
+    const me = await secondaryUser.page.request.get('/api/v1/auth/me').then((r) => r.json());
     expect(me.role.delete_books).toBe(false);
-    const otherBooks = await other.get('/api/v1/books?per_page=60').then((r) => r.json());
+    const otherBooks = await secondaryUser.page.request.get('/api/v1/books?per_page=60').then((r) => r.json());
     expect(otherBooks.items.some((item: { id: number }) => item.id === book!.id)).toBe(true);
-    const otherDetail = await other.get(`/api/v1/books/${book!.id}`).then((r) => r.json());
+    const otherDetail = await secondaryUser.page.request.get(`/api/v1/books/${book!.id}`).then((r) => r.json());
     expect(otherDetail.hidden).toBe(false);
 
     // UI role gate: Hide is personal and must not inherit the destructive
@@ -205,7 +187,6 @@ test('hiding is per-user and a non-delete user still receives Hide', async ({ pa
       headers, data: { hidden: false },
     });
     expect(cleanup.ok()).toBe(true);
-    await other.dispose();
   }
 });
 

--- a/frontend/e2e/tag-merge-delete.spec.ts
+++ b/frontend/e2e/tag-merge-delete.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page, type TestInfo } from '@playwright/test';
+import { requireRouteCapability } from './capabilities';
 
 /**
  * #973 — consolidating tags from the all-tags view.
@@ -30,11 +31,6 @@ async function tagsFromApi(page: Page): Promise<Entity[]> {
  * image, and :dev carries the routes once this lands, so both run for real —
  * the skip retires itself instead of silently hollowing out the gate.
  */
-async function serverHasTagMaintenance(page: Page): Promise<boolean> {
-  const res = await page.request.fetch('/api/v1/tags/1', { method: 'OPTIONS' });
-  return (res.headers()['allow'] ?? '').toUpperCase().includes('DELETE');
-}
-
 /**
  * Every test here destroys a tag, so none of them can borrow a seed row and put
  * it back the way tag-rename.spec.ts does — a merged or deleted tag cannot be
@@ -102,8 +98,12 @@ test.describe.configure({ mode: 'serial' });
 
 test.beforeEach(async ({ page }) => {
   await page.goto('/app/tags');
-  test.skip(!(await serverHasTagMaintenance(page)),
-    'server predates #973 (the PR e2e leg runs the :dev API with this branch\'s SPA)');
+  await requireRouteCapability(page.request, {
+    method: 'DELETE',
+    path: '/api/v1/tags/1',
+    name: '#973 tag maintenance',
+    pinnedBy: 'tests/unit/test_973_tag_merge_delete.py::test_delete_route_is_registered_for_tags',
+  });
 });
 
 test('a rename collision offers to merge instead of dead-ending', async ({ page }, testInfo) => {

--- a/scripts/alias-e2e-image.sh
+++ b/scripts/alias-e2e-image.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Give an image-neutral commit an immutable tag only when :dev demonstrably
+# names the newest image-relevant ancestor.  A missing/failed intervening build
+# must fail here; copying a stale floating tag would manufacture a verdict for
+# backend bytes that the subject commit does not contain.
+set -euo pipefail
+
+image="${1:?usage: alias-e2e-image.sh IMAGE SOURCE_SHA SUBJECT_SHA}"
+source_sha="${2:?usage: alias-e2e-image.sh IMAGE SOURCE_SHA SUBJECT_SHA}"
+subject_sha="${3:?usage: alias-e2e-image.sh IMAGE SOURCE_SHA SUBJECT_SHA}"
+repo_root="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel)}"
+classifier="${CLASSIFIER_PATH:-$repo_root/scripts/ci_path_classification.py}"
+
+if ! [[ "$source_sha" =~ ^[0-9a-f]{40,64}$ && "$subject_sha" =~ ^[0-9a-f]{40,64}$ ]]; then
+  echo "ERROR: image source and subject must be full commit IDs" >&2
+  exit 2
+fi
+
+expected_source="$(python3 "$classifier" \
+  --repo-root "$repo_root" --latest-image-commit "$subject_sha")"
+if [[ "$source_sha" != "$expected_source" ]]; then
+  echo "ERROR: refusing image alias: $source_sha is not the newest image-relevant ancestor of $subject_sha" >&2
+  echo "Expected source: $expected_source" >&2
+  exit 1
+fi
+if ! git -C "$repo_root" merge-base --is-ancestor "$source_sha" "$subject_sha"; then
+  echo "ERROR: refusing image alias: source $source_sha is not an ancestor of $subject_sha" >&2
+  exit 1
+fi
+
+manifest_digest() {
+  docker buildx imagetools inspect "$1" \
+    --format '{{json .Manifest.Digest}}' 2>/dev/null \
+    | tr -d '"[:space:]'
+}
+
+source_digest="$(manifest_digest "$image:sha-$source_sha" || true)"
+dev_digest="$(manifest_digest "$image:dev" || true)"
+if ! [[ "$source_digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+  echo "ERROR: immutable image $image:sha-$source_sha is missing or malformed" >&2
+  exit 1
+fi
+if [[ "$dev_digest" != "$source_digest" ]]; then
+  echo "ERROR: refusing image alias: :dev does not name source commit $source_sha" >&2
+  echo "The newest image-relevant build is missing, failed, or has not advanced :dev." >&2
+  exit 1
+fi
+
+docker buildx imagetools create \
+  -t "$image:sha-$subject_sha" \
+  "$image@$source_digest"

--- a/scripts/ci_path_classification.py
+++ b/scripts/ci_path_classification.py
@@ -31,7 +31,7 @@ CONCURRENCY_ROOTS = {
 # same architectural contract.  Helpers imported by these roots are discovered
 # from the AST below instead of being copied into this list.
 CONCURRENCY_PREFIXES = (
-    "cps/api/annotations",
+    "cps/api/",
     "cps/gevent",
     "cps/services/annotation_sync/",
 )

--- a/scripts/ci_path_classification.py
+++ b/scripts/ci_path_classification.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import ast
 import json
+import subprocess
 from pathlib import Path, PurePosixPath
 from typing import Iterable
 
@@ -20,8 +21,10 @@ CONCURRENCY_ROOTS = {
     "cps/__init__.py",
     "cps/annotations.py",
     "cps/db.py",
+    "cps/kobo.py",
     "cps/server.py",
     "cps/ub.py",
+    "cps/web.py",
 }
 
 # Prefixes cover package boundaries and future siblings whose names carry the
@@ -94,7 +97,14 @@ def _local_imports(path: Path, module: str) -> set[str]:
 
 
 def concurrency_paths(repo_root: Path) -> set[str]:
-    """Return the architectural roots plus their local import closure."""
+    """Return the architectural roots plus their downward import closure.
+
+    Import discovery follows dependencies imported *by* a root.  It cannot
+    discover modules that import a root (reverse dependents), so top-level
+    request surfaces such as ``web.py`` and ``kobo.py`` remain explicit roots.
+    The depth limit bounds how far each root's dependencies fan out; it is not
+    a substitute for naming those reverse-dependent entry points.
+    """
     module_paths: dict[str, Path] = {}
     for path in (repo_root / "cps").rglob("*.py"):
         relative = path.relative_to(repo_root).as_posix()
@@ -114,25 +124,31 @@ def concurrency_paths(repo_root: Path) -> set[str]:
     )
 
     discovered = set(root_modules)
+    depths = {module: 0 for module in root_modules}
     # cps/__init__.py is itself load-bearing, but walking its imports means
     # "concurrency-shaped" degenerates into almost every application module:
     # the app factory intentionally wires the whole program.  The other roots
     # are the engine/request surfaces whose dependencies we want to derive.
-    pending = [(module, 0) for module in root_modules if module != "cps"]
+    pending = [(module, 0) for module in sorted(root_modules) if module != "cps"]
     while pending:
         module, depth = pending.pop()
         path = module_paths.get(module)
         if path is None or depth >= 2:
             continue
-        for imported in _local_imports(path, module):
+        for imported in sorted(_local_imports(path, module)):
             # ``from cps.constants import ROLE_ADMIN`` records both the module
             # and a possible child name.  Keep actual Python modules only;
             # otherwise class/function names turn into thousands of imaginary
             # paths and make every unrelated edit look concurrency-shaped.
-            if imported not in module_paths or imported in discovered:
+            if imported not in module_paths:
                 continue
+            imported_depth = depth + 1
+            previous_depth = depths.get(imported)
+            if previous_depth is not None and previous_depth <= imported_depth:
+                continue
+            depths[imported] = imported_depth
             discovered.add(imported)
-            pending.append((imported, depth + 1))
+            pending.append((imported, imported_depth))
 
     paths = set(CONCURRENCY_ROOTS)
     for module in discovered:
@@ -147,12 +163,72 @@ def concurrency_paths(repo_root: Path) -> set[str]:
     return paths
 
 
-def classify_paths(paths: Iterable[str], repo_root: Path) -> dict[str, bool]:
-    changed = {
+def _clean_paths(paths: Iterable[str]) -> set[str]:
+    return {
         clean[2:] if clean.startswith("./") else clean
         for path in paths
         if (clean := path.strip())
     }
+
+
+def image_paths_changed(paths: Iterable[str]) -> bool:
+    """Whether a commit changes bytes that can affect the dev image."""
+    changed = _clean_paths(paths)
+    return any(
+        not (
+            path.endswith(".md")
+            or path.startswith(("docs/", "tests/", ".github/"))
+        )
+        for path in changed
+    )
+
+
+def _git(repo_root: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+def latest_image_commit(repo_root: Path, head: str) -> str:
+    """Newest first-parent commit at/before ``head`` that affects the image.
+
+    A neutral commit may reuse an earlier image only when this exact commit's
+    immutable tag is what ``:dev`` currently names.  Walking first-parent
+    history makes intervening image-relevant main commits impossible to skip.
+    """
+    commits = _git(repo_root, "rev-list", "--first-parent", head).splitlines()
+    for commit in commits:
+        commit_and_parents = _git(
+            repo_root, "rev-list", "--parents", "-n", "1", commit
+        ).split()
+        if len(commit_and_parents) == 1:
+            changed = _git(
+                repo_root,
+                "diff-tree",
+                "--root",
+                "--no-commit-id",
+                "--name-only",
+                "-r",
+                commit,
+            ).splitlines()
+        else:
+            # Main is normally squash-merged, but compare an actual merge to
+            # its first parent too; plain `diff-tree` can emit no paths for a
+            # merge commit and would let the alias skip relevant bytes.
+            changed = _git(
+                repo_root, "diff", "--name-only", commit_and_parents[1], commit
+            ).splitlines()
+        if image_paths_changed(changed):
+            return commit
+    raise ValueError(f"no image-relevant commit is reachable from {head}")
+
+
+def classify_paths(paths: Iterable[str], repo_root: Path) -> dict[str, bool]:
+    changed = _clean_paths(paths)
     concurrency = concurrency_paths(repo_root)
 
     frontend = any(
@@ -178,13 +254,7 @@ def classify_paths(paths: Iterable[str], repo_root: Path) -> dict[str, bool]:
     # alias job can consume.  Image-neutral main commits still get an immutable
     # sha tag pointing at the unchanged :dev manifest; they do not rebuild or
     # move :dev and therefore do not restart the canary deployment.
-    image = any(
-        not (
-            path.endswith(".md")
-            or path.startswith(("docs/", "tests/", ".github/"))
-        )
-        for path in changed
-    )
+    image = image_paths_changed(changed)
     return {
         "frontend": frontend,
         "build": build,
@@ -201,10 +271,25 @@ def main() -> int:
         type=Path,
         help="append key=value records for a GitHub Actions step",
     )
+    parser.add_argument(
+        "--latest-image-commit",
+        metavar="REV",
+        help="print the newest image-relevant first-parent commit at/before REV",
+    )
     parser.add_argument("paths", nargs="*", help="paths; stdin is used when omitted")
     args = parser.parse_args()
+    repo_root = args.repo_root.resolve()
+    if args.latest_image_commit:
+        if args.github_output or args.paths:
+            parser.error("--latest-image-commit cannot be combined with path classification")
+        try:
+            print(latest_image_commit(repo_root, args.latest_image_commit))
+        except (subprocess.CalledProcessError, ValueError) as exc:
+            parser.error(str(exc))
+        return 0
+
     paths = args.paths or [line for line in __import__("sys").stdin.read().splitlines()]
-    result = classify_paths(paths, args.repo_root.resolve())
+    result = classify_paths(paths, repo_root)
 
     if args.github_output:
         with args.github_output.open("a", encoding="utf-8") as output:

--- a/scripts/ci_path_classification.py
+++ b/scripts/ci_path_classification.py
@@ -1,0 +1,219 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Classify pull-request paths for the CI lanes that must run.
+
+The concurrency class deliberately starts from architectural entry points and
+walks their local Python imports.  It does not enumerate request-handler call
+sites: a newly extracted engine helper becomes protected as soon as one of the
+entry points imports it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+from pathlib import Path, PurePosixPath
+from typing import Iterable
+
+
+CONCURRENCY_ROOTS = {
+    "cps/__init__.py",
+    "cps/annotations.py",
+    "cps/db.py",
+    "cps/server.py",
+    "cps/ub.py",
+}
+
+# Prefixes cover package boundaries and future siblings whose names carry the
+# same architectural contract.  Helpers imported by these roots are discovered
+# from the AST below instead of being copied into this list.
+CONCURRENCY_PREFIXES = (
+    "cps/api/annotations",
+    "cps/gevent",
+    "cps/services/annotation_sync/",
+)
+
+HARNESS_PATHS = {
+    ".github/workflows/docker-image-build-dev.yml",
+    ".github/workflows/tests.yml",
+    "scripts/ci_path_classification.py",
+}
+
+
+def _path_to_module(path: str) -> str | None:
+    candidate = PurePosixPath(path)
+    if candidate.suffix != ".py" or not candidate.parts or candidate.parts[0] != "cps":
+        return None
+    parts = list(candidate.with_suffix("").parts)
+    if parts[-1] == "__init__":
+        parts.pop()
+    return ".".join(parts)
+
+
+def _relative_base(module: str, is_package: bool, level: int) -> list[str]:
+    package = module.split(".") if is_package else module.split(".")[:-1]
+    # ``from .x`` stays in the current package; every extra dot climbs once.
+    climbs = max(level - 1, 0)
+    return package[: max(len(package) - climbs, 0)]
+
+
+def _local_imports(path: Path, module: str) -> set[str]:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (OSError, SyntaxError, UnicodeDecodeError):
+        # Other gates own syntax/import failures.  Classification must remain
+        # conservative and keep the root itself protected.
+        return set()
+
+    imports: set[str] = set()
+    is_package = path.name == "__init__.py"
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names if alias.name.startswith("cps"))
+            continue
+        if not isinstance(node, ast.ImportFrom):
+            continue
+
+        if node.level:
+            base_parts = _relative_base(module, is_package, node.level)
+            if node.module:
+                base_parts.extend(node.module.split("."))
+            base = ".".join(base_parts)
+        else:
+            base = node.module or ""
+
+        if base.startswith("cps"):
+            imports.add(base)
+        for alias in node.names:
+            if alias.name == "*":
+                continue
+            child = ".".join(part for part in (base, alias.name) if part)
+            if child.startswith("cps"):
+                imports.add(child)
+    return imports
+
+
+def concurrency_paths(repo_root: Path) -> set[str]:
+    """Return the architectural roots plus their local import closure."""
+    module_paths: dict[str, Path] = {}
+    for path in (repo_root / "cps").rglob("*.py"):
+        relative = path.relative_to(repo_root).as_posix()
+        module = _path_to_module(relative)
+        if module:
+            module_paths[module] = path
+
+    root_modules = {
+        module
+        for path in CONCURRENCY_ROOTS
+        if (module := _path_to_module(path)) is not None
+    }
+    root_modules.update(
+        module
+        for module, path in module_paths.items()
+        if path.relative_to(repo_root).as_posix().startswith(CONCURRENCY_PREFIXES)
+    )
+
+    discovered = set(root_modules)
+    # cps/__init__.py is itself load-bearing, but walking its imports means
+    # "concurrency-shaped" degenerates into almost every application module:
+    # the app factory intentionally wires the whole program.  The other roots
+    # are the engine/request surfaces whose dependencies we want to derive.
+    pending = [(module, 0) for module in root_modules if module != "cps"]
+    while pending:
+        module, depth = pending.pop()
+        path = module_paths.get(module)
+        if path is None or depth >= 2:
+            continue
+        for imported in _local_imports(path, module):
+            # ``from cps.constants import ROLE_ADMIN`` records both the module
+            # and a possible child name.  Keep actual Python modules only;
+            # otherwise class/function names turn into thousands of imaginary
+            # paths and make every unrelated edit look concurrency-shaped.
+            if imported not in module_paths or imported in discovered:
+                continue
+            discovered.add(imported)
+            pending.append((imported, depth + 1))
+
+    paths = set(CONCURRENCY_ROOTS)
+    for module in discovered:
+        path = module_paths.get(module)
+        if path is not None:
+            paths.add(path.relative_to(repo_root).as_posix())
+    paths.update(
+        path.relative_to(repo_root).as_posix()
+        for path in module_paths.values()
+        if path.relative_to(repo_root).as_posix().startswith(CONCURRENCY_PREFIXES)
+    )
+    return paths
+
+
+def classify_paths(paths: Iterable[str], repo_root: Path) -> dict[str, bool]:
+    changed = {
+        clean[2:] if clean.startswith("./") else clean
+        for path in paths
+        if (clean := path.strip())
+    }
+    concurrency = concurrency_paths(repo_root)
+
+    frontend = any(
+        path.startswith(("frontend/", "cps/static/app/")) or path in HARNESS_PATHS
+        for path in changed
+    )
+    build = any(
+        path == "Dockerfile"
+        or ("/" not in path and "requirements" in path and path.endswith(".txt"))
+        or path.startswith(("root/", "cps/", "scripts/", "tests/docker/", "tests/integration/"))
+        and (
+            not path.startswith("cps/")
+            or path.endswith(".py")
+        )
+        or path == ".github/workflows/tests.yml"
+        for path in changed
+    )
+    concurrency_touched = any(
+        path in concurrency or path.startswith(CONCURRENCY_PREFIXES)
+        for path in changed
+    )
+    # Mirrors the dev channel's historical paths-ignore policy, but as data an
+    # alias job can consume.  Image-neutral main commits still get an immutable
+    # sha tag pointing at the unchanged :dev manifest; they do not rebuild or
+    # move :dev and therefore do not restart the canary deployment.
+    image = any(
+        not (
+            path.endswith(".md")
+            or path.startswith(("docs/", "tests/", ".github/"))
+        )
+        for path in changed
+    )
+    return {
+        "frontend": frontend,
+        "build": build,
+        "concurrency": concurrency_touched,
+        "image": image,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument(
+        "--github-output",
+        type=Path,
+        help="append key=value records for a GitHub Actions step",
+    )
+    parser.add_argument("paths", nargs="*", help="paths; stdin is used when omitted")
+    args = parser.parse_args()
+    paths = args.paths or [line for line in __import__("sys").stdin.read().splitlines()]
+    result = classify_paths(paths, args.repo_root.resolve())
+
+    if args.github_output:
+        with args.github_output.open("a", encoding="utf-8") as output:
+            for key, value in result.items():
+                output.write(f"{key}={'true' if value else 'false'}\n")
+    else:
+        print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/resolve-e2e-image.sh
+++ b/scripts/resolve-e2e-image.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Resolve a mutable/awaited registry tag once, then hand Docker an immutable
+# digest reference.  There is deliberately no fallback tag: absence means the
+# subject image is unknown, so the caller must fail without running a verdict.
+set -euo pipefail
+
+image="${1:?usage: resolve-e2e-image.sh IMAGE TAG [ATTEMPTS] [DELAY_SECONDS]}"
+tag="${2:?usage: resolve-e2e-image.sh IMAGE TAG [ATTEMPTS] [DELAY_SECONDS]}"
+attempts="${3:-80}"
+delay_seconds="${4:-30}"
+
+if ! [[ "$attempts" =~ ^[1-9][0-9]*$ && "$delay_seconds" =~ ^[0-9]+$ ]]; then
+  echo "attempts must be positive and delay must be non-negative" >&2
+  exit 2
+fi
+
+tagged_ref="${image}:${tag}"
+for ((attempt = 1; attempt <= attempts; attempt++)); do
+  digest="$({ docker buildx imagetools inspect "$tagged_ref" \
+    --format '{{json .Manifest.Digest}}' 2>/dev/null || true; } | tr -d '"[:space:]')"
+  if [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+    echo "resolved ${tagged_ref} to ${digest} on attempt ${attempt}/${attempts}" >&2
+    printf '%s@%s\n' "$image" "$digest"
+    exit 0
+  fi
+  if (( attempt < attempts )); then
+    echo "${tagged_ref} is not published yet (attempt ${attempt}/${attempts}); waiting ${delay_seconds}s" >&2
+    sleep "$delay_seconds"
+  fi
+done
+
+echo "ERROR: ${tagged_ref} never resolved to a manifest digest after ${attempts} attempts" >&2
+echo "Refusing to run E2E because the triggering commit's image cannot be identified." >&2
+exit 1

--- a/scripts/resolve-e2e-image.sh
+++ b/scripts/resolve-e2e-image.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 image="${1:?usage: resolve-e2e-image.sh IMAGE TAG [ATTEMPTS] [DELAY_SECONDS]}"
 tag="${2:?usage: resolve-e2e-image.sh IMAGE TAG [ATTEMPTS] [DELAY_SECONDS]}"
-attempts="${3:-80}"
+attempts="${3:-240}"
 delay_seconds="${4:-30}"
 
 if ! [[ "$attempts" =~ ^[1-9][0-9]*$ && "$delay_seconds" =~ ^[0-9]+$ ]]; then

--- a/tests/unit/test_ci_e2e_commit_gate.py
+++ b/tests/unit/test_ci_e2e_commit_gate.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 from pathlib import Path
@@ -33,6 +34,7 @@ ALIASER = REPO / "scripts" / "alias-e2e-image.sh"
         "cps/services/annotation_sync/hardcover.py",
         "cps/annotations.py",
         "cps/web.py",
+        "cps/api/shelves.py",
     ],
 )
 def test_named_engine_and_concurrency_surfaces_trigger_e2e(path):
@@ -40,8 +42,8 @@ def test_named_engine_and_concurrency_surfaces_trigger_e2e(path):
     assert result["concurrency"] is True, path
 
 
-def test_unrelated_backend_route_does_not_pay_for_concurrency_e2e():
-    result = classify_paths(["cps/api/books.py"], REPO)
+def test_unrelated_backend_module_does_not_pay_for_concurrency_e2e():
+    result = classify_paths(["cps/audio.py"], REPO)
     assert result["build"] is True
     assert result["concurrency"] is False
 
@@ -76,11 +78,11 @@ def test_documented_classifier_scope_matches_the_tree_and_names_the_real_limit()
 
 def test_concurrency_closure_is_independent_of_python_hash_order():
     command = (
-        "from pathlib import Path; "
+        "import json; from pathlib import Path; "
         "from scripts.ci_path_classification import concurrency_paths; "
-        "print(len(concurrency_paths(Path.cwd())))"
+        "print(json.dumps(sorted(concurrency_paths(Path.cwd()))))"
     )
-    counts = set()
+    path_sets = set()
     for seed in ("1", "2", "3", "42"):
         env = {**os.environ, "PYTHONHASHSEED": seed}
         proc = subprocess.run(
@@ -92,8 +94,8 @@ def test_concurrency_closure_is_independent_of_python_hash_order():
             text=True,
             timeout=10,
         )
-        counts.add(int(proc.stdout.strip()))
-    assert counts == {len(concurrency_paths(REPO))}
+        path_sets.add(frozenset(json.loads(proc.stdout)))
+    assert path_sets == {frozenset(concurrency_paths(REPO))}
 
 
 def test_workflows_wire_nonfork_concurrency_to_a_commit_image_and_hard_gate():

--- a/tests/unit/test_ci_e2e_commit_gate.py
+++ b/tests/unit/test_ci_e2e_commit_gate.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Behavioural proofs for #1927's E2E trigger and image-subject gate."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.ci_path_classification import classify_paths, concurrency_paths
+
+
+pytestmark = pytest.mark.unit
+
+REPO = Path(__file__).resolve().parents[2]
+TESTS_WORKFLOW = REPO / ".github" / "workflows" / "tests.yml"
+DEV_WORKFLOW = REPO / ".github" / "workflows" / "docker-image-build-dev.yml"
+RESOLVER = REPO / "scripts" / "resolve-e2e-image.sh"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "cps/ub.py",
+        "cps/db.py",
+        "cps/__init__.py",
+        "cps/server.py",
+        "cps/gevent_wsgi.py",
+        "cps/services/annotation_sync/hardcover.py",
+        "cps/annotations.py",
+    ],
+)
+def test_named_engine_and_concurrency_surfaces_trigger_e2e(path):
+    result = classify_paths([path], REPO)
+    assert result["concurrency"] is True, path
+
+
+def test_unrelated_backend_route_does_not_pay_for_concurrency_e2e():
+    result = classify_paths(["cps/api/books.py"], REPO)
+    assert result["build"] is True
+    assert result["concurrency"] is False
+
+
+def test_concurrency_set_derives_new_helpers_from_imports(tmp_path):
+    cps = tmp_path / "cps"
+    cps.mkdir()
+    (cps / "__init__.py").write_text("", encoding="utf-8")
+    (cps / "ub.py").write_text("from . import engine_helper\n", encoding="utf-8")
+    (cps / "engine_helper.py").write_text("from . import sqlite_tuning\n", encoding="utf-8")
+    (cps / "sqlite_tuning.py").write_text("WAL = True\n", encoding="utf-8")
+    (cps / "unrelated.py").write_text("VALUE = 1\n", encoding="utf-8")
+
+    derived = concurrency_paths(tmp_path)
+    assert "cps/engine_helper.py" in derived
+    assert "cps/sqlite_tuning.py" in derived
+    assert "cps/unrelated.py" not in derived
+
+
+def test_workflows_wire_nonfork_concurrency_to_a_commit_image_and_hard_gate():
+    tests = TESTS_WORKFLOW.read_text(encoding="utf-8")
+    dev = DEV_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "outputs.concurrency == 'true'" in tests
+    assert "github.event.pull_request.head.repo.fork != true" in tests
+    assert "IS_CONCURRENCY_PR" in tests
+    assert 'needs.e2e-tests.result }}" != "success"' in tests
+    assert "sha-$SUBJECT_SHA" in tests
+    assert "resolve-e2e-image.sh" in tests
+    assert "pull_request:" in dev
+    assert "sha-$(git rev-parse HEAD)" in dev
+    assert "full_build=$full_build" in dev
+
+
+def _stubbed_resolve(tmp_path: Path, succeeds_on: int | None, digest: str | None = None):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    state = tmp_path / "calls"
+    docker = bin_dir / "docker"
+    docker.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -eu\n"
+        "n=0; [[ -f \"$STUB_STATE\" ]] && n=$(cat \"$STUB_STATE\")\n"
+        "n=$((n+1)); echo \"$n\" > \"$STUB_STATE\"\n"
+        "if [[ -n \"${STUB_SUCCEEDS_ON:-}\" && $n -ge $STUB_SUCCEEDS_ON ]]; then\n"
+        "  printf '\"%s\"\\n' \"${STUB_DIGEST}\"\n"
+        "  exit 0\n"
+        "fi\n"
+        "exit 1\n",
+        encoding="utf-8",
+    )
+    docker.chmod(0o755)
+    env = {
+        **os.environ,
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "STUB_STATE": str(state),
+        "STUB_SUCCEEDS_ON": "" if succeeds_on is None else str(succeeds_on),
+        "STUB_DIGEST": digest or "sha256:" + "a" * 64,
+    }
+    proc = subprocess.run(
+        ["bash", str(RESOLVER), "registry.example/project/app", "sha-deadbeef", "3", "0"],
+        cwd=REPO,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    return proc, int(state.read_text(encoding="utf-8"))
+
+
+def test_resolver_waits_then_returns_only_an_immutable_digest(tmp_path):
+    proc, calls = _stubbed_resolve(tmp_path, succeeds_on=3)
+    assert proc.returncode == 0, proc.stderr
+    assert calls == 3
+    assert proc.stdout.strip() == "registry.example/project/app@sha256:" + "a" * 64
+    assert "attempt 3/3" in proc.stderr
+
+
+def test_resolver_fails_loudly_without_falling_back_to_dev(tmp_path):
+    proc, calls = _stubbed_resolve(tmp_path, succeeds_on=None)
+    assert proc.returncode == 1
+    assert calls == 3
+    assert proc.stdout == ""
+    assert "Refusing to run E2E" in proc.stderr
+    assert ":dev" not in proc.stderr
+
+
+def test_resolver_rejects_a_non_digest_response(tmp_path):
+    proc, calls = _stubbed_resolve(tmp_path, succeeds_on=1, digest="dev")
+    assert proc.returncode == 1
+    assert calls == 3
+    assert proc.stdout == ""

--- a/tests/unit/test_ci_e2e_commit_gate.py
+++ b/tests/unit/test_ci_e2e_commit_gate.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pytest
 
-from scripts.ci_path_classification import classify_paths, concurrency_paths
+from scripts.ci_path_classification import _path_to_module, classify_paths, concurrency_paths
 
 
 pytestmark = pytest.mark.unit
@@ -18,6 +18,7 @@ REPO = Path(__file__).resolve().parents[2]
 TESTS_WORKFLOW = REPO / ".github" / "workflows" / "tests.yml"
 DEV_WORKFLOW = REPO / ".github" / "workflows" / "docker-image-build-dev.yml"
 RESOLVER = REPO / "scripts" / "resolve-e2e-image.sh"
+ALIASER = REPO / "scripts" / "alias-e2e-image.sh"
 
 
 @pytest.mark.parametrize(
@@ -26,10 +27,12 @@ RESOLVER = REPO / "scripts" / "resolve-e2e-image.sh"
         "cps/ub.py",
         "cps/db.py",
         "cps/__init__.py",
+        "cps/kobo.py",
         "cps/server.py",
         "cps/gevent_wsgi.py",
         "cps/services/annotation_sync/hardcover.py",
         "cps/annotations.py",
+        "cps/web.py",
     ],
 )
 def test_named_engine_and_concurrency_surfaces_trigger_e2e(path):
@@ -58,6 +61,41 @@ def test_concurrency_set_derives_new_helpers_from_imports(tmp_path):
     assert "cps/unrelated.py" not in derived
 
 
+def test_documented_classifier_scope_matches_the_tree_and_names_the_real_limit():
+    derived = concurrency_paths(REPO)
+    modules = {
+        module
+        for path in (REPO / "cps").rglob("*.py")
+        if (module := _path_to_module(path.relative_to(REPO).as_posix())) is not None
+    }
+    readme = (REPO / "frontend" / "e2e" / "README.md").read_text(encoding="utf-8")
+    assert f"{len(derived)} of {len(modules)} local Python modules" in readme
+    assert "reverse dependents cannot be discovered" in readme
+    assert "two-level cutoff" in readme
+
+
+def test_concurrency_closure_is_independent_of_python_hash_order():
+    command = (
+        "from pathlib import Path; "
+        "from scripts.ci_path_classification import concurrency_paths; "
+        "print(len(concurrency_paths(Path.cwd())))"
+    )
+    counts = set()
+    for seed in ("1", "2", "3", "42"):
+        env = {**os.environ, "PYTHONHASHSEED": seed}
+        proc = subprocess.run(
+            ["python3", "-c", command],
+            cwd=REPO,
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        counts.add(int(proc.stdout.strip()))
+    assert counts == {len(concurrency_paths(REPO))}
+
+
 def test_workflows_wire_nonfork_concurrency_to_a_commit_image_and_hard_gate():
     tests = TESTS_WORKFLOW.read_text(encoding="utf-8")
     dev = DEV_WORKFLOW.read_text(encoding="utf-8")
@@ -71,6 +109,155 @@ def test_workflows_wire_nonfork_concurrency_to_a_commit_image_and_hard_gate():
     assert "pull_request:" in dev
     assert "sha-$(git rev-parse HEAD)" in dev
     assert "full_build=$full_build" in dev
+
+
+def test_pr_classification_executes_the_base_copy_in_both_consumers():
+    """A PR must not narrow the policy that decides whether its gate runs."""
+    for workflow in (TESTS_WORKFLOW, DEV_WORKFLOW):
+        text = workflow.read_text(encoding="utf-8")
+        assert 'classifier_ref="$BASE_SHA"' in text, workflow.name
+        assert 'classifier_ref="$HEAD_SHA"' not in text
+        assert "frontend=true\\nbuild=true\\nconcurrency=true\\nimage=true" in text
+        assert 'git archive "$classifier_ref" cps scripts/ci_path_classification.py' in text
+        assert 'python3 "$classifier_root/scripts/ci_path_classification.py"' in text
+        assert "| python3 scripts/ci_path_classification.py --github-output" not in text
+
+
+def test_wait_budget_covers_the_build_pipeline_and_retrying_suite():
+    """The resolver cannot time out before the producer's own job budgets."""
+    import re
+    import yaml
+
+    tests = yaml.safe_load(TESTS_WORKFLOW.read_text(encoding="utf-8"))
+    dev = yaml.safe_load(DEV_WORKFLOW.read_text(encoding="utf-8"))
+    e2e = tests["jobs"]["e2e-tests"]
+    resolve = next(step for step in e2e["steps"] if step.get("name") == "Resolve image to test")
+    script = resolve["run"]
+    awaited_attempts = [int(value) for value in re.findall(r"attempts=(\d+)", script) if value != "1"]
+    assert awaited_attempts and len(set(awaited_attempts)) == 1
+    wait_seconds = (awaited_attempts[0] - 1) * 30
+
+    jobs = dev["jobs"]
+    producer_minutes = (
+        jobs["classify"]["timeout-minutes"]
+        + jobs["ensure-mirror"]["timeout-minutes"]
+        + max(jobs["build-amd64"]["timeout-minutes"], jobs["build-arm"]["timeout-minutes"])
+        + jobs["merge"]["timeout-minutes"]
+    )
+    assert wait_seconds >= (producer_minutes + 20) * 60
+    assert e2e["timeout-minutes"] * 60 - wait_seconds >= 60 * 60
+
+
+def test_dev_push_fails_fast_instead_of_waiting_for_a_nonexistent_producer():
+    import yaml
+
+    workflow = yaml.safe_load(TESTS_WORKFLOW.read_text(encoding="utf-8"))
+    e2e = workflow["jobs"]["e2e-tests"]
+    refusal = next(
+        step for step in e2e["steps"] if step.get("name") == "Refuse unsupported dev-branch image wait"
+    )
+    condition = str(refusal.get("if") or "")
+    assert "refs/heads/dev" in condition and "github.event_name == 'push'" in condition
+    assert "exit 1" in refusal["run"]
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+def _commit(repo: Path, message: str, path: str, content: str) -> str:
+    target = repo / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+    _git(repo, "add", path)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=test",
+            "-c",
+            "user.email=test@example.invalid",
+            "commit",
+            "-m",
+            message,
+        ],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def _run_alias(tmp_path: Path, source: str, subject: str, *, dev_matches: bool = True):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    log = tmp_path / "docker.log"
+    log.unlink(missing_ok=True)
+    docker = bin_dir / "docker"
+    docker.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -eu\n"
+        "if [[ \"$1 $2 $3\" == \"buildx imagetools inspect\" ]]; then\n"
+        "  if [[ \"$4\" == *:dev ]]; then printf '\"%s\"\\n' \"$DEV_DIGEST\"; "
+        "else printf '\"%s\"\\n' \"$SOURCE_DIGEST\"; fi\n"
+        "  exit 0\n"
+        "fi\n"
+        "printf '%s\\n' \"$*\" >> \"$DOCKER_LOG\"\n",
+        encoding="utf-8",
+    )
+    docker.chmod(0o755)
+    digest = "sha256:" + "a" * 64
+    env = {
+        **os.environ,
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "GITHUB_WORKSPACE": str(tmp_path),
+        "CLASSIFIER_PATH": str(REPO / "scripts" / "ci_path_classification.py"),
+        "SOURCE_DIGEST": digest,
+        "DEV_DIGEST": digest if dev_matches else "sha256:" + "b" * 64,
+        "DOCKER_LOG": str(log),
+    }
+    proc = subprocess.run(
+        ["bash", str(ALIASER), "registry.example/project/app", source, subject],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    return proc, log.read_text(encoding="utf-8") if log.exists() else ""
+
+
+def test_neutral_alias_requires_the_newest_relevant_ancestor_and_matching_dev(tmp_path):
+    _git(tmp_path, "init", "-q")
+    source = _commit(tmp_path, "backend", "cps/web.py", "WRITE = 1\n")
+    subject = _commit(tmp_path, "docs", "docs/usage.md", "docs\n")
+
+    proc, log = _run_alias(tmp_path, source, subject)
+    assert proc.returncode == 0, proc.stderr
+    assert f"-t registry.example/project/app:sha-{subject}" in log
+    assert "registry.example/project/app@sha256:" + "a" * 64 in log
+
+    stale, log = _run_alias(tmp_path, source, subject, dev_matches=False)
+    assert stale.returncode == 1
+    assert ":dev does not name source commit" in stale.stderr
+    assert log == ""
+
+
+def test_neutral_alias_rejects_an_intervening_image_relevant_commit(tmp_path):
+    _git(tmp_path, "init", "-q")
+    old_source = _commit(tmp_path, "old backend", "cps/web.py", "WRITE = 1\n")
+    _commit(tmp_path, "middle docs", "docs/one.md", "one\n")
+    new_source = _commit(tmp_path, "new backend", "cps/kobo.py", "WRITE = 2\n")
+    subject = _commit(tmp_path, "new docs", "docs/two.md", "two\n")
+
+    proc, log = _run_alias(tmp_path, old_source, subject)
+    assert proc.returncode == 1
+    assert "is not the newest image-relevant ancestor" in proc.stderr
+    assert f"Expected source: {new_source}" in proc.stderr
+    assert log == ""
 
 
 def _stubbed_resolve(tmp_path: Path, succeeds_on: int | None, digest: str | None = None):

--- a/tests/unit/test_dev_image_build_once_when_image_relevant_never_when_ignored.py
+++ b/tests/unit/test_dev_image_build_once_when_image_relevant_never_when_ignored.py
@@ -70,6 +70,8 @@ from pathlib import Path
 
 import pytest
 
+from scripts.ci_path_classification import classify_paths
+
 try:
     import yaml
 except ImportError:  # pragma: no cover - yaml ships with most distros
@@ -152,10 +154,8 @@ def _dev_push_trigger() -> dict:
 
 
 def _dev_push_fires(changed_paths: list) -> bool:
-    """The dev build's push trigger fires unless EVERY changed path is
-    covered by paths-ignore."""
-    ignores = _dev_push_trigger().get("paths-ignore") or []
-    return any(not _matches_any(p, ignores) for p in changed_paths)
+    """The workflow runs on every main push; only image-relevant paths build."""
+    return classify_paths(changed_paths, REPO_ROOT)["image"]
 
 
 def _translations_runs(changed_paths: list) -> bool:
@@ -374,17 +374,16 @@ def test_translation_commit_push_self_triggers_ci_premise():
     )
 
 
-def test_dev_workflow_keeps_its_push_trigger_and_paths_ignore():
-    """Architecture pin for the matrix: the push trigger on main is the
-    intended single build path. Deleting it and keeping only the dispatch
-    would also produce 'one build per merge' on code pushes — while breaking
-    paths-ignore, non-main dev builds, and the docs-only skip. The count
-    alone must not bless that rewrite."""
-    push = _dev_push_trigger()
-    ignores = push.get("paths-ignore") or []
-    assert ignores, (
-        "docker-image-build-dev.yml lost its paths-ignore list — docs-only "
-        "merges would pay for a full image build again"
-    )
-    for pattern in ("**.md", "docs/**", "tests/**", ".github/**"):
-        assert pattern in ignores, f"paths-ignore lost {pattern!r}"
+def test_dev_workflow_keeps_push_trigger_and_aliases_image_neutral_commits():
+    """Docs/tests commits get a sha identity without rebuilding or moving dev."""
+    _dev_push_trigger()
+    wf = _load(DEV_WF)
+    jobs = wf.get("jobs") or {}
+    classifier = jobs.get("classify") or {}
+    alias = jobs.get("alias-image-neutral-commit") or {}
+    assert classifier, "dev workflow lost its path-classification job"
+    assert alias, "image-neutral commits no longer get an immutable sha alias"
+    assert "alias_image" in str(alias.get("if") or "")
+    assert classify_paths(["docs/usage.md"], REPO_ROOT)["image"] is False
+    assert classify_paths(["tests/unit/test_example.py"], REPO_ROOT)["image"] is False
+    assert classify_paths(["cps/web.py"], REPO_ROOT)["image"] is True

--- a/tests/unit/test_dev_image_build_once_when_image_relevant_never_when_ignored.py
+++ b/tests/unit/test_dev_image_build_once_when_image_relevant_never_when_ignored.py
@@ -375,7 +375,7 @@ def test_translation_commit_push_self_triggers_ci_premise():
 
 
 def test_dev_workflow_keeps_push_trigger_and_aliases_image_neutral_commits():
-    """Docs/tests commits get a sha identity without rebuilding or moving dev."""
+    """Neutral commits alias only from the classifier-proven source commit."""
     _dev_push_trigger()
     wf = _load(DEV_WF)
     jobs = wf.get("jobs") or {}
@@ -384,6 +384,25 @@ def test_dev_workflow_keeps_push_trigger_and_aliases_image_neutral_commits():
     assert classifier, "dev workflow lost its path-classification job"
     assert alias, "image-neutral commits no longer get an immutable sha alias"
     assert "alias_image" in str(alias.get("if") or "")
+    outputs = classifier.get("outputs") or {}
+    assert "image_source" in outputs
+    publish = next(
+        step for step in alias.get("steps") or [] if step.get("name") == "Publish immutable commit alias"
+    )
+    assert "needs.classify.outputs.image_source" in str((publish.get("env") or {}).get("IMAGE_SOURCE"))
+    assert "alias-e2e-image.sh" in str(publish.get("run") or "")
     assert classify_paths(["docs/usage.md"], REPO_ROOT)["image"] is False
     assert classify_paths(["tests/unit/test_example.py"], REPO_ROOT)["image"] is False
     assert classify_paths(["cps/web.py"], REPO_ROOT)["image"] is True
+
+
+def test_main_image_runs_serialize_while_pr_verification_can_cancel() -> None:
+    """A later neutral main push must not cancel its image-relevant ancestor."""
+    wf = _load(DEV_WF)
+    concurrency = wf.get("concurrency") or {}
+    cancel = str(concurrency.get("cancel-in-progress") or "")
+    assert "github.event_name == 'pull_request'" in cancel, (
+        "cancel-in-progress must be true only for superseded PR verification; "
+        "main/manual artifact publication must serialize"
+    )
+    assert "github.ref" in str(concurrency.get("group") or "")

--- a/tests/unit/test_dockerfile_contributor_build.py
+++ b/tests/unit/test_dockerfile_contributor_build.py
@@ -29,7 +29,9 @@ the default back to `ghcr` (locks contributors out again), or dropping
 `PBS_SOURCE=ghcr` from a CI build (silently returns that build to the flaky CDN).
 """
 
+import os
 import re
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -98,6 +100,142 @@ def _image_build_steps() -> list[tuple[str, str, dict]]:
                 if str(step.get("uses", "")).startswith("docker/build-push-action"):
                     found.append((path.name, job_name, step))
     return found
+
+
+def _fork_unreachable_through_classifier(
+    workflow: str,
+    job_name: str,
+    tmp_path: Path,
+) -> str | None:
+    """Return why a bare-mirror build is not proven unreachable from forks.
+
+    The proof has two halves: the build job must depend *only* on a classifier
+    output being true, and that output must evaluate false for a fork even when
+    the classifier says the changed path requires a build. Executing the
+    workflow's own classifier shell prevents a comment or familiar-looking
+    substring from satisfying a guard whose behavior was weakened (Class 9b).
+    """
+    import yaml
+
+    data = yaml.safe_load((WORKFLOWS / workflow).read_text()) or {}
+    jobs = data.get("jobs") or {}
+    job = jobs.get(job_name) or {}
+    condition = str(job.get("if") or "").strip()
+    match = re.fullmatch(
+        r"needs\.([A-Za-z0-9_-]+)\.outputs\.([A-Za-z0-9_-]+)\s*==\s*'true'",
+        condition,
+    )
+    if not match:
+        return f"job `if` is not an exclusive classifier-output gate: {condition!r}"
+    classifier_name, output_name = match.groups()
+
+    needs = job.get("needs") or []
+    if isinstance(needs, str):
+        needs = [needs]
+    if classifier_name not in needs:
+        return f"job does not declare `needs: {classifier_name}`"
+
+    classifier = jobs.get(classifier_name) or {}
+    output_expr = str((classifier.get("outputs") or {}).get(output_name) or "").strip()
+    output_match = re.fullmatch(
+        r"\$\{\{\s*steps\.([A-Za-z0-9_-]+)\.outputs\.([A-Za-z0-9_-]+)\s*}}",
+        output_expr,
+    )
+    if not output_match:
+        return f"classifier output is not wired to a step output: {output_expr!r}"
+    step_id, step_output = output_match.groups()
+    if step_output != output_name:
+        return (
+            f"classifier job exposes {output_name!r} from a differently named "
+            f"step output {step_output!r}"
+        )
+
+    classifier_step = next(
+        (
+            step
+            for step in classifier.get("steps") or []
+            if isinstance(step, dict) and step.get("id") == step_id
+        ),
+        None,
+    )
+    if classifier_step is None:
+        return f"classifier step {step_id!r} does not exist"
+    fork_expr = re.sub(
+        r"\s+", "", str((classifier_step.get("env") or {}).get("IS_FORK") or "")
+    )
+    if fork_expr != "${{github.event.pull_request.head.repo.fork==true}}":
+        return f"IS_FORK is not sourced from the PR head repository: {fork_expr!r}"
+
+    script = str(classifier_step.get("run") or "").replace(
+        "${{ github.event_name }}", "pull_request"
+    )
+    if "${{" in script:
+        return "classifier shell contains an unevaluated GitHub expression"
+
+    stub_dir = tmp_path / f"{workflow}-{job_name}"
+    stub_dir.mkdir()
+    (stub_dir / "git").write_text(
+        "#!/bin/sh\nprintf 'cps/ub.py\\n'\n", encoding="utf-8"
+    )
+    (stub_dir / "python3").write_text(
+        "#!/bin/sh\n"
+        "printf 'frontend=false\\nbuild=true\\nconcurrency=true\\nimage=true\\n' "
+        '>> "$GITHUB_OUTPUT"\n',
+        encoding="utf-8",
+    )
+    (stub_dir / "git").chmod(0o755)
+    (stub_dir / "python3").chmod(0o755)
+
+    def classify(is_fork: bool) -> tuple[int, str, str]:
+        output = stub_dir / ("fork.out" if is_fork else "same-repo.out")
+        env = {
+            **os.environ,
+            "PATH": f"{stub_dir}:/usr/bin:/bin",
+            "BASE_SHA": "base",
+            "HEAD_SHA": "head",
+            "IS_FORK": "true" if is_fork else "false",
+            "GITHUB_OUTPUT": str(output),
+        }
+        proc = subprocess.run(
+            ["/bin/bash", "-c", script],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return (
+            proc.returncode,
+            output.read_text(encoding="utf-8") if output.exists() else "",
+            proc.stderr,
+        )
+
+    fork_rc, fork_output, fork_stderr = classify(True)
+    same_rc, same_output, same_stderr = classify(False)
+    if fork_rc != 0 or same_rc != 0:
+        return (
+            "classifier shell could not be evaluated: "
+            f"fork rc={fork_rc} stderr={fork_stderr!r}; "
+            f"same-repo rc={same_rc} stderr={same_stderr!r}"
+        )
+
+    def last_output(text: str, name: str) -> str | None:
+        values = [
+            line.split("=", 1)[1]
+            for line in text.splitlines()
+            if line.startswith(f"{name}=")
+        ]
+        return values[-1] if values else None
+
+    fork_value = last_output(fork_output, output_name)
+    same_value = last_output(same_output, output_name)
+    if fork_value != "false" or same_value != "true":
+        return (
+            f"classifier must produce {output_name}=false for a fork and true "
+            "for the same concurrency-shaped PR; got "
+            f"fork={fork_value!r}, same-repo={same_value!r}"
+        )
+    return None
 
 
 @pytest.fixture(scope="module")
@@ -264,8 +402,10 @@ def test_every_ci_image_build_selects_a_pbs_source_explicitly() -> None:
     )
 
 
-def test_pull_request_image_builds_do_not_hand_forks_the_private_mirror() -> None:
-    """A build reachable from `pull_request` must use the fork-aware selector (#1263).
+def test_pull_request_image_builds_do_not_hand_forks_the_private_mirror(
+    tmp_path: Path,
+) -> None:
+    """A PR build must be fork-aware or proven unreachable from forks (#1263).
 
     A fork PR cannot pull the private mirror — the GHCR login succeeds and the
     manifest HEAD still 403s, because `packages: read` on a fork's read-only
@@ -275,7 +415,10 @@ def test_pull_request_image_builds_do_not_hand_forks_the_private_mirror() -> Non
     read.
 
     Discovered from the workflow triggers, not from a job allowlist: a new
-    PR-triggered image build inherits this requirement automatically.
+    PR-triggered image build inherits this requirement automatically. A build
+    may keep the safer literal mirror pin only when its job is exclusively
+    gated by a classifier output whose actual shell behavior is false for a
+    fork and true for the same concurrency-shaped PR.
     """
     pr_builds = [
         (workflow, job, step)
@@ -287,15 +430,25 @@ def test_pull_request_image_builds_do_not_hand_forks_the_private_mirror() -> Non
         "stopped running on PRs, community build PRs lost their only coverage"
     )
 
-    offenders = [
-        f"{workflow}:{job}: {selectors}"
-        for workflow, job, step in pr_builds
-        for selectors in [_pbs_source_selector(step)]
-        if selectors != [FORK_AWARE_PBS_SOURCE]
-    ]
+    offenders: list[str] = []
+    for workflow, job, step in pr_builds:
+        selectors = _pbs_source_selector(step)
+        if selectors == [FORK_AWARE_PBS_SOURCE]:
+            continue
+        if selectors != ["PBS_SOURCE=ghcr"]:
+            offenders.append(f"{workflow}:{job}: unapproved selector {selectors}")
+            continue
+        failure = _fork_unreachable_through_classifier(workflow, job, tmp_path)
+        if failure:
+            offenders.append(
+                f"{workflow}:{job}: bare mirror is fork-reachable: {failure}"
+            )
+
     assert not offenders, (
-        f"These PR-triggered image builds do not use the fork-aware PBS_SOURCE "
-        f"selector: {offenders}. Fork PRs will 403 on the private mirror (#1263)."
+        "These PR-triggered image builds neither use the fork-aware PBS_SOURCE "
+        "selector nor prove that their literal private-mirror build is "
+        f"unreachable from forks: {offenders}. Fork PRs will 403 on the private "
+        "mirror (#1263)."
     )
 
 

--- a/tests/unit/test_dockerfile_contributor_build.py
+++ b/tests/unit/test_dockerfile_contributor_build.py
@@ -31,6 +31,7 @@ the default back to `ghcr` (locks contributors out again), or dropping
 
 import os
 import re
+import shlex
 import subprocess
 from pathlib import Path
 
@@ -73,6 +74,7 @@ FORK_AWARE_PBS_SOURCE = (
 PR_REACHABLE_TRIGGERS = {
     "pull_request",
     "pull_request_target",
+    "merge_group",
     "workflow_call",
     "workflow_run",
 }
@@ -92,24 +94,84 @@ def _workflow_triggers(workflow: str) -> set[str]:
     return set(on)
 
 
-def _image_build_steps() -> list[tuple[str, str, dict]]:
-    """Every `docker/build-push-action` step in every workflow.
+def _is_shell_image_build(step: dict) -> bool:
+    """Whether a shell step invokes a Docker image build."""
+    return bool(
+        re.search(
+            r"\bdocker\s+(?:buildx\s+build|build)\b",
+            str(step.get("run") or ""),
+        )
+    )
+
+
+def _local_composite_steps(step: dict, workflows: Path) -> tuple[Path, list[dict]] | None:
+    """Resolve a repository-local composite action used by ``step``."""
+    import yaml
+
+    uses = str(step.get("uses") or "")
+    if not uses.startswith("./"):
+        return None
+
+    repo_root = workflows.parent.parent
+    action_path = repo_root / uses[2:]
+    candidates = (
+        (action_path / "action.yml", action_path / "action.yaml")
+        if action_path.is_dir()
+        else (action_path,)
+    )
+    definition = next((path for path in candidates if path.is_file()), None)
+    if definition is None:
+        return None
+
+    data = yaml.safe_load(definition.read_text(encoding="utf-8")) or {}
+    runs = data.get("runs") or {}
+    if runs.get("using") != "composite":
+        return None
+    return definition.resolve(), [
+        child for child in runs.get("steps") or [] if isinstance(child, dict)
+    ]
+
+
+def _image_build_steps(workflows: Path = WORKFLOWS) -> list[tuple[str, str, dict]]:
+    """Every image-build step reachable from every workflow.
 
     Discovered, not listed: a hand-maintained allowlist is how the `tests.yml`
     image build was missed in the first place, which is exactly the regression
-    this module claims to prevent. Returns (workflow, job, step) triples.
+    this module claims to prevent. Both action-based builds and Docker shell
+    commands are included, including those hidden in repository-local composite
+    actions. Returns (workflow, job, leaf build step) triples.
     """
     import yaml
 
     found: list[tuple[str, str, dict]] = []
-    for path in sorted(WORKFLOWS.glob("*.yml")) + sorted(WORKFLOWS.glob("*.yaml")):
-        data = yaml.safe_load(path.read_text()) or {}
+
+    def visit_step(
+        workflow: str,
+        job_name: str,
+        step: dict,
+        action_stack: frozenset[Path] = frozenset(),
+    ) -> None:
+        uses = str(step.get("uses") or "")
+        if uses.startswith("docker/build-push-action") or _is_shell_image_build(step):
+            found.append((workflow, job_name, step))
+
+        composite = _local_composite_steps(step, workflows)
+        if composite is None:
+            return
+        definition, children = composite
+        if definition in action_stack:
+            return
+        next_stack = action_stack | {definition}
+        for child in children:
+            visit_step(workflow, job_name, child, next_stack)
+
+    for path in sorted(workflows.glob("*.yml")) + sorted(workflows.glob("*.yaml")):
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
         for job_name, job in (data.get("jobs") or {}).items():
             for step in (job or {}).get("steps") or []:
                 if not isinstance(step, dict):
                     continue
-                if str(step.get("uses", "")).startswith("docker/build-push-action"):
-                    found.append((path.name, job_name, step))
+                visit_step(path.name, job_name, step)
     return found
 
 
@@ -376,15 +438,77 @@ def test_upstream_fallback_produces_what_downstream_copies(dockerfile_text: str)
 def _pbs_source_selector(step: dict) -> list[str]:
     """The `PBS_SOURCE=` lines a build step passes, verbatim."""
     build_args = str((step.get("with") or {}).get("build-args", ""))
-    return [
+    selectors = [
         line.strip()
         for line in build_args.splitlines()
         if line.strip().startswith("PBS_SOURCE=")
     ]
+    try:
+        words = shlex.split(str(step.get("run") or ""), comments=False, posix=True)
+    except ValueError:
+        return selectors
+    for index, word in enumerate(words):
+        if word == "--build-arg" and index + 1 < len(words):
+            candidate = words[index + 1]
+        elif word.startswith("--build-arg="):
+            candidate = word.removeprefix("--build-arg=")
+        else:
+            continue
+        if candidate.startswith("PBS_SOURCE="):
+            selectors.append(candidate)
+    return selectors
+
+
+def test_shell_and_local_composite_image_builds_are_discovered(tmp_path: Path) -> None:
+    workflows = tmp_path / ".github" / "workflows"
+    action = tmp_path / ".github" / "actions" / "image"
+    workflows.mkdir(parents=True)
+    action.mkdir(parents=True)
+    (workflows / "images.yml").write_text(
+        """
+name: images
+on: push
+jobs:
+  direct:
+    runs-on: ubuntu-latest
+    steps:
+      - run: docker buildx build --push --build-arg PBS_SOURCE=ghcr .
+  composite:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/image
+""".lstrip(),
+        encoding="utf-8",
+    )
+    (action / "action.yml").write_text(
+        """
+name: image
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: docker build --build-arg=PBS_SOURCE=ghcr .
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    builds = _image_build_steps(workflows)
+    assert [(workflow, job) for workflow, job, _step in builds] == [
+        ("images.yml", "direct"),
+        ("images.yml", "composite"),
+    ]
+    assert [_pbs_source_selector(step) for _workflow, _job, step in builds] == [
+        ["PBS_SOURCE=ghcr"],
+        ["PBS_SOURCE=ghcr"],
+    ]
+
+
+def test_merge_queue_is_treated_as_pull_request_reachable() -> None:
+    assert "merge_group" in PR_REACHABLE_TRIGGERS
 
 
 def test_every_ci_image_build_selects_a_pbs_source_explicitly() -> None:
-    """Every `docker/build-push-action` step must set `PBS_SOURCE` exactly once.
+    """Every discovered CI image build must set `PBS_SOURCE` exactly once.
 
     Omitting it does not fail anything — it silently sends that build back to
     the release CDN that 404d the Actions egress and broke every image build.
@@ -396,7 +520,7 @@ def test_every_ci_image_build_selects_a_pbs_source_explicitly() -> None:
     fails here and has to be reviewed rather than absorbed.
     """
     steps = _image_build_steps()
-    assert steps, "found no docker/build-push-action steps to check"
+    assert steps, "found no image-build steps to check"
 
     offenders: list[str] = []
     for workflow, job, step in steps:
@@ -501,7 +625,7 @@ def test_non_pull_request_image_builds_keep_the_bare_mirror_pin() -> None:
     offenders = [
         f"{workflow}:{job}: {selectors}"
         for workflow, job, step in _image_build_steps()
-        if "pull_request" not in _workflow_triggers(workflow)
+        if not (PR_REACHABLE_TRIGGERS & _workflow_triggers(workflow))
         for selectors in [_pbs_source_selector(step)]
         if selectors != ["PBS_SOURCE=ghcr"]
     ]

--- a/tests/unit/test_dockerfile_contributor_build.py
+++ b/tests/unit/test_dockerfile_contributor_build.py
@@ -66,6 +66,17 @@ FORK_AWARE_PBS_SOURCE = (
     "&& 'upstream' || 'ghcr' }}"
 )
 
+# These events can be reached from, or delegated by, a pull-request context.
+# Only ordinary `pull_request` is proven by the classifier shell below; the
+# privileged/callable variants require a separate threat model and therefore
+# fail closed if an image-building workflow acquires one.
+PR_REACHABLE_TRIGGERS = {
+    "pull_request",
+    "pull_request_target",
+    "workflow_call",
+    "workflow_run",
+}
+
 
 def _workflow_triggers(workflow: str) -> set[str]:
     """The event names a workflow is registered for.
@@ -192,7 +203,10 @@ def _fork_unreachable_through_classifier(
             **os.environ,
             "PATH": f"{stub_dir}:/usr/bin:/bin",
             "BASE_SHA": "base",
+            "CONCURRENCY": "true",
+            "GITHUB_EVENT_NAME": "pull_request",
             "HEAD_SHA": "head",
+            "IMAGE": "true",
             "IS_FORK": "true" if is_fork else "false",
             "GITHUB_OUTPUT": str(output),
         }
@@ -423,7 +437,7 @@ def test_pull_request_image_builds_do_not_hand_forks_the_private_mirror(
     pr_builds = [
         (workflow, job, step)
         for workflow, job, step in _image_build_steps()
-        if "pull_request" in _workflow_triggers(workflow)
+        if PR_REACHABLE_TRIGGERS & _workflow_triggers(workflow)
     ]
     assert pr_builds, (
         "found no pull_request-triggered image build; if the integration build "
@@ -432,6 +446,14 @@ def test_pull_request_image_builds_do_not_hand_forks_the_private_mirror(
 
     offenders: list[str] = []
     for workflow, job, step in pr_builds:
+        triggers = _workflow_triggers(workflow)
+        unsupported = (triggers & PR_REACHABLE_TRIGGERS) - {"pull_request"}
+        if unsupported:
+            offenders.append(
+                f"{workflow}:{job}: image build has unsupported PR-reachable "
+                f"trigger(s) {sorted(unsupported)}"
+            )
+            continue
         selectors = _pbs_source_selector(step)
         if selectors == [FORK_AWARE_PBS_SOURCE]:
             continue
@@ -449,6 +471,22 @@ def test_pull_request_image_builds_do_not_hand_forks_the_private_mirror(
         "selector nor prove that their literal private-mirror build is "
         f"unreachable from forks: {offenders}. Fork PRs will 403 on the private "
         "mirror (#1263)."
+    )
+
+
+def test_dev_image_workflow_trigger_set_is_security_pinned() -> None:
+    """A privileged/callable trigger must not bypass the ordinary-PR fork gate.
+
+    In particular, `pull_request_target` would execute the workflow from the
+    base repository and its event name would skip the classifier's
+    `pull_request` branch. Pinning the complete trigger set catches that change
+    even when checkout is hidden behind BUILD_REF/GITHUB_ENV indirection.
+    """
+    triggers = _workflow_triggers("docker-image-build-dev.yml")
+    assert triggers == {"push", "pull_request", "workflow_dispatch"}, (
+        "docker-image-build-dev.yml trigger set changed. Image publication is "
+        "proven safe only for push, ordinary pull_request, and explicit "
+        f"workflow_dispatch; got {sorted(triggers)}"
     )
 
 

--- a/tests/unit/test_summary_gate_requires_success.py
+++ b/tests/unit/test_summary_gate_requires_success.py
@@ -46,7 +46,7 @@ def _summary_shell():
 
 def _render(shell, *, event, ref, fast, build, integration, e2e,
             is_frontend_pr="false", is_tier2="false", is_build_pr="false",
-            changed_paths="success"):
+            is_concurrency_pr="false", changed_paths="success"):
     subs = {
         "needs.fast-tests.result": fast,
         "needs.frontend-build.result": build,
@@ -65,6 +65,7 @@ def _render(shell, *, event, ref, fast, build, integration, e2e,
         f"IS_TIER2_PR={is_tier2}\n"
         f"IS_BUILD_PR={is_build_pr}\n"
         f"IS_FRONTEND_PR={is_frontend_pr}\n"
+        f"IS_CONCURRENCY_PR={is_concurrency_pr}\n"
         f"IS_MAIN_PUSH={is_main_push}\n"
     )
     return "set -o pipefail\n" + env + shell
@@ -178,3 +179,20 @@ def test_non_frontend_pr_still_passes_with_e2e_skipped():
                  fast="success", build="success", integration="skipped",
                  e2e="skipped", is_frontend_pr="false")
     assert rc == 0
+
+
+@pytest.mark.parametrize("result", ["failure", "skipped", "cancelled"])
+def test_concurrency_pr_requires_e2e_success(result):
+    rc, out = _run(
+        event="pull_request",
+        ref="refs/heads/topic",
+        fast="success",
+        build="success",
+        integration="success",
+        e2e=result,
+        is_concurrency_pr="true",
+    )
+    assert rc == 1, (
+        f"concurrency PR with e2e={result} must fail the summary; got rc=0\n{out}"
+    )
+    assert result in out

--- a/tests/unit/test_workflow_safety_invariants.py
+++ b/tests/unit/test_workflow_safety_invariants.py
@@ -762,12 +762,15 @@ def _run_detect(repo: Path, base: str, head: str) -> dict[str, str]:
     script = _detect_step().get("run") or ""
     out_file = repo / "_gh_output"
     out_file.write_text("")
+    runner_temp = repo / "runner-temp"
+    runner_temp.mkdir()
     env = dict(os.environ)
     env.update(
         {
             "BASE_SHA": base,
             "HEAD_SHA": head,
             "GITHUB_OUTPUT": str(out_file),
+            "RUNNER_TEMP": str(runner_temp),
             "GIT_CONFIG_NOSYSTEM": "1",
             "HOME": str(repo),
         }
@@ -796,7 +799,11 @@ def _repo_touching(repo: Path, paths: list[str]) -> tuple[str, str]:
     classifier = repo / "scripts" / "ci_path_classification.py"
     classifier.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(REPO_ROOT / "scripts" / "ci_path_classification.py", classifier)
+    package = repo / "cps" / "__init__.py"
+    package.parent.mkdir(parents=True, exist_ok=True)
+    package.write_text("", encoding="utf-8")
     _git(repo, "add", "seed.txt")
+    _git(repo, "add", "cps/__init__.py")
     _git(repo, "add", "scripts/ci_path_classification.py")
     _git(repo, "commit", "-m", "base")
     base = _git(repo, "rev-parse", "HEAD").stdout.strip()
@@ -890,6 +897,23 @@ def test_changed_paths_classifies_build_definition_edits(changed, want_build, wa
     assert out["frontend"] == want_frontend, (
         f"changed={changed} → frontend={out['frontend']!r}, expected {want_frontend!r}"
     )
+
+
+def test_pr_cannot_disable_its_gate_by_replacing_its_classifier():
+    """Execute the real detect shell with a deliberately broken PR copy."""
+    with tempfile.TemporaryDirectory() as td:
+        repo = Path(td)
+        base, head = _repo_touching(
+            repo,
+            ["cps/web.py", "scripts/ci_path_classification.py"],
+        )
+        # _repo_touching replaces both files with non-Python text on the PR
+        # branch. The base classifier remains valid and must still identify
+        # web.py as a concurrency root.
+        out = _run_detect(repo, base, head)
+
+    assert out["concurrency"] == "true"
+    assert out["build"] == "true"
 
 
 def test_integration_tests_gate_keys_on_changed_paths():

--- a/tests/unit/test_workflow_safety_invariants.py
+++ b/tests/unit/test_workflow_safety_invariants.py
@@ -691,20 +691,12 @@ def test_changed_paths_treats_tests_yml_as_frontend_relevant():
     fixture could not be validated by the e2e job — the fix for a red gate
     would not run the gate.
     """
-    wf = _load(WF_DIR / "tests.yml")
-    detect = next(
-        (
-            s
-            for s in ((wf.get("jobs") or {}).get("changed_paths") or {}).get("steps", [])
-            if isinstance(s, dict) and s.get("id") == "detect"
-        ),
-        None,
-    )
-    assert detect is not None, "changed_paths has no `detect` step"
-    run = detect.get("run") or ""
-    assert "workflows/tests" in run.replace("\\", ""), (
-        "changed_paths does not treat .github/workflows/tests.yml as frontend-relevant, "
-        "so a PR that changes the e2e seed/setup will skip the e2e job that it changes."
+    from scripts.ci_path_classification import classify_paths
+
+    result = classify_paths([".github/workflows/tests.yml"], REPO_ROOT)
+    assert result["frontend"] is True, (
+        "the shared classifier does not treat .github/workflows/tests.yml as "
+        "frontend-relevant, so a PR changing the e2e seed/setup would skip the gate"
     )
 
 
@@ -801,7 +793,11 @@ def _repo_touching(repo: Path, paths: list[str]) -> tuple[str, str]:
     """Build a git repo whose PR branch changes exactly `paths`."""
     _git(repo, "init", "-b", "main")
     (repo / "seed.txt").write_text("base\n")
+    classifier = repo / "scripts" / "ci_path_classification.py"
+    classifier.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(REPO_ROOT / "scripts" / "ci_path_classification.py", classifier)
     _git(repo, "add", "seed.txt")
+    _git(repo, "add", "scripts/ci_path_classification.py")
     _git(repo, "commit", "-m", "base")
     base = _git(repo, "rev-parse", "HEAD").stdout.strip()
 
@@ -1306,10 +1302,13 @@ def test_fork_prs_run_e2e_but_do_not_hard_gate_on_it_yet():
     wf = _load(WF_DIR / "tests.yml")
     job = (wf.get("jobs") or {}).get("e2e-tests")
 
-    condition = str(job.get("if") or "")
-    assert "fork" not in condition, (
-        "e2e-tests must still RUN on fork frontend PRs — surfacing the result "
-        "is the point; only the hard gate is deferred"
+    condition = re.sub(r"\s+", " ", str(job.get("if") or ""))
+    assert "outputs.frontend == 'true' ||" in condition, (
+        "frontend PRs must enter E2E before the concurrency-specific fork carve-out"
+    )
+    assert "outputs.concurrency == 'true'" in condition and "fork != true" in condition, (
+        "only concurrency-triggered image builds exclude forks; frontend fork PRs "
+        "must still run the existing digest-pinned overlay lane"
     )
 
     coe = str(job.get("continue-on-error", ""))


### PR DESCRIPTION
Closes #1927.

**Operator-directed (2026-08-28).** Not autopilot-picked — this is the enabler for #1939, which cannot be
verified without it.

## Why

The E2E lane is the only suite that drives concurrent request handlers against a real container, so it is
the only one that can see a transaction/engine regression. Two independent holes made it unable to do that:

1. It ran on a PR only when the diff touched frontend paths, so a backend-only engine change reached main
   untested — how the `database is locked` storm in #1888 shipped and had to be reverted in #1926.
2. main's own push-triggered E2E pulled a floating `:dev` while `:dev` for that same commit was still
   building, so it rendered a verdict on the *previous* commit's backend. #1927 measured the same main
   commit red and then green, decided entirely by which image had published.

Widening the trigger without fixing the image would only produce confident answers about code that is not
under test, so both limbs are here.

## What changed

- **Trigger** — a shared path classifier (`scripts/ci_path_classification.py`) consumed by both the test
  and dev-image workflows. It starts from the architectural engine roots named in #1927 and *derives* the
  protected set by following local imports, rather than hand-maintaining a list of call sites — a
  hand-enumerated list is a known false-green shape here (FAILURE-MODES class 9b). E2E is a hard gate for
  same-repo concurrency-shaped PRs; every non-`success` result (failure, skipped, cancelled) fails the
  summary for those. Advisory elsewhere, unchanged.
- **Image** — every full dev build publishes an immutable `sha-<commit>` tag. The E2E job waits for the
  triggering commit's tag, resolves it to `image@sha256:…`, and runs only that digest. **There is no
  `:dev` fallback**: a job that cannot identify its subject refuses to report a verdict. Image-neutral
  main commits alias the unchanged manifest instead of rebuilding, so `:dev` and the canary are untouched.
- **Capability probe** (`frontend/e2e/capabilities.ts`) — FAILURE-MODES class 14: a PR's e2e leg can boot a
  backend without the PR's routes. Specs can now detect route *presence* (never correctness) and skip with
  a stated reason that retires itself. Presence-only, and route existence must also be pinned in a layer
  that runs on every PR.
- **Multi-user e2e** (`frontend/e2e/fixtures.ts`) — the suite could previously only drive one admin, so a
  per-user feature was untestable by construction. A lazy, test-scoped fixture creates a non-admin through
  the real admin API, logs it into its own browser context, and deletes it on teardown. The existing
  single-user path is untouched and does no extra work unless a spec asks for the fixture.

## Validation

- 105 targeted Python tests green (classifier derivation, workflow wiring, fork behaviour, hard-summary
  outcomes for failure/skipped/cancelled, resolver wait/refusal/malformed-digest, dev-build image-neutral).
- **Live-registry pin proof**: `:dev` resolved to `sha256:11ae97cb…` and was run by digest.
- **Live-registry refusal proof**: a nonexistent commit tag produced
  `Refusing to run E2E because the triggering commit's image cannot be identified`, exit 1, with no
  mention of or fallback to `:dev`.
- **Capability probe, both directions**: an absent route skipped with the documented reason; a present route
  (`DELETE /api/v1/tags/1`) proceeded into the real correctness test and passed.
- **Two-user proof against a running container**: two browser contexts, different `/auth/me` identities,
  admin `200` vs non-admin `403` on `/api/v1/admin/users`; teardown deleted the seeded user.
- `actionlint` clean on schema and untrusted-expression classes (PR branch-name interpolation moved into
  env vars); `shellcheck` clean on the new script; frontend production build green.

## Cost

~13–14 additional raw runner-minutes on a qualifying concurrency PR (two arch builds in parallel, so
wall-clock is nearer the 4–5 min image wait plus 7–8 min E2E, partly overlapping existing lanes). Ordinary
PRs pay under a runner-minute for checkout + classification. Main pushes already paid for the dev build —
E2E now consumes it rather than adding one. All jobs stay on GitHub-hosted ubuntu-latest;
`cancel-in-progress` and job timeouts intact.

## Known limits, stated

- The classifier follows imports two levels from the roots (110 of 215 modules). Full transitivity was
  measured at 144/215 because shared utilities fan out through most of the app, which would fire the
  expensive lane on most backend PRs. The roots remain an explicit architectural input.
- Frontend-only PRs keep the cheaper overlay path by design, with the backend now digest-pinned — which is
  exactly why the capability probe exists.
- The workflow expressions could not be executed without pushing; their behaviour under GitHub's real
  cross-workflow scheduling is ASSUMED, everything above it is OBSERVED.

## Security review

Run pre-merge on this branch (`/security-review`, scope asserted: 14 files, correct head). **No findings
at confidence ≥8.** What was traced, and the two calls that came closest:

- **Actions expression injection** — all 60 interpolations in the dev-image workflow enumerated. One real
  new sink: `BRANCH_NAME` derives from `github.head_ref`, which IS attacker-controlled on a fork PR, and
  git permits `` ` ``, `$`, `(`, `)` in ref names. Unreachable today because every job using it is gated on
  `classify.full_build`, which is forced false for forks. **Hardened anyway in f242bdf0c**: those six sites
  now read `"$BRANCH_NAME"` from the environment instead of a `${{ }}` expression substituted into the
  script text, so the sink is gone rather than merely gated. The reviewer's own note was that it "becomes
  RCE the day someone relaxes the fork clause" — this is what makes that no longer true.
- **Fork PRs reaching the package-writing job** — closed three independent ways: the repo is public so
  GitHub forces a read-only token and passes no secrets to fork PRs; the only job a fork can enter
  (`classify`) references no secrets; and every build/push job is gated on a `classify` output a fork
  cannot flip. No `pull_request_target` was added. The "malicious classifier writes its own
  `full_build=true`" path was specifically tested — the shell appends after the script, last-key-wins, and
  the unterminated-heredoc variant fails the runner's file-command parser.
- `resolve-e2e-image.sh` — clean: image is a caller-side literal, both args quoted throughout,
  attempts/delay regex-validated before the arithmetic loop and `sleep`, no `eval`, and the only stdout
  value is gated on `^sha256:[0-9a-f]{64}$`, so registry/tag confusion and newline injection into
  `$GITHUB_OUTPUT` are both impossible.
- `fixtures.ts` — role mask matches the stated contract (no over-grant, no `config_default_role`
  fallback); the generated password reaches only the two request bodies, never an assertion message; and
  cleanup is in `finally`, so it survives a failing `use()`.

87 workflow-safety/gate tests green after the hardening.

## Update — the first push was CI-red, and the red was correct

`test_pull_request_image_builds_do_not_hand_forks_the_private_mirror` failed. It is an existing
supply-chain guard that derives its requirement FROM the workflow triggers on purpose ("a new
PR-triggered image build inherits this requirement automatically"), so adding `pull_request` to the
dev-image workflow put its build steps under a rule they did not satisfy.

The obvious fix — switch that build to the fork-aware selector — is wrong: its sibling test forbids
exactly that, because this build **publishes**, and a mis-evaluating selector expression would let a
published image quietly come from the flaky CDN. That trades one real risk for another.

So the guard was taught the new invariant instead of relaxed. The rule is now "a PR-triggered image
build must use the fork-aware selector **or** be provably unreachable from a fork", and the second arm
is **verified, not assumed** — for each literal-mirror PR build the test checks the job's whole `if:`
is exclusively the classifier output, that the classifier is in `needs`, that the output is wired to a
real step output, that `IS_FORK` comes from `pull_request.head.repo.fork`, and then **executes the
classifier's actual shell** to confirm it yields `full_build=false` for a fork and `true` for the same
concurrency-shaped same-repo PR. No job allowlist was added; discovery still comes from the triggers.

**Negative control, run rather than asserted.** In an isolated scratch clone of this exact commit the
fork clause was weakened from `[[ "$concurrency" == "true" && "$IS_FORK" != "true" ]]` to
`[[ "$concurrency" == "true" ]]`:

```
FAILED test_pull_request_image_builds_do_not_hand_forks_the_private_mirror
  docker-image-build-dev.yml:build-amd64: bare mirror is fork-reachable:
    classifier must produce full_build=false for a fork and true for the
    same concurrency-shaped PR; got fork='true', same-repo='true'
  docker-image-build-dev.yml:build-arm: (same)
1 failed in 1.03s
```
Restoring the clause returned `1 passed in 0.91s`. A guard that cannot fail for the thing it pins is
this repo's named false-green class; this one demonstrably can.

The sibling protection is intact: a build that never sees a fork must still pin the bare mirror.

**Full unit suite, run independently by the merge owner rather than the author: 7263 passed, 94
skipped, 0 failed.** The original red reached CI because the authoring lane ran 105 targeted tests
instead of the suite.

**Security-review scope note:** the review above was performed at `f242bdf0c`. The later commit
`223101b27` changes exactly one file — `tests/unit/test_dockerfile_contributor_build.py` — and adds no
runtime surface, so the verdict is carried forward deliberately rather than silently.

## Update 2 — independent review found two merge-blockers; both fixed, plus a third defect found while fixing

A cross-family pre-merge review (not the author) blocked this PR. Both blockers were real:

**Blocker 1 — the PR reintroduced its own bug, on main.** The new `cancel-in-progress` covered the *main*
concurrency group, and the alias job copied whatever `:dev` happened to point at. Sequence: push A
(backend) starts a build; push B (docs-only) lands and cancels A — and before this PR, docs pushes did not
trigger this workflow at all, so that was newly reachable. `:dev` never advances to A, so B's alias tags
the **pre-A** image as `sha-B`, while B's tree contains A's backend change. B's E2E then renders a green,
immutable-looking verdict on a backend its own commit does not contain, and main is hard-gated on it.
A's own run was cancelled too, so "refuses to report" never fires — cancellation beats it.
*Fixed:* cancellation is now `${{ github.event_name == 'pull_request' }}`, so a running publisher is never
cancelled; main checkouts pin the triggering `github.sha` rather than a possibly-advanced ref; and
image-neutral commits no longer copy `:dev`. `scripts/alias-e2e-image.sh` refuses to alias unless the
declared source is the newest image-relevant first-parent ancestor, is an ancestor of the subject, its
immutable `sha-<source>` manifest exists, and `:dev` resolves to exactly that digest — then aliases from
the digest, not the tag. Three behavioural cases proved against real temporary git histories: match →
alias; stale `:dev` digest → exit 1, no alias; a newer image-relevant commit in between → exit 1 naming
the real source.

**Blocker 2 — the classifier walked the graph the wrong way.** Imports were followed *downward* from the
roots, so the roots' dependents were unreachable at any depth — and those are the app's biggest concurrent
write surfaces: `cps/web.py` (98 `ub.session` uses, 27 commit sites) and `cps/kobo.py` (44; Kobo sync *is*
concurrent device traffic). A PR lengthening a transaction in a hot `web.py` handler — exactly the
`database is locked` class this gate exists for — classified `concurrency=false`. Both are now explicit
roots. The stated limitation previously blamed the depth-2 cut, which was the wrong mechanism; it now
describes the real one.

**Third defect, found while fixing the second: the traversal was non-deterministic.** It depended on
Python set/hash order — a module reached first by a longer route was marked discovered and could suppress
a later, shorter route, so separate processes produced *different* protected sets. A gate whose scope
varies per process is a false-green generator. The traversal now records minimum discovered depth and
revisits on a shorter path; the closure returns **110** under `PYTHONHASHSEED` 1, 2, 3, 4, 5, 42, 99 and
`random`. A test derives both numbers from the tree so this document goes red when the graph changes.

**Blocker 3 — the wait budget was smaller than the pipeline it waited for.** 40 min against a producer
whose configured critical path is 95 (classify 5 + mirror 15 + max arch build 60 + merge 15). Now 240
attempts × 30 s = 119.5 min of sleep, exceeding the producer by 24.5 min, with the E2E job timeout raised
to 180 min leaving 60.5 min for the run and retries. A test computes all of this from both parsed
workflows and fails if the margins shrink. `resolve-e2e-image.sh` also defaults to 240 so a future caller
cannot silently restore the 40-minute cap. Manual `run_e2e` dispatches use a single attempt — a manual run
asserts its build was already dispatched, and waiting two hours cannot create a tag with no producer.

**Follow-up 4 — the gate was self-certifying.** Both consumers ran the PR's own copy of the classifier to
decide whether the PR needed the hard gate, so a PR touching `cps/ub.py` while narrowing the roots could
exempt itself. Both now archive the BASE ref's `cps/` and classifier and execute that against the archived
base tree. This introducing PR has no classifier on its base, and that bootstrap case **fails closed** —
it emits `frontend/build/concurrency/image = true` and pays for every gate. Proved by replacing the PR's
own classifier with invalid non-Python text while changing `cps/web.py`: the base classifier still ran and
still emitted `concurrency=true`.

**Follow-up 5 — the fork-unreachability proof was blind at trigger discovery.** It exact-matched
`pull_request`, so converting the workflow to `pull_request_target` dropped the build out of the proof and
into the sibling test that *requires* the bare pin — and the naive-form guard could not see it because the
build jobs check out via `env.BUILD_REF` indirection. Discovery now covers `pull_request`,
`pull_request_target`, `workflow_call` and `workflow_run`, and this workflow's trigger set is pinned
exactly, so indirection cannot hide a conversion. Demonstrated in a scratch clone: changing only
`pull_request:` to `pull_request_target:` turned both guards red (`unsupported PR-reachable trigger(s)`),
and restoring it returned 2 passed.

Follow-ups 6 (the latent `dev`-branch wait trap) and 7 (documenting the `run_e2e` escape hatch in the
merge gate) are also in this commit.

## Update 3 — re-review verdict, and its follow-ups shipped

The same independent reviewer re-examined the fixes at `b680c18fe` and returned **both blockers CLOSED,
merge recommended**, having re-derived each claim from the code rather than accepting the fix report. It
walked the original attack sequence again (B now pends behind A instead of cancelling it; A publishes
`sha-A` and advances `:dev` in one `imagetools create`; B's alias verifies `:dev == sha-A` and aliases by
digest) and probed shapes nobody had specified — merge commits, reverts, two image-relevant commits in one
push, force-push (fails toward building, the safe direction). It also observed that moving the checkouts
from `github.ref` to `github.sha` fixed a *latent* wrong-subject bug: a slow-starting run could previously
have checked out a newer main.

On cost it produced a measurement rather than an opinion: classifying the last 100 first-parent main
commits, the gate fires on **26%**. And on determinism it proved the property rather than the instance —
minimum-depth relaxation converges regardless of pop order for *any* graph, verified on a synthetic shape
built to defeat the old code.

Three of its four follow-ups are shipped here (`52ccce632`) because they were cheap and two were things
#1927 asked for literally:

- **`cps/api/` is now protected.** The whole SPA API blueprint tree registers through `cps/main.py`, which
  sits outside the closure, so every `/api/v1/*` handler classified `concurrency=false` — including
  `cps/api/shelves.py`, **the endpoint behind one of #1927's own two canonical red specs**. Protected set
  110 → 149 of 215 modules. Re-measured on 100 first-parent commits anchored at `e6298e0d560b`:
  **26/100 before, 26/100 after — zero additional gate fires.** Free, and it closes the last structural
  false-negative in the exact place the issue cites.
- **The supply-chain guard no longer assumes an image build is a `docker/build-push-action` step.**
  Discovery now also finds `docker build` / `docker buildx build` in `run:` shells, and those forms nested
  inside repository-local composite actions, with both guards consuming the same expanded result so a
  build cannot be visible to one and invisible to the other. `merge_group` joined the PR-reachable trigger
  set — otherwise a future merge queue with an image build would let fork-authored content build with the
  write token, undiscovered. Proved by adding `run: docker buildx build --push .` in a scratch worktree:
  guard red with `expected exactly one PBS_SOURCE= line, found 0`; removed; green again.
- **The `run_e2e` escape hatch is documented in the merge gate in `agent-context/AGENTS-DETAILS.md`**, as
  the issue asked, including the trap that dispatching without `branch=` advances `:dev` to an old build.
- The determinism test now compares the serialized protected-path **sets** across hash seeds rather than
  their counts — count-equality could mask a set difference, so the test was weaker than the property.

The fourth follow-up — aborting the resolver early when the paired build run has already failed — is
deliberately NOT here. It is a behaviour change with its own failure mode (a mis-identified paired run
would abort a legitimate wait) and this PR is large. Filed as `F-50a97d` in the findings ledger.
