### PR TITLE
fix(kobo): a replayed library sync no longer de-downloads unchanged books (#1925)

### DIFF
--- a/changelog.d/issue-1925.md
+++ b/changelog.d/issue-1925.md
@@ -1,3 +1,3 @@
 ### Fixed
 
-- **Stabilized replayed Kobo book metadata to prevent false "Download" resets.** Unchanged entitlements no longer contain response-time timestamps or advertise source-file sizes for generated and metadata-rewritten downloads.
+- Kobo no longer shows Download again for books you already have after a sync hiccup.

--- a/changelog.d/issue-1925.md
+++ b/changelog.d/issue-1925.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Stabilized replayed Kobo book metadata to prevent false "Download" resets.** Unchanged entitlements no longer contain response-time timestamps or advertise source-file sizes for generated and metadata-rewritten downloads.

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -1432,6 +1432,12 @@ def do_full_kobo_sync(userid):
     ub.session.query(ub.KoboDeviceBookEntitlement).filter(
         ub.KoboDeviceBookEntitlement.device_id.in_(device_ids),
     ).delete(synchronize_session=False)
+    ub.session.query(ub.KoboDeviceDeletedEntitlement).filter(
+        ub.KoboDeviceDeletedEntitlement.device_id.in_(device_ids),
+    ).delete(synchronize_session=False)
+    ub.session.query(ub.KoboDeviceEntitlementSeed).filter(
+        ub.KoboDeviceEntitlementSeed.device_id.in_(device_ids),
+    ).delete(synchronize_session=False)
     count = ub.session.query(ub.KoboSyncedBooks).filter(userid == ub.KoboSyncedBooks.user_id).delete()
     message = _("{} sync entries deleted").format(count)
     ub.session_commit(message)

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -1448,12 +1448,16 @@ def ajax_kobo_resend(userid, bookid):
 def do_kobo_resend(userid, bookid):
     # Force re-delivery of one book to one user's Kobo on the next sync.
     #
-    # Two writes, and only the second does what it says on its own:
+    # Three writes across the two databases, and only the timestamp bump does
+    # what it says on its own:
     #
     #   * bump Books.last_modified, so the sync filter
     #     (Books.last_modified > sync_token.books_last_modified) picks the book
     #     up regardless of where the device's cursor sits;
-    #   * clear the (user_id, book_id) row from kobo_synced_books.
+    #   * clear the (user_id, book_id) row from kobo_synced_books;
+    #   * clear every per-device entitlement fingerprint for this user/book,
+    #     otherwise Layer 2 can suppress the admin-requested replay as an exact
+    #     match even though last_modified selected it for delivery.
     #
     # ⚠️ This comment used to say the deletion is what makes the sync emit
     # NewEntitlement. It is not, and believing so is what made the only
@@ -1483,13 +1487,20 @@ def do_kobo_resend(userid, bookid):
         message = _("Book {} not found").format(bookid)
         return Response(json.dumps([{"type": "danger", "message": message}]),
                         mimetype='application/json')
+    device_ids = ub.session.query(ub.Device.id).filter(
+        ub.Device.user_id == userid,
+    ).scalar_subquery()
+    ledger_deleted = ub.session.query(ub.KoboDeviceBookEntitlement).filter(
+        ub.KoboDeviceBookEntitlement.device_id.in_(device_ids),
+        ub.KoboDeviceBookEntitlement.book_id == bookid,
+    ).delete(synchronize_session=False)
     deleted = ub.session.query(ub.KoboSyncedBooks).filter(
         ub.KoboSyncedBooks.user_id == userid,
         ub.KoboSyncedBooks.book_id == bookid,
     ).delete()
     book.last_modified = datetime.now(timezone.utc)
     calibre_db.session.commit()
-    if deleted:
+    if deleted or ledger_deleted:
         message = _("Cleared sync state for book {0} (user {1}); the device "
                     "will re-receive the book on next sync").format(bookid, userid)
     else:

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -1427,6 +1427,11 @@ def ajax_pathchooser():
 
 
 def do_full_kobo_sync(userid):
+    device_ids = ub.session.query(ub.Device.id).filter(
+        ub.Device.user_id == userid).scalar_subquery()
+    ub.session.query(ub.KoboDeviceBookEntitlement).filter(
+        ub.KoboDeviceBookEntitlement.device_id.in_(device_ids),
+    ).delete(synchronize_session=False)
     count = ub.session.query(ub.KoboSyncedBooks).filter(userid == ub.KoboSyncedBooks.user_id).delete()
     message = _("{} sync entries deleted").format(count)
     ub.session_commit(message)
@@ -2841,6 +2846,7 @@ def _configuration_update_helper():
         _config_int(to_save, "config_external_port")
         _config_checkbox_int(to_save, "config_kobo_proxy")
         _config_checkbox(to_save, "config_kobo_prefer_kepub")
+        _config_checkbox_int(to_save, "config_kobo_suppress_replayed_entitlements")
 
         # Kobo cover aspect-ratio padding (server-side letterbox elimination)
         _config_checkbox_int(to_save, "config_kobo_cover_padding_enabled")

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -160,10 +160,11 @@ class _Settings(_Base):
     config_kobo_cover_padding_fill_mode = Column(String, default="edge_mirror")
     config_kobo_cover_padding_color = Column(String, default="")
     config_kobo_prefer_kepub = Column(Boolean, default=True)
-    # Experimental issue #1925 Layer 2. Default off: Layer 1's byte-stable
-    # entitlement payload ships independently without suppressing replays.
+    # Issue #1925 replay protection. Clara hardware proved byte-stable payloads
+    # alone still de-download books after a sync hiccup, so suppression is the
+    # safe default; tokenless/factory-reset requests remain an explicit escape.
     config_kobo_suppress_replayed_entitlements = Column(
-        Boolean, nullable=False, default=False, server_default=text("0"),
+        Boolean, nullable=False, default=True, server_default=text("1"),
     )
     config_kobo_kepub_backfill_completed = Column(Boolean, default=False)
     # Legacy #1647 watermark retained only for schema/rollback compatibility.

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -160,6 +160,11 @@ class _Settings(_Base):
     config_kobo_cover_padding_fill_mode = Column(String, default="edge_mirror")
     config_kobo_cover_padding_color = Column(String, default="")
     config_kobo_prefer_kepub = Column(Boolean, default=True)
+    # Experimental issue #1925 Layer 2. Default off: Layer 1's byte-stable
+    # entitlement payload ships independently without suppressing replays.
+    config_kobo_suppress_replayed_entitlements = Column(
+        Boolean, nullable=False, default=False, server_default=text("0"),
+    )
     config_kobo_kepub_backfill_completed = Column(Boolean, default=False)
     # Legacy #1647 watermark retained only for schema/rollback compatibility.
     # It is deliberately not read: SQLite can reuse KoboSyncedBooks INTEGER

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -680,7 +680,7 @@ def HandleSyncRequest():
                            .distinct())
     log.debug("Kobo Sync: changed entries: {}".format(changed_entries.count()))
 
-    reading_states_in_new_entitlements = []
+    reading_state_book_ids_emitted = []
     # Materialize the limited result set ONCE — the prior shape called .all()
     # twice (once for the debug log, once for the for-loop) which round-tripped
     # the joined-load query twice per sync request.
@@ -720,10 +720,24 @@ def HandleSyncRequest():
 
         if (kobo_reading_state is not None
                 and kobo_reading_state.last_modified > sync_token.reading_state_last_modified):
-            if not entitlement_is_unchanged:
-                entitlement["ReadingState"] = get_kobo_reading_state_response(book.Books, kobo_reading_state)
-                new_reading_state_last_modified = max(new_reading_state_last_modified, kobo_reading_state.last_modified)
-                reading_states_in_new_entitlements.append(book.Books.id)
+            reading_state = get_kobo_reading_state_response(
+                book.Books, kobo_reading_state)
+            new_reading_state_last_modified = max(
+                new_reading_state_last_modified,
+                kobo_reading_state.last_modified,
+            )
+            reading_state_book_ids_emitted.append(book.Books.id)
+            if entitlement_is_unchanged:
+                # Replay suppression applies only to the byte-identical base
+                # entitlement. Reading state has its own cursor and must still
+                # be delivered independently; relying on the paged scan below
+                # can withhold it behind a full page of older states and leave
+                # its cursor unadvanced.
+                sync_results.append({
+                    "ChangedReadingState": {"ReadingState": reading_state}
+                })
+            else:
+                entitlement["ReadingState"] = reading_state
 
         ts_created = get_kobo_created_ts(book)
 
@@ -884,7 +898,7 @@ def HandleSyncRequest():
 
     changed_reading_states = changed_reading_states.filter(
         and_(ub.KoboReadingState.user_id == current_user.id,
-             ub.KoboReadingState.book_id.notin_(reading_states_in_new_entitlements)))\
+             ub.KoboReadingState.book_id.notin_(reading_state_book_ids_emitted)))\
         .order_by(ub.KoboReadingState.last_modified)
     log.debug("Kobo Sync: changed states: {}".format(changed_reading_states.count()))
     # Do not set local continuation for a full reading-state page.  It has the

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -14,7 +14,7 @@ from cps import cw_babel
 import os
 import uuid
 import zipfile
-from time import gmtime, strftime
+from time import gmtime, monotonic, strftime
 import json
 from urllib.parse import unquote
 
@@ -75,6 +75,181 @@ def _entitlement_fingerprint(entitlement):
         ensure_ascii=False,
     ).encode("utf-8")
     return hashlib.sha256(payload).hexdigest()
+
+
+def _seed_existing_device_entitlement_ledgers(user_id):
+    """Seed pre-#1925 delivery state once for every known Kobo of a user.
+
+    Existing installs already have the flat ``KoboSyncedBooks`` record but no
+    per-device fingerprints.  Waiting to learn fingerprints from replayed
+    responses leaves the first post-upgrade token-loss replay harmful.  On the
+    first sync after upgrade, build the exact current base payload for every
+    previously delivered book and every known physical Kobo. Payloads are
+    device-specific because cover aspect settings can change ``CoverImageId``.
+
+    A durable per-device completion marker prevents later missing rows from
+    being mistaken for migration work: resend, unsync, archive, purge and
+    duplicate-merge paths deliberately clear individual ledger rows so the
+    next sync can deliver them.
+    """
+    device_ids = kobo_sync_status.get_unseeded_kobo_device_ids(user_id)
+    if not device_ids:
+        return True
+
+    started = monotonic()
+    try:
+        # Once any device crossed the upgrade boundary, an unmarked device is
+        # newly registered rather than an old device awaiting migration. Do
+        # not copy the user's flat historical delivery state onto it: that
+        # would make one Kobo's history suppress another Kobo's first copy.
+        # Mark it complete and let its own response build its ledger.
+        existing_user_seed = \
+            kobo_sync_status.user_has_completed_entitlement_seed(user_id)
+        if existing_user_seed:
+            kobo_sync_status.mark_device_entitlement_ledgers_seeded(device_ids)
+            if ub.session_commit() is False:
+                return False
+            elapsed_ms = round((monotonic() - started) * 1000, 1)
+            log.debug(
+                "Kobo Sync ledger seed: user=%s devices=%d books=0 deleted=0 "
+                "new_devices=%d elapsed_ms=%.1f",
+                user_id, len(device_ids), len(device_ids), elapsed_ms,
+            )
+            return True
+
+        synced_book_ids = sorted({
+            row.book_id for row in ub.session.query(
+                ub.KoboSyncedBooks.book_id,
+            ).filter(
+                ub.KoboSyncedBooks.user_id == int(user_id),
+            ).all()
+        })
+        archived = {
+            row.book_id: bool(row.is_archived)
+            for row in ub.session.query(ub.ArchivedBook).filter(
+                ub.ArchivedBook.user_id == int(user_id),
+            ).all()
+        }
+
+        seed_books = []
+        for offset in range(0, len(synced_book_ids), 250):
+            chunk = synced_book_ids[offset:offset + 250]
+            seed_books.extend(
+                calibre_db.session.query(db.Books)
+                .filter(db.Books.id.in_(chunk))
+                .options(
+                    joinedload(db.Books.authors),
+                    joinedload(db.Books.publishers),
+                    joinedload(db.Books.series),
+                    joinedload(db.Books.languages),
+                    joinedload(db.Books.comments),
+                    joinedload(db.Books.data),
+                )
+                .all()
+            )
+        seed_books.sort(key=lambda book: book.id)
+
+        # get_metadata() contains per-device cover selection. Build each
+        # device's ledger under that device's request identity instead of
+        # copying the requesting Kobo's hash across the household.
+        device_models = dict(ub.session.query(
+            ub.Device.id, ub.Device.model,
+        ).filter(ub.Device.id.in_(device_ids)).all())
+        original_device_id = getattr(g, "annotation_origin_device_id", None)
+        aspect_cache_present = hasattr(g, _REQUESTING_DEVICE_ASPECT_G_KEY)
+        original_aspect_cache = getattr(
+            g, _REQUESTING_DEVICE_ASPECT_G_KEY, None,
+        )
+        book_fingerprints_by_device = {}
+        try:
+            # Download metadata and every non-cover field are device-neutral;
+            # build them once so a network-share library is not walked once
+            # per household Kobo. CoverImageId is the sole per-device field.
+            common_payloads = {}
+            for book in seed_books:
+                common_payloads[book.id] = (
+                    create_book_entitlement(
+                        book, archived=archived.get(book.id, False),
+                    ),
+                    get_metadata(book),
+                )
+            for device_id in device_ids:
+                g.annotation_origin_device_id = device_id
+                # The live request header describes only the speaking device;
+                # seed other household Kobos from their recorded model.
+                setattr(
+                    g,
+                    _REQUESTING_DEVICE_ASPECT_G_KEY,
+                    cover_preview.preset_for_device_model(
+                        device_models.get(device_id),
+                    ),
+                )
+                book_fingerprints = {}
+                for book in seed_books:
+                    book_entitlement, common_metadata = common_payloads[book.id]
+                    metadata = dict(common_metadata)
+                    metadata["CoverImageId"] = _get_cover_image_id(book)
+                    payload = {
+                        "BookEntitlement": book_entitlement,
+                        "BookMetadata": metadata,
+                    }
+                    book_fingerprints[book.id] = \
+                        _entitlement_fingerprint(payload)
+                book_fingerprints_by_device[device_id] = book_fingerprints
+        finally:
+            g.annotation_origin_device_id = original_device_id
+            if aspect_cache_present:
+                setattr(
+                    g, _REQUESTING_DEVICE_ASPECT_G_KEY, original_aspect_cache,
+                )
+            else:
+                g.pop(_REQUESTING_DEVICE_ASPECT_G_KEY, None)
+
+        deleted_fingerprints = {}
+        for tombstone in ub.session.query(ub.KoboDeletedBook).filter(
+            ub.KoboDeletedBook.user_id == int(user_id),
+        ).all():
+            payload = {
+                "BookEntitlement": create_deleted_book_entitlement(
+                    tombstone.book_uuid, tombstone.deleted_at,
+                ),
+                "BookMetadata": create_deleted_book_metadata(tombstone.book_uuid),
+            }
+            deleted_fingerprints[str(tombstone.book_uuid)] = \
+                _entitlement_fingerprint(payload)
+
+        for device_id in device_ids:
+            kobo_sync_status.stage_device_entitlement_fingerprints(
+                device_id, book_fingerprints_by_device[device_id],
+            )
+            kobo_sync_status.stage_device_deleted_entitlement_fingerprints(
+                device_id, deleted_fingerprints,
+            )
+        kobo_sync_status.mark_device_entitlement_ledgers_seeded(device_ids)
+        # Legacy tests and a few downstream integrations replace this helper
+        # with a commit callable that returns None. Only the real helper's
+        # explicit False means the transaction was rolled back.
+        if ub.session_commit() is False:
+            return False
+    except Exception:
+        ub.session.rollback()
+        log.exception(
+            "Kobo Sync: failed to seed existing entitlement ledger for user %s",
+            user_id,
+        )
+        return False
+
+    elapsed_ms = round((monotonic() - started) * 1000, 1)
+    log.debug(
+        "Kobo Sync ledger seed: user=%s devices=%d books=%d deleted=%d "
+        "new_devices=0 elapsed_ms=%.1f",
+        user_id,
+        len(device_ids),
+        len(seed_books),
+        len(deleted_fingerprints),
+        elapsed_ms,
+    )
+    return True
 
 
 def _sync_cursor_summary(sync_token):
@@ -372,7 +547,7 @@ def HandleSyncRequest():
     sync_cursor_in = _sync_cursor_summary(sync_token)
     requesting_device_id = getattr(g, "annotation_origin_device_id", None)
     replay_suppression_enabled = bool(getattr(
-        config, "config_kobo_suppress_replayed_entitlements", False))
+        config, "config_kobo_suppress_replayed_entitlements", True))
     # Layer 2 deliberately cannot suppress a tokenless request. A factory
     # reset normally preserves the hardware id but clears both the library and
     # CWNG token; treating that as a replay would strand the entire library.
@@ -414,6 +589,14 @@ def HandleSyncRequest():
     sync_results = []
 
     calibre_db.reconnect_db(config, ub.app_DB_path)
+
+    # Upgrade bridge: existing devices already have flat delivery markers but
+    # no per-device hashes. Seed before selecting any replay so the FIRST
+    # valid-token replay after upgrade is suppressible, not merely later ones.
+    # A failed seed must not fall through to the harmful full replay.
+    if (replay_suppression_enabled and requesting_device_id
+            and not _seed_existing_device_entitlement_ledgers(current_user.id)):
+        return abort(503)
 
 
     # Magic-shelf book IDs + membership timestamp are computed for BOTH sync
@@ -695,6 +878,7 @@ def HandleSyncRequest():
     )
     entitlement_fingerprint_updates = {}
     suppressed_unchanged_entitlements = 0
+    suppressed_deleted_entitlements = 0
     delivered_book_identities = []
     for book in books_list:
         kobo_reading_state = book.KoboReadingState  # None when no record exists yet
@@ -1000,18 +1184,49 @@ def HandleSyncRequest():
         .limit(SYNC_ITEM_LIMIT)
         .all()
     )
+    prior_deleted_fingerprints = (
+        kobo_sync_status.get_device_deleted_entitlement_fingerprints(
+            requesting_device_id,
+            [str(tombstone.book_uuid) for tombstone in pending_deletions],
+        )
+        if replay_suppression_eligible else {}
+    )
+    deleted_fingerprint_updates = {}
     for tombstone in pending_deletions:
-        sync_results.append({
-            "ChangedEntitlement": {
-                "BookEntitlement": create_deleted_book_entitlement(
-                    tombstone.book_uuid, tombstone.deleted_at),
-                "BookMetadata": create_deleted_book_metadata(tombstone.book_uuid),
-            }
-        })
+        book_uuid = str(tombstone.book_uuid)
+        entitlement = {
+            "BookEntitlement": create_deleted_book_entitlement(
+                book_uuid, tombstone.deleted_at),
+            "BookMetadata": create_deleted_book_metadata(book_uuid),
+        }
+        fingerprint = (
+            _entitlement_fingerprint(entitlement)
+            if replay_suppression_enabled and requesting_device_id else None
+        )
+        entitlement_is_unchanged = bool(
+            replay_suppression_eligible
+            and prior_deleted_fingerprints.get(book_uuid) == fingerprint
+        )
+        if entitlement_is_unchanged:
+            suppressed_unchanged_entitlements += 1
+            suppressed_deleted_entitlements += 1
+        else:
+            sync_results.append({"ChangedEntitlement": entitlement})
+            if replay_suppression_enabled and requesting_device_id:
+                deleted_fingerprint_updates[book_uuid] = fingerprint
         ta = tombstone.deleted_at
         if hasattr(ta, "replace") and getattr(ta, "tzinfo", None) is not None:
             ta = ta.replace(tzinfo=None)
         new_archived_last_modified = max(ta, new_archived_last_modified)
+    kobo_sync_status.stage_device_deleted_entitlement_fingerprints(
+        requesting_device_id, deleted_fingerprint_updates,
+    )
+    if (deleted_fingerprint_updates
+            and ub.session_commit() is False):
+        # Do not claim a deletion was delivered when its replay guard rolled
+        # back; returning the payload anyway recreates the every-sync loop on
+        # the next stale archive cursor.
+        return abort(503)
 
     # Likewise, never set local continuation for deletion pages.  The returned
     # archive cursor must be persisted before the next page can be selected;
@@ -1037,12 +1252,14 @@ def HandleSyncRequest():
     changed_entitlement_count = sum("ChangedEntitlement" in item for item in sync_results)
     log.debug(
         "Kobo Sync summary: device=%s entitlements new=%d changed=%d "
-        "suppressed_unchanged=%d replay_suppression enabled=%s eligible=%s "
+        "suppressed_unchanged=%d suppressed_removed=%d "
+        "replay_suppression enabled=%s eligible=%s "
         "cursors in=%s out=%s",
         requesting_device_id,
         new_entitlement_count,
         changed_entitlement_count,
         suppressed_unchanged_entitlements,
+        suppressed_deleted_entitlements,
         replay_suppression_enabled,
         replay_suppression_eligible,
         sync_cursor_in,
@@ -1425,23 +1642,18 @@ def _get_cover_image_id(book):
         return base_id
 
 def build_download_url(book, book_data, download_format, declared_format):
-    result = {
-            "Format": declared_format,
-            "Url": get_download_url_for_book(book.id, download_format),
-            "Platform": "Generic",
-            "DrmType": "None",
-        }
-    # A generated KEPUB is not the Data row named by ``book_data``: deferred
-    # conversion can start from EPUB. Metadata embedding can rewrite either an
-    # EPUB or a KEPUB at download time. Advertising the source/stored size then
-    # makes Nickel compare unlike artifacts and de-download the local copy on
-    # an entitlement replay. Kobo accepts an omitted Size; retain it only when
-    # the exact stored artifact is what the URL serves.
-    generated_kepub = download_format == "kepub" and book_data.format != "KEPUB"
-    rewritten_download = bool(getattr(config, "config_embed_metadata", False))
-    if not generated_kepub and not rewritten_download:
-        result["Size"] = book_data.uncompressed_size
-    return result
+    # Preserve the v4.1.42 wire contract. Clara hardware recorded
+    # ``___FileSize=0`` when Size was omitted, a visible regression affecting
+    # 100 books. The value is the stable stored Data size even when the route
+    # later generates or rewrites the delivered artifact; replay suppression,
+    # not Size omission, is the proven de-download fix (#1925).
+    return {
+        "Format": declared_format,
+        "Url": get_download_url_for_book(book.id, download_format),
+        "Platform": "Generic",
+        "DrmType": "None",
+        "Size": book_data.uncompressed_size,
+    }
 
 def get_metadata(book):
     download_urls = []

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -7,6 +7,7 @@
 # See CONTRIBUTORS for full list of authors.
 
 import base64
+import hashlib
 import logging
 from datetime import datetime, timezone
 from cps import cw_babel
@@ -63,6 +64,31 @@ kobo_auth.disable_failed_auth_redirect_for_blueprint(kobo)
 kobo_auth.register_url_value_preprocessor(kobo)
 
 log = logger.create()
+
+
+def _entitlement_fingerprint(entitlement):
+    """Stable hash of fields that can change Nickel's local book record."""
+    payload = json.dumps(
+        entitlement,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _sync_cursor_summary(sync_token):
+    """Compact cursor state for the one-line per-sync diagnostic."""
+    return (
+        sync_token.books_last_modified,
+        sync_token.books_last_id,
+        sync_token.books_last_created,
+        sync_token.archive_last_modified,
+        sync_token.reading_state_last_modified,
+        sync_token.tags_last_modified,
+        sync_token.magic_shelf_last_id,
+        sync_token.magic_shelf_membership_at,
+    )
 
 
 def normalized_books_last_modified(value):
@@ -216,7 +242,10 @@ def convert_to_kobo_timestamp_string(timestamp):
         return timestamp.strftime("%Y-%m-%dT%H:%M:%SZ")
     except AttributeError as exc:
         log.debug("Timestamp not valid: {}".format(exc))
-        return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        # A response-generation timestamp makes an unchanged payload mutate
+        # from one sync to the next.  Epoch is a deterministic sentinel for
+        # malformed legacy rows and is accepted by the Kobo schema.
+        return "1970-01-01T00:00:00Z"
 
 
 def get_magic_shelf_book_ids_for_kobo(user_id):
@@ -340,6 +369,18 @@ def HandleSyncRequest():
         return abort(403)
 
     sync_token = SyncToken.SyncToken.from_headers(request.headers)
+    sync_cursor_in = _sync_cursor_summary(sync_token)
+    requesting_device_id = getattr(g, "annotation_origin_device_id", None)
+    replay_suppression_enabled = bool(getattr(
+        config, "config_kobo_suppress_replayed_entitlements", False))
+    # Layer 2 deliberately cannot suppress a tokenless request. A factory
+    # reset normally preserves the hardware id but clears both the library and
+    # CWNG token; treating that as a replay would strand the entire library.
+    replay_suppression_eligible = bool(
+        replay_suppression_enabled
+        and requesting_device_id
+        and sync_token.is_cwng_token
+    )
     log.info("Kobo library sync request received")
     log.debug("SyncToken: {}".format(sync_token))
     log.debug("Download link format {}".format(get_download_url_for_book('[bookid]', '[bookformat]')))
@@ -432,6 +473,13 @@ def HandleSyncRequest():
 
                 # Remove all books from the tracking table in one go
                 if books_to_delete_ids:
+                    user_device_ids = ub.session.query(ub.Device.id).filter(
+                        ub.Device.user_id == current_user.id,
+                    ).scalar_subquery()
+                    ub.session.query(ub.KoboDeviceBookEntitlement).filter(
+                        ub.KoboDeviceBookEntitlement.device_id.in_(user_device_ids),
+                        ub.KoboDeviceBookEntitlement.book_id.in_(books_to_delete_ids),
+                    ).delete(synchronize_session=False)
                     ub.session.query(ub.KoboSyncedBooks).filter(
                         ub.KoboSyncedBooks.user_id == current_user.id,
                         ub.KoboSyncedBooks.book_id.in_(books_to_delete_ids)
@@ -638,6 +686,15 @@ def HandleSyncRequest():
     # the joined-load query twice per sync request.
     books_list = changed_entries.limit(SYNC_ITEM_LIMIT).all()
     log.debug("Kobo Sync: selected to sync: {}".format(len(books_list)))
+    prior_entitlement_fingerprints = (
+        kobo_sync_status.get_device_entitlement_fingerprints(
+            requesting_device_id,
+            [book.Books.id for book in books_list],
+        )
+        if replay_suppression_eligible else {}
+    )
+    entitlement_fingerprint_updates = {}
+    suppressed_unchanged_entitlements = 0
     delivered_book_identities = []
     for book in books_list:
         kobo_reading_state = book.KoboReadingState  # None when no record exists yet
@@ -646,18 +703,39 @@ def HandleSyncRequest():
             "BookMetadata": get_metadata(book.Books),
         }
 
+        # A device may return a valid but stale CWNG cursor after an interrupted
+        # sync. The cursor then selects already-emitted books again. Layer 2
+        # suppresses only an exact payload replay to that physical device; a
+        # tokenless request is ineligible, another device has its own ledger,
+        # and any real metadata/last_modified/archive change alters this hash.
+        entitlement_fingerprint = (
+            _entitlement_fingerprint(entitlement)
+            if replay_suppression_enabled and requesting_device_id else None
+        )
+        entitlement_is_unchanged = bool(
+            replay_suppression_eligible
+            and prior_entitlement_fingerprints.get(book.Books.id)
+            == entitlement_fingerprint
+        )
+
         if (kobo_reading_state is not None
                 and kobo_reading_state.last_modified > sync_token.reading_state_last_modified):
-            entitlement["ReadingState"] = get_kobo_reading_state_response(book.Books, kobo_reading_state)
-            new_reading_state_last_modified = max(new_reading_state_last_modified, kobo_reading_state.last_modified)
-            reading_states_in_new_entitlements.append(book.Books.id)
+            if not entitlement_is_unchanged:
+                entitlement["ReadingState"] = get_kobo_reading_state_response(book.Books, kobo_reading_state)
+                new_reading_state_last_modified = max(new_reading_state_last_modified, kobo_reading_state.last_modified)
+                reading_states_in_new_entitlements.append(book.Books.id)
 
         ts_created = get_kobo_created_ts(book)
 
-        if ts_created > sync_token.books_last_created:
-            sync_results.append({"NewEntitlement": entitlement})
+        if entitlement_is_unchanged:
+            suppressed_unchanged_entitlements += 1
         else:
-            sync_results.append({"ChangedEntitlement": entitlement})
+            if ts_created > sync_token.books_last_created:
+                sync_results.append({"NewEntitlement": entitlement})
+            else:
+                sync_results.append({"ChangedEntitlement": entitlement})
+            if replay_suppression_enabled and requesting_device_id:
+                entitlement_fingerprint_updates[book.Books.id] = entitlement_fingerprint
 
         new_books_last_modified = max(
             books_cursor_datetime(book.Books.last_modified), new_books_last_modified
@@ -686,6 +764,8 @@ def HandleSyncRequest():
     # Persist the whole emitted page before response/token construction.  In
     # particular, the next request must not observe zero synced rows and reset
     # its token.  The batch helper also avoids one SQLite fsync per book.
+    kobo_sync_status.stage_device_entitlement_fingerprints(
+        requesting_device_id, entitlement_fingerprint_updates)
     kobo_sync_status.add_synced_books_batch(delivered_book_identities)
 
     # Magic-shelf sub-cursor: advance to the highest magic-shelf book id
@@ -939,6 +1019,22 @@ def HandleSyncRequest():
     sync_token.archive_last_modified = new_archived_last_modified
     sync_token.reading_state_last_modified = new_reading_state_last_modified
 
+    new_entitlement_count = sum("NewEntitlement" in item for item in sync_results)
+    changed_entitlement_count = sum("ChangedEntitlement" in item for item in sync_results)
+    log.debug(
+        "Kobo Sync summary: device=%s entitlements new=%d changed=%d "
+        "suppressed_unchanged=%d replay_suppression enabled=%s eligible=%s "
+        "cursors in=%s out=%s",
+        requesting_device_id,
+        new_entitlement_count,
+        changed_entitlement_count,
+        suppressed_unchanged_entitlements,
+        replay_suppression_enabled,
+        replay_suppression_eligible,
+        sync_cursor_in,
+        _sync_cursor_summary(sync_token),
+    )
+
     return generate_sync_response(sync_token, sync_results)
 
 
@@ -1053,10 +1149,13 @@ def get_download_url_for_book(book_id, book_format):
 
 def create_book_entitlement(book, archived):
     book_uuid = str(book.uuid)
+    created = convert_to_kobo_timestamp_string(book.timestamp)
     return {
         "Accessibility": "Full",
-        "ActivePeriod": {"From": convert_to_kobo_timestamp_string(datetime.now(timezone.utc))},
-        "Created": convert_to_kobo_timestamp_string(book.timestamp),
+        # ActivePeriod is entitlement data, not response-generation time.  A
+        # wall-clock value made the payload mutate on every replay (#1925).
+        "ActivePeriod": {"From": created},
+        "Created": created,
         "CrossRevisionId": book_uuid,
         "Id": book_uuid,
         "IsRemoved": archived,
@@ -1312,13 +1411,23 @@ def _get_cover_image_id(book):
         return base_id
 
 def build_download_url(book, book_data, download_format, declared_format):
-    return {
+    result = {
             "Format": declared_format,
-            "Size": book_data.uncompressed_size,
             "Url": get_download_url_for_book(book.id, download_format),
             "Platform": "Generic",
             "DrmType": "None",
         }
+    # A generated KEPUB is not the Data row named by ``book_data``: deferred
+    # conversion can start from EPUB. Metadata embedding can rewrite either an
+    # EPUB or a KEPUB at download time. Advertising the source/stored size then
+    # makes Nickel compare unlike artifacts and de-download the local copy on
+    # an entitlement replay. Kobo accepts an omitted Size; retain it only when
+    # the exact stored artifact is what the URL serves.
+    generated_kepub = download_format == "kepub" and book_data.format != "KEPUB"
+    rewritten_download = bool(getattr(config, "config_embed_metadata", False))
+    if not generated_kepub and not rewritten_download:
+        result["Size"] = book_data.uncompressed_size
+    return result
 
 def get_metadata(book):
     download_urls = []

--- a/cps/kobo_sync_status.py
+++ b/cps/kobo_sync_status.py
@@ -9,6 +9,7 @@ from .cw_login import current_user
 from . import logger, ub
 from datetime import datetime, timezone
 from sqlalchemy.sql.expression import or_, and_, true
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 # from sqlalchemy import exc
 
 log = logger.create()
@@ -67,6 +68,51 @@ def add_synced_books_batch(book_identities):
             for book_id in missing_book_ids
         ])
     ub.session_commit()
+
+
+def get_device_entitlement_fingerprints(device_id, book_ids):
+    """Return the last delivered payload hash for each candidate book."""
+    if not device_id or not book_ids:
+        return {}
+    return dict(
+        ub.session.query(
+            ub.KoboDeviceBookEntitlement.book_id,
+            ub.KoboDeviceBookEntitlement.fingerprint,
+        ).filter(
+            ub.KoboDeviceBookEntitlement.device_id == int(device_id),
+            ub.KoboDeviceBookEntitlement.book_id.in_(set(book_ids)),
+        ).all()
+    )
+
+
+def stage_device_entitlement_fingerprints(device_id, fingerprints):
+    """Upsert delivered entitlement hashes into the caller's transaction.
+
+    ``add_synced_books_batch`` commits immediately after this helper in the
+    sync handler, so the per-device ledger and legacy user-level delivery
+    marker become durable together.
+    """
+    if not device_id or not fingerprints:
+        return
+    now = datetime.now(timezone.utc)
+    rows = [
+        {
+            "device_id": int(device_id),
+            "book_id": int(book_id),
+            "fingerprint": fingerprint,
+            "updated_at": now,
+        }
+        for book_id, fingerprint in fingerprints.items()
+    ]
+    statement = sqlite_insert(ub.KoboDeviceBookEntitlement).values(rows)
+    statement = statement.on_conflict_do_update(
+        index_elements=["device_id", "book_id"],
+        set_={
+            "fingerprint": statement.excluded.fingerprint,
+            "updated_at": statement.excluded.updated_at,
+        },
+    )
+    ub.session.execute(statement)
 
 
 def _record_user_book_deletions(session, user_id, book_deletions, deleted_at):
@@ -170,15 +216,23 @@ def record_book_deletion(book_id, book_uuid, session=None):
 
 # Select all entries of current book in kobo_synced_books table, which are from current user and delete them
 def remove_synced_book(book_id, all=False, session=None):
+    s = session if session is not None else ub.session
     if not all:
         user = ub.KoboSyncedBooks.user_id == current_user.id
+        device_ids = s.query(ub.Device.id).filter(
+            ub.Device.user_id == current_user.id).scalar_subquery()
+        device_filter = ub.KoboDeviceBookEntitlement.device_id.in_(device_ids)
     else:
         user = true()
-    if not session:
-        ub.session.query(ub.KoboSyncedBooks).filter(ub.KoboSyncedBooks.book_id == book_id).filter(user).delete()
+        device_filter = true()
+    s.query(ub.KoboDeviceBookEntitlement).filter(
+        ub.KoboDeviceBookEntitlement.book_id == book_id,
+    ).filter(device_filter).delete(synchronize_session=False)
+    s.query(ub.KoboSyncedBooks).filter(
+        ub.KoboSyncedBooks.book_id == book_id).filter(user).delete()
+    if session is None:
         ub.session_commit()
     else:
-        session.query(ub.KoboSyncedBooks).filter(ub.KoboSyncedBooks.book_id == book_id).filter(user).delete()
         ub.session_commit(_session=session)
 
 

--- a/cps/kobo_sync_status.py
+++ b/cps/kobo_sync_status.py
@@ -14,6 +14,8 @@ from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
 log = logger.create()
 
+_LEDGER_UPSERT_BATCH_SIZE = 250
+
 
 # Record the current user's delivered book identity.
 def add_synced_books(book_id, book_uuid=None):
@@ -95,24 +97,115 @@ def stage_device_entitlement_fingerprints(device_id, fingerprints):
     if not device_id or not fingerprints:
         return
     now = datetime.now(timezone.utc)
-    rows = [
-        {
-            "device_id": int(device_id),
-            "book_id": int(book_id),
-            "fingerprint": fingerprint,
-            "updated_at": now,
-        }
-        for book_id, fingerprint in fingerprints.items()
-    ]
-    statement = sqlite_insert(ub.KoboDeviceBookEntitlement).values(rows)
-    statement = statement.on_conflict_do_update(
-        index_elements=["device_id", "book_id"],
-        set_={
-            "fingerprint": statement.excluded.fingerprint,
-            "updated_at": statement.excluded.updated_at,
-        },
+    items = list(fingerprints.items())
+    for offset in range(0, len(items), _LEDGER_UPSERT_BATCH_SIZE):
+        rows = [
+            {
+                "device_id": int(device_id),
+                "book_id": int(book_id),
+                "fingerprint": fingerprint,
+                "updated_at": now,
+            }
+            for book_id, fingerprint in items[
+                offset:offset + _LEDGER_UPSERT_BATCH_SIZE
+            ]
+        ]
+        statement = sqlite_insert(ub.KoboDeviceBookEntitlement).values(rows)
+        statement = statement.on_conflict_do_update(
+            index_elements=["device_id", "book_id"],
+            set_={
+                "fingerprint": statement.excluded.fingerprint,
+                "updated_at": statement.excluded.updated_at,
+            },
+        )
+        ub.session.execute(statement)
+
+
+def get_device_deleted_entitlement_fingerprints(device_id, book_uuids):
+    """Return delivered hard-delete hashes for one requesting device."""
+    if not device_id or not book_uuids:
+        return {}
+    return dict(
+        ub.session.query(
+            ub.KoboDeviceDeletedEntitlement.book_uuid,
+            ub.KoboDeviceDeletedEntitlement.fingerprint,
+        ).filter(
+            ub.KoboDeviceDeletedEntitlement.device_id == int(device_id),
+            ub.KoboDeviceDeletedEntitlement.book_uuid.in_(set(book_uuids)),
+        ).all()
     )
-    ub.session.execute(statement)
+
+
+def stage_device_deleted_entitlement_fingerprints(device_id, fingerprints):
+    """Upsert hard-delete entitlement hashes into the sync transaction."""
+    if not device_id or not fingerprints:
+        return
+    now = datetime.now(timezone.utc)
+    items = list(fingerprints.items())
+    for offset in range(0, len(items), _LEDGER_UPSERT_BATCH_SIZE):
+        rows = [
+            {
+                "device_id": int(device_id),
+                "book_uuid": str(book_uuid),
+                "fingerprint": fingerprint,
+                "updated_at": now,
+            }
+            for book_uuid, fingerprint in items[
+                offset:offset + _LEDGER_UPSERT_BATCH_SIZE
+            ]
+        ]
+        statement = sqlite_insert(ub.KoboDeviceDeletedEntitlement).values(rows)
+        statement = statement.on_conflict_do_update(
+            index_elements=["device_id", "book_uuid"],
+            set_={
+                "fingerprint": statement.excluded.fingerprint,
+                "updated_at": statement.excluded.updated_at,
+            },
+        )
+        ub.session.execute(statement)
+
+
+def get_unseeded_kobo_device_ids(user_id):
+    """Return this user's physical Kobo devices lacking an upgrade seed."""
+    device_ids = {
+        row.id for row in ub.session.query(ub.Device.id).filter(
+            ub.Device.user_id == int(user_id),
+            ub.Device.kind == "kobo",
+        ).all()
+    }
+    if not device_ids:
+        return []
+    seeded = {
+        row.device_id for row in
+        ub.session.query(ub.KoboDeviceEntitlementSeed.device_id).filter(
+            ub.KoboDeviceEntitlementSeed.device_id.in_(device_ids),
+        ).all()
+    }
+    return sorted(device_ids - seeded)
+
+
+def user_has_completed_entitlement_seed(user_id):
+    """Whether this user's upgrade boundary has already been crossed."""
+    return ub.session.query(ub.KoboDeviceEntitlementSeed.device_id).join(
+        ub.Device,
+        ub.Device.id == ub.KoboDeviceEntitlementSeed.device_id,
+    ).filter(
+        ub.Device.user_id == int(user_id),
+        ub.Device.kind == "kobo",
+    ).first() is not None
+
+
+def mark_device_entitlement_ledgers_seeded(device_ids):
+    """Idempotently mark complete upgrade seeding for physical devices."""
+    device_ids = sorted({int(device_id) for device_id in device_ids if device_id})
+    if not device_ids:
+        return
+    now = datetime.now(timezone.utc)
+    statement = sqlite_insert(ub.KoboDeviceEntitlementSeed).values([
+        {"device_id": device_id, "seeded_at": now}
+        for device_id in device_ids
+    ])
+    ub.session.execute(statement.on_conflict_do_nothing(index_elements=["device_id"]))
 
 
 def _record_user_book_deletions(session, user_id, book_deletions, deleted_at):

--- a/cps/services/SyncToken.py
+++ b/cps/services/SyncToken.py
@@ -120,6 +120,7 @@ class SyncToken:
         books_last_id=-1,
         magic_shelf_last_id=-1,
         magic_shelf_membership_at=datetime.min,
+        is_cwng_token=False,
     ):  # nosec
         self.raw_kobo_store_token = raw_kobo_store_token
         self.books_last_created = books_last_created
@@ -130,6 +131,11 @@ class SyncToken:
         self.books_last_id = books_last_id
         self.magic_shelf_last_id = magic_shelf_last_id
         self.magic_shelf_membership_at = magic_shelf_membership_at
+        # Request provenance only; never serialized. True means from_headers
+        # successfully decoded and schema-validated a token produced by CWNG.
+        # Empty, malformed, and official-store tokens remain False so callers
+        # can preserve first-sync/factory-reset behavior.
+        self.is_cwng_token = is_cwng_token
 
     @staticmethod
     def from_headers(headers):
@@ -217,6 +223,20 @@ class SyncToken:
         if not isinstance(magic_shelf_last_id, int):
             magic_shelf_last_id = -1
 
+        # The historical schema intentionally accepts missing fields and
+        # degrades them to datetime.min for cursor compatibility. That is too
+        # permissive as proof that a request returned a token CWNG actually
+        # emitted. Layer 2 provenance therefore requires every original v1
+        # cursor while leaving the parser's existing fallback behavior intact.
+        core_cursor_fields = {
+            "books_last_modified",
+            "books_last_created",
+            "archive_last_modified",
+            "reading_state_last_modified",
+            "tags_last_modified",
+        }
+        is_cwng_token = core_cursor_fields.issubset(data_json)
+
         return SyncToken(
             raw_kobo_store_token=raw_kobo_store_token,
             books_last_created=books_last_created,
@@ -227,6 +247,7 @@ class SyncToken:
             books_last_id=books_last_id,
             magic_shelf_last_id=magic_shelf_last_id,
             magic_shelf_membership_at=magic_shelf_membership_at,
+            is_cwng_token=is_cwng_token,
         )
 
     def set_kobo_store_header(self, store_headers):

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -231,6 +231,11 @@
         {% endif %}
       </div>
       <div class="form-group" style="margin-left:10px;">
+        <input type="checkbox" id="config_kobo_suppress_replayed_entitlements" name="config_kobo_suppress_replayed_entitlements" {% if config.config_kobo_suppress_replayed_entitlements %}checked{% endif %} aria-describedby="kobo-replay-suppression-help">
+        <label for="config_kobo_suppress_replayed_entitlements">{{_('Suppress unchanged Kobo entitlement replays (experimental)')}}</label>
+        <p id="kobo-replay-suppression-help" class="help-block">{{_('Off by default. When enabled, unchanged books are suppressed only when the device returns a valid but stale CWNG sync token. Requests without a valid CWNG token always receive the full library, including after a factory reset.')}}</p>
+      </div>
+      <div class="form-group" style="margin-left:10px;">
         <label for="config_external_port">{{_('Server External Port (for port forwarded API calls)')}}</label>
         <input type="number" min="1" max="65535" class="form-control" name="config_external_port" id="config_external_port" value="{% if config.config_external_port != None %}{{ config.config_external_port }}{% endif %}" autocomplete="off" required>
       </div>

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -232,8 +232,8 @@
       </div>
       <div class="form-group" style="margin-left:10px;">
         <input type="checkbox" id="config_kobo_suppress_replayed_entitlements" name="config_kobo_suppress_replayed_entitlements" {% if config.config_kobo_suppress_replayed_entitlements %}checked{% endif %} aria-describedby="kobo-replay-suppression-help">
-        <label for="config_kobo_suppress_replayed_entitlements">{{_('Suppress unchanged Kobo entitlement replays (experimental)')}}</label>
-        <p id="kobo-replay-suppression-help" class="help-block">{{_('Off by default. When enabled, unchanged books are suppressed only when the device returns a valid but stale CWNG sync token. Requests without a valid CWNG token always receive the full library, including after a factory reset.')}}</p>
+        <label for="config_kobo_suppress_replayed_entitlements">{{_('Suppress unchanged Kobo entitlement replays')}}</label>
+        <p id="kobo-replay-suppression-help" class="help-block">{{_('On by default. Unchanged books are suppressed only when the device returns a valid but stale CWNG sync token. Requests without a valid CWNG token always receive the full library, including after a factory reset.')}}</p>
       </div>
       <div class="form-group" style="margin-left:10px;">
         <label for="config_external_port">{{_('Server External Port (for port forwarded API calls)')}}</label>

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -1906,11 +1906,13 @@ def add_missing_tables(engine, _session):
         ("hidden_magic_shelf_templates", HiddenMagicShelfTemplate.__table__),
         ("kobo_annotation_backup", KoboAnnotationBackup.__table__),
         ("favorite_book", FavoriteBook.__table__),
+    )
+    kobo_entitlement_tables = (
         ("kobo_device_book_entitlement", KoboDeviceBookEntitlement.__table__),
         ("kobo_device_deleted_entitlement", KoboDeviceDeletedEntitlement.__table__),
         ("kobo_device_entitlement_seed", KoboDeviceEntitlementSeed.__table__),
     )
-    for table_name, table in tables:
+    for table_name, table in tables + kobo_entitlement_tables:
         # Explicit transaction control means even schema inspection begins a
         # real read transaction. Close it before opening the separate DDL
         # transaction or the inspection connection can block its commit.

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -806,6 +806,38 @@ class KoboSyncedBooks(Base):
     )
 
 
+class KoboDeviceBookEntitlement(Base):
+    """Last stable entitlement delivered to one physical Kobo.
+
+    Kobo's opaque sync token is device-owned and can disappear after an
+    interrupted sync, firmware install, or USB interruption.  This server-side
+    ledger is deliberately per-device (not per-user): it lets a known device
+    suppress an identical entitlement replay without causing another Kobo on
+    the same account to miss its first delivery or a later real change.
+    """
+    __tablename__ = 'kobo_device_book_entitlement'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    device_id = Column(
+        Integer, ForeignKey('device.id', ondelete='CASCADE'), nullable=False,
+    )
+    # Cross-database identity: calibre's Books row lives in metadata.db, so
+    # this cannot be a foreign key in app.db.
+    book_id = Column(Integer, nullable=False)
+    fingerprint = Column(String(64), nullable=False)
+    updated_at = Column(
+        DateTime, nullable=False, default=lambda: datetime.now(timezone.utc),
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            'device_id', 'book_id',
+            name='uq_kobo_device_book_entitlement_device_book',
+        ),
+        Index('ix_kobo_device_book_entitlement_book', 'book_id'),
+    )
+
+
 class NoticeEvent(Base):
     """Device-agnostic occurrence that may need to be shown to selected users.
 
@@ -1828,6 +1860,7 @@ def add_missing_tables(engine, _session):
         ("hidden_magic_shelf_templates", HiddenMagicShelfTemplate.__table__),
         ("kobo_annotation_backup", KoboAnnotationBackup.__table__),
         ("favorite_book", FavoriteBook.__table__),
+        ("kobo_device_book_entitlement", KoboDeviceBookEntitlement.__table__),
     )
     for table_name, table in tables:
         # Explicit transaction control means even schema inspection begins a

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -838,6 +838,52 @@ class KoboDeviceBookEntitlement(Base):
     )
 
 
+class KoboDeviceDeletedEntitlement(Base):
+    """Last hard-delete entitlement delivered to one physical Kobo.
+
+    Hard-deleted books no longer have a calibre ``book_id``.  Keep their UUID
+    replay state separate from the live-book ledger so a stale archive cursor
+    cannot re-offer the same ``IsRemoved`` entitlement forever, while another
+    device and a tokenless factory-reset sync can still receive it.
+    """
+    __tablename__ = 'kobo_device_deleted_entitlement'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    device_id = Column(
+        Integer, ForeignKey('device.id', ondelete='CASCADE'), nullable=False,
+    )
+    book_uuid = Column(String(64), nullable=False)
+    fingerprint = Column(String(64), nullable=False)
+    updated_at = Column(
+        DateTime, nullable=False, default=lambda: datetime.now(timezone.utc),
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            'device_id', 'book_uuid',
+            name='uq_kobo_device_deleted_entitlement_device_uuid',
+        ),
+        Index('ix_kobo_device_deleted_entitlement_uuid', 'book_uuid'),
+    )
+
+
+class KoboDeviceEntitlementSeed(Base):
+    """Marks completion of the one-time pre-#1925 ledger seed per device.
+
+    A marker is necessary: inferring completeness from missing ledger rows
+    would recreate rows deliberately cleared by resend, unsync, archive, or
+    duplicate-merge operations and suppress the very delivery they request.
+    """
+    __tablename__ = 'kobo_device_entitlement_seed'
+
+    device_id = Column(
+        Integer, ForeignKey('device.id', ondelete='CASCADE'), primary_key=True,
+    )
+    seeded_at = Column(
+        DateTime, nullable=False, default=lambda: datetime.now(timezone.utc),
+    )
+
+
 class NoticeEvent(Base):
     """Device-agnostic occurrence that may need to be shown to selected users.
 
@@ -1861,6 +1907,8 @@ def add_missing_tables(engine, _session):
         ("kobo_annotation_backup", KoboAnnotationBackup.__table__),
         ("favorite_book", FavoriteBook.__table__),
         ("kobo_device_book_entitlement", KoboDeviceBookEntitlement.__table__),
+        ("kobo_device_deleted_entitlement", KoboDeviceDeletedEntitlement.__table__),
+        ("kobo_device_entitlement_seed", KoboDeviceEntitlementSeed.__table__),
     )
     for table_name, table in tables:
         # Explicit transaction control means even schema inspection begins a

--- a/cps/user_book_data.py
+++ b/cps/user_book_data.py
@@ -338,6 +338,28 @@ def purge_user_book_data(book_id=None, user_id=None, session=None,
             ub.KoboDeviceBookEntitlement.device_id.in_(device_ids))
     entitlement_state.delete(synchronize_session=False)
 
+    # Hard-delete replay state and the one-time upgrade marker are scoped to a
+    # device rather than a current book id. A user/privacy purge or a complete
+    # database swap must remove them; a single live-book purge must not erase
+    # unrelated deletion history or re-arm migration seeding.
+    if user_id is not None or book_id is None:
+        deleted_entitlement_state = session.query(
+            ub.KoboDeviceDeletedEntitlement,
+        )
+        entitlement_seed_state = session.query(ub.KoboDeviceEntitlementSeed)
+        if user_id is not None:
+            device_ids = session.query(ub.Device.id).filter(
+                ub.Device.user_id == user_id,
+            ).scalar_subquery()
+            deleted_entitlement_state = deleted_entitlement_state.filter(
+                ub.KoboDeviceDeletedEntitlement.device_id.in_(device_ids),
+            )
+            entitlement_seed_state = entitlement_seed_state.filter(
+                ub.KoboDeviceEntitlementSeed.device_id.in_(device_ids),
+            )
+        deleted_entitlement_state.delete(synchronize_session=False)
+        entitlement_seed_state.delete(synchronize_session=False)
+
     # BookShelf has no user_id — shelf membership is shelf-scoped, and the
     # user-delete path removes the user's shelves (with their links)
     # separately. Only book-scoped (and full) purges touch it.

--- a/cps/user_book_data.py
+++ b/cps/user_book_data.py
@@ -79,10 +79,11 @@ def _delete_annotation(session, annotation):
     ).delete(synchronize_session=False)
     session.delete(annotation)
 
-# Models keyed (user_id, book_id) handled by this module, with merge
-# semantics for migrate. BookShelf has no user_id (shelf-scoped) and
-# KoboBookmark/KoboStatistics/AnnotationSyncTarget are children reached
-# through their parents; all are still handled below.
+# Models tied to a user and book handled by this module, with merge semantics
+# for migrate. BookShelf has no user_id (shelf-scoped), the Kobo entitlement
+# ledger resolves user scope through Device, and KoboBookmark/KoboStatistics/
+# AnnotationSyncTarget are children reached through their parents; all are
+# still handled below.
 PER_USER_BOOK_MODELS = (
     "Annotation",            # + AnnotationSyncTarget children
     "Bookmark",
@@ -95,6 +96,7 @@ PER_USER_BOOK_MODELS = (
     "KoboSyncedBooks",
     "UserHiddenBook",
     "BookCoverPreview",
+    "KoboDeviceBookEntitlement",  # user scope resolves through Device
 )
 
 
@@ -219,11 +221,15 @@ def migrate_user_book_data(from_book_id, to_book_id, session=None):
         ub.KoboAnnotationBackup.book_id == from_book_id).update(
         {ub.KoboAnnotationBackup.book_id: to_book_id}, synchronize_session=False)
 
-    # KoboSyncedBooks marks "this book's file already delivered to this
-    # device". The kept book's file is a different file, so the marker must
-    # NOT migrate — drop it and let the next sync deliver the kept copy.
+    # KoboSyncedBooks is a legacy flat (user, book) marker: it says the book
+    # was offered to at least one Kobo for this user, not which device still
+    # has it. The kept book is a different file, so neither this marker nor the
+    # newer per-device payload ledger may migrate; let the next sync deliver it.
     session.query(ub.KoboSyncedBooks).filter(
         ub.KoboSyncedBooks.book_id == from_book_id).delete(synchronize_session=False)
+    session.query(ub.KoboDeviceBookEntitlement).filter(
+        ub.KoboDeviceBookEntitlement.book_id == from_book_id,
+    ).delete(synchronize_session=False)
 
     session.flush()
     log.info("[user-book-data] migrated per-user data from book %s to book %s",
@@ -318,6 +324,19 @@ def purge_user_book_data(book_id=None, user_id=None, session=None,
     for model in (ub.Bookmark, ub.ReadBook, ub.ArchivedBook, ub.Downloads,
                   ub.KoboSyncedBooks, ub.UserHiddenBook, ub.BookCoverPreview):
         _scoped(session.query(model), model).delete(synchronize_session=False)
+
+    # Per-device entitlement state has no user_id of its own.  Scope a user
+    # purge through Device, while a book/full purge can filter directly.
+    entitlement_state = session.query(ub.KoboDeviceBookEntitlement)
+    if book_id is not None:
+        entitlement_state = entitlement_state.filter(
+            ub.KoboDeviceBookEntitlement.book_id == book_id)
+    if user_id is not None:
+        device_ids = session.query(ub.Device.id).filter(
+            ub.Device.user_id == user_id).scalar_subquery()
+        entitlement_state = entitlement_state.filter(
+            ub.KoboDeviceBookEntitlement.device_id.in_(device_ids))
+    entitlement_state.delete(synchronize_session=False)
 
     # BookShelf has no user_id — shelf membership is shelf-scoped, and the
     # user-delete path removes the user's shelves (with their links)

--- a/cps/user_book_data.py
+++ b/cps/user_book_data.py
@@ -96,8 +96,12 @@ PER_USER_BOOK_MODELS = (
     "KoboSyncedBooks",
     "UserHiddenBook",
     "BookCoverPreview",
-    "KoboDeviceBookEntitlement",  # user scope resolves through Device
 )
+# This ledger is user-scoped through Device rather than a user_id column.
+# Keep the device-scoped registry extension separate from the flat-model tuple
+# so independently added flat per-user models merge without competing for the
+# tuple's final insertion point.
+PER_USER_BOOK_MODELS += ("KoboDeviceBookEntitlement",)
 
 
 def migrate_user_book_data(from_book_id, to_book_id, session=None):

--- a/notes/issue-1925-sync-dedownload-report.md
+++ b/notes/issue-1925-sync-dedownload-report.md
@@ -1,0 +1,308 @@
+# Issue #1925 — Kobo sync de-download report
+
+Status: two-layer implementation complete; focused and complete executable-unit
+verification green; Clara hardware discrimination pending.
+
+## Mechanism
+
+- **OBSERVED — discriminating integration tests:** real `HandleSyncRequest`
+  calls with one user, one unchanged book, and real SQLAlchemy cursor queries
+  reproduce the replay. With Layer 2 off, two tokenless requests both contain
+  the same `NewEntitlement`, but Layer 1 makes the two payloads byte-identical.
+  With Layer 2 on, a successfully parsed CWNG token whose cursors are behind
+  selects the book but the matching per-device fingerprint suppresses it.
+- **OBSERVED — the token is the replay trigger:** a normal request that echoes
+  the first response's `x-kobo-synctoken` advances past the unchanged book.
+  A missing, malformed, truncated, or official-store-only token becomes a
+  `SyncToken` with local cursors at `datetime.min`, so the book query selects
+  the whole library again. The old handler retained no per-device record of the
+  payload already delivered and replayed every selected entitlement.
+- **OBSERVED — candidate (1), the empty `KoboSyncedBooks` reset, is sufficient
+  but not necessary:** the red test keeps the user's `KoboSyncedBooks` row
+  present before request two, so the line-349 full-reset branch does not fire.
+  Token loss alone reproduces the server response. If that table is also empty,
+  the branch explicitly discards a valid incoming local cursor and reaches the
+  same replay path.
+- **OBSERVED — candidate (3), cursor/token loss, is the root replay
+  mechanism:** the unchanged response is replayed when the local cursor is
+  absent or behind the payload already emitted. The already-landed #468 Magic Shelf fix preserves
+  `MagicShelfCache.created_at` when membership is unchanged, so an unchanged
+  cache rebuild is not the discriminator at this HEAD.
+- **OBSERVED — first/second response diff on old code:** the same UUID was
+  re-sent as `NewEntitlement`. For requests generated in different clock
+  seconds, the sole logically-unchanged entitlement field that mutated was
+  `BookEntitlement.ActivePeriod.From`; `DownloadUrls[].Size` stayed numerically
+  equal to the source `Data` row but did not describe the generated artifact.
+  Thus token loss selects the replay, wall-clock `ActivePeriod` makes its JSON
+  unstable, and `Size` can make the stable-looking declaration untruthful.
+- **OBSERVED — candidate (2), declared size, is a contributing payload defect,
+  not the replay trigger:** `build_download_url` declared
+  `book_data.uncompressed_size`. For deferred EPUB→KEPUB conversion that is the
+  EPUB's stored size; with download-time metadata embedding, even a stored
+  KEPUB is rewritten to fresh bytes. The declared value therefore does not
+  describe the artifact Nickel receives. The fix omits `Size` for generated
+  KEPUBs and every metadata-rewritten EPUB/KEPUB, retaining it only for exact
+  stored files.
+- **OBSERVED — another unstable entitlement field:** `ActivePeriod.From` used
+  response-generation wall-clock time. Two otherwise identical entitlement
+  builds therefore differed even with no library change. It now uses the
+  stable book-created timestamp, the same value as `Created`.
+- **OBSERVED on hardware (source dossier §6n/§6q):** the abnormal post-firmware
+  Clara sync and post-USB-interruption Libra sync re-stamped unchanged `content`
+  rows and changed downloaded books to `IsDownloaded='false'`; three of four
+  flipped books also changed `___FileSize`; server `metadata.db` had no
+  `last_modified` bump.
+- **ASSUMED — Nickel's exact decision predicate:** the combined hardware and
+  server evidence is consistent with Nickel treating a replayed entitlement,
+  especially one whose declared `Size` disagrees with its local artifact, as a
+  replacement and clearing `IsDownloaded`. Nickel is closed-source and the
+  Python integration test proves the server stimulus, not Nickel's private
+  branch condition. The Layer 1 Clara experiment below tests whether stable,
+  truthful payloads alone remove the harmful client outcome.
+
+## Layer 1 — ship first: payload stabilization, no suppression
+
+- **OBSERVED:** `ActivePeriod.From` is the stable book-created timestamp, equal
+  to `Created`; malformed legacy timestamps use a deterministic epoch rather
+  than response time.
+- **OBSERVED:** `DownloadUrls[].Size` is omitted for generated KEPUBs and every
+  metadata-rewritten EPUB/KEPUB. Exact stored artifacts retain their truthful
+  stored size.
+- **OBSERVED:** the permanent DEBUG summary reports New/Changed/suppressed
+  counts, Layer 2 enabled/eligible state, and in/out book, archive,
+  reading-state, tag, and Magic Shelf cursors without logging the opaque store
+  token.
+- **OBSERVED:** with the new flag at its default `false`, the sync path computes,
+  queries, and writes no fingerprint and suppresses no entitlement. A tokenless
+  unchanged-library replay is still emitted, now byte-identically. This is the
+  default production behavior until Clara evidence justifies Layer 2.
+- **OBSERVED:** real `Books.last_modified` changes still emit exactly one
+  `ChangedEntitlement`.
+
+## Layer 2 — experimental, default off
+
+- **OBSERVED:** `config_kobo_suppress_replayed_entitlements` is additive,
+  defaults false on upgrades and fresh installs, is exposed as an experimental
+  admin checkbox, and gates all ledger reads/writes and suppression behavior.
+- **OBSERVED:** when enabled, `kobo_device_book_entitlement` stores the SHA-256
+  of stable `BookEntitlement` + `BookMetadata` per `(device_id, book_id)`. The
+  HMAC-backed device registry resolves the physical device without storing its
+  raw hardware identifier.
+- **OBSERVED — factory-reset escape:** suppression is eligible only when the
+  request has a resolved device and `SyncToken.from_headers` successfully
+  decoded and schema-validated a CWNG token. Empty, malformed, truncated, and
+  official-store tokens always receive the full replay, even when the hardware
+  already has ledger rows. Those deliveries refresh the ledger.
+- **OBSERVED:** a valid stale CWNG token plus an exact same-device fingerprint
+  suppresses New/Changed entitlement replay while still advancing cursors.
+  Reading-state changes remain independently deliverable. A second device has
+  no matching row and receives its entitlement.
+- **ASSUMED/unavoidable ambiguities:** an empty library that somehow retains a
+  valid stale CWNG token is indistinguishable from an interrupted sync whose
+  library is intact. Also, the ledger proves that the server generated a
+  response, not that the device applied it: if transmission stops before the
+  device applies a newly offered book and it retries the same valid token,
+  Layer 2 may suppress a book the device never received. The escape covers the
+  normal factory-reset/re-setup signature (no valid CWNG token), not retained-
+  token database corruption, partial restores, or pre-application response
+  loss. These residual risks are why Layer 2 defaults off.
+- **OBSERVED:** explicit unsync/resend, full-sync, archive-removal, duplicate
+  merge, book purge, user purge, and database-swap paths clear the new ledger
+  at the same boundary as the legacy delivery marker. This prevents replay
+  suppression from masking an operator-requested resend or a book returning
+  from Archive.
+- **OBSERVED:** `KoboDeviceBookEntitlement` is registered in
+  `PER_USER_BOOK_MODELS`; because its user scope is indirect, purge resolves it
+  through `Device`, while duplicate/book purges filter by `book_id`.
+
+## Pre-existing flat-marker constraint
+
+- **OBSERVED:** `KoboSyncedBooks` remains keyed only by `(user_id, book_id)`,
+  not device. Its archive/reset logic can establish only that some Kobo for the
+  user was offered the book; it cannot establish that this requesting device
+  still has it. One device's delivery/removal therefore affects the user's
+  flat archive candidate set seen by other devices.
+- **OBSERVED:** this is why neither a present `KoboSyncedBooks` row nor the
+  physical-device HMAC is a safe non-empty-library discriminator. Layer 2 uses
+  its per-device ledger only after a valid returned CWNG token, and Layer 1
+  leaves the flat-marker behavior unchanged.
+- **ASSUMED/future work:** fully resolving the archive hazard requires making
+  delivery/archive state device-scoped or receiving authoritative device
+  library state; #1925 does not attempt that migration.
+
+## Dating
+
+- **OBSERVED — earliest payload instability in upstream history:** upstream
+  commit `8e1641dac9c9211ef324d5aeb8cfd399cc496bc0` (authored 2020-02-15,
+  committed 2020-03-01, “Add support for syncing Kobo reading state”) introduced
+  the wall-clock `ActivePeriod` shape. The current CWNG ancestry acquired that
+  code in the CWA in-repo “MAJOR REFACTOR” import
+  `73eecc175bf241c4410e7e220c7d2bfb426851ce` on 2025-08-02; the first tag
+  containing that import is `V3.1.2` (2025-08-03).
+- **OBSERVED — size field provenance:** upstream commit
+  `55c0bb6d34e009b5aed241037187d17357551432` (2019-12-08) introduced
+  `DownloadUrls[].Size` from the stored `Data` row. It was truthful for the
+  exact stored KEPUB path at that point.
+- **OBSERVED — download-time KEPUB byte instability:** upstream commit
+  `b8031cd53fe19ac37f1962f5010b2669e45875d2` (2024-01-13, “Add possibility to
+  replace kepub metadata on download”) introduced `updateEpub(...); zf.writestr`
+  for every metadata-embedded KEPUB download. Python supplies the new ZIP
+  member's current local time, so identical logical input can produce different
+  bytes/size. CWNG again acquired this in `73eecc175...` / first tag `V3.1.2`.
+- **OBSERVED — first CWNG PR that made the declared-size mismatch apply to
+  deferred conversions:** `27b334cc1877655c2086560148a00094582f6591`
+  (committed 2026-06-04, authored 2026-06-05), PR **#350**, “defer kepub
+  conversion”. It selected the EPUB `Data` row while declaring a KEPUB download
+  URL, so the EPUB size was guaranteed to name a different artifact. The first
+  release tag containing it is `v4.0.146` (2026-06-04).
+- **OBSERVED — cursor-loss replay provenance:** upstream commit
+  `25422b341142729fdc6f6d32b45e27986a3d535e` (2021-12-12, fix for upstream
+  #2195) added the empty-`KoboSyncedBooks` forced-reset branch. Malformed/foreign
+  token fallback has existed since the early SyncToken implementation; neither
+  path had per-device payload memory.
+- **OBSERVED — shipped scope:** the previous stable release `v4.1.41`
+  (`VERSION` = `4.1.41`, tagged 2026-08-25) contains the import, PR #350, token
+  reset, and download-time rewrite, so it carries the complete #1925 exposure.
+
+## Automated verification
+
+### Red on old code
+
+Command:
+
+```text
+python -m pytest -q tests/unit/test_1925_kobo_sync_dedownload.py
+```
+
+Manager-verified result against old code for the nine-test regression revision:
+**6 failed, 3 passed**. The failures discriminated replay suppression, unstable
+timestamps, and untruthful generated/rewritten download sizes from the positive
+controls that old code already handled.
+
+- replay assertion failed: second response contained one unchanged
+  `NewEntitlement`;
+- stable-field assertion failed: `ActivePeriod.From` was wall-clock time rather
+  than `Created`;
+- generated-KEPUB assertion failed: response declared the source EPUB size;
+- real `last_modified` bump assertion already passed.
+
+### Green after implementation
+
+**OBSERVED — focused two-layer, lifecycle, and adjacent KEPUB selection:**
+
+```text
+python -m pytest -q \
+  tests/unit/test_1925_kobo_sync_dedownload.py \
+  tests/unit/test_kobo_synctoken_validation.py \
+  tests/unit/test_kobo_synctoken_compression_331.py \
+  tests/unit/test_kobo_annotation_stage0.py \
+  tests/unit/test_user_book_data_d4.py \
+  tests/unit/test_kobo_admin_resend_book.py \
+  tests/unit/test_kobo_prefer_kepub.py
+```
+
+Current result: **102 passed**. The #1925 module contributes 15 collected cases,
+including default-off/zero-ledger behavior, byte-identical tokenless replay,
+valid-stale-token suppression, absent/malformed/store-token factory-reset
+escapes, per-device isolation, real-change positive control, stable timestamps,
+truthful size behavior, schema creation, config migration/defaults, and strict
+suppression provenance atop permissive legacy token parsing. The D4 suite pins
+`PER_USER_BOOK_MODELS` registration and lifecycle cleanup.
+
+**OBSERVED — final complete executable unit suite:** `tests/unit` collected
+**7,362** tests. With the 17 environment-blocked node IDs below explicitly
+deselected, the post-restructure result was **7,243 passed, 102 skipped, 17
+deselected**. No executable unit test failed.
+
+The 17 deselections are existing tests whose required OS operation is denied by
+this managed sandbox:
+
+- six real-server cases in `test_gevent_wsgi_format_request.py` — loopback
+  `bind(('127.0.0.1', 0))` raises `PermissionError(EPERM)`;
+- one case in `test_health_probe_responsiveness.py` — same loopback-bind denial;
+- three cases in `test_measure_kobo_patch_failure_is_safe.py` — same
+  loopback-bind denial;
+- seven cases in `test_s6_ingest_service_shutdown.py` — executing `/bin/ps` to
+  inspect the child session raises `PermissionError(EPERM)`.
+
+**OBSERVED — earlier literal repository-default command:** `python -m pytest` collected
+7,569 tests and reached **7,348 passed, 123 skipped, 18 failed, 80 setup
+errors** before the final test-precondition pin. Seventeen of the failures are
+the sandbox-denied unit cases above. The eighteenth was the existing stored-
+KEPUB size test relying on uninitialized-config order; it is now pinned to its
+actual precondition (`config_embed_metadata=False`) and passes both focused and
+in the complete executable unit run. The 80 setup errors are environment-backed
+Docker/ingest/KOReader integration suites with no Docker container or live
+service in this offline worktree, not product assertion failures. The literal
+default command was not rerun after that test-only precondition correction;
+the complete unit tree was.
+
+**OBSERVED — static hygiene:** `git diff --check` exits cleanly.
+
+## Clara hardware-verification recipe
+
+### Phase A — decide whether Layer 1 is sufficient
+
+Run this phase with `config_kobo_suppress_replayed_entitlements = false`.
+Layer 2 must remain off throughout the experiment.
+
+1. Deploy the fixed image, confirm the flag is off, and enable DEBUG logging.
+2. With the Clara idle and disconnected from USB, pull baseline
+   `KoboReader.sqlite` (`A0`). Export the `content` identity/state tuple for all
+   CWNG books:
+
+   ```sql
+   SELECT ContentID, IsDownloaded, ___SyncTime, ___FileSize
+   FROM content
+   WHERE ContentType = 6
+   ORDER BY ContentID;
+   ```
+
+   Also snapshot server `metadata.db` book id/uuid/`last_modified` for the same
+   set.
+3. Clear only the target Kobo user's `KoboSyncedBooks` rows. Do not clear books,
+   download files, reading state, or device records. This forces the existing
+   full-resync branch while Layer 2 is provably inactive.
+4. Run one completed sync. Preserve its DEBUG summary; it must show Layer 2
+   `enabled=False eligible=False`, `suppressed_unchanged=0`, and a full set of
+   local New entitlements. Pull `A1` after the device returns idle.
+5. Compare A0→A1 by `ContentID`. For every book whose server `last_modified`
+   stayed constant, record:
+
+   - zero `IsDownloaded: true → false` transitions;
+   - zero `___SyncTime` changes;
+   - zero `___FileSize` changes;
+   - the exact replayed entitlement envelope and DEBUG counts.
+
+**Decision gate:**
+
+- If A0→A1 has zero flips and zero row re-stamps, **OBSERVED hardware result:
+  Layer 1 is sufficient**. Ship with Layer 2 off; do not enable the experimental
+  ledger merely because it exists.
+- If a byte-stable replay still flips/re-stamps unchanged rows, **OBSERVED
+  hardware result: Layer 1 is insufficient**. Only then proceed to Phase B.
+
+### Phase B — optional Layer 2 verification after an adverse Phase A
+
+1. Enable `config_kobo_suppress_replayed_entitlements`.
+2. Force one tokenless/full delivery to seed the per-device ledger. Confirm the
+   request is `eligible=False`, all books are delivered, and ledger rows exist.
+3. Use **N = 5 completed syncs**, with one deliberately interrupted attempt
+   between completed syncs 2 and 3, preserving every DEBUG summary and database
+   snapshot B0–B5. The recovery must present a valid stale CWNG token to test
+   suppression; if it presents no valid CWNG token, full delivery is the
+   intentional factory-reset-safe behavior and does not test Layer 2.
+4. For a valid stale-token recovery, require `enabled=True eligible=True`,
+   `suppressed_unchanged > 0`, zero local New/Changed envelopes for those exact
+   matches, and zero `IsDownloaded`, `___SyncTime`, or `___FileSize` changes.
+5. Repeat one request without a CWNG token and require the opposite safety
+   behavior: `eligible=False`, no suppression, and a full replay.
+6. Positive control after B5: bump `last_modified` on one disposable downloaded
+   book, run one additional sync, and require exactly that UUID to appear as one
+   `ChangedEntitlement`. Its row is expected to re-stamp/de-download under the
+   existing real-change contract; every unchanged control row must remain
+   byte-identical. Restore or re-download the disposable control afterward.
+
+Hardware status: **ASSUMED pending manager run**. Phase A, not Layer 2, is the
+first decision point. Do not label either layer hardware/end-to-end verified
+until its corresponding database comparison has been completed.

--- a/notes/issue-1925-sync-dedownload-report.md
+++ b/notes/issue-1925-sync-dedownload-report.md
@@ -95,8 +95,19 @@ verification green; Clara hardware discrimination pending.
   already has ledger rows. Those deliveries refresh the ledger.
 - **OBSERVED:** a valid stale CWNG token plus an exact same-device fingerprint
   suppresses New/Changed entitlement replay while still advancing cursors.
-  Reading-state changes remain independently deliverable. A second device has
-  no matching row and receives its entitlement.
+  A second device has no matching row and receives its entitlement.
+- **OBSERVED — Layer 2 reading-state isolation:** the committed suppression
+  block skipped both the embedded `ReadingState` payload and local
+  `reading_state_last_modified` advancement when the base entitlement matched
+  the ledger. The later generic reading-state query rescued a simple one-book
+  response, but that rescue was page-dependent: a full page of older states
+  withheld the suppressed book's newer state and left the outgoing cursor
+  behind it. Reading-state serialization, emitted-ID bookkeeping, and cursor
+  advancement now happen before the base entitlement suppression branch. A
+  suppressed base emits its newer state as `ChangedReadingState`; an
+  unsuppressed base retains the existing embedded `ReadingState` shape. Both
+  paths exclude that book from the later generic scan, so the state appears
+  once and is not re-offered after the returned cursor is echoed.
 - **ASSUMED/unavoidable ambiguities:** an empty library that somehow retains a
   valid stale CWNG token is indistinguishable from an interrupted sync whose
   library is intact. Also, the ledger proves that the server generated a
@@ -186,6 +197,14 @@ controls that old code already handled.
 - generated-KEPUB assertion failed: response declared the source EPUB size;
 - real `last_modified` bump assertion already passed.
 
+**OBSERVED — Layer 2 reading-state red:** the exact new assertion
+`test_suppressed_entitlement_emits_newer_reading_state_once_and_advances_cursor`
+was run against the committed suppression block with the generic state page
+filled by one older state (the test pins `SYNC_ITEM_LIMIT=1`). The suppressed
+book's newer target state was absent: `assert len(target_states) == 1` failed
+with `0 == 1`. This distinguishes the direct-emission fix from the generic
+fallback that makes the unsaturated one-book case pass.
+
 ### Green after implementation
 
 **OBSERVED — focused two-layer, lifecycle, and adjacent KEPUB selection:**
@@ -201,18 +220,21 @@ python -m pytest -q \
   tests/unit/test_kobo_prefer_kepub.py
 ```
 
-Current result: **102 passed**. The #1925 module contributes 15 collected cases,
+Current result: **103 passed**. The #1925 module contributes 16 collected cases,
 including default-off/zero-ledger behavior, byte-identical tokenless replay,
 valid-stale-token suppression, absent/malformed/store-token factory-reset
 escapes, per-device isolation, real-change positive control, stable timestamps,
 truthful size behavior, schema creation, config migration/defaults, and strict
-suppression provenance atop permissive legacy token parsing. The D4 suite pins
-`PER_USER_BOOK_MODELS` registration and lifecycle cleanup.
+suppression provenance atop permissive legacy token parsing. The new case also
+pins that a suppressed base entitlement emits its newer reading state once,
+advances the outgoing reading-state cursor to that timestamp, and does not
+re-offer it on the next sync. The D4 suite pins `PER_USER_BOOK_MODELS`
+registration and lifecycle cleanup.
 
 **OBSERVED — final complete executable unit suite:** `tests/unit` collected
-**7,362** tests. With the 17 environment-blocked node IDs below explicitly
-deselected, the post-restructure result was **7,243 passed, 102 skipped, 17
-deselected**. No executable unit test failed.
+**7,363** tests. With the 17 environment-blocked node IDs below explicitly
+deselected, the post-reading-state-fix result was **7,244 passed, 102 skipped,
+17 deselected**. No executable unit test failed.
 
 The 17 deselections are existing tests whose required OS operation is denied by
 this managed sandbox:

--- a/notes/issue-1925-sync-dedownload-report.md
+++ b/notes/issue-1925-sync-dedownload-report.md
@@ -1,6 +1,7 @@
 # Issue #1925 — Kobo sync de-download report
 
-Status: two-layer implementation complete; focused and complete executable-unit
+Status: two-layer implementation complete; regression-loop round 1 found and
+fixed one admin-resend lifecycle defect; focused and complete executable-unit
 verification green; Clara hardware discrimination pending.
 
 ## Mechanism
@@ -207,7 +208,8 @@ fallback that makes the unsaturated one-book case pass.
 
 ### Green after implementation
 
-**OBSERVED — focused two-layer, lifecycle, and adjacent KEPUB selection:**
+**OBSERVED — original focused two-layer, lifecycle, and adjacent KEPUB
+selection:**
 
 ```text
 python -m pytest -q \
@@ -260,6 +262,64 @@ default command was not rerun after that test-only precondition correction;
 the complete unit tree was.
 
 **OBSERVED — static hygiene:** `git diff --check` exits cleanly.
+
+## Regression loop round 1 — 2026-08-28
+
+This round adversarially exercised every surface named in the manager handoff,
+including the shelf-only reader's request shapes. The new tests are regression
+guards: each asserts an externally relevant invariant that would fail if the
+Layer 1/Layer 2 diff disturbed that surface. Where an old-code comparison was
+meaningful, it was run explicitly; unchanged-behavior guards are expected to
+pass the old implementation and are positive controls, not false red tests.
+
+| Surface | OBSERVED finding and discriminator | Fixed? / verdict |
+| --- | --- | --- |
+| Shelf-only sync, membership, remove/archive, #468 fail-safe | Real `HandleSyncRequest` tests run two unchanged shelf-only syncs, add a membership and require exactly one delivery, remove it and require the existing `ChangedEntitlement`/`IsRemoved=true` plus marker cleanup, then make Magic Shelf membership unreliable and require no removal and no marker loss. Any replay loop, lost shelf cursor, altered removal command, or fail-safe regression fails these assertions. | No defect found. All guards green. |
+| Deferred and rewritten downloads, including `NETWORK_SHARE_MODE` | Entitlement assertions require `Format`, `Url`, `Platform`, and `DrmType` to remain complete while `Size` is omitted only for generated/rewritten artifacts. Six real Flask download-route cases cover deferred EPUB→KEPUB, rewritten stored EPUB, and rewritten stored KEPUB with network-share mode both off and on; each requires HTTP 200, expected bytes, and filename. | No product defect found. The test harness initially lacked `config_unicode_filename` and attempted to read a direct-passthrough response; both were test-fixture corrections, not application changes. All six route shapes green. |
+| Legacy, partial, and store-only tokens | Parser tests omit the additive #1925 fields, omit core fields selectively, pass an official-store-only token, and run an actual store-token sync. They require preserved supplied cursors, sane `datetime.min` defaults, correct `is_cwng_token` provenance, no exception, and a valid outgoing response. | No defect found. All guards green. |
+| Second physical device, Layer 2 off/on | With Layer 2 off, two devices on one account each get an initial entitlement, subsequent cursors terminate, and no ledger row is written. With Layer 2 on, a fingerprint for device A cannot suppress device B's initial entitlement. | No cross-device defect found. All guards green. |
+| Reading state, unsuppressed and suppressed | The unsuppressed positive control requires the pre-change shape: one embedded `ReadingState`, the exact outgoing reading cursor, then no repeat. The suppressed shelf-only discriminator fills the generic-state page with an older state and requires the suppressed book's newer `ChangedReadingState` once with cursor advancement. Temporarily restoring the old suppression block made exactly this test fail (`0` target states instead of `1`); the other **37/38** #1925 cases passed. | Previously identified reading-state defect remains fixed; no new regression. |
+| Magic Shelf, sync-all and shelf-only | Parameterized real-sync tests require a Magic Shelf membership change to emit once in both modes and then terminate. The full adjacent Magic Shelf suite covers cache reset, large-shelf sub-cursors, local cursor reuse, full-page deferral, and ID-list membership. | No defect found. All guards green. |
+| Permanent DEBUG sync summary | A store-token/min-cursor request and direct nullable-cursor formatting exercise the log path. Assertions require a 200 response, one summary record, stable count fields, and no exception for `None`/minimum cursor shapes. | No defect found. All guards green. |
+| Full sync, resend, unsync, purge, duplicate merge | Full sync and unsync were correctly scoped; D4 purge/merge/registry tests remained green. A new behavioral resend test seeded two target-user devices plus another account, invoked admin resend, then synced: before the repair, both target ledger rows remained and the test failed. | **Finding R1-1 fixed:** `do_kobo_resend` now clears the requested book's fingerprints for every device belonging to the target user, preserves other users/books, validates the book before mutating either database, and allows the next speaking device to receive and re-seed the entitlement. |
+
+### Round-1 red/green evidence
+
+- **OBSERVED — R1-1 red before repair:** the lifecycle subset reported **1
+  failed, 2 passed**. `test_admin_resend_clears_target_users_entitlement_ledger`
+  expected only the unrelated account's row but observed all seeded rows still
+  present. After the repair, the expanded lifecycle subset reported **4
+  passed**, including the nonexistent-book no-mutation guard.
+- **OBSERVED — reading-state old-block comparison:** with only the committed
+  pre-fix suppression block restored temporarily, the complete expanded #1925
+  module reported **1 failed, 37 passed**. The sole failure was
+  `test_suppressed_entitlement_emits_newer_reading_state_once_and_advances_cursor`;
+  after restoring the fix, the module reported **38 passed**.
+- **OBSERVED — old-code applicability:** the 37 passing old-block cases are
+  positive controls for unchanged behavior. Reverting all of Layer 1/Layer 2
+  is not meaningful for ledger lifecycle guards because the model and config
+  gate do not exist there; the earlier implementation red remains the manager-
+  verified **6 failed, 3 passed** result documented above.
+
+### Round-1 green counts
+
+- **OBSERVED — touched-surface focused matrix:** **243 passed**. It includes the
+  38-case #1925 module plus the pre-existing resend, D4 lifecycle, book-modified,
+  #468, shelf-only archive, Magic Shelf, SyncToken, prefer-KEPUB, real download-
+  route, and metadata-rewrite suites.
+- **OBSERVED — complete unit tree:** `tests/unit` collected **7,418** tests;
+  with the same 17 managed-sandbox node IDs explicitly deselected, **7,299
+  passed, 102 skipped, 17 deselected** in 209.83 seconds. The sandbox-blocked
+  list remains six gevent loopback binds, one health-probe loopback bind, three
+  Kobo measurement loopback binds, and seven `s6` process-tree inspections
+  requiring `/bin/ps`.
+- **OBSERVED — final clean pass, `Regression-loop round 1 / clean pass 2`:**
+  the complete 243-test touched-surface matrix was rerun after the repair and
+  report audit; **243 passed** in 5.55 seconds with **zero new findings**.
+
+**ASSUMED:** these executable tests cover the server contracts and route bytes,
+not Nickel's closed-source response to the payload. The Clara database-snapshot
+procedure remains the hardware discriminator.
 
 ## Clara hardware-verification recipe
 

--- a/tests/unit/test_1925_kobo_sync_dedownload.py
+++ b/tests/unit/test_1925_kobo_sync_dedownload.py
@@ -38,6 +38,66 @@ def _changed_reading_states(response):
     ]
 
 
+def _add_kobo_shelf(sync_harness, *, include_book=True, date_added=None):
+    from cps import ub
+
+    shelf = ub.Shelf(
+        name="Regression Kobo Shelf",
+        user_id=sync_harness.user.id,
+        kobo_sync=True,
+        uuid="issue-1925-regression-shelf",
+        is_public=0,
+    )
+    sync_harness.session.add(shelf)
+    sync_harness.session.flush()
+    link = None
+    if include_book:
+        link = ub.BookShelf(
+            book_id=sync_harness.book.id,
+            shelf=shelf.id,
+            order=1,
+            date_added=date_added,
+        )
+        link.ub_shelf = shelf
+        sync_harness.session.add(link)
+    sync_harness.session.commit()
+    return shelf, link
+
+
+def _add_reading_state(sync_harness, modified, progress=42.0):
+    from cps import ub
+
+    read = ub.ReadBook(
+        user_id=sync_harness.user.id,
+        book_id=sync_harness.book.id,
+        read_status=ub.ReadBook.STATUS_IN_PROGRESS,
+    )
+    state = ub.KoboReadingState(
+        user_id=sync_harness.user.id,
+        book_id=sync_harness.book.id,
+        priority_timestamp=modified,
+    )
+    state.current_bookmark = ub.KoboBookmark(
+        last_modified=modified,
+        progress_percent=progress,
+    )
+    state.statistics = ub.KoboStatistics(last_modified=modified)
+    read.kobo_reading_state = state
+    sync_harness.session.add(read)
+    sync_harness.session.commit()
+    # The before_flush listener stamps the parent when the bookmark changes.
+    sync_harness.session.query(ub.KoboReadingState).filter_by(
+        user_id=sync_harness.user.id,
+        book_id=sync_harness.book.id,
+    ).update({ub.KoboReadingState.last_modified: modified})
+    sync_harness.session.commit()
+    sync_harness.session.expire_all()
+    return sync_harness.session.query(ub.KoboReadingState).filter_by(
+        user_id=sync_harness.user.id,
+        book_id=sync_harness.book.id,
+    ).one()
+
+
 @pytest.fixture
 def sync_harness(monkeypatch):
     from cps import db, kobo, kobo_sync_status, ub
@@ -93,6 +153,7 @@ def sync_harness(monkeypatch):
         session=session,
         reconnect_db=lambda *_args, **_kwargs: None,
         common_filters=lambda **_kwargs: true(),
+        get_book=lambda book_id: session.query(db.Books).filter_by(id=book_id).one_or_none(),
     )
 
     monkeypatch.setattr(ub, "session", session)
@@ -136,11 +197,14 @@ def sync_harness(monkeypatch):
             return kobo.HandleSyncRequest.__wrapped__()
 
     yield SimpleNamespace(
+        app=app,
         book=book,
         device=device,
+        calibre_db=fake_calibre_db,
         session=session,
         sync=sync,
         token_header=kobo.SyncToken.SyncToken.SYNC_TOKEN_HEADER,
+        user=user,
     )
 
     session.close()
@@ -191,6 +255,11 @@ def test_suppressed_entitlement_emits_newer_reading_state_once_and_advances_curs
         kobo.config, "config_kobo_suppress_replayed_entitlements", True,
     )
     monkeypatch.setattr(kobo, "SYNC_ITEM_LIMIT", 1)
+    sync_harness.user.kobo_only_shelves_sync = True
+    shelf, _target_link = _add_kobo_shelf(
+        sync_harness,
+        date_added=datetime(2026, 8, 28, 12, 5, 0),
+    )
 
     # Seed the per-device entitlement fingerprint without a reading state.
     assert len(_entitlements(sync_harness.sync())) == 1
@@ -235,7 +304,14 @@ def test_suppressed_entitlement_emits_newer_reading_state_once_and_advances_curs
         read_status=ub.ReadBook.STATUS_IN_PROGRESS,
     )
     background_read.kobo_reading_state = background_state
-    sync_harness.session.add(background_read)
+    background_link = ub.BookShelf(
+        book_id=background_book.id,
+        shelf=shelf.id,
+        order=2,
+        date_added=datetime(2026, 8, 28, 12, 6, 0),
+    )
+    background_link.ub_shelf = shelf
+    sync_harness.session.add_all([background_read, background_link])
 
     state_modified = datetime(2026, 8, 28, 12, 30, 0)
     read = ub.ReadBook(
@@ -301,6 +377,187 @@ def test_suppressed_entitlement_emits_newer_reading_state_once_and_advances_curs
     )
 
 
+def test_shelf_only_unchanged_library_terminates_after_first_sync(sync_harness):
+    """The household's shelf-only Kobo must not loop an unchanged shelf."""
+    from cps import ub
+
+    sync_harness.user.kobo_only_shelves_sync = True
+    _add_kobo_shelf(
+        sync_harness,
+        date_added=datetime(2026, 8, 28, 12, 5, 0),
+    )
+
+    first = sync_harness.sync()
+    second = sync_harness.sync(first.headers[sync_harness.token_header])
+
+    assert len(_entitlements(first)) == 1
+    assert _entitlements(second) == []
+    assert sync_harness.session.query(ub.KoboDeviceBookEntitlement).count() == 0
+
+
+def test_shelf_only_membership_addition_emits_once(sync_harness):
+    """Adding an old book to a Kobo shelf must move the shelf cursor once."""
+    from cps import ub
+
+    sync_harness.user.kobo_only_shelves_sync = True
+    shelf, _link = _add_kobo_shelf(sync_harness, include_book=False)
+    empty = sync_harness.sync()
+    assert _entitlements(empty) == []
+
+    link = ub.BookShelf(
+        book_id=sync_harness.book.id,
+        shelf=shelf.id,
+        order=1,
+        date_added=datetime(2026, 8, 28, 12, 10, 0),
+    )
+    link.ub_shelf = shelf
+    sync_harness.session.add(link)
+    sync_harness.session.commit()
+
+    added = sync_harness.sync(empty.headers[sync_harness.token_header])
+    stable = sync_harness.sync(added.headers[sync_harness.token_header])
+
+    assert len(_entitlements(added)) == 1
+    assert _entitlements(stable) == []
+
+
+def test_shelf_only_removal_command_and_ledger_cleanup_are_unchanged(
+    sync_harness, monkeypatch,
+):
+    """Removing a shelf member still emits IsRemoved and clears both markers."""
+    from cps import kobo, ub
+
+    sync_harness.user.kobo_only_shelves_sync = True
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+    _shelf, link = _add_kobo_shelf(
+        sync_harness,
+        date_added=datetime(2026, 8, 28, 12, 5, 0),
+    )
+    first = sync_harness.sync()
+    assert len(_entitlements(first)) == 1
+    assert sync_harness.session.query(ub.KoboDeviceBookEntitlement).count() == 1
+
+    sync_harness.session.delete(link)
+    sync_harness.session.commit()
+    removed = sync_harness.sync(first.headers[sync_harness.token_header])
+
+    envelopes = _entitlements(removed)
+    assert len(envelopes) == 1
+    assert "ChangedEntitlement" in envelopes[0]
+    assert envelopes[0]["ChangedEntitlement"]["BookEntitlement"]["IsRemoved"] is True
+    assert sync_harness.session.query(ub.KoboSyncedBooks).count() == 0
+    assert sync_harness.session.query(ub.KoboDeviceBookEntitlement).count() == 0
+
+
+def test_shelf_only_magic_membership_failure_preserves_book_and_ledger(
+    sync_harness, monkeypatch,
+):
+    """#468: an unreliable empty magic shelf must never remove a live book."""
+    from cps import kobo, ub
+
+    sync_harness.user.kobo_only_shelves_sync = True
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+    membership = {"ids": {sync_harness.book.id}, "reliable": True}
+    membership_added = datetime(2026, 8, 28, 12, 20, 0)
+    monkeypatch.setattr(
+        kobo,
+        "get_magic_shelf_book_ids_for_kobo",
+        lambda _user_id: (set(membership["ids"]), membership["reliable"]),
+    )
+    monkeypatch.setattr(
+        kobo,
+        "get_magic_shelf_membership_added_at",
+        lambda _user_id: membership_added,
+    )
+
+    first = sync_harness.sync()
+    assert len(_entitlements(first)) == 1
+    assert sync_harness.session.query(ub.KoboDeviceBookEntitlement).count() == 1
+
+    membership["ids"] = set()
+    membership["reliable"] = False
+    failed_refresh = sync_harness.sync(first.headers[sync_harness.token_header])
+
+    assert _entitlements(failed_refresh) == []
+    assert sync_harness.session.query(ub.KoboSyncedBooks).count() == 1
+    assert sync_harness.session.query(ub.KoboDeviceBookEntitlement).count() == 1
+    assert sync_harness.session.query(ub.ArchivedBook).count() == 0
+
+
+@pytest.mark.parametrize("shelf_only", [False, True])
+def test_magic_shelf_membership_arm_emits_once_in_both_sync_modes(
+    sync_harness, monkeypatch, shelf_only,
+):
+    """Magic-shelf users retain the one-shot membership cursor behavior."""
+    from cps import kobo, ub
+
+    sync_harness.user.kobo_only_shelves_sync = shelf_only
+    membership_added = datetime(2026, 8, 28, 12, 20, 0)
+    monkeypatch.setattr(
+        kobo,
+        "get_magic_shelf_book_ids_for_kobo",
+        lambda _user_id: ({sync_harness.book.id}, True),
+    )
+    monkeypatch.setattr(
+        kobo,
+        "get_magic_shelf_membership_added_at",
+        lambda _user_id: membership_added,
+    )
+    # Prevent the legacy empty-marker reset so this specifically exercises the
+    # magic membership arm past an already-advanced book cursor.
+    sync_harness.session.add(ub.KoboSyncedBooks(
+        user_id=sync_harness.user.id,
+        book_id=sync_harness.book.id,
+        book_uuid=sync_harness.book.uuid,
+    ))
+    sync_harness.session.commit()
+    advanced = kobo.SyncToken.SyncToken(
+        books_last_modified=datetime(2026, 8, 28, 12, 10, 0),
+        books_last_created=datetime(2026, 8, 28, 12, 10, 0),
+    ).build_sync_token()
+
+    membership_sync = sync_harness.sync(advanced)
+    stable = sync_harness.sync(
+        membership_sync.headers[sync_harness.token_header]
+    )
+
+    assert len(_entitlements(membership_sync)) == 1
+    assert _entitlements(stable) == []
+    parsed = kobo.SyncToken.SyncToken.from_headers({
+        sync_harness.token_header:
+            membership_sync.headers[sync_harness.token_header],
+    })
+    assert parsed.magic_shelf_membership_at == membership_added
+
+
+def test_unsuppressed_reading_state_count_and_cursor_remain_one_shot(
+    sync_harness,
+):
+    """Layer 2's refactor must not alter the normal reading-state feed."""
+    from cps import kobo, ub
+
+    first = sync_harness.sync()
+    modified = datetime(2026, 8, 28, 12, 30, 0)
+    _add_reading_state(sync_harness, modified, progress=37.0)
+
+    changed = sync_harness.sync(first.headers[sync_harness.token_header])
+    unchanged = sync_harness.sync(changed.headers[sync_harness.token_header])
+
+    states = _changed_reading_states(changed)
+    assert len(states) == 1
+    assert states[0]["CurrentBookmark"]["ProgressPercent"] == 37
+    assert _changed_reading_states(unchanged) == []
+    parsed = kobo.SyncToken.SyncToken.from_headers({
+        sync_harness.token_header: changed.headers[sync_harness.token_header],
+    })
+    assert parsed.reading_state_last_modified == modified
+    assert sync_harness.session.query(ub.KoboDeviceBookEntitlement).count() == 0
+
+
 def test_payload_stabilization_replays_byte_identically_with_layer2_off(
     sync_harness,
 ):
@@ -340,7 +597,7 @@ def test_entitlement_replay_state_is_per_device(sync_harness, monkeypatch):
     monkeypatch.setattr(
         kobo.config, "config_kobo_suppress_replayed_entitlements", True,
     )
-    sync_harness.sync()
+    first = sync_harness.sync()
     second_device = ub.Device(
         user_id=17,
         kind="kobo",
@@ -359,6 +616,235 @@ def test_entitlement_replay_state_is_per_device(sync_harness, monkeypatch):
     )
 
     assert len(_entitlements(first_for_second_device)) == 1
+
+
+def test_second_device_has_no_cross_device_state_when_layer2_is_off(sync_harness):
+    """The default-off layer writes no ledger and does not starve device two."""
+    from cps import kobo, ub
+
+    first_device = sync_harness.sync()
+    assert len(_entitlements(first_device)) == 1
+    assert sync_harness.session.query(ub.KoboDeviceBookEntitlement).count() == 0
+
+    second_device = ub.Device(
+        user_id=sync_harness.user.id,
+        kind="kobo",
+        display_name="Household Shelf Kobo",
+        model="Kobo Libra Colour",
+        active=True,
+        created_by="auto",
+    )
+    sync_harness.session.add(second_device)
+    sync_harness.session.commit()
+    first_for_second = sync_harness.sync(
+        kobo.SyncToken.SyncToken().build_sync_token(),
+        internal_device_id=second_device.id,
+        raw_device_id="b" * 64,
+    )
+    stable_for_second = sync_harness.sync(
+        first_for_second.headers[sync_harness.token_header],
+        internal_device_id=second_device.id,
+        raw_device_id="b" * 64,
+    )
+
+    assert len(_entitlements(first_for_second)) == 1
+    assert _entitlements(stable_for_second) == []
+    assert sync_harness.session.query(ub.KoboDeviceBookEntitlement).count() == 0
+
+
+def _seed_other_user_ledger(sync_harness):
+    from cps import ub
+
+    other_device = ub.Device(
+        user_id=18,
+        kind="kobo",
+        display_name="Other Account Kobo",
+        model="Kobo Libra Colour",
+        active=True,
+        created_by="auto",
+    )
+    sync_harness.session.add(other_device)
+    sync_harness.session.flush()
+    sync_harness.session.add_all([
+        ub.KoboSyncedBooks(
+            user_id=18,
+            book_id=sync_harness.book.id,
+            book_uuid=sync_harness.book.uuid,
+        ),
+        ub.KoboDeviceBookEntitlement(
+            device_id=other_device.id,
+            book_id=sync_harness.book.id,
+            fingerprint="f" * 64,
+        ),
+    ])
+    sync_harness.session.commit()
+    return other_device
+
+
+def _seed_same_user_device_ledger(sync_harness):
+    from cps import ub
+
+    second_device = ub.Device(
+        user_id=sync_harness.user.id,
+        kind="kobo",
+        display_name="Second Target Kobo",
+        model="Kobo Clara BW",
+        active=True,
+        created_by="auto",
+    )
+    sync_harness.session.add(second_device)
+    sync_harness.session.flush()
+    sync_harness.session.add(ub.KoboDeviceBookEntitlement(
+        device_id=second_device.id,
+        book_id=sync_harness.book.id,
+        fingerprint="e" * 64,
+    ))
+    sync_harness.session.commit()
+    return second_device
+
+
+def test_full_sync_clears_only_target_users_entitlement_ledger(
+    sync_harness, monkeypatch,
+):
+    """Full Sync clears every target device without touching another account."""
+    from cps import admin, kobo, ub
+
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+    first = sync_harness.sync()
+    _seed_same_user_device_ledger(sync_harness)
+    other_device = _seed_other_user_ledger(sync_harness)
+    monkeypatch.setattr(admin, "_", lambda value: value)
+
+    with sync_harness.app.test_request_context("/ajax/fullsync/17", method="POST"):
+        response = admin.do_full_kobo_sync(sync_harness.user.id)
+
+    assert response.status_code == 200
+    rows = sync_harness.session.query(ub.KoboDeviceBookEntitlement).all()
+    assert [(row.device_id, row.book_id) for row in rows] == [
+        (other_device.id, sync_harness.book.id),
+    ]
+    assert {
+        row.user_id for row in sync_harness.session.query(ub.KoboSyncedBooks)
+    } == {18}
+
+    replay = sync_harness.sync(first.headers[sync_harness.token_header])
+    replay_envelopes = _entitlements(replay)
+    assert len(replay_envelopes) == 1
+    assert "NewEntitlement" in replay_envelopes[0]
+    assert {
+        row.device_id
+        for row in sync_harness.session.query(ub.KoboDeviceBookEntitlement)
+    } == {sync_harness.device.id, other_device.id}
+
+
+def test_admin_resend_clears_target_users_entitlement_ledger(
+    sync_harness, monkeypatch,
+):
+    """A requested resend must not be suppressed by its own stale fingerprint."""
+    from cps import admin, kobo, ub
+
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+    first = sync_harness.sync()
+    _seed_same_user_device_ledger(sync_harness)
+    other_device = _seed_other_user_ledger(sync_harness)
+    monkeypatch.setattr(admin, "calibre_db", sync_harness.calibre_db)
+    monkeypatch.setattr(admin, "_", lambda value: value)
+    before = sync_harness.book.last_modified
+
+    with sync_harness.app.test_request_context(
+        f"/ajax/kobo_resend/{sync_harness.user.id}/{sync_harness.book.id}",
+        method="POST",
+    ):
+        response = admin.do_kobo_resend(
+            sync_harness.user.id, sync_harness.book.id,
+        )
+
+    assert response.status_code == 200
+    assert sync_harness.book.last_modified > before
+    rows = sync_harness.session.query(ub.KoboDeviceBookEntitlement).all()
+    assert [(row.device_id, row.book_id) for row in rows] == [
+        (other_device.id, sync_harness.book.id),
+    ]
+    assert {
+        row.user_id for row in sync_harness.session.query(ub.KoboSyncedBooks)
+    } == {18}
+
+    replay = sync_harness.sync(first.headers[sync_harness.token_header])
+    replay_envelopes = _entitlements(replay)
+    assert len(replay_envelopes) == 1
+    assert "NewEntitlement" in replay_envelopes[0]
+    assert {
+        row.device_id
+        for row in sync_harness.session.query(ub.KoboDeviceBookEntitlement)
+    } == {sync_harness.device.id, other_device.id}
+
+
+def test_admin_resend_missing_book_preserves_all_sync_state(
+    sync_harness, monkeypatch,
+):
+    """Validation must precede every ledger/marker mutation."""
+    from cps import admin, kobo, ub
+
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+    sync_harness.sync()
+    second_device = _seed_same_user_device_ledger(sync_harness)
+    monkeypatch.setattr(admin, "calibre_db", sync_harness.calibre_db)
+    monkeypatch.setattr(admin, "_", lambda value: value)
+
+    with sync_harness.app.test_request_context(
+        f"/ajax/kobo_resend/{sync_harness.user.id}/999999",
+        method="POST",
+    ):
+        response = admin.do_kobo_resend(sync_harness.user.id, 999999)
+
+    assert response.status_code == 200
+    assert response.get_json()[0]["type"] == "danger"
+    assert {
+        row.device_id
+        for row in sync_harness.session.query(ub.KoboDeviceBookEntitlement)
+    } == {sync_harness.device.id, second_device.id}
+    assert sync_harness.session.query(ub.KoboSyncedBooks).count() == 1
+
+
+def test_unsync_scopes_ledger_to_current_user_and_all_mode_clears_everyone(
+    sync_harness, monkeypatch,
+):
+    """Ordinary unsync is account-scoped; all=True remains the global escape."""
+    from cps import kobo, kobo_sync_status, ub
+
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+    sync_harness.sync()
+    _seed_same_user_device_ledger(sync_harness)
+    other_device = _seed_other_user_ledger(sync_harness)
+
+    kobo_sync_status.remove_synced_book(
+        sync_harness.book.id,
+        all=False,
+        session=sync_harness.session,
+    )
+    rows = sync_harness.session.query(ub.KoboDeviceBookEntitlement).all()
+    assert [(row.device_id, row.book_id) for row in rows] == [
+        (other_device.id, sync_harness.book.id),
+    ]
+    assert {
+        row.user_id for row in sync_harness.session.query(ub.KoboSyncedBooks)
+    } == {18}
+
+    kobo_sync_status.remove_synced_book(
+        sync_harness.book.id,
+        all=True,
+        session=sync_harness.session,
+    )
+    assert sync_harness.session.query(ub.KoboDeviceBookEntitlement).count() == 0
+    assert sync_harness.session.query(ub.KoboSyncedBooks).count() == 0
 
 
 def test_real_last_modified_bump_still_emits_changed_entitlement(
@@ -430,6 +916,9 @@ def test_generated_kepub_does_not_declare_source_epub_size(sync_harness):
         download = kobo.get_metadata(sync_harness.book)["DownloadUrls"][0]
 
     assert download["Format"] == "KEPUB"
+    assert download["Url"] == f"/download/{sync_harness.book.id}/kepub"
+    assert download["Platform"] == "Generic"
+    assert download["DrmType"] == "None"
     assert "Size" not in download, (
         "the source EPUB size is not the size of the KEPUB bytes served after "
         "download-time conversion/metadata rewriting"
@@ -464,6 +953,164 @@ def test_metadata_rewritten_epub_does_not_declare_stored_size(
         )
 
     assert "Size" not in download
+    assert download == {
+        "Format": "EPUB3",
+        "Url": f"/download/{sync_harness.book.id}/epub",
+        "Platform": "Generic",
+        "DrmType": "None",
+    }
+
+
+def test_rewritten_stored_epub_and_kepub_keep_complete_download_fields(
+    sync_harness, monkeypatch,
+):
+    """Omitting inexact Size must not damage any URL/format/DRM field."""
+    from cps import db, kobo
+
+    monkeypatch.setattr(kobo.config, "config_embed_metadata", True, raising=False)
+    monkeypatch.setattr(kobo.config, "config_kobo_prefer_kepub", False, raising=False)
+    with Flask(__name__).test_request_context("/v1/library/sync"):
+        epub_urls = kobo.get_metadata(sync_harness.book)["DownloadUrls"]
+    assert epub_urls == [
+        {
+            "Format": "EPUB3",
+            "Url": f"/download/{sync_harness.book.id}/epub",
+            "Platform": "Generic",
+            "DrmType": "None",
+        },
+        {
+            "Format": "EPUB",
+            "Url": f"/download/{sync_harness.book.id}/epub",
+            "Platform": "Generic",
+            "DrmType": "None",
+        },
+    ]
+
+    sync_harness.session.add(db.Data(
+        sync_harness.book.id, "KEPUB", 1_345_678, "stable-book",
+    ))
+    sync_harness.session.commit()
+    sync_harness.session.expire(sync_harness.book, ["data"])
+    monkeypatch.setattr(kobo.config, "config_kobo_prefer_kepub", True, raising=False)
+    with Flask(__name__).test_request_context("/v1/library/sync"):
+        kepub_urls = kobo.get_metadata(sync_harness.book)["DownloadUrls"]
+    assert kepub_urls == [{
+        "Format": "KEPUB",
+        "Url": f"/download/{sync_harness.book.id}/kepub",
+        "Platform": "Generic",
+        "DrmType": "None",
+    }]
+
+
+@pytest.mark.parametrize("network_share_mode", [False, True])
+@pytest.mark.parametrize("download_case", [
+    "deferred_epub_to_kepub",
+    "rewritten_stored_epub",
+    "rewritten_stored_kepub",
+])
+def test_size_omission_paths_still_serve_the_kobo_download_route(
+    tmp_path, monkeypatch, network_share_mode, download_case,
+):
+    """Every artifact whose entitlement omits Size still reaches the wire."""
+    import inspect
+
+    from cps import helper, kobo
+
+    if network_share_mode:
+        monkeypatch.setenv("NETWORK_SHARE_MODE", "true")
+    else:
+        monkeypatch.delenv("NETWORK_SHARE_MODE", raising=False)
+
+    library = tmp_path / "library"
+    book_dir = library / "Author" / "Book"
+    book_dir.mkdir(parents=True)
+    book = SimpleNamespace(
+        id=1925,
+        uuid="route-1925",
+        title="Route Book",
+        path="Author/Book",
+        authors=[SimpleNamespace(name="Author")],
+    )
+    epub = SimpleNamespace(format="EPUB", name="stable-book", uncompressed_size=11)
+    kepub = SimpleNamespace(format="KEPUB", name="stable-book", uncompressed_size=13)
+    converted = {"ready": False}
+
+    if download_case == "deferred_epub_to_kepub":
+        requested_format = "kepub"
+        expected_bytes = b"deferred-kepub-bytes"
+        (book_dir / "stable-book.epub").write_bytes(b"source-epub-bytes")
+
+        def get_format(_book_id, fmt):
+            if fmt == "EPUB":
+                return epub
+            if fmt == "KEPUB" and converted["ready"]:
+                return kepub
+            return None
+
+        def convert(*_args, **kwargs):
+            assert kwargs == {"blocking": True, "timeout": 25}
+            (book_dir / "stable-book.kepub").write_bytes(expected_bytes)
+            converted["ready"] = True
+            return None
+
+        monkeypatch.setattr(helper, "convert_book_format", convert)
+        embed_metadata = False
+    elif download_case == "rewritten_stored_epub":
+        requested_format = "epub"
+        expected_bytes = b"rewritten-epub-bytes"
+        (book_dir / "stable-book.epub").write_bytes(expected_bytes)
+        get_format = lambda _book_id, fmt: epub if fmt == "EPUB" else None
+        monkeypatch.setattr(
+            helper,
+            "do_calibre_export",
+            lambda *_args, **_kwargs: (str(book_dir), "stable-book"),
+        )
+        embed_metadata = True
+    else:
+        requested_format = "kepub"
+        expected_bytes = b"rewritten-kepub-bytes"
+        (book_dir / "stable-book.kepub").write_bytes(expected_bytes)
+        get_format = lambda _book_id, fmt: kepub if fmt == "KEPUB" else None
+        monkeypatch.setattr(
+            helper,
+            "do_kepubify_metadata_replace",
+            lambda *_args, **_kwargs: (str(book_dir), "stable-book"),
+        )
+        embed_metadata = True
+
+    monkeypatch.setattr(
+        helper.calibre_db,
+        "get_filtered_book",
+        lambda *_args, **_kwargs: book,
+    )
+    monkeypatch.setattr(helper.calibre_db, "get_book_format", get_format)
+    monkeypatch.setattr(
+        helper,
+        "current_user",
+        SimpleNamespace(is_authenticated=False, role_admin=lambda: False),
+    )
+    monkeypatch.setattr(helper.config, "config_use_google_drive", False, raising=False)
+    monkeypatch.setattr(helper.config, "config_embed_metadata", embed_metadata, raising=False)
+    monkeypatch.setattr(helper.config, "config_binariesdir", "/bin", raising=False)
+    monkeypatch.setattr(helper.config, "config_kepubifypath", "/bin/kepubify", raising=False)
+    monkeypatch.setattr(helper.config, "config_kobo_prefer_kepub", True, raising=False)
+    monkeypatch.setattr(helper.config, "config_unicode_filename", False, raising=False)
+    monkeypatch.setattr(helper.config, "get_book_path", lambda: str(library), raising=False)
+
+    app = Flask(__name__)
+    with app.test_request_context(
+        f"/kobo/token/download/{book.id}/{requested_format}"
+    ):
+        response = inspect.unwrap(kobo.download_book)(
+            str(book.id), requested_format,
+        )
+
+    assert response.status_code == 200
+    response.direct_passthrough = False
+    assert response.get_data() == expected_bytes
+    assert "attachment" in response.headers["Content-Disposition"]
+    if requested_format == "kepub":
+        assert ".kepub.epub" in response.headers["Content-Disposition"]
 
 
 def test_device_entitlement_table_is_created_by_app_db_migration_path():
@@ -537,3 +1184,91 @@ def test_layer2_provenance_requires_cwng_core_cursor_fields():
 
     assert parsed_emitted.is_cwng_token is True
     assert parsed_legacy.is_cwng_token is False
+
+
+def test_legacy_token_missing_additive_fields_keeps_old_cursors_sane():
+    """Pre-books-id/magic tokens remain valid and receive safe defaults."""
+    from cps.services import SyncToken
+
+    legacy = SyncToken.b64encode_json({
+        "version": "1-1-0",
+        "data": {
+            "raw_kobo_store_token": "",
+            "books_last_modified": 1735689600.0,
+            "books_last_created": 1735689600.0,
+            "archive_last_modified": 1735689600.0,
+            "reading_state_last_modified": 1735689600.0,
+            "tags_last_modified": 1735689600.0,
+            # No books_last_id, magic_shelf_last_id, or membership timestamp.
+        },
+    })
+
+    parsed = SyncToken.SyncToken.from_headers({
+        SyncToken.SyncToken.SYNC_TOKEN_HEADER: legacy,
+    })
+
+    assert parsed.is_cwng_token is True
+    assert parsed.books_last_modified == datetime(2025, 1, 1)
+    assert parsed.books_last_id == -1
+    assert parsed.magic_shelf_last_id == -1
+    assert parsed.magic_shelf_membership_at == datetime.min
+
+
+def test_partial_legacy_and_store_tokens_degrade_without_exception():
+    """Missing legacy cursors and official-store tokens are tolerant but unsafe to suppress."""
+    from cps.services import SyncToken
+
+    partial = SyncToken.b64encode_json({
+        "version": "1-0-0",
+        "data": {
+            "raw_kobo_store_token": "",
+            "books_last_modified": 1735689600.0,
+            # Older/partial shape: no remaining core cursors.
+        },
+    })
+    parsed_partial = SyncToken.SyncToken.from_headers({
+        SyncToken.SyncToken.SYNC_TOKEN_HEADER: partial,
+    })
+    parsed_store = SyncToken.SyncToken.from_headers({
+        SyncToken.SyncToken.SYNC_TOKEN_HEADER: "official.store-token",
+    })
+
+    assert parsed_partial.books_last_modified == datetime(2025, 1, 1)
+    assert parsed_partial.reading_state_last_modified == datetime.min
+    assert parsed_partial.books_last_id == -1
+    assert parsed_partial.is_cwng_token is False
+    assert parsed_store.raw_kobo_store_token == "official.store-token"
+    assert parsed_store.books_last_modified == datetime.min
+    assert parsed_store.is_cwng_token is False
+
+
+def test_sync_summary_handles_store_min_and_nullable_cursor_shapes(
+    sync_harness, caplog,
+):
+    """The permanent DEBUG diagnostic must never become a sync failure."""
+    from cps import kobo
+
+    caplog.set_level(logging.DEBUG, logger="cps.kobo")
+    response = sync_harness.sync("official.store-token")
+    assert response.status_code == 200
+    summaries = [
+        record.getMessage() for record in caplog.records
+        if record.getMessage().startswith("Kobo Sync summary:")
+    ]
+    assert len(summaries) == 1
+    assert "entitlements new=1 changed=0" in summaries[0]
+    assert "cursors in=" in summaries[0] and " out=" in summaries[0]
+
+    nullable = SimpleNamespace(
+        books_last_modified=None,
+        books_last_id=None,
+        books_last_created=datetime.min,
+        archive_last_modified=None,
+        reading_state_last_modified=datetime.min,
+        tags_last_modified=None,
+        magic_shelf_last_id=None,
+        magic_shelf_membership_at=datetime.min,
+    )
+    assert kobo._sync_cursor_summary(nullable) == (
+        None, None, datetime.min, None, datetime.min, None, None, datetime.min,
+    )

--- a/tests/unit/test_1925_kobo_sync_dedownload.py
+++ b/tests/unit/test_1925_kobo_sync_dedownload.py
@@ -1,0 +1,411 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Regression coverage for fork issue #1925.
+
+An interrupted/abnormal device sync can lose CWNG's opaque sync token.  The
+same physical device then presents a fresh cursor even though its library is
+already populated.  Replaying an unchanged entitlement makes Nickel mark the
+local book as not downloaded; a genuine Books.last_modified change must still
+be delivered.
+"""
+
+from datetime import datetime, timedelta, timezone
+import logging
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask, g
+from sqlalchemy import create_engine, event, true
+from sqlalchemy.orm import sessionmaker
+
+
+pytestmark = pytest.mark.unit
+
+
+def _entitlements(response):
+    return [
+        item for item in response.get_json()
+        if "NewEntitlement" in item or "ChangedEntitlement" in item
+    ]
+
+
+@pytest.fixture
+def sync_harness(monkeypatch):
+    from cps import db, kobo, kobo_sync_status, ub
+
+    engine = create_engine("sqlite://")
+    event.listen(
+        engine,
+        "connect",
+        lambda connection, _record: connection.execute(
+            "ATTACH DATABASE ':memory:' AS calibre"
+        ),
+    )
+    db.Base.metadata.create_all(engine)
+    ub.Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+
+    modified = datetime(2026, 8, 28, 12, 0, 0)
+    book = db.Books(
+        "Stable Book",
+        "Stable Book",
+        "Author",
+        modified,
+        db.Books.DEFAULT_PUBDATE,
+        "1.0",
+        modified,
+        "stable-book",
+        0,
+        [],
+        [],
+    )
+    session.add(book)
+    session.flush()
+    book.uuid = "00000000-0000-0000-0000-000000001925"
+    session.add(db.Data(book.id, "EPUB", 1_234_567, "stable-book"))
+    device = ub.Device(
+        user_id=17,
+        kind="kobo",
+        display_name="Regression Kobo",
+        model="Kobo Clara BW",
+        active=True,
+        created_by="auto",
+    )
+    session.add(device)
+    session.commit()
+
+    user = SimpleNamespace(
+        id=17,
+        name="issue-1925-test",
+        kobo_only_shelves_sync=False,
+        role_download=lambda: True,
+    )
+    fake_calibre_db = SimpleNamespace(
+        session=session,
+        reconnect_db=lambda *_args, **_kwargs: None,
+        common_filters=lambda **_kwargs: true(),
+    )
+
+    monkeypatch.setattr(ub, "session", session)
+    monkeypatch.setattr(ub, "session_commit", lambda *_args, **_kwargs: session.commit())
+    monkeypatch.setattr(kobo, "calibre_db", fake_calibre_db)
+    monkeypatch.setattr(kobo, "current_user", user)
+    monkeypatch.setattr(kobo_sync_status, "current_user", user)
+    monkeypatch.setattr(kobo.config, "config_kobo_proxy", False, raising=False)
+    monkeypatch.setattr(kobo.config, "config_kobo_sync_magic_shelves", False, raising=False)
+    monkeypatch.setattr(kobo.config, "config_kobo_prefer_kepub", True, raising=False)
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", False,
+        raising=False,
+    )
+    monkeypatch.setattr(kobo.config, "config_kepubifypath", "/usr/bin/kepubify", raising=False)
+    monkeypatch.setattr(kobo.config, "config_embed_metadata", True, raising=False)
+    monkeypatch.setattr(kobo.config, "config_use_google_drive", False, raising=False)
+    monkeypatch.setattr(kobo.config, "get_book_path", lambda: "/nonexistent")
+    monkeypatch.setattr(kobo, "get_download_url_for_book", lambda book_id, fmt: f"/download/{book_id}/{fmt}")
+    monkeypatch.setattr(kobo, "get_epub_layout", lambda *_args: "reflowable")
+    monkeypatch.setattr(kobo, "get_magic_shelf_book_ids_for_kobo", lambda _user_id: (set(), True))
+    monkeypatch.setattr(kobo, "get_magic_shelf_membership_added_at", lambda _user_id: None)
+    monkeypatch.setattr(kobo, "sync_shelves", lambda *_args, **_kwargs: None)
+
+    app = Flask(__name__)
+    app.secret_key = "issue-1925-test-key"
+    app.wsgi_app = SimpleNamespace(is_proxied=True)
+
+    def sync(token=None, *, internal_device_id=None, raw_device_id=None):
+        internal_device_id = internal_device_id or device.id
+        raw_device_id = raw_device_id or ("a" * 64)
+        headers = {
+            "x-kobo-deviceid": raw_device_id,
+            "x-kobo-devicemodel": "Kobo Clara BW",
+        }
+        if token is not None:
+            headers[kobo.SyncToken.SyncToken.SYNC_TOKEN_HEADER] = token
+        with app.test_request_context("/v1/library/sync", headers=headers):
+            # The auth decorator normally sets this from x-kobo-deviceid.
+            g.annotation_origin_device_id = internal_device_id
+            return kobo.HandleSyncRequest.__wrapped__()
+
+    yield SimpleNamespace(
+        book=book,
+        device=device,
+        session=session,
+        sync=sync,
+        token_header=kobo.SyncToken.SyncToken.SYNC_TOKEN_HEADER,
+    )
+
+    session.close()
+    engine.dispose()
+
+
+def test_interrupted_sync_token_loss_does_not_redeliver_unchanged_entitlement(
+    sync_harness, caplog, monkeypatch,
+):
+    """Layer 2 suppresses an exact replay selected by a stale valid token."""
+    from cps import kobo
+
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+    caplog.set_level(logging.DEBUG, logger="cps.kobo")
+    first = sync_harness.sync()
+    assert len(_entitlements(first)) == 1
+
+    # Model the safely distinguishable interrupted-sync case: the device sends
+    # a valid CWNG token, but its local book cursors are behind the payload the
+    # server already delivered. An entirely absent token is deliberately not
+    # eligible because it is also the factory-reset signature.
+    stale_cwng_token = kobo.SyncToken.SyncToken().build_sync_token()
+    second = sync_harness.sync(stale_cwng_token)
+
+    assert _entitlements(second) == [], (
+        "an unchanged entitlement replay makes Nickel flip an already-downloaded "
+        "book back to Download"
+    )
+    summaries = [
+        record.getMessage() for record in caplog.records
+        if record.getMessage().startswith("Kobo Sync summary:")
+    ]
+    assert len(summaries) == 2
+    assert "entitlements new=0 changed=0 suppressed_unchanged=1" in summaries[-1]
+    assert "replay_suppression enabled=True eligible=True" in summaries[-1]
+    assert "cursors in=" in summaries[-1] and " out=" in summaries[-1]
+
+
+def test_payload_stabilization_replays_byte_identically_with_layer2_off(
+    sync_harness,
+):
+    """Layer 1 is default-safe: replay unchanged, byte-identical payloads."""
+    from cps import ub
+
+    first = _entitlements(sync_harness.sync())
+    second = _entitlements(sync_harness.sync())
+
+    assert len(first) == len(second) == 1
+    assert first == second
+    assert sync_harness.session.query(ub.KoboDeviceBookEntitlement).count() == 0
+
+
+@pytest.mark.parametrize("reset_token", [None, "not-a-token", "store.part"])
+def test_factory_reset_escape_never_suppresses_without_valid_cwng_token(
+    sync_harness, monkeypatch, reset_token,
+):
+    """Known hardware with an empty library must receive a complete replay."""
+    from cps import kobo, ub
+
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+    assert len(_entitlements(sync_harness.sync())) == 1
+    assert sync_harness.session.query(ub.KoboDeviceBookEntitlement).count() == 1
+
+    reset_response = sync_harness.sync(reset_token)
+
+    assert len(_entitlements(reset_response)) == 1
+
+
+def test_entitlement_replay_state_is_per_device(sync_harness, monkeypatch):
+    """One Kobo's delivery must never suppress another Kobo's first copy."""
+    from cps import kobo, ub
+
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+    sync_harness.sync()
+    second_device = ub.Device(
+        user_id=17,
+        kind="kobo",
+        display_name="Regression Kobo 2",
+        model="Kobo Libra Colour",
+        active=True,
+        created_by="auto",
+    )
+    sync_harness.session.add(second_device)
+    sync_harness.session.commit()
+
+    first_for_second_device = sync_harness.sync(
+        kobo.SyncToken.SyncToken().build_sync_token(),
+        internal_device_id=second_device.id,
+        raw_device_id="b" * 64,
+    )
+
+    assert len(_entitlements(first_for_second_device)) == 1
+
+
+def test_real_last_modified_bump_still_emits_changed_entitlement(
+    sync_harness, monkeypatch,
+):
+    """Per-device replay suppression must not mask a real library change."""
+    from cps import kobo
+
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+    first = sync_harness.sync()
+    first_token = first.headers[sync_harness.token_header]
+    original_last_modified = sync_harness.book.last_modified
+
+    sync_harness.book.last_modified = original_last_modified + timedelta(minutes=1)
+    sync_harness.session.commit()
+    changed = sync_harness.sync(first_token)
+
+    envelopes = _entitlements(changed)
+    assert len(envelopes) == 1
+    assert "ChangedEntitlement" in envelopes[0]
+    assert (
+        envelopes[0]["ChangedEntitlement"]["BookEntitlement"]["LastModified"]
+        == "2026-08-28T12:01:00Z"
+    )
+
+
+def test_entitlement_declared_fields_are_byte_stable_for_unchanged_book(
+    sync_harness, monkeypatch,
+):
+    """No wall-clock field may mutate an unchanged entitlement payload."""
+    from cps import kobo
+
+    class AdvancingClock:
+        calls = 0
+        min = datetime.min
+
+        @classmethod
+        def now(cls, _tz=None):
+            cls.calls += 1
+            return datetime(2026, 8, 28, 13, cls.calls, tzinfo=timezone.utc)
+
+    # Before the fix, ActivePeriod called datetime.now() and these two calls
+    # differed. The stable implementation does not consult this clock.
+    monkeypatch.setattr(kobo, "datetime", AdvancingClock)
+    with Flask(__name__).test_request_context("/v1/library/sync"):
+        first = kobo.create_book_entitlement(sync_harness.book, archived=False)
+        second = kobo.create_book_entitlement(sync_harness.book, archived=False)
+
+    assert first == second
+    assert first["ActivePeriod"]["From"] == first["Created"]
+
+
+def test_invalid_legacy_timestamp_fallback_is_byte_stable():
+    """A malformed unchanged row must not inherit response wall-clock time."""
+    from cps import kobo
+
+    assert kobo.convert_to_kobo_timestamp_string(None) == "1970-01-01T00:00:00Z"
+
+
+def test_generated_kepub_does_not_declare_source_epub_size(sync_harness):
+    """A download-time generated KEPUB must not advertise the EPUB's size."""
+    from cps import kobo
+
+    app = Flask(__name__)
+    app.wsgi_app = SimpleNamespace(is_proxied=True)
+    with app.test_request_context("/v1/library/sync"):
+        download = kobo.get_metadata(sync_harness.book)["DownloadUrls"][0]
+
+    assert download["Format"] == "KEPUB"
+    assert "Size" not in download, (
+        "the source EPUB size is not the size of the KEPUB bytes served after "
+        "download-time conversion/metadata rewriting"
+    )
+
+
+def test_exact_stored_epub_keeps_truthful_declared_size(sync_harness, monkeypatch):
+    """Only generated artifacts lose Size; exact stored downloads retain it."""
+    from cps import kobo
+
+    monkeypatch.setattr(kobo.config, "config_embed_metadata", False, raising=False)
+    stored_epub = SimpleNamespace(format="EPUB", uncompressed_size=321)
+    with Flask(__name__).test_request_context("/v1/library/sync"):
+        download = kobo.build_download_url(
+            sync_harness.book, stored_epub, "epub", "EPUB3",
+        )
+
+    assert download["Size"] == 321
+
+
+def test_metadata_rewritten_epub_does_not_declare_stored_size(
+    sync_harness, monkeypatch,
+):
+    """Metadata embedding makes an EPUB Data-row size inexact as well."""
+    from cps import kobo
+
+    monkeypatch.setattr(kobo.config, "config_embed_metadata", True, raising=False)
+    stored_epub = SimpleNamespace(format="EPUB", uncompressed_size=321)
+    with Flask(__name__).test_request_context("/v1/library/sync"):
+        download = kobo.build_download_url(
+            sync_harness.book, stored_epub, "epub", "EPUB3",
+        )
+
+    assert "Size" not in download
+
+
+def test_device_entitlement_table_is_created_by_app_db_migration_path():
+    """An existing app.db missing the new ledger receives it at startup."""
+    from cps import ub
+    from sqlalchemy import inspect as sa_inspect
+
+    engine = create_engine("sqlite:///:memory:")
+    session = sessionmaker(bind=engine)()
+    try:
+        # Create the existing referenced table but deliberately omit the new
+        # ledger, then exercise the same additive path migrate_Database calls.
+        ub.Device.__table__.create(bind=engine)
+        assert "kobo_device_book_entitlement" not in sa_inspect(engine).get_table_names()
+        ub.add_missing_tables(engine, session)
+        assert "kobo_device_book_entitlement" in sa_inspect(engine).get_table_names()
+    finally:
+        session.close()
+        engine.dispose()
+
+
+def test_replay_suppression_config_migrates_and_defaults_off():
+    """Layer 2 must remain dormant on both upgrades and fresh installs."""
+    from cps import config_sql
+    from sqlalchemy import text
+
+    engine = create_engine("sqlite:///:memory:")
+    with engine.begin() as connection:
+        connection.execute(text("CREATE TABLE settings (id INTEGER PRIMARY KEY)"))
+        connection.execute(text("INSERT INTO settings (id) VALUES (1)"))
+    session = sessionmaker(bind=engine)()
+    try:
+        config_sql._migrate_table(session, config_sql._Settings)
+        assert session.execute(text(
+            "SELECT config_kobo_suppress_replayed_entitlements FROM settings"
+        )).scalar() == 0
+
+        fresh_engine = create_engine("sqlite:///:memory:")
+        try:
+            config_sql._Base.metadata.create_all(fresh_engine)
+            fresh_session = sessionmaker(bind=fresh_engine)()
+            fresh_session.add(config_sql._Settings())
+            fresh_session.commit()
+            assert (
+                fresh_session.query(config_sql._Settings).one()
+                .config_kobo_suppress_replayed_entitlements is False
+            )
+            fresh_session.close()
+        finally:
+            fresh_engine.dispose()
+    finally:
+        session.close()
+        engine.dispose()
+
+
+def test_layer2_provenance_requires_cwng_core_cursor_fields():
+    """Permissive legacy-token fallback is not suppression authorization."""
+    from cps.services import SyncToken
+
+    emitted = SyncToken.SyncToken().build_sync_token()
+    parsed_emitted = SyncToken.SyncToken.from_headers({
+        SyncToken.SyncToken.SYNC_TOKEN_HEADER: emitted,
+    })
+    permissive_legacy = SyncToken.b64encode_json({
+        "version": SyncToken.SyncToken.VERSION,
+        "data": {},
+    })
+    parsed_legacy = SyncToken.SyncToken.from_headers({
+        SyncToken.SyncToken.SYNC_TOKEN_HEADER: permissive_legacy,
+    })
+
+    assert parsed_emitted.is_cwng_token is True
+    assert parsed_legacy.is_cwng_token is False

--- a/tests/unit/test_1925_kobo_sync_dedownload.py
+++ b/tests/unit/test_1925_kobo_sync_dedownload.py
@@ -12,6 +12,7 @@ be delivered.
 
 from datetime import datetime, timedelta, timezone
 import logging
+import re
 from types import SimpleNamespace
 
 import pytest
@@ -185,9 +186,12 @@ def sync_harness(monkeypatch):
     def sync(token=None, *, internal_device_id=None, raw_device_id=None):
         internal_device_id = internal_device_id or device.id
         raw_device_id = raw_device_id or ("a" * 64)
+        speaking_device = session.get(ub.Device, internal_device_id)
         headers = {
             "x-kobo-deviceid": raw_device_id,
-            "x-kobo-devicemodel": "Kobo Clara BW",
+            "x-kobo-devicemodel": (
+                speaking_device.model if speaking_device else "Kobo Clara BW"
+            ),
         }
         if token is not None:
             headers[kobo.SyncToken.SyncToken.SYNC_TOKEN_HEADER] = token
@@ -243,6 +247,169 @@ def test_interrupted_sync_token_loss_does_not_redeliver_unchanged_entitlement(
     assert "entitlements new=0 changed=0 suppressed_unchanged=1" in summaries[-1]
     assert "replay_suppression enabled=True eligible=True" in summaries[-1]
     assert "cursors in=" in summaries[-1] and " out=" in summaries[-1]
+
+
+def test_upgrade_seed_suppresses_first_218_book_replay_for_all_existing_devices(
+    sync_harness, caplog, monkeypatch,
+):
+    """The first post-upgrade 3-page replay is protected before delivery."""
+    from cps import db, kobo, ub
+
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_cover_padding_enabled", True, raising=False,
+    )
+    caplog.set_level(logging.DEBUG, logger="cps.kobo")
+
+    second_device = ub.Device(
+        user_id=sync_harness.user.id,
+        kind="kobo",
+        display_name="Existing Household Kobo",
+        model="Kobo Libra Colour",
+        active=True,
+        created_by="auto",
+    )
+    sync_harness.session.add(second_device)
+    sync_harness.session.flush()
+
+    delivered = [sync_harness.book]
+    modified = sync_harness.book.last_modified
+    for number in range(2, 219):
+        book = db.Books(
+            f"Upgrade Book {number}",
+            f"Upgrade Book {number}",
+            "Author",
+            modified,
+            db.Books.DEFAULT_PUBDATE,
+            "1.0",
+            modified,
+            f"upgrade-book-{number}",
+            0,
+            [],
+            [],
+        )
+        sync_harness.session.add(book)
+        sync_harness.session.flush()
+        book.uuid = f"00000000-0000-0000-0000-{number:012d}"
+        sync_harness.session.add(db.Data(
+            book.id, "EPUB", 1_000_000 + number, f"upgrade-book-{number}",
+        ))
+        delivered.append(book)
+    sync_harness.session.add_all([
+        ub.KoboSyncedBooks(
+            user_id=sync_harness.user.id,
+            book_id=book.id,
+            book_uuid=str(book.uuid),
+        )
+        for book in delivered
+    ])
+    sync_harness.session.commit()
+
+    token = kobo.SyncToken.SyncToken().build_sync_token()
+    responses = []
+    for _page in range(3):
+        response = sync_harness.sync(token)
+        responses.append(response)
+        token = response.headers[sync_harness.token_header]
+
+    assert all(_entitlements(response) == [] for response in responses)
+    assert sync_harness.session.query(ub.KoboDeviceBookEntitlement).count() == 436
+    assert sync_harness.session.query(ub.KoboDeviceEntitlementSeed).count() == 2
+    first_book_hashes = {
+        row.device_id: row.fingerprint
+        for row in sync_harness.session.query(
+            ub.KoboDeviceBookEntitlement,
+        ).filter(
+            ub.KoboDeviceBookEntitlement.book_id == sync_harness.book.id,
+        ).all()
+    }
+    assert first_book_hashes[sync_harness.device.id] != \
+        first_book_hashes[second_device.id], (
+            "upgrade seeding must reproduce device-specific cover metadata, "
+            "not copy the speaking Kobo's payload across the household"
+        )
+
+    summaries = [
+        record.getMessage() for record in caplog.records
+        if record.getMessage().startswith("Kobo Sync summary:")
+    ]
+    assert sum(
+        int(re.search(r"suppressed_unchanged=(\d+)", line).group(1))
+        for line in summaries
+    ) == 218
+    seed_lines = [
+        record.getMessage() for record in caplog.records
+        if record.getMessage().startswith("Kobo Sync ledger seed:")
+    ]
+    assert len(seed_lines) == 1
+    assert "devices=2 books=218 deleted=0 new_devices=0" in seed_lines[0]
+    assert float(re.search(r"elapsed_ms=([0-9.]+)", seed_lines[0]).group(1)) >= 0
+
+    # Even a device whose historical ledger was seeded gets a full initial
+    # library after factory reset because a tokenless request is ineligible.
+    factory_reset = sync_harness.sync(
+        internal_device_id=second_device.id,
+        raw_device_id="b" * 64,
+    )
+    assert len(_entitlements(factory_reset)) == 100
+
+
+def test_hard_delete_entitlements_emit_once_then_suppress_exact_stale_replay(
+    sync_harness, caplog, monkeypatch,
+):
+    """Two hard-delete probes cannot remain ChangedEntitlements forever."""
+    from cps import kobo, ub
+
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+    caplog.set_level(logging.DEBUG, logger="cps.kobo")
+
+    # Cross the upgrade boundary before these new tombstones exist, so their
+    # first delivery is real rather than migration-seeded.
+    assert len(_entitlements(sync_harness.sync())) == 1
+    deleted_at = datetime(2026, 8, 28, 13, 30, 0)
+    sync_harness.session.add_all([
+        ub.KoboDeletedBook(
+            user_id=sync_harness.user.id,
+            book_uuid="00000000-0000-0000-0000-deleted0001",
+            deleted_at=deleted_at,
+        ),
+        ub.KoboDeletedBook(
+            user_id=sync_harness.user.id,
+            book_uuid="00000000-0000-0000-0000-deleted0002",
+            deleted_at=deleted_at + timedelta(seconds=1),
+        ),
+    ])
+    sync_harness.session.commit()
+
+    stale_token = kobo.SyncToken.SyncToken().build_sync_token()
+    first_offer = sync_harness.sync(stale_token)
+    # Model request teardown. A staged-but-uncommitted deletion fingerprint
+    # disappears here and makes the exact replay re-offer both tombstones.
+    sync_harness.session.rollback()
+    exact_replay = sync_harness.sync(stale_token)
+
+    first_removed = [
+        item["ChangedEntitlement"]
+        for item in _entitlements(first_offer)
+        if item.get("ChangedEntitlement", {}).get(
+            "BookEntitlement", {},
+        ).get("IsRemoved") is True
+    ]
+    assert len(first_removed) == 2
+    assert _entitlements(exact_replay) == []
+    assert sync_harness.session.query(
+        ub.KoboDeviceDeletedEntitlement,
+    ).count() == 2
+    summaries = [
+        record.getMessage() for record in caplog.records
+        if record.getMessage().startswith("Kobo Sync summary:")
+    ]
+    assert "entitlements new=0 changed=0" in summaries[-1]
+    assert "suppressed_unchanged=3 suppressed_removed=2" in summaries[-1]
 
 
 def test_suppressed_entitlement_emits_newer_reading_state_once_and_advances_cursor(
@@ -619,7 +786,7 @@ def test_entitlement_replay_state_is_per_device(sync_harness, monkeypatch):
 
 
 def test_second_device_has_no_cross_device_state_when_layer2_is_off(sync_harness):
-    """The default-off layer writes no ledger and does not starve device two."""
+    """An explicit flag-off override writes no ledger or cross-device state."""
     from cps import kobo, ub
 
     first_device = sync_harness.sync()
@@ -713,8 +880,28 @@ def test_full_sync_clears_only_target_users_entitlement_ledger(
         kobo.config, "config_kobo_suppress_replayed_entitlements", True,
     )
     first = sync_harness.sync()
-    _seed_same_user_device_ledger(sync_harness)
+    second_target_device = _seed_same_user_device_ledger(sync_harness)
     other_device = _seed_other_user_ledger(sync_harness)
+    sync_harness.session.add_all([
+        ub.KoboDeviceDeletedEntitlement(
+            device_id=sync_harness.device.id,
+            book_uuid="target-deleted",
+            fingerprint="a" * 64,
+        ),
+        ub.KoboDeviceDeletedEntitlement(
+            device_id=second_target_device.id,
+            book_uuid="target-deleted",
+            fingerprint="b" * 64,
+        ),
+        ub.KoboDeviceDeletedEntitlement(
+            device_id=other_device.id,
+            book_uuid="other-deleted",
+            fingerprint="c" * 64,
+        ),
+        ub.KoboDeviceEntitlementSeed(device_id=second_target_device.id),
+        ub.KoboDeviceEntitlementSeed(device_id=other_device.id),
+    ])
+    sync_harness.session.commit()
     monkeypatch.setattr(admin, "_", lambda value: value)
 
     with sync_harness.app.test_request_context("/ajax/fullsync/17", method="POST"):
@@ -728,6 +915,14 @@ def test_full_sync_clears_only_target_users_entitlement_ledger(
     assert {
         row.user_id for row in sync_harness.session.query(ub.KoboSyncedBooks)
     } == {18}
+    assert {
+        row.device_id for row in
+        sync_harness.session.query(ub.KoboDeviceDeletedEntitlement)
+    } == {other_device.id}
+    assert {
+        row.device_id for row in
+        sync_harness.session.query(ub.KoboDeviceEntitlementSeed)
+    } == {other_device.id}
 
     replay = sync_harness.sync(first.headers[sync_harness.token_header])
     replay_envelopes = _entitlements(replay)
@@ -737,6 +932,10 @@ def test_full_sync_clears_only_target_users_entitlement_ledger(
         row.device_id
         for row in sync_harness.session.query(ub.KoboDeviceBookEntitlement)
     } == {sync_harness.device.id, other_device.id}
+    assert {
+        row.device_id for row in
+        sync_harness.session.query(ub.KoboDeviceEntitlementSeed)
+    } == {sync_harness.device.id, second_target_device.id, other_device.id}
 
 
 def test_admin_resend_clears_target_users_entitlement_ledger(
@@ -906,8 +1105,8 @@ def test_invalid_legacy_timestamp_fallback_is_byte_stable():
     assert kobo.convert_to_kobo_timestamp_string(None) == "1970-01-01T00:00:00Z"
 
 
-def test_generated_kepub_does_not_declare_source_epub_size(sync_harness):
-    """A download-time generated KEPUB must not advertise the EPUB's size."""
+def test_generated_kepub_restores_stable_v4142_source_size(sync_harness):
+    """Generated KEPUB metadata retains v4.1.42's nonzero stable Size."""
     from cps import kobo
 
     app = Flask(__name__)
@@ -919,10 +1118,7 @@ def test_generated_kepub_does_not_declare_source_epub_size(sync_harness):
     assert download["Url"] == f"/download/{sync_harness.book.id}/kepub"
     assert download["Platform"] == "Generic"
     assert download["DrmType"] == "None"
-    assert "Size" not in download, (
-        "the source EPUB size is not the size of the KEPUB bytes served after "
-        "download-time conversion/metadata rewriting"
-    )
+    assert download["Size"] == 1_234_567
 
 
 def test_exact_stored_epub_keeps_truthful_declared_size(sync_harness, monkeypatch):
@@ -939,10 +1135,10 @@ def test_exact_stored_epub_keeps_truthful_declared_size(sync_harness, monkeypatc
     assert download["Size"] == 321
 
 
-def test_metadata_rewritten_epub_does_not_declare_stored_size(
+def test_metadata_rewritten_epub_restores_stable_stored_size(
     sync_harness, monkeypatch,
 ):
-    """Metadata embedding makes an EPUB Data-row size inexact as well."""
+    """Metadata embedding still declares the stable v4.1.42 Data-row size."""
     from cps import kobo
 
     monkeypatch.setattr(kobo.config, "config_embed_metadata", True, raising=False)
@@ -952,19 +1148,19 @@ def test_metadata_rewritten_epub_does_not_declare_stored_size(
             sync_harness.book, stored_epub, "epub", "EPUB3",
         )
 
-    assert "Size" not in download
     assert download == {
         "Format": "EPUB3",
         "Url": f"/download/{sync_harness.book.id}/epub",
         "Platform": "Generic",
         "DrmType": "None",
+        "Size": 321,
     }
 
 
-def test_rewritten_stored_epub_and_kepub_keep_complete_download_fields(
+def test_rewritten_stored_epub_and_kepub_keep_v4142_download_fields(
     sync_harness, monkeypatch,
 ):
-    """Omitting inexact Size must not damage any URL/format/DRM field."""
+    """Rewritten routes retain all URL/format/DRM/Size fields."""
     from cps import db, kobo
 
     monkeypatch.setattr(kobo.config, "config_embed_metadata", True, raising=False)
@@ -977,12 +1173,14 @@ def test_rewritten_stored_epub_and_kepub_keep_complete_download_fields(
             "Url": f"/download/{sync_harness.book.id}/epub",
             "Platform": "Generic",
             "DrmType": "None",
+            "Size": 1_234_567,
         },
         {
             "Format": "EPUB",
             "Url": f"/download/{sync_harness.book.id}/epub",
             "Platform": "Generic",
             "DrmType": "None",
+            "Size": 1_234_567,
         },
     ]
 
@@ -999,6 +1197,7 @@ def test_rewritten_stored_epub_and_kepub_keep_complete_download_fields(
         "Url": f"/download/{sync_harness.book.id}/kepub",
         "Platform": "Generic",
         "DrmType": "None",
+        "Size": 1_345_678,
     }]
 
 
@@ -1008,10 +1207,10 @@ def test_rewritten_stored_epub_and_kepub_keep_complete_download_fields(
     "rewritten_stored_epub",
     "rewritten_stored_kepub",
 ])
-def test_size_omission_paths_still_serve_the_kobo_download_route(
+def test_restored_size_paths_still_serve_the_kobo_download_route(
     tmp_path, monkeypatch, network_share_mode, download_case,
 ):
-    """Every artifact whose entitlement omits Size still reaches the wire."""
+    """Generated/rewritten artifacts retain their working download routes."""
     import inspect
 
     from cps import helper, kobo
@@ -1113,8 +1312,8 @@ def test_size_omission_paths_still_serve_the_kobo_download_route(
         assert ".kepub.epub" in response.headers["Content-Disposition"]
 
 
-def test_device_entitlement_table_is_created_by_app_db_migration_path():
-    """An existing app.db missing the new ledger receives it at startup."""
+def test_device_entitlement_tables_are_created_by_app_db_migration_path():
+    """An existing app.db receives every replay ledger table at startup."""
     from cps import ub
     from sqlalchemy import inspect as sa_inspect
 
@@ -1124,16 +1323,21 @@ def test_device_entitlement_table_is_created_by_app_db_migration_path():
         # Create the existing referenced table but deliberately omit the new
         # ledger, then exercise the same additive path migrate_Database calls.
         ub.Device.__table__.create(bind=engine)
-        assert "kobo_device_book_entitlement" not in sa_inspect(engine).get_table_names()
+        expected = {
+            "kobo_device_book_entitlement",
+            "kobo_device_deleted_entitlement",
+            "kobo_device_entitlement_seed",
+        }
+        assert expected.isdisjoint(sa_inspect(engine).get_table_names())
         ub.add_missing_tables(engine, session)
-        assert "kobo_device_book_entitlement" in sa_inspect(engine).get_table_names()
+        assert expected.issubset(sa_inspect(engine).get_table_names())
     finally:
         session.close()
         engine.dispose()
 
 
-def test_replay_suppression_config_migrates_and_defaults_off():
-    """Layer 2 must remain dormant on both upgrades and fresh installs."""
+def test_replay_suppression_config_migrates_and_defaults_on():
+    """Hardware-proven replay suppression defaults on for upgrades and fresh installs."""
     from cps import config_sql
     from sqlalchemy import text
 
@@ -1146,7 +1350,7 @@ def test_replay_suppression_config_migrates_and_defaults_off():
         config_sql._migrate_table(session, config_sql._Settings)
         assert session.execute(text(
             "SELECT config_kobo_suppress_replayed_entitlements FROM settings"
-        )).scalar() == 0
+        )).scalar() == 1
 
         fresh_engine = create_engine("sqlite:///:memory:")
         try:
@@ -1156,7 +1360,7 @@ def test_replay_suppression_config_migrates_and_defaults_off():
             fresh_session.commit()
             assert (
                 fresh_session.query(config_sql._Settings).one()
-                .config_kobo_suppress_replayed_entitlements is False
+                .config_kobo_suppress_replayed_entitlements is True
             )
             fresh_session.close()
         finally:

--- a/tests/unit/test_1925_kobo_sync_dedownload.py
+++ b/tests/unit/test_1925_kobo_sync_dedownload.py
@@ -30,6 +30,14 @@ def _entitlements(response):
     ]
 
 
+def _changed_reading_states(response):
+    return [
+        item["ChangedReadingState"]["ReadingState"]
+        for item in response.get_json()
+        if "ChangedReadingState" in item
+    ]
+
+
 @pytest.fixture
 def sync_harness(monkeypatch):
     from cps import db, kobo, kobo_sync_status, ub
@@ -171,6 +179,126 @@ def test_interrupted_sync_token_loss_does_not_redeliver_unchanged_entitlement(
     assert "entitlements new=0 changed=0 suppressed_unchanged=1" in summaries[-1]
     assert "replay_suppression enabled=True eligible=True" in summaries[-1]
     assert "cursors in=" in summaries[-1] and " out=" in summaries[-1]
+
+
+def test_suppressed_entitlement_emits_newer_reading_state_once_and_advances_cursor(
+    sync_harness, monkeypatch,
+):
+    """Layer 2 suppression must not suppress or loop reading-state changes."""
+    from cps import db, kobo, ub
+
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+    monkeypatch.setattr(kobo, "SYNC_ITEM_LIMIT", 1)
+
+    # Seed the per-device entitlement fingerprint without a reading state.
+    assert len(_entitlements(sync_harness.sync())) == 1
+
+    # Fill the (test-sized) independent reading-state page with an older,
+    # legitimate library state. Before the fix, the suppressed book relied on
+    # that later paged scan; its newer state was therefore withheld until
+    # another sync. Keeping this book out of Data makes it reading-state-only
+    # background, not an additional base entitlement in this regression.
+    background_modified = datetime(2026, 8, 28, 12, 15, 0)
+    background_book = db.Books(
+        "Background State",
+        "Background State",
+        "Author",
+        background_modified,
+        db.Books.DEFAULT_PUBDATE,
+        "1.0",
+        background_modified,
+        "background-state",
+        0,
+        [],
+        [],
+    )
+    background_book.uuid = "10000000-0000-0000-0000-000000000001"
+    sync_harness.session.add(background_book)
+    sync_harness.session.flush()
+    background_state = ub.KoboReadingState(
+        user_id=17,
+        book_id=background_book.id,
+        priority_timestamp=background_modified,
+    )
+    background_state.current_bookmark = ub.KoboBookmark(
+        last_modified=background_modified,
+        progress_percent=1.0,
+    )
+    background_state.statistics = ub.KoboStatistics(
+        last_modified=background_modified,
+    )
+    background_read = ub.ReadBook(
+        user_id=17,
+        book_id=background_book.id,
+        read_status=ub.ReadBook.STATUS_IN_PROGRESS,
+    )
+    background_read.kobo_reading_state = background_state
+    sync_harness.session.add(background_read)
+
+    state_modified = datetime(2026, 8, 28, 12, 30, 0)
+    read = ub.ReadBook(
+        user_id=17,
+        book_id=sync_harness.book.id,
+        read_status=ub.ReadBook.STATUS_IN_PROGRESS,
+    )
+    state = ub.KoboReadingState(
+        user_id=17,
+        book_id=sync_harness.book.id,
+        priority_timestamp=state_modified,
+    )
+    state.current_bookmark = ub.KoboBookmark(
+        last_modified=state_modified,
+        progress_percent=42.0,
+    )
+    state.statistics = ub.KoboStatistics(last_modified=state_modified)
+    read.kobo_reading_state = state
+    sync_harness.session.add(read)
+    sync_harness.session.commit()
+    # The before_flush hook deliberately stamps the parent when its bookmark
+    # changes. Pin the cursor carrier after the graph has been flushed.
+    sync_harness.session.query(ub.KoboReadingState).filter_by(
+        user_id=17,
+        book_id=sync_harness.book.id,
+    ).update({ub.KoboReadingState.last_modified: state_modified})
+    sync_harness.session.query(ub.KoboReadingState).filter(
+        ub.KoboReadingState.user_id == 17,
+        ub.KoboReadingState.book_id == background_book.id,
+    ).update(
+        {ub.KoboReadingState.last_modified: background_modified},
+        synchronize_session=False,
+    )
+    sync_harness.session.commit()
+    sync_harness.session.expire_all()
+
+    # A valid but stale CWNG token selects the unchanged base entitlement and
+    # the newer reading state together. Layer 2 may suppress only the former.
+    stale_cwng_token = kobo.SyncToken.SyncToken().build_sync_token()
+    changed = sync_harness.sync(stale_cwng_token)
+
+    assert _entitlements(changed) == []
+    target_states = [
+        state for state in _changed_reading_states(changed)
+        if state["EntitlementId"] == sync_harness.book.uuid
+    ]
+    assert len(target_states) == 1
+    assert target_states[0]["CurrentBookmark"]["ProgressPercent"] == 42
+
+    advanced_token = kobo.SyncToken.SyncToken.from_headers({
+        sync_harness.token_header: changed.headers[sync_harness.token_header],
+    })
+    assert advanced_token.reading_state_last_modified == state_modified
+
+    unchanged = sync_harness.sync(changed.headers[sync_harness.token_header])
+    target_states_again = [
+        state for state in _changed_reading_states(unchanged)
+        if state["EntitlementId"] == sync_harness.book.uuid
+    ]
+    assert target_states_again == [], (
+        "the advanced reading-state cursor must not re-offer the same state "
+        "on the next sync"
+    )
 
 
 def test_payload_stabilization_replays_byte_identically_with_layer2_off(

--- a/tests/unit/test_kobo_prefer_kepub.py
+++ b/tests/unit/test_kobo_prefer_kepub.py
@@ -39,6 +39,9 @@ def test_download_selection_honours_off_but_keeps_existing_kepub(monkeypatch):
     monkeypatch.setattr(kobo, "get_subtitle", lambda book: None)
     monkeypatch.setattr(kobo.config, "config_kepubifypath", "/bin/kepubify", raising=False)
     monkeypatch.setattr(kobo.config, "config_kobo_prefer_kepub", False, raising=False)
+    # This assertion covers an exact stored KEPUB.  Metadata embedding rewrites
+    # the download and intentionally makes its stored Data-row size inexact.
+    monkeypatch.setattr(kobo.config, "config_embed_metadata", False, raising=False)
 
     epub = SimpleNamespace(format="EPUB", uncompressed_size=10)
     kepub = SimpleNamespace(format="KEPUB", uncompressed_size=12)

--- a/tests/unit/test_user_book_data_d4.py
+++ b/tests/unit/test_user_book_data_d4.py
@@ -85,6 +85,13 @@ def _annotation(ub, book_id, annotation_id="ann-1", user_id=USER, **kw):
 
 
 @pytest.mark.unit
+def test_per_user_book_registry_includes_device_entitlement_ledger():
+    from cps.user_book_data import PER_USER_BOOK_MODELS
+
+    assert "KoboDeviceBookEntitlement" in PER_USER_BOOK_MODELS
+
+
+@pytest.mark.unit
 class TestMigrate:
     def test_annotation_moves_to_winner_with_sync_targets(self, session):
         from cps import ub
@@ -299,7 +306,18 @@ class TestMigrate:
     def test_kobo_synced_marker_dropped_not_migrated(self, session):
         from cps import ub
         from cps.user_book_data import migrate_user_book_data
-        session.add(ub.KoboSyncedBooks(user_id=USER, book_id=LOSER))
+        device = ub.Device(
+            user_id=USER, kind="kobo", display_name="D4 Kobo",
+            active=True, created_by="auto",
+        )
+        session.add(device)
+        session.flush()
+        session.add_all([
+            ub.KoboSyncedBooks(user_id=USER, book_id=LOSER),
+            ub.KoboDeviceBookEntitlement(
+                device_id=device.id, book_id=LOSER, fingerprint="a" * 64,
+            ),
+        ])
         session.commit()
 
         migrate_user_book_data(LOSER, WINNER, session=session)
@@ -308,6 +326,7 @@ class TestMigrate:
         # the marker means "this file was delivered" — the kept book is a
         # different file, so it must sync fresh, not inherit the marker.
         assert session.query(ub.KoboSyncedBooks).count() == 0
+        assert session.query(ub.KoboDeviceBookEntitlement).count() == 0
 
     def test_simple_flags_migrate_and_dedupe(self, session):
         from cps import ub
@@ -335,6 +354,12 @@ class TestPurge:
         state = ub.KoboReadingState(user_id=USER, book_id=LOSER)
         state.current_bookmark = ub.KoboBookmark(progress_percent=10.0)
         state.statistics = ub.KoboStatistics(spent_reading_minutes=5)
+        device = ub.Device(
+            user_id=USER, kind="kobo", display_name="D4 Kobo",
+            active=True, created_by="auto",
+        )
+        session.add(device)
+        session.flush()
         session.add_all([
             ann, state,
             ub.ReadBook(user_id=USER, book_id=LOSER, read_status=1),
@@ -342,6 +367,9 @@ class TestPurge:
             ub.ArchivedBook(user_id=USER, book_id=LOSER, is_archived=False),
             ub.Downloads(user_id=USER, book_id=LOSER),
             ub.KoboSyncedBooks(user_id=USER, book_id=LOSER),
+            ub.KoboDeviceBookEntitlement(
+                device_id=device.id, book_id=LOSER, fingerprint="b" * 64,
+            ),
         ])
         _shelf_link(session, ub, LOSER, 1, 1)
         session.commit()
@@ -356,7 +384,8 @@ class TestPurge:
 
         for model in (ub.Annotation, ub.AnnotationSyncTarget, ub.KoboReadingState,
                       ub.KoboBookmark, ub.KoboStatistics, ub.ReadBook, ub.Bookmark,
-                      ub.ArchivedBook, ub.Downloads, ub.BookShelf, ub.KoboSyncedBooks):
+                      ub.ArchivedBook, ub.Downloads, ub.BookShelf, ub.KoboSyncedBooks,
+                      ub.KoboDeviceBookEntitlement):
             assert session.query(model).count() == 0, model.__name__
 
     def test_purge_by_book_leaves_other_books_alone(self, session):

--- a/tests/unit/test_user_book_data_d4.py
+++ b/tests/unit/test_user_book_data_d4.py
@@ -434,6 +434,71 @@ class TestPurge:
 
         assert session.query(ub.BookShelf).count() == 1
 
+    def test_purge_by_user_scopes_deleted_entitlements_and_seed_markers(self, session):
+        from cps import ub
+        from cps.user_book_data import purge_user_book_data
+
+        target = ub.Device(
+            user_id=USER, kind="kobo", display_name="Target Kobo",
+            active=True, created_by="auto",
+        )
+        other = ub.Device(
+            user_id=USER + 1, kind="kobo", display_name="Other Kobo",
+            active=True, created_by="auto",
+        )
+        session.add_all([target, other])
+        session.flush()
+        for device, suffix in ((target, "target"), (other, "other")):
+            session.add_all([
+                ub.KoboDeviceDeletedEntitlement(
+                    device_id=device.id,
+                    book_uuid=f"deleted-{suffix}",
+                    fingerprint="d" * 64,
+                ),
+                ub.KoboDeviceEntitlementSeed(device_id=device.id),
+            ])
+        session.commit()
+
+        purge_user_book_data(user_id=USER, session=session)
+        session.commit()
+
+        assert [
+            row.device_id for row in
+            session.query(ub.KoboDeviceDeletedEntitlement).all()
+        ] == [other.id]
+        assert [
+            row.device_id for row in
+            session.query(ub.KoboDeviceEntitlementSeed).all()
+        ] == [other.id]
+
+    def test_complete_database_purge_clears_deleted_entitlements_and_seed_markers(
+        self, session,
+    ):
+        from cps import ub
+        from cps.user_book_data import purge_user_book_data
+
+        device = ub.Device(
+            user_id=USER, kind="kobo", display_name="Database Swap Kobo",
+            active=True, created_by="auto",
+        )
+        session.add(device)
+        session.flush()
+        session.add_all([
+            ub.KoboDeviceDeletedEntitlement(
+                device_id=device.id,
+                book_uuid="old-library-deleted",
+                fingerprint="e" * 64,
+            ),
+            ub.KoboDeviceEntitlementSeed(device_id=device.id),
+        ])
+        session.commit()
+
+        purge_user_book_data(session=session)
+        session.commit()
+
+        assert session.query(ub.KoboDeviceDeletedEntitlement).count() == 0
+        assert session.query(ub.KoboDeviceEntitlementSeed).count() == 0
+
     def test_stage0_evidence_is_purged_before_annotation_id_reuse(self, session):
         """Account erasure must not alias old raw bytes onto a recycled id."""
         from cps import ub


### PR DESCRIPTION
Closes #1925.

A Kobo that replayed a library sync — after a dropped connection, a token loss, or a factory reset — was re-offered entitlements for books it already had, so the device showed **Download again** across an unchanged library.

## What changed

- A per-device entitlement ledger records the fingerprint of what each physical Kobo was last given, so a replayed sync suppresses entitlements the device already holds instead of re-emitting them.
- A suppressed replay still delivers a newer reading state and still advances the sync cursor, so suppression never strands progress or wedges the cursor (layer 2).
- Hard-deleted books keep their replay state in a separate UUID-keyed ledger, since they no longer have a calibre `book_id` — a stale archive cursor can't re-offer the same `IsRemoved` entitlement forever, while a second device and a tokenless factory-reset sync still receive it.
- A one-time per-device seed marker means existing installs don't replay their whole library once on upgrade. The marker is explicit rather than inferred from empty ledger rows, because inference would recreate rows that resend/unsync/archive/duplicate-merge deliberately cleared and suppress the very delivery those actions request.
- Admin resend and unsync clear the ledger for the right scope; user purge and full-database purge clear both the deleted-entitlement rows and the seed markers.
- Replay suppression is on by default with a config toggle, and a factory-reset/tokenless sync escapes suppression so a genuinely empty device is refilled.

## Merge with per-user libraries

`main` gained per-user libraries (#1947) while this was open. Both changes appended to the same two registries (`add_missing_tables()` in `cps/ub.py`, `PER_USER_BOOK_MODELS` in `cps/user_book_data.py`). The Kobo registries are now separate tuples concatenated at the point of use, so the two features no longer compete for one insertion point. Both `UserLibraryBook` and the Kobo device ledgers are created and migrated; duplicate-merge and purge handle both.

## Evidence

Verified on the actual merged tree (this head merged with `origin/main` `a038792b3`), not on the branch in isolation:

- `tests/unit/test_1925_kobo_sync_dedownload.py test_user_book_data_d4.py test_kobo_prefer_kepub.py` — **75 passed**.
- Per-user-libraries suites on the same merged tree (`test_my_library_backend_1939.py`, `test_my_library_leg6_regressions.py`, `test_1939_migration_ordering.py`, `test_user_book_data_d4.py`) — **76 passed**.
- Kobo-wide unit sweep — **959 passed, 1 skipped**.
- **Red proof:** reverting the round-2 source files to `2fb5f501e` and re-running the same tests gives **10 failed, 54 passed**.

No new dependencies, packaging, licence or external-URL changes. No new routes and no auth/session/CSRF/subprocess/file-path surface, so `/security-review` does not apply per the standing directive.

Full trail: `notes/issue-1925-sync-dedownload-report.md` and `state/completed.log`.
