### PR TITLE
docs(changelog): say My Library in the words the interface uses

### DIFF
--- a/changelog.d/1939-my-library-backend.md
+++ b/changelog.d/1939-my-library-backend.md
@@ -1,37 +1,42 @@
 ### Added
 
-- **Each account can now choose Monolibrary or Personal Library mode over one
-  shared Calibre archive.** Monolibrary continuously follows the global
-  archive. The first switch to Personal Library safely seeds everything the
-  account can already see; later switches restore the exact saved selection,
-  including an intentionally empty one. Accounts allowed to view the whole
-  archive can switch their own mode; otherwise their mode is administrator-
-  managed. Administrators also have an explicit seed-once action for one or
-  every account, with a per-account report. Authorized users can browse the
-  global archive and add or remove books from their set; ordinary shelves and
-  Kobo sync follow that set. Removing a book also removes that account's
-  ordinary shelf links, and adding the book back does not restore those shelf
-  links; reading progress, bookmarks, annotations, sync settings, roles, and
-  ownership records do survive mode changes, removals, and later re-adds. An
-  old book selected from the global archive now reaches Kobo immediately even
-  when its metadata predates the device cursor, while the initial seed remains
-  a no-op for already-synced hidden and archived books. Administrators can add
-  a specific book to a managed account. The new introductory card has a
-  durable per-account dismissal.
-  Recently added global books absent from a personal set have a dedicated
-  discovery filter, and a successful browser upload joins the uploader's own
-  library. The React and classic interfaces now expose the same mode controls,
-  global-library discovery, membership actions, introduction, confirmations,
-  and explanatory empty states. SQLite builds without JSON functions use a
-  compatible fallback. KOReader progress exports apply that same canonical
-  per-user visibility policy, and a rejected first switch can no longer leave
-  the durable seed marker ahead of the user's actual library state. Responses
-  whose book visibility depends on the requesting account now send
-  `Cache-Control: private, no-store` and identity-aware `Vary` headers; reverse
-  proxies must not reuse cached OPDS or library responses across accounts.
-  The classic library's persisted newest-sort key changes from `newest` to
-  `root`, so an existing saved newest selection is reset once to keep the
-  sidebar's active state consistent.
-  Existing and new accounts start in Monolibrary mode; upgrades do not switch
-  anyone automatically. Implements
-  [#1939](https://github.com/new-usemame/Calibre-Web-NextGen/issues/1939).
+- **Each account can now keep its own selection of books, out of one shared library.** Useful on a
+  server holding a big archive where one person only reads a few dozen of them. There is still one copy
+  of each file on disk and one set of metadata — only *which books you keep* is per-account, so two
+  readers can both have a book without there being two copies of it.
+
+  **Upgrading changes nothing.** Every existing and new account stays in *the whole library* mode, which
+  is exactly how the server behaved before. Nothing switches on by itself and no book moves.
+
+  When you do switch an account to *my selection*, it starts out holding everything that account can
+  already see, so the change is invisible on day one — including on an e-reader, which keeps every book
+  it already had. Pruning afterwards is a book-at-a-time decision. Switching back and forth loses
+  nothing: your selection is restored exactly, even if you had deliberately emptied it.
+
+  **Removing a book from your library deletes nothing** — not the file, not the metadata, not your
+  highlights, notes or reading position. Add it back later and your notes and your place in the book are
+  where you left them. It does drop the book from your own shelves, and re-adding does not put it back
+  on them. If you have an e-reader, the book leaves the device on its next update, and the confirmation
+  says so before you commit. Deleting a book *from the global library* is a separate, clearly separated
+  action that still erases it for everyone.
+
+  Accounts allowed to browse the whole archive get a **Global Library** section — everything on the
+  server, with a *recently added that you don't have* view — and can switch their own mode; for other
+  accounts an administrator manages it. Administrators can move one account or every account at once
+  (safe to re-run, never re-seeds), and can put a specific book into a managed account's selection.
+  Shelves, search, facet counts, OPDS and Kobo sync all follow the account's selection. Adding a book to
+  a shelf, or uploading one, adds it to your library first — you cannot shelve or upload into a library
+  you cannot see. Both the new and classic interfaces have the whole feature.
+
+  ⚠️ **My Library is a curation tool, not a privacy boundary.** It decides what an account sees by
+  default, not what it is permitted to reach. To actually keep books away from an account, use the
+  existing allowed/denied tags or the restricted custom column, which are enforced separately and still
+  apply.
+
+  Two notes for people running a proxy or a bare-metal install: responses whose contents depend on who
+  asked now send `Cache-Control: private, no-store` and identity-aware `Vary` headers, so a reverse proxy
+  must not reuse cached OPDS or library responses across accounts; and a SQLite build without JSON
+  support uses a slower but correct fallback rather than failing. The classic library's saved
+  newest-sort key is renamed internally, which resets an existing saved *newest* selection once.
+
+  Implements [#1939](https://github.com/new-usemame/Calibre-Web-NextGen/issues/1939).


### PR DESCRIPTION
Documentation only. One file: the changelog fragment for #1939.

## Why

Release notes are built from these fragments, so this text is the first thing a user reads about the
feature. The entry led with **"Monolibrary"** and **"Personal Library"** — those are the internal flag
names. The feature's own design ruled they must never ship, because they are jargon and do not
translate, and the interface says *the whole library* and *my selection*. So the release notes were
about to introduce the feature using two words the product never says to the user.

It was also one thirty-line paragraph that buried the single fact an upgrading admin most needs — that
nothing switches on by itself — in its final sentence.

## What changed

Same facts, reordered by what a reader needs first: what it is → **upgrading changes nothing** → what
removing does and does not destroy → the administrator surface → the proxy and bare-metal notes.

Two things were added rather than reworded, both because their absence could mislead:

- **"My Library is a curation tool, not a privacy boundary."** The implementation audit says membership
  is "a curation boundary, not a complete authorization boundary". Without that sentence an administrator
  could reasonably read the release notes and conclude they can use this to keep books away from an
  account. The entry now says so plainly and points at allowed/denied tags and the restricted custom
  column, which are enforced separately and do still apply.
- That removing a book **drops it from your own shelves and re-adding does not restore them**. It was
  present before but phrased as an aside; it is the one part of "removing deletes nothing" that is not
  strictly true, so it now sits next to that claim rather than after it.

No behaviour change, no code touched. 64 changelog-gate tests pass.
