### PR TITLE
fix(i18n): the Dutch delete button now says it is permanent

### DIFF
--- a/changelog.d/1951-i18n-delete-wording.md
+++ b/changelog.d/1951-i18n-delete-wording.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **Dutch: the button that permanently deletes a book for everyone now says so.**
+  Dutch used *verwijderen* for both removing a book from your own library
+  (reversible, deletes nothing) and deleting it from the shared library
+  (irreversible, for every member) — the two differed only by "mijn" versus "de
+  globale". The destructive one now reads *Definitief uit de globale bibliotheek
+  verwijderen*, restoring the distinction English and French already carry.
+- **French: the account setting for keeping your own selection is no longer
+  labelled "Sélection propre"**, which reads as "clean selection". It is now
+  *Sélection personnelle*.

--- a/cps/translations/fr/LC_MESSAGES/messages.po
+++ b/cps/translations/fr/LC_MESSAGES/messages.po
@@ -2977,7 +2977,7 @@ msgstr ""
 #: cps/spa_strings.py cps/templates/user_edit.html
 #: cps/templates/user_table.html
 msgid "Own selection"
-msgstr "Sélection propre"
+msgstr "Sélection personnelle"
 
 #: cps/spa_strings.py
 msgid "Recently added"

--- a/cps/translations/nl/LC_MESSAGES/messages.po
+++ b/cps/translations/nl/LC_MESSAGES/messages.po
@@ -2762,7 +2762,7 @@ msgstr ""
 
 #: cps/spa_strings.py
 msgid "Delete from the global library"
-msgstr "Uit de globale bibliotheek verwijderen"
+msgstr "Definitief uit de globale bibliotheek verwijderen"
 
 #: cps/spa_strings.py cps/templates/index.html
 msgid "Every book here is already in your library."

--- a/tests/unit/test_615_residual_i18n.py
+++ b/tests/unit/test_615_residual_i18n.py
@@ -7,8 +7,10 @@ absent from the SPA catalog, and default smart-shelf names are canonical
 English database values rendered as if they were already display text.
 """
 import ast
+import gettext
 import importlib.util
 import re
+import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -123,6 +125,43 @@ def _live_catalog(locale):
 # 100%; ru (@sinyawskiy) and pl (@bywciu, #1249) are not. Don't add a locale
 # here just because the README shows it at 100%.
 COMPLETE_LOCALES = ("fr", "nl")
+
+
+def _word_tokens(value):
+    return set(re.findall(r"[^\W_]+", value.casefold()))
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("locale", COMPLETE_LOCALES)
+def test_global_delete_label_is_distinct_from_reversible_removal(locale, tmp_path):
+    """#1939: scope words alone must not distinguish delete from remove."""
+    po = ROOT / "cps" / "translations" / locale / "LC_MESSAGES" / "messages.po"
+    mo = tmp_path / "messages.mo"
+    subprocess.run(["msgfmt", po, "-o", mo], check=True, capture_output=True)
+    with open(mo, "rb") as handle:
+        catalog = gettext.GNUTranslations(handle)
+
+    destructive = catalog.gettext("Delete from the global library")
+    reversible = catalog.gettext("Remove from my library")
+    scope_tokens = set().union(
+        *(
+            _word_tokens(catalog.gettext(msgid))
+            for msgid in ("Global Library", "My Library", "The whole library")
+        )
+    )
+    destructive_signal = (
+        _word_tokens(destructive) - _word_tokens(reversible) - scope_tokens
+    )
+
+    assert destructive_signal, (
+        f"{locale}: the control that permanently deletes a file for every member "
+        "is lexically indistinguishable from reversible My Library removal once "
+        "translated scope words are ignored. Shipping this lets a destructive "
+        "control read like the safe one. Give the destructive label a deletion "
+        "or permanence token that is absent from both the reversible label and "
+        f"the translated scope labels. destructive={destructive!r}, "
+        f"reversible={reversible!r}, scope_tokens={sorted(scope_tokens)!r}"
+    )
 
 
 @pytest.mark.unit


### PR DESCRIPTION
A translation review of all 55 strings #1939 added, in both gated locales, found two defects. One is a
safety defect rather than a wording preference.

## Dutch collapsed the reversible and irreversible actions into one word

| English | shipped Dutch |
|---|---|
| Remove from my library — reversible, deletes nothing | Uit **mijn** bibliotheek verwijderen |
| Delete from the global library — destroys the file for every member | Uit **de globale** bibliotheek verwijderen |

To a Dutch reader those differ only by *mijn* / *de globale*, and *verwijderen* is the delete-word
everywhere else in Dutch software. So the safe action read scarier than it is, and the destructive one
carried no lexical warning at all. English (remove/delete) and French (*retirer*/*supprimer*) both carry
the distinction; Dutch was the only locale where it vanished.

Fixed by marking permanence at the label, which is the Dutch platform convention for a permanent delete:
**"Definitief uit de globale bibliotheek verwijderen"**, fronted so the danger word is read first.

The seven reversible strings are deliberately **not** touched. They are consistent with the rest of the
catalog (*Verwijderen van boekenplank*, *Verwijderen uit favorieten*), and changing the whole family
would make this feature inconsistent with the product to fix a problem that only exists on the
destructive side. The dialog body copy in both languages was verified correct and already explains the
consequence, so the residual risk after this change is label-only surfaces.

## French mislabelled the own-selection scope

"Own selection" → "Sélection propre", where postposed *propre* means *clean* — a French reader parses
"clean selection". Now **"Sélection personnelle"**. Notably the review found *propre* used **correctly**
elsewhere in the same feature ("{name} conserve maintenant sa propre sélection"), where it is adjectival
inside a possessive phrase — so this is a real sense error, not a blanket objection to the word.

## What was checked

All 55 added msgids, both locales: **55/55 present, 0 empty, 0 fuzzy**, every placeholder intact and in a
grammatically valid position. Register consistent (FR *vous*, NL informal *je*). Both fixes verified
against the **compiled `.mo`**, not the `.po`, because `msgfmt` silently drops fuzzy entries. 225 i18n
tests pass.

One finding from an earlier pass was **withdrawn**: a claimed "plank" vs "boekenplank" terminology break
is not in this feature at all — all three shelf strings here use *boekenplank(en)*. The two bare "plank"
instances live in the shelf feature's own strings and are out of scope here.

## A note on how this was nearly missed

My first extraction of the pairs treated `msgstr ""` as an empty translation. In PO that is the standard
multi-line continuation, with the text on the following line — so it silently dropped ~21 pairs per
language, and those dropped pairs were **precisely the long explanatory sentences**: the reassurance copy,
the e-reader consequence, the destructive-side warnings. The first review therefore saw labels and buttons
while the entire safety-critical body copy was invisible to it, and reported two strings as untranslated
that were not. Re-run with a real PO parser over the complete set, it found zero further defects — but the
lesson is that a review is only as good as the extraction feeding it, and a truncated input produces
confident, specific, wrong findings.

## A guard, so the next translator cannot recreate this

The wording fix alone would not stop this recurring, so the branch also adds a property test
(`test_615_residual_i18n.py`): **in every gated locale, the destructive label must be distinguishable
from the reversible one by something other than the scope words.**

It derives the scope tokens from the compiled translations of *Global Library*, *My Library* and *The
whole library*, then requires

```
destructive tokens − reversible tokens − derived scope tokens
```

to be non-empty. No per-locale word table — a hand-maintained stop-list would rot the moment a locale is
added, and is the false-green shape this repo already has a name for. It reads the compiled `.mo`, not
the `.po`, because `msgfmt` silently drops fuzzy entries.

Red on the parent commit, and note *which* locale failed:

```
AssertionError: nl: the control that permanently deletes a file for every member
is lexically indistinguishable from reversible My Library removal once
translated scope words are ignored.
  destructive='Uit de globale bibliotheek verwijderen',
  reversible='Uit mijn bibliotheek verwijderen',
  scope_tokens=['bibliotheek', 'de', 'globale', 'hele', 'mijn']
assert set()

1 failed, 1 passed
```

**French passed on that same parent commit** — its `supprimer` was already distinct. That asymmetry is
the positive control: the guard discriminates rather than merely going red. Current residual tokens are
`supprimer` (fr) and `definitief` (nl).

The message states the consequence rather than the assertion, so whoever trips it later understands they
are about to ship a destructive control that reads like a safe one.

**7,362 unit tests pass**, run by the merge owner.
