### PR TITLE
fix(tests): reap the per-run pytest temp dirs nothing ever deleted

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -463,11 +463,62 @@ def _isolate_pytest_tempdir():
     `test_802`'s. This promotes that workaround to the harness, and the local one
     can go once this has settled.
     """
-    root = os.path.join(tempfile.gettempdir(), "cwng-pytest", str(os.getpid()))
+    base = os.path.join(tempfile.gettempdir(), "cwng-pytest")
+    _reap_stale_pytest_tempdirs(base)
+    root = os.path.join(base, str(os.getpid()))
     os.makedirs(root, exist_ok=True)
     os.environ["TMPDIR"] = root
     tempfile.tempdir = root
     return root
+
+
+
+def _reap_stale_pytest_tempdirs(base, max_age_seconds=6 * 3600):
+    """Delete per-run temp dirs left behind by runs that are no longer alive.
+
+    Each run gets ``cwng-pytest/<pid>/`` and nothing ever removed it, so every
+    pytest invocation since this fixture landed leaked a directory; they had
+    accumulated to 8.4 GB on the developer machine before anyone noticed.
+
+    Reaping happens at STARTUP rather than at exit on purpose. A run that is
+    killed -- OOM, Ctrl-C, a timed-out CI job -- never reaches an exit hook, and
+    those are precisely the runs that leave the largest directories behind. A
+    cleanup that only runs on the happy path would not have prevented this.
+
+    Two independent conditions must both hold before anything is removed, so a
+    concurrently running suite is never touched: the owning pid must be gone,
+    and the directory must be older than ``max_age_seconds``. Parallel xdist
+    workers each own a live pid, and a sibling that exited seconds ago is still
+    protected by the age floor.
+
+    Never raises. Failing to tidy up is not a reason to fail someone's test run.
+    """
+    try:
+        entries = os.listdir(base)
+    except OSError:
+        return
+    now = time.time()
+    for name in entries:
+        if not name.isdigit():
+            continue
+        pid = int(name)
+        if pid == os.getpid():
+            continue
+        path = os.path.join(base, name)
+        try:
+            if now - os.path.getmtime(path) < max_age_seconds:
+                continue
+        except OSError:
+            continue
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            pass          # owner is gone: reapable
+        except OSError:
+            continue      # e.g. EPERM -- another user's live process; leave it
+        else:
+            continue      # still running
+        shutil.rmtree(path, ignore_errors=True)
 
 
 def pytest_configure(config):

--- a/tests/unit/test_pytest_tempdir_reaper.py
+++ b/tests/unit/test_pytest_tempdir_reaper.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""The per-run temp directory reaper must not eat a running suite's directory.
+
+``_isolate_pytest_tempdir`` gives every run its own ``cwng-pytest/<pid>/`` and
+nothing ever removed them, so each pytest invocation leaked a directory; they
+reached 8.4 GB on a developer machine before anyone noticed.
+
+The cleanup that fixes that is more dangerous than the leak it replaces: a
+reaper that mistakes a live run for a dead one deletes the temp directory out
+from under a suite that is currently using it, which surfaces as unrelated,
+irreproducible failures somewhere else entirely. So the discriminating cases --
+not the happy path -- are what these tests pin.
+
+Reaping deliberately happens at startup rather than at exit, because the runs
+that leave the biggest directories behind (OOM, Ctrl-C, a timed-out CI job) are
+exactly the ones that never reach an exit hook.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+
+from tests.conftest import _reap_stale_pytest_tempdirs
+
+pytestmark = pytest.mark.unit
+
+STALE = 7 * 3600
+
+
+def _dir(base, name, *, age_seconds=0):
+    path = os.path.join(base, name)
+    os.makedirs(path)
+    if age_seconds:
+        stamp = time.time() - age_seconds
+        os.utime(path, (stamp, stamp))
+    return path
+
+
+def test_a_dead_owner_with_an_old_directory_is_reaped(tmp_path):
+    """The only case that should actually free disk."""
+    base = str(tmp_path)
+    victim = _dir(base, "999999", age_seconds=STALE)
+
+    _reap_stale_pytest_tempdirs(base)
+
+    assert not os.path.exists(victim)
+
+
+def test_this_running_process_is_never_reaped(tmp_path):
+    """Age alone must not condemn a directory whose owner is still alive.
+
+    A long suite can easily run past the age floor while still using its own
+    directory; deleting it mid-run would corrupt that run.
+    """
+    base = str(tmp_path)
+    mine = _dir(base, str(os.getpid()), age_seconds=STALE)
+
+    _reap_stale_pytest_tempdirs(base)
+
+    assert os.path.exists(mine)
+
+
+def test_a_recently_exited_owner_is_protected_by_the_age_floor(tmp_path):
+    """Liveness alone is not enough: pids are recycled and siblings race.
+
+    An xdist worker that exited seconds ago may still have peers writing under
+    its tree, so a fresh directory is never reaped even once its owner is gone.
+    """
+    base = str(tmp_path)
+    young = _dir(base, "999998")
+
+    _reap_stale_pytest_tempdirs(base)
+
+    assert os.path.exists(young)
+
+
+def test_a_live_unrelated_process_is_never_reaped(tmp_path):
+    """pid 1 is always alive and never ours; nothing about age may override that."""
+    base = str(tmp_path)
+    launchd = _dir(base, "1", age_seconds=STALE)
+
+    _reap_stale_pytest_tempdirs(base)
+
+    assert os.path.exists(launchd)
+
+
+def test_directories_that_are_not_pids_are_left_alone(tmp_path):
+    """Anything not named for a pid was put there by something else."""
+    base = str(tmp_path)
+    stranger = _dir(base, "notapid", age_seconds=STALE)
+
+    _reap_stale_pytest_tempdirs(base)
+
+    assert os.path.exists(stranger)
+
+
+def test_a_missing_base_directory_is_not_an_error(tmp_path):
+    """First run on a clean machine must not fail before the suite starts."""
+    _reap_stale_pytest_tempdirs(os.path.join(str(tmp_path), "does-not-exist"))
+
+
+def test_an_unreadable_entry_never_fails_the_run(tmp_path, monkeypatch):
+    """Tidying up is best-effort; it may never take a test run down with it."""
+    base = str(tmp_path)
+    _dir(base, "999997", age_seconds=STALE)
+
+    def boom(*_args, **_kwargs):
+        raise OSError("nope")
+
+    monkeypatch.setattr(os.path, "getmtime", boom)
+
+    _reap_stale_pytest_tempdirs(base)


### PR DESCRIPTION
## Symptom

The boot volume hit **97% full**. 8.4 GB of it was `cwng-pytest/` — one leaked directory per pytest run, going back to whenever `_isolate_pytest_tempdir` landed. Nothing ever deleted them.

## Fix

`_reap_stale_pytest_tempdirs()` clears them at **startup, not at exit**.

That ordering is the point: a run killed by OOM, Ctrl-C or a CI timeout never reaches an exit hook — and those are precisely the runs that leave the biggest directories behind. A cleanup on the happy path would not have prevented this leak.

## Why the guard is strict

The reaper is more dangerous than the leak. Deleting a *live* run's temp directory surfaces as unrelated, irreproducible failures somewhere else entirely. So two independent conditions must both hold:

1. the owning pid is gone, **and**
2. the directory is older than six hours.

A parallel xdist worker holds a live pid. A sibling that exited seconds ago is still covered by the age floor. Cleanup never raises — failing to tidy up must not fail someone's test run.

## Tests

`tests/unit/test_pytest_tempdir_reaper.py` pins the **discriminating** cases rather than the happy path: a live pid with an old directory, a dead pid with a young one, an unrelated live process (pid 1), and a non-pid directory must all survive; only dead-and-old is reaped.

Verified by sabotage — removing the liveness check fails `test_a_live_unrelated_process_is_never_reaped`.

Full unit suite: **7420 passed, 94 skipped, 0 failed**.