### PR TITLE
fix(kobo): a declared payload-schema change no longer re-delivers the library, and every format writer now advances the sync cursor (#1953)

### DIFF
--- a/changelog.d/1953-fingerprint-reseed.md
+++ b/changelog.d/1953-fingerprint-reseed.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Declared Kobo entitlement payload-schema transitions no longer re-deliver unchanged books or removals.** Replay protection preserves the separate book and archive change clocks, always suppresses byte-identical replays, and delivers same-schema or unproven mismatches; manual merges now advance the Kobo book cursor after adding or replacing a Kobo-visible format, while automatic duplicate merges and conversion recovery advance it after adding one.

--- a/cps/duplicates.py
+++ b/cps/duplicates.py
@@ -2146,6 +2146,12 @@ def merge_duplicate_group(book_to_keep, books_to_merge):
                                         element.format,
                                         element.uncompressed_size,
                                         to_name))
+        if any(
+                element.format.upper() in {'KEPUB', 'EPUB'}
+                for _filepath_old, _filepath_new, element in staged):
+            # Added formats change Kobo DownloadUrls/Size selection, so the
+            # keeper must cross the same cursor boundary as other book edits.
+            helper.mark_book_modified(to_book, set_dirty=False)
         calibre_db.session.commit()
     except Exception:
         calibre_db.session.rollback()

--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -853,6 +853,7 @@ def merge_list_book():
         to_book = calibre_db.get_book(vals[0])
         vals.pop(0)
         if to_book:
+            target_formats_changed = False
             for file in to_book.data:
                 to_file.append(file.format)
             to_name = helper.get_valid_filename(to_book.title,
@@ -875,14 +876,21 @@ def merge_list_book():
                                                         element.uncompressed_size,
                                                         to_name))
                             to_file.append(element.format)
+                            target_formats_changed = True
                         elif element.format in overwrite_formats:
                             # Replace keeper's existing format file and update its size
                             copyfile(filepath_old, filepath_new)
                             for data_entry in to_book.data:
                                 if data_entry.format == element.format:
                                     data_entry.uncompressed_size = element.uncompressed_size
+                                    target_formats_changed = True
                                     break
                     delete_book_from_table(from_book.id, "", True, skip_cache_invalidation=True)
+            if target_formats_changed:
+                # Format availability and Size are rendered into Kobo
+                # entitlements, so every add/overwrite must advance the same
+                # cursor provenance as ordinary metadata edits.
+                helper.mark_book_modified(to_book)
             calibre_db.session.commit()
             _queue_duplicate_scan_after_change([to_book.id] + vals)
             return json.dumps({'success': True})

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -59,6 +59,12 @@ KOBO_IMAGEHOST_URL = "https://cdn.kobo.com/book-images"
 
 SYNC_ITEM_LIMIT = 100
 
+# Stored alongside the payload hash, never sent to Kobo.  Increment this when
+# the server intentionally changes the entitlement renderer's declared shape;
+# unchanged book/tombstone bases will then be lazily re-fingerprinted instead
+# of being re-delivered to Nickel.
+ENTITLEMENT_PAYLOAD_SCHEMA_VERSION = 1
+
 kobo = Blueprint("kobo", __name__, url_prefix="/kobo/<auth_token>")
 kobo_auth.disable_failed_auth_redirect_for_blueprint(kobo)
 kobo_auth.register_url_value_preprocessor(kobo)
@@ -75,6 +81,75 @@ def _entitlement_fingerprint(entitlement):
         ensure_ascii=False,
     ).encode("utf-8")
     return hashlib.sha256(payload).hexdigest()
+
+
+def _ledger_timestamp_component(value):
+    """Return one fixed-width UTC component for byte-comparable provenance."""
+    if value is None:
+        return "none"
+    if getattr(value, "tzinfo", None) is not None:
+        value = value.astimezone(timezone.utc).replace(tzinfo=None)
+    return value.isoformat(timespec="microseconds") + "Z"
+
+
+def _book_entitlement_change_basis(
+    book_last_modified, archived_last_modified=None,
+):
+    """Canonical per-book proof used by both seed and live delivery paths.
+
+    Membership clocks deliberately do not participate: they select a book but
+    do not describe its entitlement bytes, and a book may have several shelf
+    rows while its ledger has only one row.  Fingerprint equality handles
+    byte-identical membership churn before this basis is consulted.
+    """
+    if book_last_modified is None and archived_last_modified is None:
+        return None
+    return "v1|book={}|archive={}".format(
+        _ledger_timestamp_component(book_last_modified),
+        _ledger_timestamp_component(archived_last_modified),
+    )
+
+
+def _deleted_entitlement_change_basis(deleted_at):
+    """Canonical provenance for a hard-delete entitlement."""
+    if deleted_at is None:
+        return None
+    return "v1|deleted={}".format(_ledger_timestamp_component(deleted_at))
+
+
+def _entitlement_replay_decision(record, fingerprint, change_basis):
+    """Return ``(suppress, shape_reseed, refresh_record)`` for one candidate.
+
+    Exact bytes are always safe to suppress. A differing fingerprint is safe
+    to reseed only across an explicitly declared renderer-schema transition
+    whose non-null canonical book basis is unchanged. Every ambiguous case,
+    including a legacy #1925 row with no basis, fails open by delivering.
+    Out-of-tree metadata writers must advance ``Books.last_modified`` for each
+    payload-affecting edit; direct writes that do not are indistinguishable
+    from the declared renderer change at this server-side boundary.
+    """
+    if record is None:
+        return False, False, False
+
+    stored_basis = record.change_basis
+    if record.fingerprint == fingerprint:
+        refresh_record = bool(
+            record.payload_schema_version
+            != ENTITLEMENT_PAYLOAD_SCHEMA_VERSION
+            or stored_basis != change_basis
+        )
+        return True, False, refresh_record
+
+    declared_shape_transition = (
+        record.payload_schema_version != ENTITLEMENT_PAYLOAD_SCHEMA_VERSION
+        and stored_basis is not None
+        and change_basis is not None
+        and stored_basis == change_basis
+    )
+    if declared_shape_transition:
+        return True, True, True
+
+    return False, False, False
 
 
 def _seed_existing_device_entitlement_ledgers(user_id):
@@ -125,7 +200,7 @@ def _seed_existing_device_entitlement_ledgers(user_id):
             ).all()
         })
         archived = {
-            row.book_id: bool(row.is_archived)
+            row.book_id: row
             for row in ub.session.query(ub.ArchivedBook).filter(
                 ub.ArchivedBook.user_id == int(user_id),
             ).all()
@@ -167,12 +242,24 @@ def _seed_existing_device_entitlement_ledgers(user_id):
             # per household Kobo. CoverImageId is the sole per-device field.
             common_payloads = {}
             for book in seed_books:
+                archived_row = archived.get(book.id)
                 common_payloads[book.id] = (
                     create_book_entitlement(
-                        book, archived=archived.get(book.id, False),
+                        book,
+                        archived=bool(
+                            archived_row and archived_row.is_archived
+                        ),
                     ),
                     get_metadata(book),
                 )
+            book_change_bases = {
+                book.id: _book_entitlement_change_basis(
+                    book.last_modified,
+                    archived[book.id].last_modified
+                    if book.id in archived else None,
+                )
+                for book in seed_books
+            }
             for device_id in device_ids:
                 g.annotation_origin_device_id = device_id
                 # The live request header describes only the speaking device;
@@ -206,6 +293,7 @@ def _seed_existing_device_entitlement_ledgers(user_id):
                 g.pop(_REQUESTING_DEVICE_ASPECT_G_KEY, None)
 
         deleted_fingerprints = {}
+        deleted_change_bases = {}
         for tombstone in ub.session.query(ub.KoboDeletedBook).filter(
             ub.KoboDeletedBook.user_id == int(user_id),
         ).all():
@@ -217,13 +305,21 @@ def _seed_existing_device_entitlement_ledgers(user_id):
             }
             deleted_fingerprints[str(tombstone.book_uuid)] = \
                 _entitlement_fingerprint(payload)
+            deleted_change_bases[str(tombstone.book_uuid)] = \
+                _deleted_entitlement_change_basis(tombstone.deleted_at)
 
         for device_id in device_ids:
             kobo_sync_status.stage_device_entitlement_fingerprints(
-                device_id, book_fingerprints_by_device[device_id],
+                device_id,
+                book_fingerprints_by_device[device_id],
+                book_change_bases,
+                ENTITLEMENT_PAYLOAD_SCHEMA_VERSION,
             )
             kobo_sync_status.stage_device_deleted_entitlement_fingerprints(
-                device_id, deleted_fingerprints,
+                device_id,
+                deleted_fingerprints,
+                deleted_change_bases,
+                ENTITLEMENT_PAYLOAD_SCHEMA_VERSION,
             )
         kobo_sync_status.mark_device_entitlement_ledgers_seeded(device_ids)
         # Legacy tests and a few downstream integrations replace this helper
@@ -610,6 +706,7 @@ def HandleSyncRequest():
 
     new_archived_last_modified = datetime.min
     sync_results = []
+    books_to_delete_ids = set()
 
     calibre_db.reconnect_db(config, ub.app_DB_path)
 
@@ -647,6 +744,7 @@ def HandleSyncRequest():
         == constants.LIBRARY_MODE_PERSONAL
     )
     if current_user.kobo_only_shelves_sync or membership_enabled:
+        removal_result_start = len(sync_results)
         try:
             # Check all books that are on Kobo according to the database
             synced_books_query = ub.session.query(ub.KoboSyncedBooks.book_id).filter(ub.KoboSyncedBooks.user_id == current_user.id)
@@ -703,24 +801,11 @@ def HandleSyncRequest():
                         }
                         sync_results.append({"ChangedEntitlement": entitlement})
 
-                # Remove all books from the tracking table in one go
-                if books_to_delete_ids:
-                    user_device_ids = ub.session.query(ub.Device.id).filter(
-                        ub.Device.user_id == current_user.id,
-                    ).scalar_subquery()
-                    ub.session.query(ub.KoboDeviceBookEntitlement).filter(
-                        ub.KoboDeviceBookEntitlement.device_id.in_(user_device_ids),
-                        ub.KoboDeviceBookEntitlement.book_id.in_(books_to_delete_ids),
-                    ).delete(synchronize_session=False)
-                    ub.session.query(ub.KoboSyncedBooks).filter(
-                        ub.KoboSyncedBooks.user_id == current_user.id,
-                        ub.KoboSyncedBooks.book_id.in_(books_to_delete_ids)
-                    ).delete(synchronize_session=False)
-                    ub.session_commit()
-
         except Exception as e:
             log.error(f"Kobo Sync: Error during deletion logic: {e}")
             ub.session.rollback()
+            books_to_delete_ids = set()
+            del sync_results[removal_result_start:]
 
     only_kobo_shelves = current_user.kobo_only_shelves_sync
 
@@ -951,8 +1036,11 @@ def HandleSyncRequest():
         if replay_suppression_eligible else {}
     )
     entitlement_fingerprint_updates = {}
-    suppressed_unchanged_entitlements = 0
-    suppressed_deleted_entitlements = 0
+    entitlement_change_basis_updates = {}
+    suppressed_unchanged_book_ids = set()
+    suppressed_deleted_entitlement_uuids = set()
+    reseeded_shape_change_book_ids = set()
+    reseeded_shape_change_deleted_uuids = set()
     delivered_book_identities = []
     for book in books_list:
         kobo_reading_state = book.KoboReadingState  # None when no record exists yet
@@ -970,11 +1058,24 @@ def HandleSyncRequest():
             _entitlement_fingerprint(entitlement)
             if replay_suppression_enabled and requesting_device_id else None
         )
-        entitlement_is_unchanged = bool(
-            replay_suppression_eligible
-            and prior_entitlement_fingerprints.get(book.Books.id)
-            == entitlement_fingerprint
+        entitlement_change_basis = _book_entitlement_change_basis(
+            book.Books.last_modified,
+            book.last_modified,
         )
+        if replay_suppression_eligible:
+            (
+                entitlement_is_unchanged,
+                shape_reseed,
+                refresh_fingerprint_record,
+            ) = _entitlement_replay_decision(
+                prior_entitlement_fingerprints.get(book.Books.id),
+                entitlement_fingerprint,
+                entitlement_change_basis,
+            )
+        else:
+            entitlement_is_unchanged = False
+            shape_reseed = False
+            refresh_fingerprint_record = False
 
         if (kobo_reading_state is not None
                 and kobo_reading_state.last_modified > sync_token.reading_state_last_modified):
@@ -1000,7 +1101,14 @@ def HandleSyncRequest():
         ts_created = get_kobo_created_ts(book)
 
         if entitlement_is_unchanged:
-            suppressed_unchanged_entitlements += 1
+            suppressed_unchanged_book_ids.add(book.Books.id)
+            if shape_reseed:
+                reseeded_shape_change_book_ids.add(book.Books.id)
+            if refresh_fingerprint_record:
+                entitlement_fingerprint_updates[book.Books.id] = \
+                    entitlement_fingerprint
+                entitlement_change_basis_updates[book.Books.id] = \
+                    entitlement_change_basis
         else:
             if ts_created > sync_token.books_last_created:
                 sync_results.append({"NewEntitlement": entitlement})
@@ -1008,6 +1116,8 @@ def HandleSyncRequest():
                 sync_results.append({"ChangedEntitlement": entitlement})
             if replay_suppression_enabled and requesting_device_id:
                 entitlement_fingerprint_updates[book.Books.id] = entitlement_fingerprint
+                entitlement_change_basis_updates[book.Books.id] = \
+                    entitlement_change_basis
 
         new_books_last_modified = max(
             books_cursor_datetime(book.Books.last_modified), new_books_last_modified
@@ -1045,12 +1155,19 @@ def HandleSyncRequest():
         new_books_last_created = max(ts_created, new_books_last_created)
         delivered_book_identities.append((book.Books.id, str(book.Books.uuid)))
 
-    # Persist the whole emitted page before response/token construction.  In
-    # particular, the next request must not observe zero synced rows and reset
-    # its token.  The batch helper also avoids one SQLite fsync per book.
+    # Stage the whole emitted page for the checked request-level commit below.
+    # In particular, the next request must not observe zero synced rows and
+    # reset its token. The batch helper also avoids one SQLite fsync per book.
     kobo_sync_status.stage_device_entitlement_fingerprints(
-        requesting_device_id, entitlement_fingerprint_updates)
-    kobo_sync_status.add_synced_books_batch(delivered_book_identities)
+        requesting_device_id,
+        entitlement_fingerprint_updates,
+        entitlement_change_basis_updates,
+        ENTITLEMENT_PAYLOAD_SCHEMA_VERSION,
+    )
+    kobo_sync_status.add_synced_books_batch(
+        delivered_book_identities,
+        commit=False,
+    )
 
     # Magic-shelf sub-cursor: advance to the highest magic-shelf book id
     # emitted this round. magic_shelf_book_ids may be empty when the arm
@@ -1284,6 +1401,7 @@ def HandleSyncRequest():
         if replay_suppression_eligible else {}
     )
     deleted_fingerprint_updates = {}
+    deleted_change_basis_updates = {}
     for tombstone in pending_deletions:
         book_uuid = str(tombstone.book_uuid)
         entitlement = {
@@ -1295,29 +1413,68 @@ def HandleSyncRequest():
             _entitlement_fingerprint(entitlement)
             if replay_suppression_enabled and requesting_device_id else None
         )
-        entitlement_is_unchanged = bool(
-            replay_suppression_eligible
-            and prior_deleted_fingerprints.get(book_uuid) == fingerprint
+        deleted_change_basis = _deleted_entitlement_change_basis(
+            tombstone.deleted_at,
         )
+        if replay_suppression_eligible:
+            (
+                entitlement_is_unchanged,
+                shape_reseed,
+                refresh_fingerprint_record,
+            ) = _entitlement_replay_decision(
+                prior_deleted_fingerprints.get(book_uuid),
+                fingerprint,
+                deleted_change_basis,
+            )
+        else:
+            entitlement_is_unchanged = False
+            shape_reseed = False
+            refresh_fingerprint_record = False
         if entitlement_is_unchanged:
-            suppressed_unchanged_entitlements += 1
-            suppressed_deleted_entitlements += 1
+            suppressed_deleted_entitlement_uuids.add(book_uuid)
+            if shape_reseed:
+                reseeded_shape_change_deleted_uuids.add(book_uuid)
+            if refresh_fingerprint_record:
+                deleted_fingerprint_updates[book_uuid] = fingerprint
+                deleted_change_basis_updates[book_uuid] = deleted_change_basis
         else:
             sync_results.append({"ChangedEntitlement": entitlement})
             if replay_suppression_enabled and requesting_device_id:
                 deleted_fingerprint_updates[book_uuid] = fingerprint
+                deleted_change_basis_updates[book_uuid] = deleted_change_basis
         ta = tombstone.deleted_at
         if hasattr(ta, "replace") and getattr(ta, "tzinfo", None) is not None:
             ta = ta.replace(tzinfo=None)
         new_archived_last_modified = max(ta, new_archived_last_modified)
     kobo_sync_status.stage_device_deleted_entitlement_fingerprints(
-        requesting_device_id, deleted_fingerprint_updates,
+        requesting_device_id,
+        deleted_fingerprint_updates,
+        deleted_change_basis_updates,
+        ENTITLEMENT_PAYLOAD_SCHEMA_VERSION,
     )
-    if (deleted_fingerprint_updates
-            and ub.session_commit() is False):
-        # Do not claim a deletion was delivered when its replay guard rolled
-        # back; returning the payload anyway recreates the every-sync loop on
-        # the next stale archive cursor.
+
+    # Two-way removals are response commands, so their tracking rows must stay
+    # intact until every other app-db effect for this request is ready. If the
+    # one checked commit below rolls back, the next request can reconstruct the
+    # removal envelope from KoboSyncedBooks instead of losing it permanently.
+    if books_to_delete_ids:
+        user_device_ids = ub.session.query(ub.Device.id).filter(
+            ub.Device.user_id == current_user.id,
+        ).scalar_subquery()
+        ub.session.query(ub.KoboDeviceBookEntitlement).filter(
+            ub.KoboDeviceBookEntitlement.device_id.in_(user_device_ids),
+            ub.KoboDeviceBookEntitlement.book_id.in_(books_to_delete_ids),
+        ).delete(synchronize_session=False)
+        ub.session.query(ub.KoboSyncedBooks).filter(
+            ub.KoboSyncedBooks.user_id == current_user.id,
+            ub.KoboSyncedBooks.book_id.in_(books_to_delete_ids),
+        ).delete(synchronize_session=False)
+
+    # Commit the live ledger, synced-book markers, hard-delete ledger, and
+    # two-way-removal cleanup atomically before token construction. In
+    # particular, the next request must not observe zero synced rows and reset
+    # its token after a response that never reached the device (#1925/#1953).
+    if ub.session_commit() is False:
         return abort(503)
 
     # Likewise, never set local continuation for deletion pages.  The returned
@@ -1345,13 +1502,17 @@ def HandleSyncRequest():
     log.debug(
         "Kobo Sync summary: device=%s entitlements new=%d changed=%d "
         "suppressed_unchanged=%d suppressed_removed=%d "
+        "reseeded_shape_change=%d "
         "replay_suppression enabled=%s eligible=%s "
         "cursors in=%s out=%s",
         requesting_device_id,
         new_entitlement_count,
         changed_entitlement_count,
-        suppressed_unchanged_entitlements,
-        suppressed_deleted_entitlements,
+        len(suppressed_unchanged_book_ids)
+        + len(suppressed_deleted_entitlement_uuids),
+        len(suppressed_deleted_entitlement_uuids),
+        len(reseeded_shape_change_book_ids)
+        + len(reseeded_shape_change_deleted_uuids),
         replay_suppression_enabled,
         replay_suppression_eligible,
         sync_cursor_in,

--- a/cps/kobo_sync_status.py
+++ b/cps/kobo_sync_status.py
@@ -41,11 +41,11 @@ def _book_identity(identity):
     return int(identity), None
 
 
-def add_synced_books_batch(book_identities):
-    """Record a delivered page, retaining each UUID when the caller has it."""
+def add_synced_books_batch(book_identities, *, commit=True):
+    """Stage a delivered page, optionally committing the shared transaction."""
     page_books = dict(_book_identity(identity) for identity in book_identities)
     if not page_books:
-        return
+        return True
 
     user_id = current_user.id
     present = {
@@ -69,33 +69,38 @@ def add_synced_books_batch(book_identities):
             )
             for book_id in missing_book_ids
         ])
-    ub.session_commit()
+    return ub.session_commit() if commit else True
 
 
 def get_device_entitlement_fingerprints(device_id, book_ids):
-    """Return the last delivered payload hash for each candidate book."""
+    """Return the last delivered ledger record for each candidate book."""
     if not device_id or not book_ids:
         return {}
-    return dict(
-        ub.session.query(
+    rows = ub.session.query(
             ub.KoboDeviceBookEntitlement.book_id,
             ub.KoboDeviceBookEntitlement.fingerprint,
+            ub.KoboDeviceBookEntitlement.payload_schema_version,
+            ub.KoboDeviceBookEntitlement.change_basis,
+            ub.KoboDeviceBookEntitlement.updated_at,
         ).filter(
             ub.KoboDeviceBookEntitlement.device_id == int(device_id),
             ub.KoboDeviceBookEntitlement.book_id.in_(set(book_ids)),
         ).all()
-    )
+    return {row.book_id: row for row in rows}
 
 
-def stage_device_entitlement_fingerprints(device_id, fingerprints):
+def stage_device_entitlement_fingerprints(
+    device_id, fingerprints, change_bases=None, payload_schema_version=1,
+):
     """Upsert delivered entitlement hashes into the caller's transaction.
 
-    ``add_synced_books_batch`` commits immediately after this helper in the
-    sync handler, so the per-device ledger and legacy user-level delivery
-    marker become durable together.
+    The sync handler stages this alongside ``add_synced_books_batch``
+    (``commit=False``) and makes both durable in one checked request-level
+    commit before the response token is constructed.
     """
     if not device_id or not fingerprints:
         return
+    change_bases = change_bases or {}
     now = datetime.now(timezone.utc)
     items = list(fingerprints.items())
     for offset in range(0, len(items), _LEDGER_UPSERT_BATCH_SIZE):
@@ -104,6 +109,8 @@ def stage_device_entitlement_fingerprints(device_id, fingerprints):
                 "device_id": int(device_id),
                 "book_id": int(book_id),
                 "fingerprint": fingerprint,
+                "payload_schema_version": int(payload_schema_version),
+                "change_basis": change_bases.get(book_id),
                 "updated_at": now,
             }
             for book_id, fingerprint in items[
@@ -115,6 +122,8 @@ def stage_device_entitlement_fingerprints(device_id, fingerprints):
             index_elements=["device_id", "book_id"],
             set_={
                 "fingerprint": statement.excluded.fingerprint,
+                "payload_schema_version": statement.excluded.payload_schema_version,
+                "change_basis": statement.excluded.change_basis,
                 "updated_at": statement.excluded.updated_at,
             },
         )
@@ -122,24 +131,29 @@ def stage_device_entitlement_fingerprints(device_id, fingerprints):
 
 
 def get_device_deleted_entitlement_fingerprints(device_id, book_uuids):
-    """Return delivered hard-delete hashes for one requesting device."""
+    """Return delivered hard-delete ledger records for one device."""
     if not device_id or not book_uuids:
         return {}
-    return dict(
-        ub.session.query(
+    rows = ub.session.query(
             ub.KoboDeviceDeletedEntitlement.book_uuid,
             ub.KoboDeviceDeletedEntitlement.fingerprint,
+            ub.KoboDeviceDeletedEntitlement.payload_schema_version,
+            ub.KoboDeviceDeletedEntitlement.change_basis,
+            ub.KoboDeviceDeletedEntitlement.updated_at,
         ).filter(
             ub.KoboDeviceDeletedEntitlement.device_id == int(device_id),
             ub.KoboDeviceDeletedEntitlement.book_uuid.in_(set(book_uuids)),
         ).all()
-    )
+    return {row.book_uuid: row for row in rows}
 
 
-def stage_device_deleted_entitlement_fingerprints(device_id, fingerprints):
+def stage_device_deleted_entitlement_fingerprints(
+    device_id, fingerprints, change_bases=None, payload_schema_version=1,
+):
     """Upsert hard-delete entitlement hashes into the sync transaction."""
     if not device_id or not fingerprints:
         return
+    change_bases = change_bases or {}
     now = datetime.now(timezone.utc)
     items = list(fingerprints.items())
     for offset in range(0, len(items), _LEDGER_UPSERT_BATCH_SIZE):
@@ -148,6 +162,8 @@ def stage_device_deleted_entitlement_fingerprints(device_id, fingerprints):
                 "device_id": int(device_id),
                 "book_uuid": str(book_uuid),
                 "fingerprint": fingerprint,
+                "payload_schema_version": int(payload_schema_version),
+                "change_basis": change_bases.get(book_uuid),
                 "updated_at": now,
             }
             for book_uuid, fingerprint in items[
@@ -159,6 +175,8 @@ def stage_device_deleted_entitlement_fingerprints(device_id, fingerprints):
             index_elements=["device_id", "book_uuid"],
             set_={
                 "fingerprint": statement.excluded.fingerprint,
+                "payload_schema_version": statement.excluded.payload_schema_version,
+                "change_basis": statement.excluded.change_basis,
                 "updated_at": statement.excluded.updated_at,
             },
         )

--- a/cps/tasks/convert.py
+++ b/cps/tasks/convert.py
@@ -172,6 +172,12 @@ class TaskConvert(CalibreTask):
                                      book=book_id, uncompressed_size=os.path.getsize(file_path + format_new_ext))
                 try:
                     local_db.session.merge(new_format)
+                    if self.settings['new_book_format'].upper() in [
+                            'KEPUB', 'EPUB', 'EPUB3']:
+                        # Recovery adopted a Kobo-visible file that existed on
+                        # disk without a Data row; mirror the ordinary
+                        # conversion path's cursor provenance update below.
+                        helper.mark_book_modified(cur_book, set_dirty=False)
                     local_db.session.commit()
                 except SQLAlchemyError as e:
                     local_db.session.rollback()

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -876,6 +876,15 @@ class KoboDeviceBookEntitlement(Base):
     # this cannot be a foreign key in app.db.
     book_id = Column(Integer, nullable=False)
     fingerprint = Column(String(64), nullable=False)
+    payload_schema_version = Column(
+        Integer, nullable=False, default=1, server_default="1",
+    )
+    # Canonical, constituent-preserving book/archive clock encoding that
+    # justified the delivered entitlement. A declared renderer-schema
+    # transition may replace the fingerprint only while this entire non-null
+    # tuple is byte-identical. NULL is retained for #1925 rows and deliberately
+    # fails open on a changed payload.
+    change_basis = Column(Text, nullable=True)
     updated_at = Column(
         DateTime, nullable=False, default=lambda: datetime.now(timezone.utc),
     )
@@ -905,6 +914,10 @@ class KoboDeviceDeletedEntitlement(Base):
     )
     book_uuid = Column(String(64), nullable=False)
     fingerprint = Column(String(64), nullable=False)
+    payload_schema_version = Column(
+        Integer, nullable=False, default=1, server_default="1",
+    )
+    change_basis = Column(Text, nullable=True)
     updated_at = Column(
         DateTime, nullable=False, default=lambda: datetime.now(timezone.utc),
     )
@@ -1972,6 +1985,33 @@ def add_missing_tables(engine, _session):
             table_exists = engine.dialect.has_table(connection, table_name)
         if not table_exists:
             table.create(bind=engine, checkfirst=True)
+
+
+def migrate_kobo_entitlement_ledger_columns(engine, _session):
+    """Add #1953 replay-ledger provenance before any mapped-row load.
+
+    ``add_missing_tables`` creates the complete current tables on fresh app.db
+    files.  Existing #1925 tables need additive columns, and SQLAlchemy selects
+    every mapped column when a ledger entity is loaded.  Keep this migration
+    immediately after table creation in ``migrate_Database`` so no ORM query
+    can observe the old physical shape (the same ordering invariant as #1950).
+    """
+    for table_name in (
+        "kobo_device_book_entitlement",
+        "kobo_device_deleted_entitlement",
+    ):
+        _add_column_if_missing(
+            engine,
+            table_name,
+            "payload_schema_version",
+            "payload_schema_version INTEGER NOT NULL DEFAULT 1",
+        )
+        _add_column_if_missing(
+            engine,
+            table_name,
+            "change_basis",
+            "change_basis TEXT",
+        )
 
 
 # migrate all settings missing in registration table
@@ -4253,6 +4293,7 @@ def migrate_thumbnail_lookup_index(engine, _session):
 def migrate_Database(_session):
     engine = _session.bind
     add_missing_tables(engine, _session)
+    migrate_kobo_entitlement_ledger_columns(engine, _session)
     migrate_thumbnail_lookup_index(engine, _session)
     migrate_registration_table(engine, _session)
     migrate_user_session_table(engine, _session)

--- a/tests/unit/test_1925_kobo_sync_dedownload.py
+++ b/tests/unit/test_1925_kobo_sync_dedownload.py
@@ -39,14 +39,21 @@ def _changed_reading_states(response):
     ]
 
 
-def _add_kobo_shelf(sync_harness, *, include_book=True, date_added=None):
+def _add_kobo_shelf(
+    sync_harness,
+    *,
+    include_book=True,
+    date_added=None,
+    name="Regression Kobo Shelf",
+    shelf_uuid="issue-1925-regression-shelf",
+):
     from cps import ub
 
     shelf = ub.Shelf(
-        name="Regression Kobo Shelf",
+        name=name,
         user_id=sync_harness.user.id,
         kobo_sync=True,
-        uuid="issue-1925-regression-shelf",
+        uuid=shelf_uuid,
         is_public=0,
     )
     sync_harness.session.add(shelf)
@@ -249,6 +256,456 @@ def test_interrupted_sync_token_loss_does_not_redeliver_unchanged_entitlement(
     assert "cursors in=" in summaries[-1] and " out=" in summaries[-1]
 
 
+def test_same_version_payload_mismatch_delivers_and_restamps(
+    sync_harness, caplog, monkeypatch,
+):
+    """An undeclared renderer change fails open for non-bumping writers."""
+    from cps import kobo, ub
+
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+    caplog.set_level(logging.DEBUG, logger="cps.kobo")
+    assert len(_entitlements(sync_harness.sync())) == 1
+    before = sync_harness.session.query(
+        ub.KoboDeviceBookEntitlement,
+    ).one()
+    old_fingerprint = before.fingerprint
+
+    original_get_metadata = kobo.get_metadata
+
+    def shape_b(book):
+        payload = original_get_metadata(book)
+        payload["Issue1953ShapeProbe"] = "shape-b"
+        return payload
+
+    monkeypatch.setattr(kobo, "get_metadata", shape_b)
+    stale_token = kobo.SyncToken.SyncToken().build_sync_token()
+    replay = sync_harness.sync(stale_token)
+
+    assert len(_entitlements(replay)) == 1
+    sync_harness.session.expire_all()
+    after = sync_harness.session.query(
+        ub.KoboDeviceBookEntitlement,
+    ).one()
+    assert after.fingerprint != old_fingerprint
+    assert (
+        after.payload_schema_version
+        == kobo.ENTITLEMENT_PAYLOAD_SCHEMA_VERSION
+    )
+    assert _entitlements(sync_harness.sync(stale_token)) == []
+    summaries = [
+        record.getMessage() for record in caplog.records
+        if record.getMessage().startswith("Kobo Sync summary:")
+    ]
+    assert "reseeded_shape_change=0" in summaries[-1]
+
+
+def test_declared_payload_schema_transition_reseeds_without_delivery(
+    sync_harness, caplog, monkeypatch,
+):
+    """A declared renderer transition rewrites an unchanged book in place."""
+    from cps import kobo, ub
+
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+    caplog.set_level(logging.DEBUG, logger="cps.kobo")
+    assert len(_entitlements(sync_harness.sync())) == 1
+    before = sync_harness.session.query(
+        ub.KoboDeviceBookEntitlement,
+    ).one()
+    old_fingerprint = before.fingerprint
+    old_basis = before.change_basis
+    next_schema = kobo.ENTITLEMENT_PAYLOAD_SCHEMA_VERSION + 1
+
+    original_get_metadata = kobo.get_metadata
+
+    def shape_b(book):
+        payload = original_get_metadata(book)
+        payload["Issue1953ShapeProbe"] = "shape-b"
+        return payload
+
+    monkeypatch.setattr(kobo, "get_metadata", shape_b)
+    monkeypatch.setattr(
+        kobo, "ENTITLEMENT_PAYLOAD_SCHEMA_VERSION", next_schema,
+    )
+    stale_token = kobo.SyncToken.SyncToken().build_sync_token()
+    replay = sync_harness.sync(stale_token)
+
+    assert _entitlements(replay) == []
+    sync_harness.session.expire_all()
+    after = sync_harness.session.query(
+        ub.KoboDeviceBookEntitlement,
+    ).one()
+    assert after.fingerprint != old_fingerprint
+    assert after.change_basis == old_basis
+    assert after.payload_schema_version == next_schema
+    summaries = [
+        record.getMessage() for record in caplog.records
+        if record.getMessage().startswith("Kobo Sync summary:")
+    ]
+    assert "reseeded_shape_change=1" in summaries[-1]
+
+
+def test_failed_live_reseed_commit_aborts_before_summary(
+    sync_harness, caplog, monkeypatch,
+):
+    """A rolled-back live ledger update is neither returned nor reported."""
+    from cps import kobo, ub
+    from werkzeug.exceptions import ServiceUnavailable
+
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+    caplog.set_level(logging.DEBUG, logger="cps.kobo")
+    assert len(_entitlements(sync_harness.sync())) == 1
+    before = sync_harness.session.query(
+        ub.KoboDeviceBookEntitlement,
+    ).one()
+    old_fingerprint = before.fingerprint
+    old_version = before.payload_schema_version
+    caplog.clear()
+
+    original_get_metadata = kobo.get_metadata
+
+    def shape_b(book):
+        payload = original_get_metadata(book)
+        payload["Issue1953ShapeProbe"] = "shape-b"
+        return payload
+
+    def fail_commit(*_args, **_kwargs):
+        sync_harness.session.rollback()
+        return False
+
+    monkeypatch.setattr(kobo, "get_metadata", shape_b)
+    monkeypatch.setattr(
+        kobo,
+        "ENTITLEMENT_PAYLOAD_SCHEMA_VERSION",
+        kobo.ENTITLEMENT_PAYLOAD_SCHEMA_VERSION + 1,
+    )
+    monkeypatch.setattr(ub, "session_commit", fail_commit)
+    stale_token = kobo.SyncToken.SyncToken().build_sync_token()
+
+    with pytest.raises(ServiceUnavailable) as raised:
+        sync_harness.sync(stale_token)
+
+    assert raised.value.code == 503
+    sync_harness.session.expire_all()
+    after = sync_harness.session.query(
+        ub.KoboDeviceBookEntitlement,
+    ).one()
+    assert after.fingerprint == old_fingerprint
+    assert after.payload_schema_version == old_version
+    assert not any(
+        record.getMessage().startswith("Kobo Sync summary:")
+        for record in caplog.records
+    )
+
+
+def test_entitlement_payload_shape_matches_declared_schema_version(
+    sync_harness, monkeypatch,
+):
+    """Pin the complete renderer output beside its declared schema version."""
+    from cps import db, kobo
+
+    book = sync_harness.book
+    book.title = "Pinned Entitlement Title"
+    book.sort = "Entitlement Title, Pinned"
+    book.author_sort = "Author, Pinned"
+    book.pubdate = datetime(2020, 2, 3, 4, 5, 6)
+    book.series_index = 2.5
+    book.has_cover = 1
+    book.authors = [db.Authors("Pinned Author", "Author, Pinned")]
+    book.publishers = [
+        db.Publishers("Pinned Publisher", "Pinned Publisher"),
+    ]
+    book.series = [db.Series("Pinned Series", "Pinned Series")]
+    book.languages = [db.Languages("eng")]
+    book.comments = [db.Comments("Pinned description.", book.id)]
+    sync_harness.session.commit()
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_cover_padding_enabled", False,
+        raising=False,
+    )
+
+    headers = {
+        "x-kobo-deviceid": "a" * 64,
+        "x-kobo-devicemodel": sync_harness.device.model,
+    }
+    with sync_harness.app.test_request_context(
+        "/v1/library/sync", headers=headers,
+    ):
+        g.annotation_origin_device_id = sync_harness.device.id
+        rendered = {
+            "BookEntitlement": kobo.create_book_entitlement(
+                book, archived=False,
+            ),
+            "BookMetadata": kobo.get_metadata(book),
+        }
+        archived_rendered = {
+            "BookEntitlement": kobo.create_book_entitlement(
+                book, archived=True,
+            ),
+            "BookMetadata": kobo.get_metadata(book),
+        }
+        deleted_uuid = "00000000-0000-0000-0000-deleted1953"
+        deleted_at = datetime(2026, 8, 28, 13, 30, 0)
+        deleted_rendered = {
+            "BookEntitlement": kobo.create_deleted_book_entitlement(
+                deleted_uuid, deleted_at,
+            ),
+            "BookMetadata": kobo.create_deleted_book_metadata(deleted_uuid),
+        }
+
+    pinned_schema_and_hashes = {
+        "live": (
+            1,
+            "28ba9f171cd833b2779b549c9bff86347447d40c011439a06408babe656da0c2",
+        ),
+        "archived_live": (
+            1,
+            "ad2030d15995f1083b42c90f751af6e24b6a74c02cddfe0e6e5af38674cb7e02",
+        ),
+        "hard_delete": (
+            1,
+            "8d72ce590309549d65cf110a0d44b61d2145bb2401ca4d6bf204ad41f5244011",
+        ),
+    }
+    rendered_variants = {
+        "live": rendered,
+        "archived_live": archived_rendered,
+        "hard_delete": deleted_rendered,
+    }
+    for variant, payload in rendered_variants.items():
+        assert (
+            kobo.ENTITLEMENT_PAYLOAD_SCHEMA_VERSION,
+            kobo._entitlement_fingerprint(payload),
+        ) == pinned_schema_and_hashes[variant], (
+            "entitlement payload shape changed: bump "
+            "ENTITLEMENT_PAYLOAD_SCHEMA_VERSION and update the pinned hash together"
+        )
+
+
+def test_identical_payload_suppresses_and_refreshes_moved_basis(
+    sync_harness, caplog, monkeypatch,
+):
+    """Byte-identical payloads never re-deliver, even when the basis moves."""
+    from cps import kobo, ub
+
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+    caplog.set_level(logging.DEBUG, logger="cps.kobo")
+    archived = ub.ArchivedBook(
+        user_id=sync_harness.user.id,
+        book_id=sync_harness.book.id,
+        is_archived=False,
+        last_modified=sync_harness.book.last_modified,
+    )
+    sync_harness.session.add(archived)
+    sync_harness.session.commit()
+    assert len(_entitlements(sync_harness.sync())) == 1
+    before = sync_harness.session.query(
+        ub.KoboDeviceBookEntitlement,
+    ).one()
+    original_fingerprint = before.fingerprint
+
+    moved_basis = sync_harness.book.last_modified + timedelta(minutes=5)
+    archived.last_modified = moved_basis
+    sync_harness.session.commit()
+    stale_token = kobo.SyncToken.SyncToken().build_sync_token()
+    replay = sync_harness.sync(stale_token)
+
+    assert _entitlements(replay) == []
+    sync_harness.session.expire_all()
+    after = sync_harness.session.query(
+        ub.KoboDeviceBookEntitlement,
+    ).one()
+    assert after.fingerprint == original_fingerprint
+    assert after.change_basis == kobo._book_entitlement_change_basis(
+        sync_harness.book.last_modified,
+        moved_basis,
+    )
+    summaries = [
+        record.getMessage() for record in caplog.records
+        if record.getMessage().startswith("Kobo Sync summary:")
+    ]
+    assert "reseeded_shape_change=0" in summaries[-1]
+
+
+def test_constituent_basis_detects_book_move_below_archive_max(
+    sync_harness, monkeypatch,
+):
+    """A changed lower book clock cannot collide with the archive component."""
+    from cps import kobo, ub
+
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+    archive_clock = datetime(2026, 8, 28, 12, 10, 0)
+    archived = ub.ArchivedBook(
+        user_id=sync_harness.user.id,
+        book_id=sync_harness.book.id,
+        is_archived=False,
+        last_modified=archive_clock,
+    )
+    sync_harness.session.add(archived)
+    sync_harness.session.commit()
+    assert len(_entitlements(sync_harness.sync())) == 1
+    before = sync_harness.session.query(
+        ub.KoboDeviceBookEntitlement,
+    ).one()
+    assert before.change_basis == (
+        "v1|book=2026-08-28T12:00:00.000000Z|"
+        "archive=2026-08-28T12:10:00.000000Z"
+    )
+
+    sync_harness.book.last_modified = datetime(2026, 8, 28, 12, 5, 0)
+    sync_harness.session.commit()
+    original_get_metadata = kobo.get_metadata
+
+    def shape_b(book):
+        payload = original_get_metadata(book)
+        payload["Issue1953ShapeProbe"] = "shape-b"
+        return payload
+
+    monkeypatch.setattr(kobo, "get_metadata", shape_b)
+    monkeypatch.setattr(
+        kobo,
+        "ENTITLEMENT_PAYLOAD_SCHEMA_VERSION",
+        kobo.ENTITLEMENT_PAYLOAD_SCHEMA_VERSION + 1,
+    )
+    stale_token = kobo.SyncToken.SyncToken().build_sync_token()
+    replay = sync_harness.sync(stale_token)
+
+    assert len(_entitlements(replay)) == 1
+    sync_harness.session.expire_all()
+    after = sync_harness.session.query(
+        ub.KoboDeviceBookEntitlement,
+    ).one()
+    assert after.change_basis == (
+        "v1|book=2026-08-28T12:05:00.000000Z|"
+        "archive=2026-08-28T12:10:00.000000Z"
+    )
+
+
+def test_constituent_basis_normalizes_aware_clocks_to_utc():
+    """Equivalent instants produce one canonical byte-comparable encoding."""
+    from cps import kobo
+
+    utc_clock = datetime(2026, 8, 28, 12, 0, tzinfo=timezone.utc)
+    offset_clock = datetime(
+        2026, 8, 28, 14, 0,
+        tzinfo=timezone(timedelta(hours=2)),
+    )
+
+    assert kobo._book_entitlement_change_basis(
+        offset_clock, None,
+    ) == kobo._book_entitlement_change_basis(utc_clock, None)
+    assert kobo._book_entitlement_change_basis(utc_clock, None) == (
+        "v1|book=2026-08-28T12:00:00.000000Z|archive=none"
+    )
+
+
+def test_legacy_null_basis_version_transition_delivers_then_suppresses(
+    sync_harness, caplog, monkeypatch,
+):
+    """A legacy NULL basis is ambiguous, so its first mismatch fails open."""
+    from cps import kobo, ub
+
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+    caplog.set_level(logging.DEBUG, logger="cps.kobo")
+    assert len(_entitlements(sync_harness.sync())) == 1
+    row = sync_harness.session.query(ub.KoboDeviceBookEntitlement).one()
+    row.change_basis = None
+    row.updated_at = sync_harness.book.last_modified + timedelta(seconds=1)
+    sync_harness.session.commit()
+
+    original_get_metadata = kobo.get_metadata
+
+    def shape_b(book):
+        payload = original_get_metadata(book)
+        payload["Issue1953ShapeProbe"] = "shape-b"
+        return payload
+
+    monkeypatch.setattr(kobo, "get_metadata", shape_b)
+    next_schema = kobo.ENTITLEMENT_PAYLOAD_SCHEMA_VERSION + 1
+    monkeypatch.setattr(
+        kobo, "ENTITLEMENT_PAYLOAD_SCHEMA_VERSION", next_schema,
+    )
+    stale_token = kobo.SyncToken.SyncToken().build_sync_token()
+    delivered = sync_harness.sync(stale_token)
+
+    assert len(_entitlements(delivered)) == 1
+    sync_harness.session.expire_all()
+    migrated = sync_harness.session.query(
+        ub.KoboDeviceBookEntitlement,
+    ).one()
+    assert migrated.change_basis == kobo._book_entitlement_change_basis(
+        sync_harness.book.last_modified,
+        None,
+    )
+    assert migrated.payload_schema_version == next_schema
+    assert _entitlements(sync_harness.sync(stale_token)) == []
+    summaries = [
+        record.getMessage() for record in caplog.records
+        if record.getMessage().startswith("Kobo Sync summary:")
+    ]
+    assert "reseeded_shape_change=0" in summaries[-1]
+
+
+def test_real_last_modified_bump_under_new_payload_shape_delivers_once(
+    sync_harness, monkeypatch,
+):
+    """A shape reseed cannot hide a later movement of the book cursor basis."""
+    from cps import kobo, ub
+
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+    assert len(_entitlements(sync_harness.sync())) == 1
+    original_get_metadata = kobo.get_metadata
+
+    def shape_b(book):
+        payload = original_get_metadata(book)
+        payload["Issue1953ShapeProbe"] = "shape-b"
+        return payload
+
+    monkeypatch.setattr(kobo, "get_metadata", shape_b)
+    monkeypatch.setattr(
+        kobo,
+        "ENTITLEMENT_PAYLOAD_SCHEMA_VERSION",
+        kobo.ENTITLEMENT_PAYLOAD_SCHEMA_VERSION + 1,
+    )
+    stale_token = kobo.SyncToken.SyncToken().build_sync_token()
+    reseeded = sync_harness.sync(stale_token)
+    assert _entitlements(reseeded) == []
+
+    sync_harness.book.last_modified += timedelta(minutes=1)
+    sync_harness.session.commit()
+    changed = sync_harness.sync(
+        reseeded.headers[sync_harness.token_header],
+    )
+    stable = sync_harness.sync(changed.headers[sync_harness.token_header])
+
+    envelopes = _entitlements(changed)
+    assert len(envelopes) == 1
+    assert "ChangedEntitlement" in envelopes[0]
+    assert (
+        envelopes[0]["ChangedEntitlement"]["BookEntitlement"]["LastModified"]
+        == "2026-08-28T12:01:00Z"
+    )
+    assert _entitlements(stable) == []
+    row = sync_harness.session.query(ub.KoboDeviceBookEntitlement).one()
+    assert row.change_basis == kobo._book_entitlement_change_basis(
+        sync_harness.book.last_modified,
+        None,
+    )
+
+
 def test_upgrade_seed_suppresses_first_218_book_replay_for_all_existing_devices(
     sync_harness, caplog, monkeypatch,
 ):
@@ -356,6 +813,105 @@ def test_upgrade_seed_suppresses_first_218_book_replay_for_all_existing_devices(
     assert len(_entitlements(factory_reset)) == 100
 
 
+def test_upgrade_seed_skips_null_archived_last_modified(
+    sync_harness, monkeypatch,
+):
+    """Legacy NULL archive clocks do not break canonical-basis seeding."""
+    from cps import kobo, ub
+
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+    archived = ub.ArchivedBook(
+        user_id=sync_harness.user.id,
+        book_id=sync_harness.book.id,
+        is_archived=False,
+    )
+    sync_harness.session.add_all([
+        archived,
+        ub.KoboSyncedBooks(
+            user_id=sync_harness.user.id,
+            book_id=sync_harness.book.id,
+            book_uuid=str(sync_harness.book.uuid),
+        ),
+    ])
+    sync_harness.session.flush()
+    archived.last_modified = None
+    sync_harness.session.commit()
+
+    stale_token = kobo.SyncToken.SyncToken().build_sync_token()
+    replay = sync_harness.sync(stale_token)
+
+    assert replay.status_code == 200
+    assert _entitlements(replay) == []
+    row = sync_harness.session.query(
+        ub.KoboDeviceBookEntitlement,
+    ).one()
+    assert row.change_basis == kobo._book_entitlement_change_basis(
+        sync_harness.book.last_modified,
+        None,
+    )
+
+
+def test_two_shelf_rows_reseed_one_book_once_on_declared_transition(
+    sync_harness, caplog, monkeypatch,
+):
+    """A per-book ledger and counter are independent of shelf-row clocks."""
+    from cps import kobo, ub
+
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+    caplog.set_level(logging.DEBUG, logger="cps.kobo")
+    sync_harness.user.kobo_only_shelves_sync = True
+    _add_kobo_shelf(
+        sync_harness,
+        date_added=datetime(2026, 8, 28, 12, 5, 0),
+    )
+    _add_kobo_shelf(
+        sync_harness,
+        date_added=datetime(2026, 8, 28, 12, 10, 0),
+        name="Second Regression Kobo Shelf",
+        shelf_uuid="issue-1953-second-regression-shelf",
+    )
+    assert _entitlements(sync_harness.sync())
+    assert sync_harness.session.query(
+        ub.KoboDeviceBookEntitlement,
+    ).count() == 1
+
+    original_get_metadata = kobo.get_metadata
+
+    def shape_b(book):
+        payload = original_get_metadata(book)
+        payload["Issue1953ShapeProbe"] = "shape-b"
+        return payload
+
+    monkeypatch.setattr(kobo, "get_metadata", shape_b)
+    next_schema = kobo.ENTITLEMENT_PAYLOAD_SCHEMA_VERSION + 1
+    monkeypatch.setattr(
+        kobo, "ENTITLEMENT_PAYLOAD_SCHEMA_VERSION", next_schema,
+    )
+    stale_token = kobo.SyncToken.SyncToken().build_sync_token()
+    replay = sync_harness.sync(stale_token)
+
+    assert _entitlements(replay) == []
+    rows = sync_harness.session.query(
+        ub.KoboDeviceBookEntitlement,
+    ).all()
+    assert len(rows) == 1
+    assert rows[0].payload_schema_version == next_schema
+    assert rows[0].change_basis == kobo._book_entitlement_change_basis(
+        sync_harness.book.last_modified,
+        None,
+    )
+    summaries = [
+        record.getMessage() for record in caplog.records
+        if record.getMessage().startswith("Kobo Sync summary:")
+    ]
+    assert "suppressed_unchanged=1" in summaries[-1]
+    assert "reseeded_shape_change=1" in summaries[-1]
+
+
 def test_hard_delete_entitlements_emit_once_then_suppress_exact_stale_replay(
     sync_harness, caplog, monkeypatch,
 ):
@@ -410,6 +966,70 @@ def test_hard_delete_entitlements_emit_once_then_suppress_exact_stale_replay(
     ]
     assert "entitlements new=0 changed=0" in summaries[-1]
     assert "suppressed_unchanged=3 suppressed_removed=2" in summaries[-1]
+
+
+def test_hard_delete_payload_shape_change_reseeds_without_delivery(
+    sync_harness, caplog, monkeypatch,
+):
+    """IsRemoved tombstones use the same declared-transition reseed path."""
+    from cps import kobo, ub
+
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+    caplog.set_level(logging.DEBUG, logger="cps.kobo")
+    assert len(_entitlements(sync_harness.sync())) == 1
+    deleted_at = datetime(2026, 8, 28, 13, 30, 0)
+    book_uuid = "00000000-0000-0000-0000-deleted1953"
+    sync_harness.session.add(ub.KoboDeletedBook(
+        user_id=sync_harness.user.id,
+        book_uuid=book_uuid,
+        deleted_at=deleted_at,
+    ))
+    sync_harness.session.commit()
+    stale_token = kobo.SyncToken.SyncToken().build_sync_token()
+    first_offer = sync_harness.sync(stale_token)
+    assert any(
+        item.get("ChangedEntitlement", {}).get(
+            "BookEntitlement", {},
+        ).get("IsRemoved") is True
+        for item in _entitlements(first_offer)
+    )
+    before = sync_harness.session.query(
+        ub.KoboDeviceDeletedEntitlement,
+    ).filter_by(book_uuid=book_uuid).one()
+    old_fingerprint = before.fingerprint
+
+    original_deleted_metadata = kobo.create_deleted_book_metadata
+
+    def shape_b(deleted_uuid):
+        payload = original_deleted_metadata(deleted_uuid)
+        payload["Issue1953ShapeProbe"] = "shape-b"
+        return payload
+
+    monkeypatch.setattr(kobo, "create_deleted_book_metadata", shape_b)
+    next_schema = kobo.ENTITLEMENT_PAYLOAD_SCHEMA_VERSION + 1
+    monkeypatch.setattr(
+        kobo, "ENTITLEMENT_PAYLOAD_SCHEMA_VERSION", next_schema,
+    )
+    replay = sync_harness.sync(stale_token)
+
+    assert _entitlements(replay) == []
+    sync_harness.session.expire_all()
+    after = sync_harness.session.query(
+        ub.KoboDeviceDeletedEntitlement,
+    ).filter_by(book_uuid=book_uuid).one()
+    assert after.fingerprint != old_fingerprint
+    assert after.change_basis == kobo._deleted_entitlement_change_basis(
+        deleted_at,
+    )
+    assert after.payload_schema_version == next_schema
+    summaries = [
+        record.getMessage() for record in caplog.records
+        if record.getMessage().startswith("Kobo Sync summary:")
+    ]
+    assert "reseeded_shape_change=1" in summaries[-1]
+    assert "suppressed_removed=1" in summaries[-1]
 
 
 def test_suppressed_entitlement_emits_newer_reading_state_once_and_advances_cursor(
@@ -616,6 +1236,128 @@ def test_shelf_only_removal_command_and_ledger_cleanup_are_unchanged(
     assert envelopes[0]["ChangedEntitlement"]["BookEntitlement"]["IsRemoved"] is True
     assert sync_harness.session.query(ub.KoboSyncedBooks).count() == 0
     assert sync_harness.session.query(ub.KoboDeviceBookEntitlement).count() == 0
+
+
+@pytest.mark.parametrize("removed_book_was_sole_marker", [False, True])
+def test_failed_request_retains_shelf_removal_for_retry(
+    sync_harness, monkeypatch, removed_book_was_sole_marker,
+):
+    """A 503 cannot consume an IsRemoved command that was never returned."""
+    from cps import db, kobo, ub
+    from werkzeug.exceptions import ServiceUnavailable
+
+    sync_harness.user.kobo_only_shelves_sync = True
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+    shelf, removed_link = _add_kobo_shelf(
+        sync_harness,
+        date_added=datetime(2026, 8, 28, 12, 5, 0),
+    )
+
+    def add_shelf_book(number, title, modified):
+        book = db.Books(
+            title,
+            title,
+            "Author",
+            modified,
+            db.Books.DEFAULT_PUBDATE,
+            "1.0",
+            modified,
+            f"issue-1953-{number}",
+            0,
+            [],
+            [],
+        )
+        sync_harness.session.add(book)
+        sync_harness.session.flush()
+        book.uuid = f"00000000-0000-0000-1953-{number:012d}"
+        link = ub.BookShelf(
+            book_id=book.id,
+            shelf=shelf.id,
+            order=number,
+            date_added=modified,
+        )
+        link.ub_shelf = shelf
+        sync_harness.session.add_all([
+            db.Data(book.id, "EPUB", 1_000_000 + number, book.path),
+            link,
+        ])
+        sync_harness.session.commit()
+        return book
+
+    if not removed_book_was_sole_marker:
+        add_shelf_book(
+            1,
+            "Retained Shelf Book",
+            datetime(2026, 8, 28, 12, 1, 0),
+        )
+    first = sync_harness.sync()
+    expected_initial = 1 if removed_book_was_sole_marker else 2
+    assert len(_entitlements(first)) == expected_initial
+
+    sync_harness.session.delete(removed_link)
+    later_book = add_shelf_book(
+        2,
+        "Later Live Book",
+        datetime(2026, 8, 28, 12, 20, 0),
+    )
+    sync_harness.session.commit()
+
+    def fail_request_commit(*_args, **_kwargs):
+        sync_harness.session.rollback()
+        return False
+
+    monkeypatch.setattr(ub, "session_commit", fail_request_commit)
+    with pytest.raises(ServiceUnavailable) as raised:
+        sync_harness.sync(first.headers[sync_harness.token_header])
+    assert raised.value.code == 503
+
+    # The removal command was discarded with the 503, so both sources needed
+    # to reconstruct it must still be durable. In the sole-marker case this
+    # also prevents the next request's zero-marker token-reset branch.
+    assert sync_harness.session.query(ub.KoboSyncedBooks).filter_by(
+        user_id=sync_harness.user.id,
+        book_id=sync_harness.book.id,
+    ).count() == 1
+    assert sync_harness.session.query(
+        ub.KoboDeviceBookEntitlement,
+    ).filter_by(book_id=sync_harness.book.id).count() == 1
+    assert sync_harness.session.query(ub.KoboSyncedBooks).filter_by(
+        user_id=sync_harness.user.id,
+        book_id=later_book.id,
+    ).count() == 0
+
+    monkeypatch.setattr(
+        ub,
+        "session_commit",
+        lambda *_args, **_kwargs: sync_harness.session.commit(),
+    )
+    retry = sync_harness.sync(first.headers[sync_harness.token_header])
+    removals = [
+        item["ChangedEntitlement"]["BookEntitlement"]
+        for item in _entitlements(retry)
+        if item.get("ChangedEntitlement", {}).get(
+            "BookEntitlement", {},
+        ).get("IsRemoved") is True
+    ]
+
+    assert [item["Id"] for item in removals] == [
+        str(sync_harness.book.uuid),
+    ]
+    assert any(
+        envelope.get("NewEntitlement", {}).get(
+            "BookEntitlement", {},
+        ).get("Id") == str(later_book.uuid)
+        or envelope.get("ChangedEntitlement", {}).get(
+            "BookEntitlement", {},
+        ).get("Id") == str(later_book.uuid)
+        for envelope in _entitlements(retry)
+    )
+    assert sync_harness.session.query(ub.KoboSyncedBooks).filter_by(
+        user_id=sync_harness.user.id,
+        book_id=sync_harness.book.id,
+    ).count() == 0
 
 
 def test_shelf_only_magic_membership_failure_preserves_book_and_ledger(
@@ -1331,6 +2073,89 @@ def test_device_entitlement_tables_are_created_by_app_db_migration_path():
         assert expected.isdisjoint(sa_inspect(engine).get_table_names())
         ub.add_missing_tables(engine, session)
         assert expected.issubset(sa_inspect(engine).get_table_names())
+    finally:
+        session.close()
+        engine.dispose()
+
+
+def test_existing_entitlement_ledgers_receive_additive_provenance_columns(
+    monkeypatch,
+):
+    """A migrated #1925 app.db accepts both provenance-aware upserts."""
+    from cps import kobo_sync_status, ub
+    from sqlalchemy import inspect as sa_inspect, text
+
+    engine = create_engine("sqlite:///:memory:")
+    with engine.begin() as connection:
+        connection.execute(text(
+            "CREATE TABLE kobo_device_book_entitlement ("
+            "id INTEGER PRIMARY KEY, device_id INTEGER NOT NULL, "
+            "book_id INTEGER NOT NULL, fingerprint VARCHAR(64) NOT NULL, "
+            "updated_at DATETIME NOT NULL, "
+            "UNIQUE (device_id, book_id))"
+        ))
+        connection.execute(text(
+            "CREATE TABLE kobo_device_deleted_entitlement ("
+            "id INTEGER PRIMARY KEY, device_id INTEGER NOT NULL, "
+            "book_uuid VARCHAR(64) NOT NULL, fingerprint VARCHAR(64) NOT NULL, "
+            "updated_at DATETIME NOT NULL, "
+            "UNIQUE (device_id, book_uuid))"
+        ))
+        connection.execute(text(
+            "INSERT INTO kobo_device_book_entitlement "
+            "(device_id, book_id, fingerprint, updated_at) "
+            "VALUES (7, 19, :fingerprint, :updated_at)"
+        ), {"fingerprint": "a" * 64, "updated_at": "2026-08-28 12:00:01"})
+    session = sessionmaker(bind=engine)()
+    try:
+        monkeypatch.setattr(ub, "session", session)
+        ub.migrate_kobo_entitlement_ledger_columns(engine, session)
+        ub.migrate_kobo_entitlement_ledger_columns(engine, session)
+        for table_name in (
+            "kobo_device_book_entitlement",
+            "kobo_device_deleted_entitlement",
+        ):
+            columns = {
+                column["name"]: column
+                for column in sa_inspect(engine).get_columns(table_name)
+            }
+            assert {"payload_schema_version", "change_basis"} <= set(columns)
+            assert str(columns["change_basis"]["type"]) == "TEXT"
+
+        row = session.query(ub.KoboDeviceBookEntitlement).one()
+        assert row.payload_schema_version == 1
+        assert row.change_basis is None
+
+        book_basis = (
+            "v1|book=2026-08-28T12:05:00.000000Z|archive=none"
+        )
+        deleted_basis = "v1|deleted=2026-08-28T12:05:00.000000Z"
+        kobo_sync_status.stage_device_entitlement_fingerprints(
+            7, {19: "b" * 64}, {19: book_basis}, 2,
+        )
+        kobo_sync_status.stage_device_deleted_entitlement_fingerprints(
+            7,
+            {"deleted-1953": "c" * 64},
+            {"deleted-1953": deleted_basis},
+            2,
+        )
+        kobo_sync_status.stage_device_deleted_entitlement_fingerprints(
+            7,
+            {"deleted-1953": "d" * 64},
+            {"deleted-1953": deleted_basis},
+            2,
+        )
+        session.commit()
+        session.expire_all()
+
+        row = session.query(ub.KoboDeviceBookEntitlement).one()
+        assert row.fingerprint == "b" * 64
+        assert row.payload_schema_version == 2
+        assert row.change_basis == book_basis
+        deleted = session.query(ub.KoboDeviceDeletedEntitlement).one()
+        assert deleted.fingerprint == "d" * 64
+        assert deleted.payload_schema_version == 2
+        assert deleted.change_basis == deleted_basis
     finally:
         session.close()
         engine.dispose()

--- a/tests/unit/test_1953_merge_marks_modified.py
+++ b/tests/unit/test_1953_merge_marks_modified.py
@@ -1,0 +1,195 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Regression coverage for #1953's merge-format cursor provenance."""
+
+from datetime import datetime, timezone
+import inspect
+import json
+from types import SimpleNamespace
+
+from flask import Flask
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+class _Data:
+    def __init__(self, book, book_format, uncompressed_size, name):
+        self.book = book
+        self.format = book_format
+        self.uncompressed_size = uncompressed_size
+        self.name = name
+
+
+@pytest.mark.parametrize("overwrite", [False, True])
+def test_merge_format_mutation_advances_target_last_modified(
+    tmp_path, monkeypatch, overwrite,
+):
+    """Adding or overwriting a format advances Kobo's book cursor."""
+    from cps import editbooks
+
+    target_dir = tmp_path / "target"
+    source_dir = tmp_path / "source"
+    target_dir.mkdir()
+    source_dir.mkdir()
+    old_modified = datetime(2020, 1, 2, tzinfo=timezone.utc)
+    target_format = "EPUB" if overwrite else "KEPUB"
+    target_data = [
+        SimpleNamespace(
+            format="EPUB",
+            name="Target - Author",
+            uncompressed_size=10,
+        ),
+    ]
+    target = SimpleNamespace(
+        id=1,
+        title="Target",
+        path="target",
+        authors=[SimpleNamespace(name="Author")],
+        data=target_data,
+        last_modified=old_modified,
+    )
+    source = SimpleNamespace(
+        id=2,
+        title="Source",
+        path="source",
+        authors=[SimpleNamespace(name="Author")],
+        data=[
+            SimpleNamespace(
+                format=target_format,
+                name="source-format",
+                uncompressed_size=20,
+            ),
+        ],
+    )
+    (source_dir / f"source-format.{target_format.lower()}").write_bytes(
+        b"replacement format bytes",
+    )
+    if overwrite:
+        (target_dir / "Target - Author.epub").write_bytes(
+            b"old target bytes",
+        )
+
+    commits = []
+    dirty_book_ids = []
+    books = {1: target, 2: source}
+    monkeypatch.setattr(
+        editbooks.calibre_db, "get_book", lambda book_id: books.get(book_id),
+    )
+    monkeypatch.setattr(
+        editbooks.calibre_db,
+        "session",
+        SimpleNamespace(commit=lambda: commits.append(True)),
+    )
+    monkeypatch.setattr(
+        editbooks.calibre_db,
+        "set_metadata_dirty",
+        lambda book_id: dirty_book_ids.append(book_id),
+    )
+    monkeypatch.setattr(
+        editbooks.config, "get_book_path", lambda: str(tmp_path),
+    )
+    monkeypatch.setattr(
+        editbooks.helper, "get_valid_filename", lambda value, chars=96: value,
+    )
+    monkeypatch.setattr(editbooks.db, "Data", _Data)
+    monkeypatch.setattr(
+        editbooks,
+        "delete_book_from_table",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        editbooks, "_queue_duplicate_scan_after_change", lambda *_args: None,
+    )
+
+    payload = {
+        "Merge_books": [target.id, source.id],
+        "overwrite_formats": [target_format] if overwrite else [],
+    }
+    app = Flask(__name__)
+    with app.test_request_context("/ajax/mergebooks", json=payload):
+        result = inspect.unwrap(editbooks.merge_list_book)()
+
+    assert json.loads(result) == {"success": True}
+    assert target.last_modified > old_modified
+    assert dirty_book_ids == [target.id]
+    assert commits == [True]
+    changed = next(row for row in target.data if row.format == target_format)
+    assert changed.uncompressed_size == 20
+
+
+def test_automatic_duplicate_merge_advances_keeper_last_modified(
+    tmp_path, monkeypatch,
+):
+    """Automatic resolution exposes an added KEPUB to Kobo's cursor."""
+    from cps import duplicates
+
+    target_dir = tmp_path / "target"
+    source_dir = tmp_path / "source"
+    target_dir.mkdir()
+    source_dir.mkdir()
+    old_modified = datetime(2020, 1, 2, tzinfo=timezone.utc)
+    target = SimpleNamespace(
+        id=1,
+        title="Target",
+        path="target",
+        authors=[SimpleNamespace(name="Author")],
+        data=[
+            SimpleNamespace(
+                format="EPUB",
+                name="Target - Author",
+                uncompressed_size=10,
+            ),
+        ],
+        last_modified=old_modified,
+    )
+    source = SimpleNamespace(
+        id=2,
+        title="Source",
+        path="source",
+        authors=[SimpleNamespace(name="Author")],
+        data=[
+            SimpleNamespace(
+                format="KEPUB",
+                name="source-format",
+                uncompressed_size=20,
+            ),
+        ],
+    )
+    (source_dir / "source-format.kepub").write_bytes(b"kepub bytes")
+    commits = []
+    books = {1: target, 2: source}
+    monkeypatch.setattr(
+        duplicates.calibre_db,
+        "get_book",
+        lambda book_id: books.get(book_id),
+    )
+    monkeypatch.setattr(
+        duplicates.calibre_db,
+        "session",
+        SimpleNamespace(
+            commit=lambda: commits.append(True),
+            rollback=lambda: None,
+        ),
+    )
+    monkeypatch.setattr(
+        duplicates.config, "get_book_path", lambda: str(tmp_path),
+    )
+    monkeypatch.setattr(
+        duplicates.helper,
+        "get_valid_filename",
+        lambda value, chars=96: value,
+    )
+    monkeypatch.setattr(duplicates.db, "Data", _Data)
+
+    duplicates.merge_duplicate_group(
+        SimpleNamespace(id=target.id),
+        [SimpleNamespace(id=source.id)],
+    )
+
+    assert target.last_modified > old_modified
+    assert commits == [True]
+    added = next(row for row in target.data if row.format == "KEPUB")
+    assert added.uncompressed_size == 20

--- a/tests/unit/test_duplicate_merge_copy_guard.py
+++ b/tests/unit/test_duplicate_merge_copy_guard.py
@@ -25,6 +25,7 @@ importlib so there is exactly one copy of the stub harness).
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 import importlib.util
 import pathlib
 import re
@@ -79,7 +80,14 @@ def _load_merge_world(tmp_path):
     harness = _harness()
     module, calibre_books, calls = harness._load_duplicates_module([])
     # merge_duplicate_group needs pieces the shared loader doesn't stub:
-    sys.modules["cps.helper"].get_valid_filename = lambda value, chars=128: value
+    helper = sys.modules["cps.helper"]
+    helper.get_valid_filename = lambda value, chars=128: value
+
+    def mark_book_modified(book, *, set_dirty=True, unsync=False):
+        book.last_modified += timedelta(seconds=1)
+        calls.append("mark-book-modified")
+
+    helper.mark_book_modified = mark_book_modified
     sys.modules["cps.db"].Data = _FakeData
     sys.modules["cps.config"].get_book_path = lambda: str(tmp_path)
     return module, calibre_books, calls
@@ -92,6 +100,7 @@ def _book(book_id, title, path, data):
         path=path,
         authors=[SimpleNamespace(name="Author")],
         data=data,
+        last_modified=datetime(2020, 1, 1, tzinfo=timezone.utc),
     )
 
 
@@ -209,18 +218,21 @@ class TestD8HappyPathStillMerges:
         to_book, _ = _setup_pair(
             tmp_path, calibre_books,
             keep_data=[_fmt("Title - Author", "EPUB")],
-            merge_data=[_fmt("dupfile", "EPUB"), _fmt("dupfile", "PDF")],
+            merge_data=[_fmt("dupfile", "EPUB"), _fmt("dupfile", "KEPUB")],
         )
         (tmp_path / "dup" / "dupfile.epub").write_bytes(b"epub bytes")
-        (tmp_path / "dup" / "dupfile.pdf").write_bytes(b"pdf bytes")
+        (tmp_path / "dup" / "dupfile.kepub").write_bytes(b"kepub bytes")
 
+        old_modified = to_book.last_modified
         module.merge_duplicate_group(SimpleNamespace(id=1), [SimpleNamespace(id=2)])
 
-        # EPUB already on the kept book -> only PDF merges.
-        assert [d.format for d in to_book.data if isinstance(d, _FakeData)] == ["PDF"]
-        copied = tmp_path / "keep" / "Title - Author.pdf"
-        assert copied.read_bytes() == b"pdf bytes"
+        # EPUB already on the kept book -> only the Kobo-visible KEPUB merges.
+        assert [d.format for d in to_book.data if isinstance(d, _FakeData)] == ["KEPUB"]
+        copied = tmp_path / "keep" / "Title - Author.kepub"
+        assert copied.read_bytes() == b"kepub bytes"
         assert not (tmp_path / "keep" / "Title - Author.epub").exists() or True
+        assert to_book.last_modified > old_modified
+        assert calls.index("mark-book-modified") < calls.index("commit")
         assert calls.count("commit") == 1
 
 

--- a/tests/unit/test_kobo_prefer_kepub.py
+++ b/tests/unit/test_kobo_prefer_kepub.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime, timezone
 from types import SimpleNamespace
+import zipfile
 
 import pytest
 from flask import Flask, has_app_context, has_request_context
@@ -257,6 +258,73 @@ def test_conversion_advances_modified_without_touching_synced_rows(monkeypatch):
     assert book.last_modified > old_modified
     assert synced_rows == [(1, 1), (2, 1)]
     assert len(merged) == 1
+
+
+def test_conversion_recovery_adoption_advances_modified(monkeypatch, tmp_path):
+    """Adopting a valid orphan KEPUB crosses the same Kobo cursor boundary."""
+    from cps.tasks import convert
+
+    old_modified = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    book = SimpleNamespace(
+        id=1,
+        title="Book",
+        path="Author/Book",
+        last_modified=old_modified,
+        data=[SimpleNamespace(name="book")],
+    )
+    merged = []
+    commits = []
+
+    class Query:
+        def filter(self, *_args):
+            return self
+
+        def one_or_none(self):
+            return None
+
+    class Session:
+        def query(self, *_args):
+            return Query()
+
+        def merge(self, row):
+            merged.append(row)
+
+        def commit(self):
+            commits.append(True)
+
+        def rollback(self):
+            pass
+
+        def close(self):
+            pass
+
+    class LocalDB:
+        def __init__(self, **_kwargs):
+            self.session = Session()
+
+        def get_book(self, _book_id):
+            return book
+
+        def get_book_format(self, *_args):
+            return None
+
+    file_path = tmp_path / "book"
+    with zipfile.ZipFile(str(file_path) + ".kepub", "w") as archive:
+        archive.writestr("mimetype", "application/epub+zip")
+
+    monkeypatch.setattr(convert.db, "CalibreDB", LocalDB)
+    task = convert.TaskConvert(
+        str(file_path),
+        1,
+        "convert",
+        {"old_book_format": "EPUB", "new_book_format": "KEPUB"},
+        None,
+    )
+
+    assert task._convert_ebook_format() == "book.kepub"
+    assert book.last_modified > old_modified
+    assert len(merged) == 1
+    assert commits == [True]
 
 
 def test_truncated_kepub_is_not_adopted_as_database_format(monkeypatch, tmp_path):

--- a/tests/unit/test_kobo_sync_batch_commits.py
+++ b/tests/unit/test_kobo_sync_batch_commits.py
@@ -42,7 +42,9 @@ def test_sync_page_uses_one_commit_and_inserts_only_missing_user_book_pairs(monk
 
     # Repeated IDs model defensive page input; book 2 already belongs to this
     # user, while book 3 currently belongs only to another user.
-    kobo_sync_status.add_synced_books_batch([1, 2, 2, 3, 4])
+    assert kobo_sync_status.add_synced_books_batch(
+        [1, 2, 2, 3, 4],
+    ) is True
 
     assert commits == 1
     assert statements.count("SELECT") == 1


### PR DESCRIPTION
Closes #1953. Follow-on to #1925 (v4.1.43).

## What
- Ledger rows gain `payload_schema_version` + a constituent-preserving `change_basis` (TEXT tuple; scalar max can't prove both clocks unchanged).
- Replay decision table: **byte-identical → always suppress** (refresh provenance) · **same-version mismatch → always deliver** (fail open; an unproven difference is treated as a genuine change) · **declared schema transition + proven-unchanged basis → reseed in place**, counted per unique book (`reseeded_shape_change`). Legacy #1925 rows fail open once.
- Renderer tripwire test pins (version, payload-hash) for all three payload variants — any renderer change fails CI until `ENTITLEMENT_PAYLOAD_SCHEMA_VERSION` is bumped with it.
- Sync handler app-db mutations are now one request-level transaction with a single checked commit before token/summary/response; a failed commit 503s with removal tracking rows intact (fixes a path where an early-committed shelf removal could be lost forever on a later failure).
- Three in-tree writers (manual merge, automatic duplicate resolution, conversion recovery adoption) now advance `Books.last_modified` when they change Kobo-visible formats.

## Verification
- Full unit suite: **7421 passed, 0 failed** (OBSERVED).
- Four adversarial review rounds by an independent Sol thread; final verdict **MERGE** (rounds 1–3 findings all dispositioned with regressions: legacy-boundary data loss, byte-identical re-delivery regression, seed/live basis mismatch, multi-shelf rows, request atomicity, counter semantics).
- Documented residual (stated boundary, not a hedge): an out-of-tree writer editing metadata.db without bumping `last_modified`, coincident with a declared schema transition, is indistinguishable from renderer noise server-side.

Hardware verification of the reseed path on the Clara follows the next declared version bump; the fingerprint-versioning mechanics are unit-proven.