### PR TITLE
feat(devices): each browser is a first-class device with its own identity (#1942 M1)

### DIFF
--- a/changelog.d/1942-m1-browser-device.md
+++ b/changelog.d/1942-m1-browser-device.md
@@ -1,5 +1,6 @@
 ### Added
 
-- **Each browser is now listed as its own web-reader device.** New highlights,
-  notes, and reading-position saves are attributed to a private browser
-  identity instead of collapsing every browser into one shared web-reader.
+- **Each browser is now listed as its own web-reader device.** New highlights
+  and notes persist their private browser origin instead of collapsing every
+  browser into one shared web-reader. Position requests carry the same
+  request-scoped identity for the per-device position store planned in M3.

--- a/changelog.d/1942-m1-browser-device.md
+++ b/changelog.d/1942-m1-browser-device.md
@@ -1,0 +1,5 @@
+### Added
+
+- **Each browser is now listed as its own web-reader device.** New highlights,
+  notes, and reading-position saves are attributed to a private browser
+  identity instead of collapsing every browser into one shared web-reader.

--- a/cps/annotations.py
+++ b/cps/annotations.py
@@ -42,7 +42,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Optional
 
-from flask import Blueprint, Response, abort, flash, jsonify, redirect, request, url_for
+from flask import Blueprint, Response, abort, flash, g, jsonify, redirect, request, url_for
 from flask_babel import gettext as _
 from sqlalchemy import and_, func
 from sqlalchemy.exc import SQLAlchemyError
@@ -103,6 +103,7 @@ def _device_json(device, annotation_count=0):
         "public_id": device.public_id,
         "label": device.display_name,
         "type": device.kind,
+        "kind": device.kind,
         "model": device.model,
         "firmware": device.firmware_version,
         "first_seen": device.first_seen_at.isoformat() if device.first_seen_at else None,
@@ -1188,6 +1189,7 @@ def create_annotation(payload, *, user_id, book, session, commit,
             # it just cannot be placed in the book. Attribution is orthogonal to
             # anchoring, so it carries an origin exactly like the other two.
             origin_device_id=origin_device_id,
+            last_editor_device_id=origin_device_id,
             # No highlighted passage, so no colour to render on it.
             highlighted_text=None,
             highlight_color=None,
@@ -1221,6 +1223,7 @@ def create_annotation(payload, *, user_id, book, session, commit,
             # text attached to it does not make it a note.
             annotation_type=type_for_webreader_annotation(has_anchor=True),
             origin_device_id=origin_device_id,
+            last_editor_device_id=origin_device_id,
             highlighted_text=payload.get("highlighted_text"),
             highlight_color=color,
             note_text=payload.get("note_text"),
@@ -1252,6 +1255,7 @@ def create_annotation(payload, *, user_id, book, session, commit,
         # text attached to it does not make it a note.
         annotation_type=type_for_webreader_annotation(has_anchor=True),
         origin_device_id=origin_device_id,
+        last_editor_device_id=origin_device_id,
         highlighted_text=payload.get("highlighted_text"),
         highlight_color=color,
         note_text=payload.get("note_text"),
@@ -1303,7 +1307,7 @@ def _find_owned_annotation(annotation_id, user_id, book_id, session):
 
 
 def edit_annotation(annotation_id, *, user_id, book_id, session, commit,
-                    color=_UNSET, note=_UNSET):
+                    color=_UNSET, note=_UNSET, editor_device_id=None):
     """Update an annotation's color and/or note. Position is immutable.
 
     Returns the row, or ``None`` if no annotation with that id belongs to
@@ -1320,6 +1324,8 @@ def edit_annotation(annotation_id, *, user_id, book_id, session, commit,
         row.highlight_color = to_storage_color(normalized)
     if note is not _UNSET:
         row.note_text = note
+    if editor_device_id is not None:
+        row.last_editor_device_id = editor_device_id
     row.last_synced = datetime.now(timezone.utc)
     if commit is not None:
         _commit_required(commit)
@@ -1429,7 +1435,8 @@ def bulk_reassign_annotations(items, *, user_id, assigned_device_public_id, sess
     return results
 
 
-def delete_annotation(annotation_id, *, user_id, book_id, session, commit):
+def delete_annotation(annotation_id, *, user_id, book_id, session, commit,
+                      editor_device_id=None):
     """Soft-delete an annotation (``hidden=True``). Idempotent: deleting an
     already-hidden row resolves + returns it (route 200). Returns ``None`` when
     no such row belongs to ``(user_id, book_id)`` (route 404)."""
@@ -1437,6 +1444,8 @@ def delete_annotation(annotation_id, *, user_id, book_id, session, commit):
     if row is None:
         return None
     row.hidden = True
+    if editor_device_id is not None:
+        row.last_editor_device_id = editor_device_id
     row.last_synced = datetime.now(timezone.utc)
     _commit_required(commit)
     return row
@@ -1453,18 +1462,31 @@ def _fanout_to_sync_targets(row, book):
         log.warning("annotations: sync-target fan-out failed: %s", e)
 
 
+def _observe_webreader_request_device():
+    """Resolve this browser without ever exposing its installation id."""
+    try:
+        from .services.device_registry import (
+            WEBREADER_INSTALLATION_ID_HEADER,
+            ensure_webreader_device_best_effort,
+        )
+        device_id = ensure_webreader_device_best_effort(
+            user_id=current_user.id,
+            installation_id=request.headers.get(WEBREADER_INSTALLATION_ID_HEADER),
+        )
+    except Exception:
+        log.warning("annotations: web-reader attribution failed", exc_info=True)
+        device_id = None
+    g.annotation_origin_device_id = device_id
+    return device_id
+
+
 @annotations_bp.route("/annotations/<int:book_id>", methods=["POST"])
 @user_login_required
 def annotations_create(book_id):
     """Create a highlight from a web-reader selection (source='webreader')."""
     book = _resolve_book_or_404(book_id)
     payload = request.get_json(silent=True) or {}
-    origin_device_id = None
-    try:
-        from .services.device_registry import ensure_webreader_device_best_effort
-        origin_device_id = ensure_webreader_device_best_effort(user_id=current_user.id)
-    except Exception:
-        log.warning("annotations: web-reader attribution failed", exc_info=True)
+    origin_device_id = _observe_webreader_request_device()
     try:
         row = create_annotation(
             payload, user_id=current_user.id, book=book,
@@ -1489,6 +1511,7 @@ def annotations_edit(book_id, annotation_id):
     """Edit a highlight's color and/or note (position immutable)."""
     book = _resolve_book_or_404(book_id)
     data = request.get_json(silent=True) or {}
+    editor_device_id = _observe_webreader_request_device()
     kwargs = {}
     if "highlight_color" in data:
         kwargs["color"] = data.get("highlight_color")
@@ -1504,7 +1527,8 @@ def annotations_edit(book_id, annotation_id):
             )
         row = edit_annotation(
             annotation_id, user_id=current_user.id, book_id=book_id,
-            session=ub.session, commit=ub.session_commit, **kwargs,
+            session=ub.session, commit=ub.session_commit,
+            editor_device_id=editor_device_id, **kwargs,
         )
     except AssignmentError as error:
         ub.session.rollback()
@@ -1553,10 +1577,12 @@ def annotation_assignments_bulk():
 def annotations_delete(book_id, annotation_id):
     """Soft-delete a highlight + tombstone any remote sync targets."""
     _resolve_book_or_404(book_id)
+    editor_device_id = _observe_webreader_request_device()
     try:
         row = delete_annotation(
             annotation_id, user_id=current_user.id, book_id=book_id,
             session=ub.session, commit=ub.session_commit,
+            editor_device_id=editor_device_id,
         )
     except (RuntimeError, SQLAlchemyError):
         return _database_error_response("single annotation delete")

--- a/cps/api/reader.py
+++ b/cps/api/reader.py
@@ -7,7 +7,7 @@ Reads/writes the SAME ub.Bookmark row the legacy reader uses
 progress is shared between the legacy reader and the SPA reader: open a book in
 one, resume in the other. The bookmark_key is the epub.js CFI string.
 """
-from flask import jsonify, request
+from flask import g, jsonify, request
 from sqlalchemy import and_
 from sqlalchemy.orm.attributes import flag_modified
 
@@ -59,6 +59,18 @@ def save_bookmark(book_id):
     guard = _require_real_user()
     if guard:
         return guard
+    try:
+        from ..services.device_registry import (
+            WEBREADER_INSTALLATION_ID_HEADER,
+            ensure_webreader_device_best_effort,
+        )
+        g.annotation_origin_device_id = ensure_webreader_device_best_effort(
+            user_id=current_user.id,
+            installation_id=request.headers.get(WEBREADER_INSTALLATION_ID_HEADER),
+        )
+    except Exception:
+        log.warning("Best-effort web-reader device observation failed", exc_info=True)
+        g.annotation_origin_device_id = None
     data = request.get_json(silent=True) or {}
     fmt = (data.get("format") or "epub").lower()
     bookmark_key = data.get("bookmark") or ""
@@ -84,7 +96,12 @@ def save_bookmark(book_id):
         percentage = reading_position.coerce_percentage(data.get("percentage"))
         if percentage is not None:
             try:
-                reading_position.record_web_reader_progress(current_user, book_id, percentage)
+                reading_position.record_web_reader_progress(
+                    current_user,
+                    book_id,
+                    percentage,
+                    origin_device_id=g.annotation_origin_device_id,
+                )
             except Exception as e:
                 # Position sharing must never cost the user their bookmark.
                 log.warning("Could not share web reader progress for book %s: %s", book_id, e)

--- a/cps/services/device_registry.py
+++ b/cps/services/device_registry.py
@@ -15,9 +15,15 @@ from sqlalchemy.orm import sessionmaker
 log = logging.getLogger(__name__)
 SCHEME = "kobo-header-hmac-sha256-v1"
 KOREADER_SCHEME = "koreader-client-hmac-sha256-v1"
-WEBREADER_SCHEME = "webreader-cookie-hmac-sha256-v1"
+WEBREADER_SCHEME = "webreader-cookie-hmac-sha256-v2"
+WEBREADER_SCHEME_PREFIX = "webreader-cookie-hmac-sha256-"
 WEBREADER_INSTALLATION_ID_HEADER = "X-CWNG-Webreader-Installation-Id"
 LAST_SEEN_WRITE_INTERVAL = timedelta(minutes=5)
+# A hard cap over identity-backed browser rows (including retired rows) is
+# deliberately stronger than an active-only cap: soft-delete/recreate churn
+# must not turn a client-controlled header into unbounded persistent rows.
+MAX_WEBREADER_DEVICES_PER_USER = 20
+_webreader_cap_logged_users = set()
 
 
 def _bounded_header(value, limit):
@@ -47,13 +53,88 @@ def _opaque_fingerprint(raw_id, secret_key, *, namespace):
     return hmac.new(key, namespace + b"\0" + raw_id.encode(), hashlib.sha256).hexdigest()
 
 
-def _webreader_fingerprint(installation_id, secret_key):
+def _webreader_fingerprint(user_id, installation_id, secret_key):
     """Key a browser-held installation id without retaining the raw value."""
-    return _opaque_fingerprint(
-        installation_id,
-        secret_key,
-        namespace=b"cwng-device:webreader:v1",
+    installation_id = _bounded_header(installation_id, 100)
+    key = secret_key.encode() if isinstance(secret_key, str) else secret_key
+    try:
+        user_id_bytes = str(int(user_id)).encode("ascii")
+    except (TypeError, ValueError):
+        return None
+    if not installation_id or not key:
+        return None
+    # The namespace stays v1 because it identifies the message format; the
+    # DeviceIdentity scheme is v2 because user-domain separation changed the
+    # preimage. v1 rows existed only on the unreleased #1942 feature branch.
+    message = (
+        b"cwng-device:webreader:v1\0"
+        + user_id_bytes
+        + b"\0"
+        + installation_id.encode()
     )
+    return hmac.new(key, message, hashlib.sha256).hexdigest()
+
+
+def _log_webreader_cap_once(user_id):
+    """Emit one privacy-safe process-lifetime diagnostic for each capped user."""
+    if user_id in _webreader_cap_logged_users:
+        return
+    _webreader_cap_logged_users.add(user_id)
+    log.info("Web-reader device limit reached; using the legacy device bucket")
+
+
+def _webreader_identity_count(session, ub, *, user_id):
+    """Count all browser identities, active or retired, to bound stored rows."""
+    return (
+        session.query(ub.Device.id)
+        .join(ub.DeviceIdentity, ub.DeviceIdentity.device_id == ub.Device.id)
+        .filter(
+            ub.Device.user_id == user_id,
+            ub.Device.kind == "webreader",
+            ub.DeviceIdentity.scheme.like(f"{WEBREADER_SCHEME_PREFIX}%"),
+        )
+        .distinct()
+        .count()
+    )
+
+
+def _ensure_legacy_webreader_device(session, ub, *, user_id, seen_at=None):
+    """Return the bounded historical fallback, reactivating it if retired."""
+    device = (
+        session.query(ub.Device)
+        .filter_by(user_id=user_id, kind="webreader", created_by="auto")
+        .filter(~ub.Device.identities.any(
+            ub.DeviceIdentity.scheme.like(f"{WEBREADER_SCHEME_PREFIX}%"),
+        ))
+        .order_by(ub.Device.id.asc())
+        .first()
+    )
+    now = seen_at or datetime.now(timezone.utc)
+    if device is None:
+        device = ub.Device(
+            user_id=user_id,
+            kind="webreader",
+            display_name=_deduplicated_label(
+                session, ub, user_id=user_id, base="Web reader",
+            ),
+            model="CWNG web reader",
+            platform="epub.js",
+            first_seen_at=now,
+            last_seen_at=now,
+            last_metadata_at=now,
+            active=True,
+            created_by="auto",
+        )
+        session.add(device)
+        session.flush()
+    elif not device.active:
+        # This row is the logical fallback bucket, not a physical browser.
+        # Reactivating the same singleton prevents delete/recreate cycles from
+        # becoming another persistent-row growth path.
+        device.active = True
+        device.last_seen_at = now
+        session.flush()
+    return device
 
 
 def _deduplicated_label(session, ub, *, user_id, base):
@@ -154,7 +235,7 @@ def upsert_webreader_device(session, *, user_id, installation_id, secret_key, se
     """Resolve one browser installation to one Device without storing its id."""
     from cps import ub
 
-    fingerprint = _webreader_fingerprint(installation_id, secret_key)
+    fingerprint = _webreader_fingerprint(user_id, installation_id, secret_key)
     if not fingerprint:
         return None
     identity = session.query(ub.DeviceIdentity).filter_by(
@@ -163,11 +244,21 @@ def upsert_webreader_device(session, *, user_id, installation_id, secret_key, se
         fingerprint=fingerprint,
     ).first()
     if identity and identity.device.user_id != user_id:
-        log.warning("Ignoring web-reader device identity already bound to another user")
+        # Defensive only: v2 fingerprints are user-domain-separated.
+        log.warning("Ignoring web-reader device identity with inconsistent ownership")
         return None
 
     now = seen_at or datetime.now(timezone.utc)
+    if identity is not None and not identity.device.active:
+        # Device deletion is explicit in the management UI. Do not silently
+        # undo it; the write uses the legacy bucket until the user restores the
+        # browser, at which point this identity resolves normally again.
+        return None
+
     if identity is None:
+        if _webreader_identity_count(session, ub, user_id=user_id) >= MAX_WEBREADER_DEVICES_PER_USER:
+            _log_webreader_cap_once(user_id)
+            return None
         device = ub.Device(
             user_id=user_id,
             kind="webreader",
@@ -228,37 +319,14 @@ def ensure_webreader_device_best_effort(*, user_id, installation_id=None,
                 installation_id=installation_id,
                 secret_key=key,
             )
-        else:
-            # A legacy bucket is specifically a web-reader Device without the
-            # new cookie identity. Once per-browser rows exist, the old broad
-            # query would otherwise select one of them as the fallback.
-            device = (
-                owned.query(ub.Device)
-                .filter_by(user_id=user_id, kind="webreader", created_by="auto")
-                .filter(~ub.Device.identities.any(
-                    ub.DeviceIdentity.scheme == WEBREADER_SCHEME,
-                ))
-                .order_by(ub.Device.id.asc())
-                .first()
-            )
             if device is None:
-                now = datetime.now(timezone.utc)
-                device = ub.Device(
-                    user_id=user_id,
-                    kind="webreader",
-                    display_name=_deduplicated_label(
-                        owned, ub, user_id=user_id, base="Web reader",
-                    ),
-                    model="CWNG web reader",
-                    platform="epub.js",
-                    first_seen_at=now,
-                    last_seen_at=now,
-                    last_metadata_at=now,
-                    active=True,
-                    created_by="auto",
+                device = _ensure_legacy_webreader_device(
+                    owned, ub, user_id=user_id,
                 )
-                owned.add(device)
-                owned.flush()
+        else:
+            device = _ensure_legacy_webreader_device(
+                owned, ub, user_id=user_id,
+            )
         if device is None:
             return None
         device_id = device.id

--- a/cps/services/device_registry.py
+++ b/cps/services/device_registry.py
@@ -15,6 +15,8 @@ from sqlalchemy.orm import sessionmaker
 log = logging.getLogger(__name__)
 SCHEME = "kobo-header-hmac-sha256-v1"
 KOREADER_SCHEME = "koreader-client-hmac-sha256-v1"
+WEBREADER_SCHEME = "webreader-cookie-hmac-sha256-v1"
+WEBREADER_INSTALLATION_ID_HEADER = "X-CWNG-Webreader-Installation-Id"
 LAST_SEEN_WRITE_INTERVAL = timedelta(minutes=5)
 
 
@@ -43,6 +45,15 @@ def _opaque_fingerprint(raw_id, secret_key, *, namespace):
     if not raw_id or not key:
         return None
     return hmac.new(key, namespace + b"\0" + raw_id.encode(), hashlib.sha256).hexdigest()
+
+
+def _webreader_fingerprint(installation_id, secret_key):
+    """Key a browser-held installation id without retaining the raw value."""
+    return _opaque_fingerprint(
+        installation_id,
+        secret_key,
+        namespace=b"cwng-device:webreader:v1",
+    )
 
 
 def _deduplicated_label(session, ub, *, user_id, base):
@@ -139,27 +150,120 @@ def register_kobo_device_best_effort(*, user_id, headers, secret_key=None, retur
                 pass
 
 
-def ensure_webreader_device_best_effort(*, user_id):
-    """Return the logical web-reader device id without risking the save session."""
+def upsert_webreader_device(session, *, user_id, installation_id, secret_key, seen_at=None):
+    """Resolve one browser installation to one Device without storing its id."""
+    from cps import ub
+
+    fingerprint = _webreader_fingerprint(installation_id, secret_key)
+    if not fingerprint:
+        return None
+    identity = session.query(ub.DeviceIdentity).filter_by(
+        scheme=WEBREADER_SCHEME,
+        key_version=1,
+        fingerprint=fingerprint,
+    ).first()
+    if identity and identity.device.user_id != user_id:
+        log.warning("Ignoring web-reader device identity already bound to another user")
+        return None
+
+    now = seen_at or datetime.now(timezone.utc)
+    if identity is None:
+        device = ub.Device(
+            user_id=user_id,
+            kind="webreader",
+            display_name=_deduplicated_label(
+                session, ub, user_id=user_id, base="Web reader",
+            ),
+            model="CWNG web reader",
+            platform="epub.js",
+            first_seen_at=now,
+            last_seen_at=now,
+            last_metadata_at=now,
+            active=True,
+            created_by="auto",
+        )
+        identity = ub.DeviceIdentity(
+            device=device,
+            scheme=WEBREADER_SCHEME,
+            key_version=1,
+            fingerprint=fingerprint,
+            first_seen_at=now,
+            last_seen_at=now,
+        )
+        session.add(device)
+    else:
+        device = identity.device
+        observed_is_newer = (
+            device.last_seen_at is None
+            or now >= device.last_seen_at.replace(tzinfo=now.tzinfo)
+        )
+        last_seen_due = (
+            device.last_seen_at is None
+            or now - device.last_seen_at.replace(tzinfo=now.tzinfo)
+            >= LAST_SEEN_WRITE_INTERVAL
+        )
+        # Browser position writes can arrive every 800ms. Keep the identity
+        # observation read-only until the same coarse heartbeat Kobo uses is
+        # due, so those saves do not add another SQLite writer-lock contender.
+        if observed_is_newer and last_seen_due:
+            device.last_seen_at = now
+            identity.last_seen_at = now
+    session.flush()
+    return device
+
+
+def ensure_webreader_device_best_effort(*, user_id, installation_id=None,
+                                        secret_key=None):
+    """Return a per-browser device id, or the historical singleton fallback."""
     owned = None
     try:
+        from flask import current_app
         from cps import ub
+        key = secret_key if secret_key is not None else current_app.secret_key
         owned = sessionmaker(bind=ub.session.get_bind())()
-        device = owned.query(ub.Device).filter_by(
-            user_id=user_id, kind="webreader", created_by="auto",
-        ).order_by(ub.Device.id.asc()).first()
-        if device is None:
-            now = datetime.now(timezone.utc)
-            device = ub.Device(
-                user_id=user_id, kind="webreader",
-                display_name=_deduplicated_label(owned, ub, user_id=user_id, base="Web reader"),
-                model="CWNG web reader", platform="epub.js",
-                first_seen_at=now, last_seen_at=now, last_metadata_at=now,
-                active=True, created_by="auto",
+        if installation_id:
+            device = upsert_webreader_device(
+                owned,
+                user_id=user_id,
+                installation_id=installation_id,
+                secret_key=key,
             )
-            owned.add(device)
+        else:
+            # A legacy bucket is specifically a web-reader Device without the
+            # new cookie identity. Once per-browser rows exist, the old broad
+            # query would otherwise select one of them as the fallback.
+            device = (
+                owned.query(ub.Device)
+                .filter_by(user_id=user_id, kind="webreader", created_by="auto")
+                .filter(~ub.Device.identities.any(
+                    ub.DeviceIdentity.scheme == WEBREADER_SCHEME,
+                ))
+                .order_by(ub.Device.id.asc())
+                .first()
+            )
+            if device is None:
+                now = datetime.now(timezone.utc)
+                device = ub.Device(
+                    user_id=user_id,
+                    kind="webreader",
+                    display_name=_deduplicated_label(
+                        owned, ub, user_id=user_id, base="Web reader",
+                    ),
+                    model="CWNG web reader",
+                    platform="epub.js",
+                    first_seen_at=now,
+                    last_seen_at=now,
+                    last_metadata_at=now,
+                    active=True,
+                    created_by="auto",
+                )
+                owned.add(device)
+                owned.flush()
+        if device is None:
+            return None
+        device_id = device.id
         owned.commit()
-        return device.id
+        return device_id
     except Exception:
         if owned is not None:
             try:

--- a/cps/services/reading_position.py
+++ b/cps/services/reading_position.py
@@ -85,11 +85,14 @@ def coerce_percentage(raw) -> Optional[float]:
     return value
 
 
-def record_web_reader_progress(user, book_id: int, percentage: float) -> bool:
+def record_web_reader_progress(user, book_id: int, percentage: float,
+                               *, origin_device_id=None) -> bool:
     """Advance the shared progress carrier from a web-reader position.
 
     Returns ``True`` when the carrier was advanced.  The caller is responsible
-    for committing the session — both bookmark routes already do.
+    for committing the session — both bookmark routes already do. M1 carries
+    ``origin_device_id`` through this write boundary; M3 adds the per-device
+    position row that can persist it without changing the resolved carrier.
 
     Skipped without a write when:
       * ``percentage`` is not a positive number.  A 0% sample is what the
@@ -104,6 +107,28 @@ def record_web_reader_progress(user, book_id: int, percentage: float) -> bool:
         user_id = int(user.id)
     except (AttributeError, TypeError, ValueError):
         return False
+
+    # Direct service callers inside a browser request get the same identity as
+    # both routes. Non-request unit callers deliberately stay side-effect free.
+    if origin_device_id is None:
+        try:
+            from flask import g, has_request_context, request
+            if has_request_context():
+                from .device_registry import (
+                    WEBREADER_INSTALLATION_ID_HEADER,
+                    ensure_webreader_device_best_effort,
+                )
+                origin_device_id = getattr(g, "annotation_origin_device_id", None)
+                if origin_device_id is None:
+                    origin_device_id = ensure_webreader_device_best_effort(
+                        user_id=user_id,
+                        installation_id=request.headers.get(
+                            WEBREADER_INSTALLATION_ID_HEADER,
+                        ),
+                    )
+                    g.annotation_origin_device_id = origin_device_id
+        except Exception:
+            log.warning("Best-effort web-reader device observation failed", exc_info=True)
 
     # ``ub.session`` is a single long-lived Session shared across requests
     # (``init_db`` builds it once), so a plain query can answer from the identity

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -1311,6 +1311,7 @@ class Annotation(Base):
     __table_args__ = (
         Index('ix_annotation_user_annotation', 'user_id', 'annotation_id'),
         Index('ix_annotation_user_book', 'user_id', 'book_id'),
+        Index('ix_annotation_user_book_origin', 'user_id', 'book_id', 'origin_device_id'),
         UniqueConstraint(
             'user_id', 'book_id', 'annotation_id',
             name='uq_annotation_user_book_annotation',
@@ -3641,6 +3642,19 @@ def migrate_device_management_slice(engine, _session):
         ))
 
 
+def migrate_webreader_device_identity_slice(engine, _session):
+    """Add the M1 composite origin lookup without loading ORM rows."""
+    with engine.begin() as conn:
+        if not conn.execute(text(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='annotation'"
+        )).first():
+            return
+        conn.execute(text(
+            "CREATE INDEX IF NOT EXISTS ix_annotation_user_book_origin "
+            "ON annotation(user_id, book_id, origin_device_id)"
+        ))
+
+
 _KOBO_TWO_WAY_TABLES = (
     KoboAnnotationMaterialization.__table__,
     KoboAnnotationBookState.__table__,
@@ -4321,6 +4335,7 @@ def migrate_Database(_session):
     migrate_annotation_koreader_identity(engine, _session)
     migrate_multi_device_annotation_safe_slice(engine, _session)
     migrate_device_management_slice(engine, _session)
+    migrate_webreader_device_identity_slice(engine, _session)
     migrate_kobo_two_way_annotation_sync(engine, _session)
     migrate_book_cover_preview_table(engine, _session)
     migrate_notice_tables(engine, _session)

--- a/cps/web.py
+++ b/cps/web.py
@@ -275,6 +275,18 @@ def get_email_status_json():
 @web.route("/ajax/bookmark/<int:book_id>/<book_format>", methods=['POST'])
 @user_login_required
 def set_bookmark(book_id, book_format):
+    try:
+        from .services.device_registry import (
+            WEBREADER_INSTALLATION_ID_HEADER,
+            ensure_webreader_device_best_effort,
+        )
+        g.annotation_origin_device_id = ensure_webreader_device_best_effort(
+            user_id=current_user.id,
+            installation_id=request.headers.get(WEBREADER_INSTALLATION_ID_HEADER),
+        )
+    except Exception:
+        log.warning("Best-effort web-reader device observation failed", exc_info=True)
+        g.annotation_origin_device_id = None
     book_format = (book_format or "").lower()
     bookmark_key = request.form["bookmark"]
     ub.session.query(ub.Bookmark).filter(and_(ub.Bookmark.user_id == int(current_user.id),
@@ -308,7 +320,12 @@ def set_bookmark(book_id, book_format):
     percentage = reading_position.coerce_percentage(request.form.get("percentage"))
     if percentage is not None:
         try:
-            reading_position.record_web_reader_progress(current_user, book_id, percentage)
+            reading_position.record_web_reader_progress(
+                current_user,
+                book_id,
+                percentage,
+                origin_device_id=g.annotation_origin_device_id,
+            )
         except Exception as e:
             # Position sharing must never cost the user their bookmark.
             log.warning("Could not share web reader progress for book %s: %s", book_id, e)

--- a/frontend/e2e/annotation-origin-real.spec.ts
+++ b/frontend/e2e/annotation-origin-real.spec.ts
@@ -6,64 +6,97 @@ import { expect, test } from '@playwright/test';
  * soft-deletes its own row. It exists specifically because route.fulfill()
  * cannot prove an origin producer is wired.
  */
-test('real web-reader create persists a non-null origin device', async ({ page }) => {
+test('two real browser contexts persist separate non-null origin devices', async ({ browser, page }) => {
+  const storageState = await page.context().storageState();
+  const installationHeader = 'X-CWNG-Webreader-Installation-Id';
+  const firstContext = await browser.newContext({
+    storageState,
+    extraHTTPHeaders: {
+      [installationHeader]: '19420000-0000-4000-8000-000000000001',
+    },
+  });
+  const secondContext = await browser.newContext({
+    storageState,
+    extraHTTPHeaders: {
+      [installationHeader]: '19420000-0000-4000-8000-000000000002',
+    },
+  });
+  const firstRequest = firstContext.request;
+  const secondRequest = secondContext.request;
   // Ask the library which books exist rather than naming one. A hardcoded id
   // passed against a dev container carrying hundreds of books and 404'd in CI,
   // whose seed is three — the probe was coupled to one machine's data, which is
   // the opposite of what an unstubbed integration test is for.
-  const catalog = await page.request.get('/api/v1/books?per_page=1');
+  const catalog = await firstRequest.get('/api/v1/books?per_page=1');
   expect(catalog.ok()).toBeTruthy();
   const items = (await catalog.json() as { items?: { id: number }[] }).items ?? [];
   expect(items.length, 'library seed must contain at least one book').toBeGreaterThan(0);
   const bookId = items[0].id;
   const marker = `origin-e2e-${Date.now()}`;
-  const csrfResponse = await page.request.get('/api/v1/auth/csrf');
-  expect(csrfResponse.ok()).toBeTruthy();
-  const { csrf_token: csrf } = await csrfResponse.json() as { csrf_token: string };
-  let annotationId: string | undefined;
+  const [firstCsrfResponse, secondCsrfResponse] = await Promise.all([
+    firstRequest.get('/api/v1/auth/csrf'),
+    secondRequest.get('/api/v1/auth/csrf'),
+  ]);
+  expect(firstCsrfResponse.ok()).toBeTruthy();
+  expect(secondCsrfResponse.ok()).toBeTruthy();
+  const { csrf_token: firstCsrf } = await firstCsrfResponse.json() as { csrf_token: string };
+  const { csrf_token: secondCsrf } = await secondCsrfResponse.json() as { csrf_token: string };
+  const createdIds: { request: typeof firstRequest; csrf: string; id: string }[] = [];
 
   try {
-    const created = await page.request.post(`/annotations/${bookId}`, {
-      headers: { 'X-CSRFToken': csrf },
-      data: {
-        cfi_range: 'epubcfi(/6/4!/4/2,/1:0,/1:9)',
-        highlighted_text: marker,
-        highlight_color: 'yellow',
-      },
-    });
-    expect(created.status()).toBe(201);
-    const createdBody = await created.json() as { annotation_id: string };
-    annotationId = createdBody.annotation_id;
+    for (const [index, requestContext, csrf] of [
+      [1, firstRequest, firstCsrf],
+      [2, secondRequest, secondCsrf],
+    ] as const) {
+      const created = await requestContext.post(`/annotations/${bookId}`, {
+        headers: { 'X-CSRFToken': csrf },
+        data: {
+          cfi_range: 'epubcfi(/6/4!/4/2,/1:0,/1:9)',
+          highlighted_text: `${marker}-${index}`,
+          highlight_color: 'yellow',
+        },
+      });
+      expect(created.status()).toBe(201);
+      const createdBody = await created.json() as { annotation_id: string };
+      createdIds.push({ request: requestContext, csrf, id: createdBody.annotation_id });
+    }
 
-    const listed = await page.request.get(`/annotations/${bookId}/data.json`);
+    const listed = await firstRequest.get(`/annotations/${bookId}/data.json`);
     expect(listed.ok()).toBeTruthy();
     const payload = await listed.json() as {
       annotations: { annotation_id: string; origin_device_id: string | null }[];
       devices: Record<string, { label: string; type: string }>;
     };
-    // The PR e2e lane takes the API from :dev and overlays only this PR's SPA
-    // bundle (see .github/workflows/tests.yml). So on a PR this probe is aimed
-    // at main's backend, which has no devices envelope, and it cannot pass here
-    // by construction. Skip loudly rather than assert against the wrong server
-    // or, worse, let a null-ish assertion pass on an absent field.
+    const deviceListResponse = await firstRequest.get('/api/annotations/devices');
+    const deviceList = await deviceListResponse.json() as {
+      devices?: { kind?: string }[];
+    };
+    // The PR e2e lane overlays this branch's SPA on :dev's backend. `kind` was
+    // added with the M1 backend, so its absence proves this probe is aimed at
+    // the old server and cannot test per-browser resolution there.
     test.skip(
-      payload.devices === undefined,
-      'API has no devices envelope — this lane runs :dev\'s backend, not this branch. '
+      payload.devices === undefined || !deviceList.devices?.some((device) => device.kind),
+      'API has no M1 device-kind field — this lane runs :dev\'s backend, not this branch. '
       + 'The origin producer is covered by tests/unit/test_annotation_route_device_resolution.py '
       + 'and by running this spec against a container built from this branch.',
     );
 
-    const row = payload.annotations.find((annotation) => annotation.annotation_id === annotationId);
-    expect(row, 'the real data.json must return the row just created').toBeDefined();
-    // toBeNull() passes on undefined, which is how an absent field slipped
-    // through as "not null". Require an actual value.
-    expect(row!.origin_device_id, 'origin must be populated, not absent').toBeTruthy();
-    expect(payload.devices[row!.origin_device_id!]?.type).toBe('webreader');
-  } finally {
-    if (annotationId) {
-      await page.request.delete(`/annotations/${bookId}/${encodeURIComponent(annotationId)}`, {
-        headers: { 'X-CSRFToken': csrf },
-      });
+    const rows = createdIds.map(({ id }) =>
+      payload.annotations.find((annotation) => annotation.annotation_id === id));
+    expect(rows.every(Boolean), 'the real data.json must return both created rows').toBeTruthy();
+    for (const row of rows) {
+      // toBeNull() passes on undefined, which is how an absent field slipped
+      // through as "not null". Require an actual value.
+      expect(row!.origin_device_id, 'origin must be populated, not absent').toBeTruthy();
+      expect(payload.devices[row!.origin_device_id!]?.type).toBe('webreader');
     }
+    expect(rows[0]!.origin_device_id).not.toBe(rows[1]!.origin_device_id);
+  } finally {
+    await Promise.all(createdIds.map(({ request: requestContext, csrf, id }) =>
+      requestContext.delete(`/annotations/${bookId}/${encodeURIComponent(id)}`, {
+        headers: { 'X-CSRFToken': csrf },
+      })));
+    await firstContext.close();
+    await secondContext.close();
   }
 });

--- a/frontend/e2e/theme.spec.ts
+++ b/frontend/e2e/theme.spec.ts
@@ -1,4 +1,6 @@
 import { expect, test } from '@playwright/test';
+import { webreaderInstallationId } from '../src/lib/deviceIdentity';
+import { safeLocalStorageGet, safeLocalStorageSet } from '../src/lib/safeStorage';
 import { DEFAULT_THEME, resolveTheme } from '../src/lib/themes';
 
 test.describe('theme logic', () => {
@@ -8,6 +10,28 @@ test.describe('theme logic', () => {
     expect(resolveTheme('system')).toBe('dark'); // Node has no matchMedia.
     expect(resolveTheme(undefined)).toBe(DEFAULT_THEME);
     expect(resolveTheme('not-a-theme')).toBe(DEFAULT_THEME);
+  });
+
+  test('storage SecurityError degrades reader preferences and identity safely', () => {
+    const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: {
+        crypto: { randomUUID: () => '55555555-5555-4555-8555-555555555555' },
+        localStorage: {
+          getItem: () => { throw new DOMException('Storage disabled', 'SecurityError'); },
+          setItem: () => { throw new DOMException('Storage disabled', 'SecurityError'); },
+        },
+      },
+    });
+    try {
+      expect(safeLocalStorageGet('cwng.reader.theme')).toBeNull();
+      expect(safeLocalStorageSet('cwng.reader.font', '100')).toBe(false);
+      expect(webreaderInstallationId()).toBeNull();
+    } finally {
+      if (originalWindow) Object.defineProperty(globalThis, 'window', originalWindow);
+      else delete (globalThis as { window?: unknown }).window;
+    }
   });
 });
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,5 +1,7 @@
 /* Typed fetch helpers — same-origin, credentials included. */
 
+import { webreaderDeviceHeaders } from './deviceIdentity';
+
 declare global {
   interface Window { __CWNG_PREFIX__?: string; }
 }
@@ -563,6 +565,8 @@ export function navigateToLogout(): void {
 
 export interface ApiRequestOptions {
   auth?: 'protected' | 'public';
+  /** Attribute a reading-data mutation to this browser installation. */
+  webreaderDevice?: boolean;
 }
 
 function isProtected(options?: ApiRequestOptions): boolean {
@@ -745,11 +749,14 @@ export async function apiPost<T>(
   requestOptions?: Pick<RequestInit, 'keepalive'> & ApiRequestOptions,
 ): Promise<T> {
   const doPost = async (csrf: string): Promise<Response> => {
-    const { auth: _auth, ...fetchOptions } = requestOptions ?? {};
+    const { auth: _auth, webreaderDevice: _device, ...fetchOptions } = requestOptions ?? {};
     return classifiedFetch(path, {
       method: 'POST',
       credentials: 'include',
-      headers: {
+      headers: requestOptions?.webreaderDevice ? webreaderDeviceHeaders({
+        'Content-Type': 'application/json',
+        'X-CSRFToken': csrf,
+      }) : {
         'Content-Type': 'application/json',
         'X-CSRFToken': csrf,
       },
@@ -822,7 +829,9 @@ export async function apiDelete<T>(path: string, options?: ApiRequestOptions): P
     classifiedFetch(path, {
       method: 'DELETE',
       credentials: 'include',
-      headers: { 'X-CSRFToken': csrf },
+      headers: options?.webreaderDevice
+        ? webreaderDeviceHeaders({ 'X-CSRFToken': csrf })
+        : { 'X-CSRFToken': csrf },
     }, options);
 
   let csrf = await getCsrf(options);
@@ -860,7 +869,10 @@ export async function apiPatch<T>(path: string, body?: unknown, options?: ApiReq
     classifiedFetch(path, {
       method: 'PATCH',
       credentials: 'include',
-      headers: {
+      headers: options?.webreaderDevice ? webreaderDeviceHeaders({
+        'Content-Type': 'application/json',
+        'X-CSRFToken': csrf,
+      }) : {
         'Content-Type': 'application/json',
         'X-CSRFToken': csrf,
       },

--- a/frontend/src/lib/deviceIdentity.ts
+++ b/frontend/src/lib/deviceIdentity.ts
@@ -1,0 +1,35 @@
+/** Browser-local identity for reading-data attribution (#1942 M1).
+ *
+ * The opaque installation id never appears in an API response and the server
+ * stores only its keyed HMAC. If storage or randomUUID is unavailable, callers
+ * omit the header and the server deliberately uses the legacy web-reader
+ * bucket instead.
+ */
+
+export const WEBREADER_INSTALLATION_STORAGE_KEY = 'cwng.webreader.installation-id.v1';
+export const WEBREADER_INSTALLATION_HEADER = 'X-CWNG-Webreader-Installation-Id';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function webreaderInstallationId(): string | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const stored = window.localStorage.getItem(WEBREADER_INSTALLATION_STORAGE_KEY);
+    if (stored && UUID_RE.test(stored)) return stored;
+    if (typeof window.crypto?.randomUUID !== 'function') return null;
+    const minted = window.crypto.randomUUID();
+    window.localStorage.setItem(WEBREADER_INSTALLATION_STORAGE_KEY, minted);
+    return minted;
+  } catch {
+    // Storage can be denied in hardened/private contexts. Falling back is part
+    // of the server contract and must not prevent the reading-data write.
+    return null;
+  }
+}
+
+export function webreaderDeviceHeaders(base?: HeadersInit): Headers {
+  const headers = new Headers(base);
+  const installationId = webreaderInstallationId();
+  if (installationId) headers.set(WEBREADER_INSTALLATION_HEADER, installationId);
+  return headers;
+}

--- a/frontend/src/lib/deviceIdentity.ts
+++ b/frontend/src/lib/deviceIdentity.ts
@@ -6,6 +6,8 @@
  * bucket instead.
  */
 
+import { safeLocalStorageGet, safeLocalStorageSet } from './safeStorage';
+
 export const WEBREADER_INSTALLATION_STORAGE_KEY = 'cwng.webreader.installation-id.v1';
 export const WEBREADER_INSTALLATION_HEADER = 'X-CWNG-Webreader-Installation-Id';
 
@@ -14,12 +16,11 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f
 export function webreaderInstallationId(): string | null {
   if (typeof window === 'undefined') return null;
   try {
-    const stored = window.localStorage.getItem(WEBREADER_INSTALLATION_STORAGE_KEY);
+    const stored = safeLocalStorageGet(WEBREADER_INSTALLATION_STORAGE_KEY);
     if (stored && UUID_RE.test(stored)) return stored;
     if (typeof window.crypto?.randomUUID !== 'function') return null;
     const minted = window.crypto.randomUUID();
-    window.localStorage.setItem(WEBREADER_INSTALLATION_STORAGE_KEY, minted);
-    return minted;
+    return safeLocalStorageSet(WEBREADER_INSTALLATION_STORAGE_KEY, minted) ? minted : null;
   } catch {
     // Storage can be denied in hardened/private contexts. Falling back is part
     // of the server contract and must not prevent the reading-data write.

--- a/frontend/src/lib/queries.ts
+++ b/frontend/src/lib/queries.ts
@@ -1132,7 +1132,7 @@ export function useSaveBookmark(bookId: string | number) {
     // it to the shared Kobo/KOReader carrier so browser reading reaches the
     // user's devices. Omitted until epub.js has generated locations.
     mutationFn: (vars: { format: string; bookmark: string; percentage?: number }) =>
-      apiPost(`/api/v1/books/${bookId}/bookmark`, vars),
+      apiPost(`/api/v1/books/${bookId}/bookmark`, vars, { webreaderDevice: true }),
     // #1318: deliberately NO react-query `retry` here. The route now answers
     // 5xx when the write did not land, which is worth re-sending — but a
     // built-in retry re-sends the SAME variables, and the reader fires a save

--- a/frontend/src/lib/safeStorage.ts
+++ b/frontend/src/lib/safeStorage.ts
@@ -1,0 +1,21 @@
+/** Best-effort browser storage access for environments that expose
+ * localStorage but throw SecurityError when it is touched. */
+
+export function safeLocalStorageGet(key: string): string | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+export function safeLocalStorageSet(key: string, value: string): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    window.localStorage.setItem(key, value);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/frontend/src/pages/Reader.tsx
+++ b/frontend/src/pages/Reader.tsx
@@ -21,6 +21,7 @@ import {
   DEFAULT_HIT_CAP, MIN_QUERY_LENGTH, searchBook, type SearchHit,
 } from '../lib/reader/searchBook';
 import { chapterLabelForHref, splitSearchExcerpt } from '../lib/reader/searchUi';
+import { safeLocalStorageGet, safeLocalStorageSet } from '../lib/safeStorage';
 import styles from './Reader.module.css';
 
 // Highlight colors as ARIA/label keys (SC 1.4.1: a color must never be conveyed
@@ -171,7 +172,7 @@ const FONT_FAMILY: Record<ReaderSettings['font'], string> = {
 };
 
 function loadTheme(): ReaderTheme {
-  const v = localStorage.getItem(LS_THEME);
+  const v = safeLocalStorageGet(LS_THEME);
   if (v === 'light' || v === 'sepia' || v === 'dark' || v === 'black') return v;
   // First reader visit follows the already-resolved per-user app palette.
   // Thereafter the reader's explicit page-theme choice remains independent.
@@ -181,7 +182,7 @@ function loadTheme(): ReaderTheme {
   return 'dark';
 }
 function loadFont(): number {
-  const v = Number(localStorage.getItem(LS_FONT));
+  const v = Number(safeLocalStorageGet(LS_FONT));
   return v >= FONT_MIN && v <= FONT_MAX ? v : 100;
 }
 
@@ -1149,11 +1150,11 @@ export function Reader({ id }: { id: string }) {
   // Apply theme / font changes to a live rendition without rebuilding it, and
   // remember the preference across sessions.
   useEffect(() => {
-    localStorage.setItem(LS_THEME, theme);
+    safeLocalStorageSet(LS_THEME, theme);
     applyTheme(theme);
   }, [theme, applyTheme]);
   useEffect(() => {
-    localStorage.setItem(LS_FONT, String(fontPct));
+    safeLocalStorageSet(LS_FONT, String(fontPct));
     applyTypography();
   }, [fontPct, fontFamily, margin, lineHeight, applyTypography]);
 

--- a/frontend/src/pages/Reader.tsx
+++ b/frontend/src/pages/Reader.tsx
@@ -558,7 +558,7 @@ export function Reader({ id }: { id: string }) {
       const created = await apiPost<Partial<AnnRow>>(`/annotations/${id}`, {
         cfi_range: cfiRange, highlighted_text: text, highlight_color: color,
         ...(note ? { note_text: note } : {}),
-      });
+      }, { webreaderDevice: true });
       const newId = created?.annotation_id ?? '';
       if (note && newId) notesRef.current.set(newId, note);
       setAnnList((rows) => [...rows, {
@@ -640,7 +640,7 @@ export function Reader({ id }: { id: string }) {
       try {
         const created = await apiPost<Partial<AnnRow>>(`/annotations/${id}`, {
           position_type: 'unanchored', note_text: note,
-        });
+        }, { webreaderDevice: true });
         setAnnList((rows) => [...rows, {
           annotation_id: created?.annotation_id ?? '',
           cfi_range: null,
@@ -661,7 +661,8 @@ export function Reader({ id }: { id: string }) {
     }
     if (!c.annotationId) return;
     try {
-      await apiPatch(`/annotations/${id}/${c.annotationId}`, { note_text: note });
+      await apiPatch(`/annotations/${id}/${c.annotationId}`, { note_text: note },
+        { webreaderDevice: true });
       if (note) notesRef.current.set(c.annotationId, note);
       else notesRef.current.delete(c.annotationId);
       setAnnList((rows) => rows.map((r) =>
@@ -774,7 +775,7 @@ export function Reader({ id }: { id: string }) {
     if (!hl) return;
     setActiveHl(null);
     try {
-      await apiDelete(`/annotations/${id}/${hl.id}`);
+      await apiDelete(`/annotations/${id}/${hl.id}`, { webreaderDevice: true });
       notesRef.current.delete(hl.id);
       setAnnList((rows) => rows.filter((r) => r.annotation_id !== hl.id));
       try { renditionRef.current?.annotations?.remove(hl.cfiRange, 'highlight'); } catch { /* noop */ }
@@ -791,7 +792,8 @@ export function Reader({ id }: { id: string }) {
     setActiveHl(null);
     if (hl.color === color) return;
     try {
-      await apiPatch(`/annotations/${id}/${hl.id}`, { highlight_color: color });
+      await apiPatch(`/annotations/${id}/${hl.id}`, { highlight_color: color },
+        { webreaderDevice: true });
       setAnnList((rows) => rows.map((r) =>
         r.annotation_id === hl.id ? { ...r, highlight_color: color } : r));
       // Recolouring must not silently drop the note marker.
@@ -1131,7 +1133,7 @@ export function Reader({ id }: { id: string }) {
             `/api/v1/books/${id}/bookmark`,
             pct != null ? { format: 'epub', bookmark: cfi, percentage: pct }
                         : { format: 'epub', bookmark: cfi },
-            { keepalive: true },
+            { keepalive: true, webreaderDevice: true },
           );
         }
       }

--- a/tests/unit/test_1942_webreader_device_identity.py
+++ b/tests/unit/test_1942_webreader_device_identity.py
@@ -1,0 +1,165 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""#1942 M1: a browser installation is a private, first-class Device."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+from datetime import datetime, timedelta, timezone
+
+import flask
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+
+INSTALLATION_A = "11111111-1111-4111-8111-111111111111"
+INSTALLATION_B = "22222222-2222-4222-8222-222222222222"
+
+
+@pytest.fixture
+def registry(tmp_path):
+    from cps import ub
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'app.db'}", future=True)
+    ub.Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine, future=True)()
+    original = ub.session
+    ub.session = session
+    app = flask.Flask(__name__)
+    app.secret_key = "issue-1942-test-secret"
+    try:
+        with app.app_context():
+            yield session
+    finally:
+        session.close()
+        ub.session = original
+        engine.dispose()
+
+
+def test_webreader_hmac_is_exact_and_deterministic():
+    from cps.services.device_registry import _webreader_fingerprint
+
+    secret = b"deterministic-secret"
+    expected = hmac.new(
+        secret,
+        b"cwng-device:webreader:v1\0" + INSTALLATION_A.encode(),
+        hashlib.sha256,
+    ).hexdigest()
+    assert _webreader_fingerprint(INSTALLATION_A, secret) == expected
+    assert _webreader_fingerprint(INSTALLATION_A, secret) == expected
+    assert _webreader_fingerprint(INSTALLATION_B, secret) != expected
+    assert _webreader_fingerprint(INSTALLATION_A, b"another-secret") != expected
+
+
+def test_installation_creates_device_identity_without_storing_raw_id(registry):
+    from cps import ub
+    from cps.services.device_registry import (
+        WEBREADER_SCHEME,
+        ensure_webreader_device_best_effort,
+    )
+
+    device_id = ensure_webreader_device_best_effort(
+        user_id=7,
+        installation_id=INSTALLATION_A,
+    )
+    registry.expire_all()
+    device = registry.query(ub.Device).filter_by(id=device_id).one()
+    identity = registry.query(ub.DeviceIdentity).filter_by(device_id=device_id).one()
+
+    assert device.kind == "webreader"
+    assert device.created_by == "auto"
+    assert device.display_name == "Web reader"
+    assert identity.scheme == WEBREADER_SCHEME
+    assert identity.key_version == 1
+    assert len(identity.fingerprint) == 64
+    stored_values = (
+        device.public_id,
+        device.display_name,
+        device.model,
+        device.platform,
+        identity.scheme,
+        identity.fingerprint,
+    )
+    assert all(INSTALLATION_A not in (value or "") for value in stored_values)
+
+
+def test_same_installation_is_stable_and_two_browsers_are_separate(registry):
+    from cps import ub
+    from cps.services.device_registry import ensure_webreader_device_best_effort
+
+    first = ensure_webreader_device_best_effort(user_id=7, installation_id=INSTALLATION_A)
+    first_again = ensure_webreader_device_best_effort(user_id=7, installation_id=INSTALLATION_A)
+    second = ensure_webreader_device_best_effort(user_id=7, installation_id=INSTALLATION_B)
+
+    assert first_again == first
+    assert second != first
+    devices = registry.query(ub.Device).filter_by(user_id=7, kind="webreader").all()
+    assert {device.id for device in devices} == {first, second}
+    assert {device.display_name for device in devices} == {"Web reader", "Web reader 2"}
+    assert registry.query(ub.DeviceIdentity).count() == 2
+
+
+def test_missing_installation_id_keeps_a_distinct_legacy_singleton(registry):
+    from cps import ub
+    from cps.services.device_registry import ensure_webreader_device_best_effort
+
+    browser = ensure_webreader_device_best_effort(user_id=7, installation_id=INSTALLATION_A)
+    legacy = ensure_webreader_device_best_effort(user_id=7)
+    legacy_again = ensure_webreader_device_best_effort(user_id=7, installation_id=None)
+
+    assert legacy_again == legacy
+    assert legacy != browser
+    assert registry.query(ub.DeviceIdentity).filter_by(device_id=legacy).count() == 0
+    assert registry.query(ub.Device).filter_by(user_id=7, kind="webreader").count() == 2
+
+
+def test_repeated_position_observations_throttle_last_seen_writes(registry):
+    from cps.services.device_registry import upsert_webreader_device
+
+    first_seen = datetime(2026, 8, 28, 12, 0, tzinfo=timezone.utc)
+    device = upsert_webreader_device(
+        registry,
+        user_id=7,
+        installation_id=INSTALLATION_A,
+        secret_key="issue-1942-test-secret",
+        seen_at=first_seen,
+    )
+    registry.commit()
+    upsert_webreader_device(
+        registry,
+        user_id=7,
+        installation_id=INSTALLATION_A,
+        secret_key="issue-1942-test-secret",
+        seen_at=first_seen + timedelta(seconds=1),
+    )
+    assert device.last_seen_at.replace(tzinfo=timezone.utc) == first_seen
+    assert not registry.dirty
+
+    upsert_webreader_device(
+        registry,
+        user_id=7,
+        installation_id=INSTALLATION_A,
+        secret_key="issue-1942-test-secret",
+        seen_at=first_seen + timedelta(minutes=5),
+    )
+    assert device.last_seen_at.replace(tzinfo=timezone.utc) == first_seen + timedelta(minutes=5)
+
+
+def test_origin_index_migration_is_additive_and_idempotent():
+    from cps import ub
+
+    engine = create_engine("sqlite:///:memory:", future=True)
+    with engine.begin() as conn:
+        conn.execute(text(
+            "CREATE TABLE annotation ("
+            "id INTEGER PRIMARY KEY, user_id INTEGER, book_id INTEGER, "
+            "origin_device_id INTEGER)"
+        ))
+    ub.migrate_webreader_device_identity_slice(engine, None)
+    ub.migrate_webreader_device_identity_slice(engine, None)
+    with engine.connect() as conn:
+        indexes = {row[1] for row in conn.execute(text("PRAGMA index_list(annotation)"))}
+    assert "ix_annotation_user_book_origin" in indexes

--- a/tests/unit/test_1942_webreader_device_identity.py
+++ b/tests/unit/test_1942_webreader_device_identity.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 import flask
 import pytest
@@ -17,6 +18,7 @@ from sqlalchemy.orm import sessionmaker
 
 INSTALLATION_A = "11111111-1111-4111-8111-111111111111"
 INSTALLATION_B = "22222222-2222-4222-8222-222222222222"
+REPO = Path(__file__).resolve().parents[2]
 
 
 @pytest.fixture
@@ -45,13 +47,14 @@ def test_webreader_hmac_is_exact_and_deterministic():
     secret = b"deterministic-secret"
     expected = hmac.new(
         secret,
-        b"cwng-device:webreader:v1\0" + INSTALLATION_A.encode(),
+        b"cwng-device:webreader:v1\0" + b"7\0" + INSTALLATION_A.encode(),
         hashlib.sha256,
     ).hexdigest()
-    assert _webreader_fingerprint(INSTALLATION_A, secret) == expected
-    assert _webreader_fingerprint(INSTALLATION_A, secret) == expected
-    assert _webreader_fingerprint(INSTALLATION_B, secret) != expected
-    assert _webreader_fingerprint(INSTALLATION_A, b"another-secret") != expected
+    assert _webreader_fingerprint(7, INSTALLATION_A, secret) == expected
+    assert _webreader_fingerprint(7, INSTALLATION_A, secret) == expected
+    assert _webreader_fingerprint(8, INSTALLATION_A, secret) != expected
+    assert _webreader_fingerprint(7, INSTALLATION_B, secret) != expected
+    assert _webreader_fingerprint(7, INSTALLATION_A, b"another-secret") != expected
 
 
 def test_installation_creates_device_identity_without_storing_raw_id(registry):
@@ -73,6 +76,7 @@ def test_installation_creates_device_identity_without_storing_raw_id(registry):
     assert device.created_by == "auto"
     assert device.display_name == "Web reader"
     assert identity.scheme == WEBREADER_SCHEME
+    assert identity.scheme == "webreader-cookie-hmac-sha256-v2"
     assert identity.key_version == 1
     assert len(identity.fingerprint) == 64
     stored_values = (
@@ -102,6 +106,25 @@ def test_same_installation_is_stable_and_two_browsers_are_separate(registry):
     assert registry.query(ub.DeviceIdentity).count() == 2
 
 
+def test_same_browser_profile_is_domain_separated_between_users(registry):
+    from cps import ub
+    from cps.services.device_registry import ensure_webreader_device_best_effort
+
+    user_7 = ensure_webreader_device_best_effort(
+        user_id=7, installation_id=INSTALLATION_A,
+    )
+    user_8 = ensure_webreader_device_best_effort(
+        user_id=8, installation_id=INSTALLATION_A,
+    )
+
+    assert user_7 != user_8
+    assert registry.query(ub.Device).filter_by(id=user_7, user_id=7).one()
+    assert registry.query(ub.Device).filter_by(id=user_8, user_id=8).one()
+    identities = registry.query(ub.DeviceIdentity).order_by(ub.DeviceIdentity.id).all()
+    assert len(identities) == 2
+    assert identities[0].fingerprint != identities[1].fingerprint
+
+
 def test_missing_installation_id_keeps_a_distinct_legacy_singleton(registry):
     from cps import ub
     from cps.services.device_registry import ensure_webreader_device_best_effort
@@ -114,6 +137,105 @@ def test_missing_installation_id_keeps_a_distinct_legacy_singleton(registry):
     assert legacy != browser
     assert registry.query(ub.DeviceIdentity).filter_by(device_id=legacy).count() == 0
     assert registry.query(ub.Device).filter_by(user_id=7, kind="webreader").count() == 2
+
+
+def test_device_cap_uses_one_legacy_fallback_and_logs_once(registry, caplog):
+    from cps import ub
+    from cps.services import device_registry
+
+    device_registry._webreader_cap_logged_users.clear()
+    caplog.set_level("INFO", logger=device_registry.__name__)
+    browser_ids = []
+    for index in range(device_registry.MAX_WEBREADER_DEVICES_PER_USER):
+        installation_id = f"{index:08x}-0000-4000-8000-000000000000"
+        browser_ids.append(device_registry.ensure_webreader_device_best_effort(
+            user_id=7, installation_id=installation_id,
+        ))
+
+    over_cap = device_registry.ensure_webreader_device_best_effort(
+        user_id=7,
+        installation_id="aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    )
+    over_cap_again = device_registry.ensure_webreader_device_best_effort(
+        user_id=7,
+        installation_id="bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    )
+
+    assert len(set(browser_ids)) == device_registry.MAX_WEBREADER_DEVICES_PER_USER
+    assert over_cap_again == over_cap
+    assert over_cap not in browser_ids
+    assert registry.query(ub.DeviceIdentity).count() == device_registry.MAX_WEBREADER_DEVICES_PER_USER
+    assert registry.query(ub.Device).filter_by(user_id=7, kind="webreader").count() == (
+        device_registry.MAX_WEBREADER_DEVICES_PER_USER + 1
+    )
+    messages = [record.getMessage() for record in caplog.records]
+    assert messages.count(
+        "Web-reader device limit reached; using the legacy device bucket"
+    ) == 1
+    assert all("aaaaaaaa" not in message and "bbbbbbbb" not in message for message in messages)
+
+    # Retiring a browser does not free a persistent-row slot. Otherwise a
+    # delete/new-id loop would evade an active-only cap and restore the flood.
+    registry.query(ub.Device).filter_by(id=browser_ids[0]).one().active = False
+    registry.commit()
+    after_retirement = device_registry.ensure_webreader_device_best_effort(
+        user_id=7,
+        installation_id="cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+    )
+    assert after_retirement == over_cap
+    assert registry.query(ub.DeviceIdentity).count() == device_registry.MAX_WEBREADER_DEVICES_PER_USER
+
+
+def test_retired_browser_falls_back_until_explicitly_restored(registry):
+    from cps import ub
+    from cps.annotations import restore_annotation_device
+    from cps.services.device_registry import ensure_webreader_device_best_effort
+
+    browser_id = ensure_webreader_device_best_effort(
+        user_id=7, installation_id=INSTALLATION_A,
+    )
+    browser = registry.query(ub.Device).filter_by(id=browser_id).one()
+    browser.active = False
+    registry.commit()
+
+    fallback_id = ensure_webreader_device_best_effort(
+        user_id=7, installation_id=INSTALLATION_A,
+    )
+    registry.expire_all()
+    assert fallback_id != browser_id
+    assert registry.query(ub.Device).filter_by(id=browser_id).one().active is False
+    assert registry.query(ub.DeviceIdentity).filter_by(device_id=fallback_id).count() == 0
+
+    restored, restored_count, conflicts = restore_annotation_device(
+        browser.public_id,
+        user_id=7,
+        session=registry,
+        commit=registry.commit,
+    )
+    assert restored.id == browser_id
+    assert (restored_count, conflicts) == (0, 0)
+    assert ensure_webreader_device_best_effort(
+        user_id=7, installation_id=INSTALLATION_A,
+    ) == browser_id
+
+
+def test_retired_legacy_singleton_is_reactivated_before_reuse(registry):
+    from cps import ub
+    from cps.services.device_registry import ensure_webreader_device_best_effort
+
+    legacy_id = ensure_webreader_device_best_effort(user_id=7)
+    legacy = registry.query(ub.Device).filter_by(id=legacy_id).one()
+    prior_seen = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    legacy.active = False
+    legacy.last_seen_at = prior_seen
+    registry.commit()
+
+    assert ensure_webreader_device_best_effort(user_id=7) == legacy_id
+    registry.expire_all()
+    reactivated = registry.query(ub.Device).filter_by(id=legacy_id).one()
+    assert reactivated.active is True
+    assert reactivated.last_seen_at.replace(tzinfo=timezone.utc) > prior_seen
+    assert registry.query(ub.Device).filter_by(user_id=7, kind="webreader").count() == 1
 
 
 def test_repeated_position_observations_throttle_last_seen_writes(registry):
@@ -163,3 +285,15 @@ def test_origin_index_migration_is_additive_and_idempotent():
     with engine.connect() as conn:
         indexes = {row[1] for row in conn.execute(text("PRAGMA index_list(annotation)"))}
     assert "ix_annotation_user_book_origin" in indexes
+
+
+def test_reader_storage_access_is_guarded_for_identity_theme_and_font():
+    reader = (REPO / "frontend/src/pages/Reader.tsx").read_text(encoding="utf-8")
+    identity = (REPO / "frontend/src/lib/deviceIdentity.ts").read_text(encoding="utf-8")
+    helper = (REPO / "frontend/src/lib/safeStorage.ts").read_text(encoding="utf-8")
+
+    assert "localStorage." not in reader
+    assert "localStorage." not in identity
+    assert "safeLocalStorageGet" in reader and "safeLocalStorageSet" in reader
+    assert "safeLocalStorageGet" in identity and "safeLocalStorageSet" in identity
+    assert "try {" in helper and "catch {" in helper

--- a/tests/unit/test_324_web_reader_progress_writeback.py
+++ b/tests/unit/test_324_web_reader_progress_writeback.py
@@ -308,17 +308,27 @@ def test_api_v1_save_bookmark_records_progress():
     ctx = app.test_request_context(
         "/api/v1/books/5/bookmark", method="POST",
         json={"format": "epub", "bookmark": "epubcfi(/6/8)", "percentage": 61},
+        headers={"X-CWNG-Webreader-Installation-Id":
+                 "33333333-3333-4333-8333-333333333333"},
         content_type="application/json")
     recorder = MagicMock()
+    resolver = MagicMock(return_value=73)
     with ctx:
         with patch.object(mod, "current_user",
                           SimpleNamespace(is_authenticated=True, is_anonymous=False, id=1)), \
              patch.object(mod, "ub", MagicMock()), \
+             patch("cps.services.device_registry.ensure_webreader_device_best_effort", resolver), \
              patch("cps.services.reading_position.record_web_reader_progress", recorder):
             inspect.unwrap(mod.save_bookmark)(5)
+            assert flask.g.annotation_origin_device_id == 73
     assert recorder.called, "SPA bookmark save must write progress through"
     assert recorder.call_args[0][1] == 5
     assert recorder.call_args[0][2] == 61.0
+    assert recorder.call_args.kwargs["origin_device_id"] == 73
+    assert resolver.call_args.kwargs == {
+        "user_id": 1,
+        "installation_id": "33333333-3333-4333-8333-333333333333",
+    }
 
 
 @pytest.mark.unit
@@ -369,15 +379,25 @@ def test_classic_set_bookmark_records_progress():
     app.config["WTF_CSRF_ENABLED"] = False
     ctx = app.test_request_context(
         "/ajax/bookmark/5/epub", method="POST",
-        data={"bookmark": "epubcfi(/6/8)", "percentage": "61"})
+        data={"bookmark": "epubcfi(/6/8)", "percentage": "61"},
+        headers={"X-CWNG-Webreader-Installation-Id":
+                 "44444444-4444-4444-8444-444444444444"})
     recorder = MagicMock()
+    resolver = MagicMock(return_value=74)
     with ctx:
         with patch.object(mod, "current_user", SimpleNamespace(id=1)), \
              patch.object(mod, "ub", MagicMock()), \
+             patch("cps.services.device_registry.ensure_webreader_device_best_effort", resolver), \
              patch("cps.services.reading_position.record_web_reader_progress", recorder):
             inspect.unwrap(mod.set_bookmark)(5, "epub")
+            assert flask.g.annotation_origin_device_id == 74
     assert recorder.called, "classic bookmark save must write progress through"
     assert recorder.call_args[0][2] == 61.0
+    assert recorder.call_args.kwargs["origin_device_id"] == 74
+    assert resolver.call_args.kwargs == {
+        "user_id": 1,
+        "installation_id": "44444444-4444-4444-8444-444444444444",
+    }
 
 
 @pytest.mark.unit

--- a/tests/unit/test_annotation_device_management.py
+++ b/tests/unit/test_annotation_device_management.py
@@ -49,6 +49,27 @@ def test_device_list_aggregates_zero_and_many_annotation_counts(session):
     assert rows[busy.public_id]["annotation_count"] == 12
 
 
+def test_device_list_exposes_webreader_kind_without_faking_legacy_rows(session):
+    from cps import ub
+    from cps.annotations import list_annotation_devices
+
+    browser = ub.Device(
+        user_id=7,
+        kind="webreader",
+        display_name="Web reader",
+        model="CWNG web reader",
+        platform="epub.js",
+        active=True,
+        created_by="auto",
+    )
+    session.add(browser)
+    session.commit()
+    payload = list_annotation_devices(user_id=7, session=session)[0]
+    assert payload["kind"] == "webreader"
+    assert payload["type"] == "webreader"
+    assert payload["label"] == "Web reader"
+
+
 @pytest.mark.parametrize("label", ["", "x" * 61, " leading", "trailing ", "bad\nlabel"])
 def test_device_rename_rejects_out_of_range_or_unsafe_labels(session, label):
     from cps.annotations import rename_annotation_device

--- a/tests/unit/test_annotation_route_device_resolution.py
+++ b/tests/unit/test_annotation_route_device_resolution.py
@@ -63,6 +63,7 @@ def attributed_row(session):
         user_id=1, book_id=223, annotation_id="cwn-web-probe",
         source="webreader", highlighted_text="probe",
         origin_device_id=device.id, assigned_device_id=device.id,
+        last_editor_device_id=device.id,
         routing_revision=1,
     )
     session.add(row)
@@ -165,11 +166,82 @@ def test_every_annotation_constructor_in_create_annotation_sets_origin():
         name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")
         if name != "Annotation":
             continue
-        if "origin_device_id" not in {kw.arg for kw in node.keywords if kw.arg}:
+        keyword_names = {kw.arg for kw in node.keywords if kw.arg}
+        if not {"origin_device_id", "last_editor_device_id"}.issubset(keyword_names):
             missing.append(node.lineno)
 
     assert not missing, (
-        "ub.Annotation(...) built without origin_device_id in create_annotation at "
+        "ub.Annotation(...) built without origin_device_id/last_editor_device_id "
+        "in create_annotation at "
         f"line(s) {missing} (relative to the function). Every construction path must "
         "attribute the row, or that path's annotations are silently unattributed."
     )
+
+
+def test_create_route_resolves_the_browser_installation_header(
+    app, monkeypatch, attributed_row,
+):
+    from cps import annotations as ann
+    from cps.services import device_registry
+
+    captured = {}
+
+    def ensure(**kwargs):
+        captured.update(kwargs)
+        return attributed_row.origin_device_id
+
+    def create(*args, **kwargs):
+        captured["create_origin_device_id"] = kwargs["origin_device_id"]
+        return attributed_row
+
+    monkeypatch.setattr(ann, "current_user", SimpleNamespace(id=1), raising=False)
+    monkeypatch.setattr(ann, "_resolve_book_or_404", lambda book_id: SimpleNamespace(id=book_id, uuid="u"))
+    monkeypatch.setattr(ann, "_fanout_to_sync_targets", lambda *a, **k: None)
+    monkeypatch.setattr(ann, "create_annotation", create)
+    monkeypatch.setattr(device_registry, "ensure_webreader_device_best_effort", ensure)
+    view = app.view_functions["annotations.annotations_create"]
+    fn = getattr(view, "__wrapped__", view)
+    installation_id = "33333333-3333-4333-8333-333333333333"
+    with app.test_request_context(
+        json={},
+        headers={device_registry.WEBREADER_INSTALLATION_ID_HEADER: installation_id},
+    ):
+        response, status = fn(book_id=223)
+        assert flask.g.annotation_origin_device_id == attributed_row.origin_device_id
+
+    assert status == 201
+    assert response.get_json()["origin_device_id"] == "pub-device-1"
+    assert captured["user_id"] == 1
+    assert captured["installation_id"] == installation_id
+    assert captured["create_origin_device_id"] == attributed_row.origin_device_id
+
+
+def test_edit_and_delete_record_the_browser_as_last_editor(session, attributed_row):
+    from cps.annotations import delete_annotation, edit_annotation
+
+    editor_id = attributed_row.origin_device_id
+    attributed_row.last_editor_device_id = None
+    session.commit()
+    edited = edit_annotation(
+        attributed_row.annotation_id,
+        user_id=1,
+        book_id=223,
+        session=session,
+        commit=session.commit,
+        note="changed",
+        editor_device_id=editor_id,
+    )
+    assert edited.last_editor_device_id == editor_id
+
+    attributed_row.last_editor_device_id = None
+    session.commit()
+    deleted = delete_annotation(
+        attributed_row.annotation_id,
+        user_id=1,
+        book_id=223,
+        session=session,
+        commit=session.commit,
+        editor_device_id=editor_id,
+    )
+    assert deleted.hidden is True
+    assert deleted.last_editor_device_id == editor_id


### PR DESCRIPTION
Milestone M1 of #1942 (spec milestone table in the issue comments).

- New `webreader-cookie-hmac-sha256-v1` DeviceIdentity scheme: SPA mints a random installation id (localStorage), sends it as a header; server resolves via HMAC over the app secret — raw id never stored/returned/logged. Header-less requests keep the legacy singleton.
- Browser annotation + reading-position writes populate `origin_device_id`/`last_editor_device_id`; new additive `ix_annotation_user_book_origin` index (migration ordered per #1950).
- `/api/annotations/devices` gains an explicit `kind`; browser devices render as distinct "Web reader N" rows.
- NULL-origin legacy rows: never a fake device, never excluded from any Kobo wire path (server-set-completeness).

Verification: full unit suite **7441 passed / 0 failed**; frontend `tsc && vite build` green (1905 modules); new `test_1942_webreader_device_identity.py` (6) + extended route-resolution tests; two-browser-context e2e added (executes on the PR lane's commit-pinned backend — could not run in the sandbox, listed as the one non-local gap).