### PR TITLE
The Docker integration lane stopped authenticating and kept reporting green

### DIFF
--- a/changelog.d/integration-fixture-auth.md
+++ b/changelog.d/integration-fixture-auth.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **The Docker integration suite no longer reports success while skipping 48 of its tests.** The shared API-client fixture signed in without a CSRF token, which the login form rejects, and it treated that rejection as "no test environment available" — so every test needing an authenticated session was quietly skipped while the lane still passed, including the whole KOSync authentication and validation set. The fixture now signs in properly, verifies the session really is authenticated rather than trusting a redirect, and fails loudly when a reachable server refuses the test credentials.

--- a/changelog.d/kosync-unauthorized-status.md
+++ b/changelog.d/kosync-unauthorized-status.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **An unauthenticated sync request now answers "Unauthorized" instead of "Bad Request".** Every KOSync error was reported with HTTP 400, so a request with missing or wrong credentials came back as a malformed request even though its own body said `Unauthorized` — leaving a reader unable to tell "sign in again" from "that request was broken". Authentication failures now use 401, matching what the rest of the sync endpoints already did; every other error is unchanged.

--- a/cps/progress_syncing/protocols/kosync.py
+++ b/cps/progress_syncing/protocols/kosync.py
@@ -358,13 +358,20 @@ def handle_sync_error(error: KOSyncError) -> tuple:
         error: KOSyncError with error code and message
 
     Returns:
-        JSON error response with 400 status code
+        JSON error response, 401 for an authentication failure and 400 otherwise
     """
     log.error(f"KOSync Error {error.error_code}: {error.message}")
+    # Every KOSyncError used to become a 400, including this one -- so an
+    # unauthenticated request was answered "Bad Request" while its own body said
+    # {"error": 2001, "message": "Unauthorized"}. A client cannot tell "log in
+    # again" from "your request was malformed" by status, which is the one thing
+    # the status line is for, and other kosync handlers already answer 401
+    # directly for the same condition.
+    status = 401 if error.error_code == ERROR_UNAUTHORIZED_USER else 400
     return create_sync_response({
         "error": error.error_code,
         "message": error.message
-    }, 400)
+    }, status)
 
 
 def get_book_by_checksum(document_checksum: str, version: str = None):

--- a/scripts/ci_path_classification.py
+++ b/scripts/ci_path_classification.py
@@ -244,6 +244,12 @@ def classify_paths(paths: Iterable[str], repo_root: Path) -> dict[str, bool]:
             or path.endswith(".py")
         )
         or path == ".github/workflows/tests.yml"
+        # tests/conftest.py decides whether the Docker integration tests can
+        # authenticate at all, so a change to it can silently disable the whole
+        # lane while every individual test file is untouched. Changing one
+        # integration test already runs the lane; changing the fixture all of
+        # them depend on must too.
+        or path == "tests/conftest.py"
         for path in changed
     )
     concurrency_touched = any(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -905,8 +905,73 @@ def container_name(cwa_container) -> str:
     return "cwa-test-container"
 
 
+class CWAApiClient:
+    """An authenticated client that is BOTH a mapping and an HTTP client.
+
+    Two call styles exist in the suite and both are load-bearing:
+
+        tests/docker/       client["session"].get(client["base_url"] + path)
+        tests/integration/  client.get("/kosync/users/auth", headers=...)
+
+    The fixture used to return a plain dict, so the second style raised
+    ``AttributeError: 'dict' object has no attribute 'put'`` -- on 47 call sites
+    across three files. Nobody saw it, because those tests were being skipped for
+    an unrelated reason (the fixture could not log in), so the suite reported
+    green while most of it could not have run at all.
+
+    Deliberately NOT a dict subclass: ``dict.get`` is a mapping method, and
+    overriding it to mean "HTTP GET" makes ``client.get("base_url")`` silently do
+    something entirely different. Mapping access is ``[]`` only, so ``.get`` can
+    mean exactly one thing.
+    """
+
+    def __init__(self, base_url, session, container):
+        self._values = {
+            "base_url": base_url,
+            "session": session,
+            "container": container,
+        }
+
+    def __getitem__(self, key):
+        return self._values[key]
+
+    def __contains__(self, key):
+        return key in self._values
+
+    @property
+    def base_url(self):
+        return self._values["base_url"]
+
+    @property
+    def session(self):
+        return self._values["session"]
+
+    def _url(self, path):
+        # Relative paths resolve against the container under test; an absolute
+        # URL passes through, so a test can reach elsewhere on purpose.
+        if path.startswith(("http://", "https://")):
+            return path
+        return f"{self._values['base_url']}{path}"
+
+    def request(self, method, path, **kwargs):
+        kwargs.setdefault("timeout", 30)
+        return self._values["session"].request(method, self._url(path), **kwargs)
+
+    def get(self, path, **kwargs):
+        return self.request("GET", path, **kwargs)
+
+    def put(self, path, **kwargs):
+        return self.request("PUT", path, **kwargs)
+
+    def post(self, path, **kwargs):
+        return self.request("POST", path, **kwargs)
+
+    def delete(self, path, **kwargs):
+        return self.request("DELETE", path, **kwargs)
+
+
 @pytest.fixture(scope="function")
-def cwa_api_client(cwa_container) -> dict:
+def cwa_api_client(cwa_container) -> "CWAApiClient":
     """
     Provide a configured API client for interacting with CWA container.
 
@@ -977,11 +1042,7 @@ def cwa_api_client(cwa_container) -> dict:
     except requests.exceptions.RequestException as e:
         pytest.skip(f"Could not connect to CWA container: {e}")
 
-    return {
-        "base_url": base_url,
-        "session": session,
-        "container": cwa_container,
-    }
+    return CWAApiClient(base_url, session, cwa_container)
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ Environment Variables:
 """
 
 import os
+import re
 import sys
 import pytest
 import tempfile
@@ -930,17 +931,49 @@ def cwa_api_client(cwa_container) -> dict:
     # Create session with default credentials
     session = requests.Session()
 
-    # Login to CWA (default credentials: admin/admin123)
+    # Login to CWA (default credentials: admin/admin123).
+    #
+    # The login form is CSRF-protected, so the token has to be read off the
+    # rendered page first. Posting credentials alone returns 400 -- which reads
+    # like a malformed request rather than a missing token, and is why this went
+    # unnoticed: the fixture treated it as "no usable container" and skipped.
     try:
+        form = session.get(f"{base_url}/login", timeout=10)
+        token_match = re.search(
+            r'name="csrf_token"[^>]*value="([^"]+)"', form.text,
+        )
+        credentials = {"username": "admin", "password": "admin123"}
+        if token_match:
+            credentials["csrf_token"] = token_match.group(1)
+
         login_response = session.post(
             f"{base_url}/login",
-            data={"username": "admin", "password": "admin123"},
+            data=credentials,
             allow_redirects=False,
-            timeout=5
+            timeout=10
         )
 
+        # A reachable container that refuses our credentials is a FAILURE, not a
+        # skip. The two are different facts and only one of them is about the
+        # environment: skipping here turned a login regression into 48 silently
+        # disabled tests while the CI lane still reported success.
         if login_response.status_code not in (200, 302):
-            pytest.skip("Could not authenticate with CWA container")
+            pytest.fail(
+                f"CWA container on port {test_port} is reachable but rejected the "
+                f"test credentials (HTTP {login_response.status_code}). This is a "
+                f"regression in the login flow, not a missing test environment."
+            )
+
+        # A 302 alone does not mean success: a failed login also redirects, back
+        # to the login page. Confirm the session is actually authenticated before
+        # handing it to tests that would otherwise all fail in confusing ways.
+        whoami = session.get(f"{base_url}/api/v1/me", timeout=10)
+        if whoami.status_code != 200:
+            pytest.fail(
+                f"login to the CWA container appeared to succeed (HTTP "
+                f"{login_response.status_code}) but the session is not "
+                f"authenticated (/api/v1/me returned {whoami.status_code})."
+            )
     except requests.exceptions.RequestException as e:
         pytest.skip(f"Could not connect to CWA container: {e}")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -905,6 +905,66 @@ def container_name(cwa_container) -> str:
     return "cwa-test-container"
 
 
+@pytest.fixture(scope="session")
+def koreader_sync_enabled(container_name):
+    """Turn on KOReader sync in the container under test, and put it back after.
+
+    KOReader sync ships OFF. While it is off, ``_require_kosync_enabled`` answers
+    **503** on every /kosync endpoint before any handler runs -- so a suite that
+    does not enable it first is not testing authentication, validation or
+    progress at all. It is measuring one branch that returns 503, forty-one
+    times.
+
+    That is not a hypothetical: when the API-client fixture was repaired and
+    these tests could finally execute, all 41 of them failed on ``assert 503``,
+    which looks like a product outage and is really a missing precondition.
+
+    The setting lives in cwa.db rather than the Flask config, and it is read
+    fresh on each request, so writing it is enough -- no restart. The write goes
+    directly to the database on purpose: the /cwa-settings form POST rebuilds
+    every boolean from the submitted fields, so saving through it would silently
+    switch off everything this fixture did not think to include.
+    """
+    import json
+    import subprocess
+
+    def _set(value):
+        script = (
+            "import sqlite3;"
+            "c=sqlite3.connect('/config/cwa.db');"
+            f"c.execute('UPDATE cwa_settings SET koreader_sync_enabled=?', ({value},));"
+            "c.commit();"
+            "print(list(c.execute('SELECT koreader_sync_enabled FROM cwa_settings'))[0][0])"
+        )
+        result = subprocess.run(
+            ["docker", "exec", container_name, "python3", "-c", script],
+            capture_output=True, text=True, timeout=60, check=False,
+        )
+        if result.returncode != 0:
+            pytest.skip(
+                "could not reach cwa.db in the container to enable KOReader "
+                f"sync: {result.stderr[-400:]}"
+            )
+        return result.stdout.strip()
+
+    previous = subprocess.run(
+        ["docker", "exec", container_name, "python3", "-c",
+         "import sqlite3;print(list(sqlite3.connect('/config/cwa.db')"
+         ".execute('SELECT koreader_sync_enabled FROM cwa_settings'))[0][0])"],
+        capture_output=True, text=True, timeout=60, check=False,
+    )
+    was_enabled = previous.stdout.strip() == "1" if previous.returncode == 0 else None
+
+    assert _set(1) == "1", "KOReader sync did not stay enabled after the write"
+    try:
+        yield
+    finally:
+        # Leave the container as we found it; other tests in the same session
+        # should not silently inherit a setting this one turned on.
+        if was_enabled is False:
+            _set(0)
+
+
 class CWAApiClient:
     """An authenticated client that is BOTH a mapping and an HTTP client.
 

--- a/tests/integration/test_kosync_edge_cases.py
+++ b/tests/integration/test_kosync_edge_cases.py
@@ -10,6 +10,11 @@ import pytest
 import base64
 import json
 
+# Every endpoint in this file answers 503 while KOReader sync is disabled, which
+# it is by default. Without this the whole module measures one early-return.
+pytestmark = pytest.mark.usefixtures("koreader_sync_enabled")
+
+
 
 @pytest.mark.docker_integration
 @pytest.mark.slow

--- a/tests/integration/test_kosync_update_read_status.py
+++ b/tests/integration/test_kosync_update_read_status.py
@@ -16,6 +16,11 @@ import sys
 import base64
 from pathlib import Path
 
+# Every endpoint in this file answers 503 while KOReader sync is disabled, which
+# it is by default. Without this the whole module measures one early-return.
+pytestmark = pytest.mark.usefixtures("koreader_sync_enabled")
+
+
 # Add project root to path
 project_root = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(project_root))

--- a/tests/integration/test_progress_syncing_kosync.py
+++ b/tests/integration/test_progress_syncing_kosync.py
@@ -19,6 +19,11 @@ import json
 import base64
 from pathlib import Path
 
+# Every endpoint in this file answers 503 while KOReader sync is disabled, which
+# it is by default. Without this the whole module measures one early-return.
+pytestmark = pytest.mark.usefixtures("koreader_sync_enabled")
+
+
 # Add project root to path
 project_root = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(project_root))

--- a/tests/unit/test_conftest_change_runs_the_integration_lane.py
+++ b/tests/unit/test_conftest_change_runs_the_integration_lane.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""A change to the integration fixtures must run the lane those fixtures gate.
+
+``tests/conftest.py`` owns ``cwa_api_client``: it decides whether the Docker
+integration tests can reach and authenticate against the container. A change
+there can disable the entire lane without touching a single test file.
+
+That is not hypothetical. The fixture signed in without a CSRF token, the login
+began rejecting it, and the fixture reported the rejection as a skip -- 48 tests
+stopped running and CI kept reporting the lane green. Nothing in the path
+classifier would have run the lane on the commit that broke it, because
+``tests/conftest.py`` is not ``tests/integration/``.
+
+Changing one integration test already runs the lane. Changing the fixture every
+one of them depends on must too.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.ci_path_classification import classify_paths
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _build(*paths: str) -> bool:
+    """``build`` is what gates Integration Tests (Docker) on a pull request."""
+    return classify_paths(list(paths), REPO_ROOT)["build"]
+
+
+def test_changing_the_shared_test_fixtures_runs_the_integration_lane():
+    assert _build("tests/conftest.py"), (
+        "a change to tests/conftest.py can silently disable the Docker "
+        "integration lane, so it must trigger that lane"
+    )
+
+
+def test_changing_an_integration_test_still_runs_the_lane():
+    """The established behaviour this extends, pinned so it cannot regress."""
+    assert _build("tests/integration/test_ingest_pipeline.py")
+
+
+def test_an_unrelated_test_file_does_not_pay_the_integration_cost():
+    """The exemption is the point of the classifier; widening it to all of
+    tests/ would make every unit-test PR wait fifteen minutes."""
+    assert not _build("tests/unit/test_some_pure_unit_behaviour.py")

--- a/tests/unit/test_kosync_unauthorized_status.py
+++ b/tests/unit/test_kosync_unauthorized_status.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""An unauthenticated kosync request must answer 401, not 400.
+
+``handle_sync_error`` turned every ``KOSyncError`` into a 400, including
+``ERROR_UNAUTHORIZED_USER``. So ``GET /kosync/syncs/progress/<document>`` without
+credentials replied ``400 Bad Request`` with a body reading
+``{"error": 2001, "message": "Unauthorized"}`` -- the status contradicting the
+payload, and a client unable to tell "log in again" from "your request was
+malformed" by the one field that exists to say so.
+
+Sibling handlers in the same blueprint already return 401 directly for exactly
+this condition, so the protocol was inconsistent with itself.
+
+This was invisible for a long time because the integration test that covers it
+could not run: the shared API-client fixture had stopped authenticating, and the
+lane skipped rather than failed. The fix that revived the lane is what surfaced
+this.
+
+Both directions are pinned. Mapping *every* error to 401 would be as wrong as
+mapping every one to 400, and would be just as green if only the auth case were
+asserted.
+"""
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+# The blueprint inside this module is also called ``kosync``, so a plain
+# ``from ... import kosync`` binds the Blueprint and not the module.
+import cps.progress_syncing.protocols.kosync  # noqa: F401
+
+kosync = sys.modules["cps.progress_syncing.protocols.kosync"]
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def app_context():
+    """handle_sync_error builds a JSON response, which needs an app context."""
+    from flask import Flask
+
+    app = Flask(__name__)
+    with app.app_context():
+        yield
+
+
+def _status(error_code):
+    """handle_sync_error returns Flask's (response, status) tuple."""
+    _response, status = kosync.handle_sync_error(
+        kosync.KOSyncError(error_code, "irrelevant to the status"),
+    )
+    return status
+
+
+def test_an_unauthorized_error_answers_401(app_context):
+    assert _status(kosync.ERROR_UNAUTHORIZED_USER) == 401
+
+
+@pytest.mark.parametrize("error_code", [
+    kosync.ERROR_DOCUMENT_FIELD_MISSING,
+    kosync.ERROR_INTERNAL,
+])
+def test_other_errors_still_answer_400(app_context, error_code):
+    """The change must be narrow: only the authentication case moves."""
+    assert _status(error_code) == 400


### PR DESCRIPTION
The integration lane has been passing while skipping most of itself. This is CI's own junit artifact from run 33229626317 on `main`, counted by skip reason:

```
48  Could not authenticate with CWA container
 1  Requires mocking infrastructure
 1  Cannot check sentinel file
```

`68 passed, 50 skipped` in 462 seconds, green check. Everything gated on an authenticated session was dark — including the entire KOSync authentication and data-validation set.

## Cause

`cwa_api_client` signs in with a bare credentials POST. The login form is CSRF-protected, so that returns **400**, and the fixture treats any non-200/302 as `pytest.skip("Could not authenticate with CWA container")`.

The 400 is what hid it: it reads as a malformed request rather than a missing token, so the skip message looked like an environment problem and was believed.

## Three changes

**Read the CSRF token off the login form** before posting it.

**Fail, don't skip, when a reachable server refuses the credentials.** "Nothing is listening" is a fact about the environment. "It answered and rejected me" is a fact about the code. Skipping on both is what turned a login change into permanent, invisible coverage loss — the lane cannot go red, so nothing ever prompts anyone to look.

**Verify the session is actually authenticated.** A *failed* login also returns 302, back to the login page, so the previous `status_code in (200, 302)` check would accept a session that was never logged in. Now confirmed against `/api/v1/me`.

## What to expect on this PR

These 48 tests have not executed in some time, so some may fail. **That is the point of the PR, not a reason to hold it** — those failures are the coverage the lane was supposed to be providing, and they are worth seeing before anything else is built on top of them. I'll report what comes back rather than quietly fixing the fixture until it goes quiet again.

## Verification

- Unit lane green: `7440 passed, 106 skipped`.
- The same CSRF login sequence authenticates against a live instance — it is what the new send-to-device end-to-end test uses.
- ASSUMED until this PR's integration lane runs: that all 48 revived tests pass.

Found while adding integration coverage for KOReader device delivery, on noticing that the protocol I was extending had integration tests that never ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xc6tdQ4uwXEzUezFFG2LgG