### PR TITLE
fix(notices): dismissing a large notice group works and failures are visible (#1912)

### DIFF
--- a/changelog.d/1912.md
+++ b/changelog.d/1912.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- **Large notice banners can be dismissed reliably.** Dismissing hundreds of
+  notices now uses bounded batches, and any failure is shown visibly so it can
+  be retried instead of appearing to do nothing.

--- a/frontend/e2e/user-notices.spec.ts
+++ b/frontend/e2e/user-notices.spec.ts
@@ -136,7 +136,8 @@ test('shows a visible error when bulk dismissal fails', async ({ page }) => {
   await page.goto('/app');
   await page.getByRole('button', { name: 'Dismiss permanently' }).click();
 
-  await expect(page.getByRole('alert')).toHaveText('Could not dismiss the notices. Please try again.');
+  const noticeBanner = page.locator('section[aria-labelledby="user-notice-title"]');
+  await expect(noticeBanner.getByRole('alert')).toHaveText('Could not dismiss the notices. Please try again.');
   await expect(page.getByText('Kobo book compatibility repaired')).toBeVisible();
 });
 

--- a/frontend/e2e/user-notices.spec.ts
+++ b/frontend/e2e/user-notices.spec.ts
@@ -86,6 +86,60 @@ test('aggregates repaired books and permanently bulk-dismisses explicit occurren
   expect(dismissedIds).toEqual([101, 102]);
 });
 
+test('chunks the reported 872-notice dismissal at the API cap', async ({ page }) => {
+  await serveCurrentSpaBuild(page);
+  const repaired = Array.from({ length: 872 }, (_, index) =>
+    notice(index + 1, index + 1, `Repaired book ${index + 1}`));
+  let active = true;
+  const dismissedBatches: number[][] = [];
+  await page.route(/\/api\/v1\/notices(?:\/[^?]*)?(?:\?.*)?$/, async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    if (request.method() === 'POST' && url.pathname.endsWith('/notices/dismiss')) {
+      const ids = request.postDataJSON().notice_ids as number[];
+      dismissedBatches.push(ids);
+      active = dismissedBatches.flat().length < repaired.length;
+      return json(route, {
+        dismissed: ids.length,
+        remaining: repaired.length - dismissedBatches.flat().length,
+      });
+    }
+    return json(route, {
+      notices: active ? repaired : [],
+      summary: { count: active ? repaired.length : 0 },
+    });
+  });
+
+  await page.goto('/app');
+  await page.getByRole('button', { name: 'Dismiss all 872 notices permanently' }).click();
+
+  await expect(page.getByText('Kobo book compatibility repaired')).toHaveCount(0);
+  expect(dismissedBatches.map((ids) => ids.length)).toEqual([500, 372]);
+  expect(dismissedBatches.every((ids) => ids.length <= 500)).toBe(true);
+  expect(dismissedBatches.flat()).toEqual(repaired.map((item) => item.id));
+});
+
+test('shows a visible error when bulk dismissal fails', async ({ page }) => {
+  await serveCurrentSpaBuild(page);
+  const repaired = [notice(301, 1, 'Still active')];
+  await page.route(/\/api\/v1\/notices(?:\/[^?]*)?(?:\?.*)?$/, async (route) => {
+    if (route.request().method() === 'POST') {
+      return route.fulfill({
+        status: 400,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: { code: 'dismiss_failed', message: 'Nope' } }),
+      });
+    }
+    return json(route, { notices: repaired, summary: { count: repaired.length } });
+  });
+
+  await page.goto('/app');
+  await page.getByRole('button', { name: 'Dismiss permanently' }).click();
+
+  await expect(page.getByRole('alert')).toHaveText('Could not dismiss the notices. Please try again.');
+  await expect(page.getByText('Kobo book compatibility repaired')).toBeVisible();
+});
+
 test('book detail presents and independently dismisses its book-scoped occurrence', async ({ page }) => {
   await serveCurrentSpaBuild(page);
   await page.goto('/app');

--- a/frontend/src/components/UserNotices.module.css
+++ b/frontend/src/components/UserNotices.module.css
@@ -14,6 +14,7 @@
 .details summary { cursor: pointer; font-weight: var(--fw-medium); }
 .bookList { margin: var(--sp-2) 0 0; padding-left: var(--sp-5); }
 .bookList a { color: var(--accent-text); }
+.error { color: var(--danger); font-weight: var(--fw-medium); }
 
 .dismiss,
 .dismissBook {

--- a/frontend/src/components/UserNotices.tsx
+++ b/frontend/src/components/UserNotices.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type MouseEvent } from 'react';
+import { useMemo, useState, type MouseEvent } from 'react';
 import { AlertTriangle, X } from 'lucide-react';
 import { Link } from 'wouter';
 import type { UserNotice } from '../lib/api';
@@ -52,6 +52,7 @@ export function UserNoticeBanner() {
   const announce = useAnnouncer();
   const { data } = useNotices();
   const dismissMany = useDismissNotices();
+  const [dismissError, setDismissError] = useState<string | null>(null);
   const notices = data?.notices ?? [];
   const group = useMemo(() => {
     if (!notices.length) return [];
@@ -66,9 +67,10 @@ export function UserNoticeBanner() {
   ).size;
   const dismiss = (event: MouseEvent<HTMLButtonElement>) => {
     const count = group.length;
+    setDismissError(null);
     dismissMany.mutate(group.map((notice) => notice.id), {
       onSuccess: () => announce(t('{count} notices dismissed permanently.', { count })),
-      onError: () => announce(t('Could not dismiss the notices. Please try again.'), { assertive: true }),
+      onError: () => setDismissError(t('Could not dismiss the notices. Please try again.')),
     });
     restoreFocusIfKeyboard(event);
   };
@@ -86,6 +88,7 @@ export function UserNoticeBanner() {
           <p>{typeof first.payload.message === 'string' ? first.payload.message : t('There is new information about your library.')}</p>
         )}
         <BookLinks notices={group} />
+        <p className={dismissError ? styles.error : undefined} role="alert">{dismissError}</p>
       </div>
       <button type="button" className={styles.dismiss} onClick={dismiss}
         disabled={dismissMany.isPending}
@@ -104,6 +107,7 @@ export function BookUserNotices({ bookId }: { bookId: number }) {
   const announce = useAnnouncer();
   const { data } = useNotices(bookId);
   const dismissOne = useDismissNotice();
+  const [dismissErrors, setDismissErrors] = useState<Record<number, string>>({});
   const notices = data?.notices ?? [];
   if (!notices.length) return null;
 
@@ -118,13 +122,20 @@ export function BookUserNotices({ bookId }: { bookId: number }) {
               ? t('We repaired this book for your Kobo. If you were having trouble highlighting, try after sync — and if it still doesn’t work, remove the book from your Kobo and let it download again. If you read it some other way, download it again to get the repaired copy.')
               : (typeof notice.payload.message === 'string'
                 ? notice.payload.message : t('There is new information about this book.'))}</p>
+            <p className={dismissErrors[notice.id] ? styles.error : undefined} role="alert">
+              {dismissErrors[notice.id]}
+            </p>
           </div>
           <button type="button" className={styles.dismissBook}
             disabled={dismissOne.isPending}
             onClick={(event) => {
+              setDismissErrors((current) => ({ ...current, [notice.id]: '' }));
               dismissOne.mutate(notice.id, {
                 onSuccess: () => announce(t('Notice dismissed permanently.')),
-                onError: () => announce(t('Could not dismiss the notice. Please try again.'), { assertive: true }),
+                onError: () => setDismissErrors((current) => ({
+                  ...current,
+                  [notice.id]: t('Could not dismiss the notice. Please try again.'),
+                })),
               });
               restoreFocusIfKeyboard(event);
             }}>

--- a/frontend/src/lib/noticeDismissal.ts
+++ b/frontend/src/lib/noticeDismissal.ts
@@ -1,0 +1,28 @@
+export const NOTICE_DISMISS_BATCH_SIZE = 500;
+
+export interface NoticeDismissResult {
+  dismissed: number;
+  remaining: number;
+}
+
+/**
+ * Dismiss an arbitrarily large notice selection without exceeding the API's
+ * deliberately bounded bulk-request contract. Batches run sequentially so a
+ * failure stops at the first unconfirmed batch; the endpoint is idempotent, so
+ * retrying the original selection is safe even when earlier batches succeeded.
+ */
+export async function dismissNoticeIdsInBatches(
+  noticeIds: number[],
+  dismissBatch: (noticeIds: number[]) => Promise<NoticeDismissResult>,
+): Promise<NoticeDismissResult> {
+  let dismissed = 0;
+  let remaining = 0;
+
+  for (let start = 0; start < noticeIds.length; start += NOTICE_DISMISS_BATCH_SIZE) {
+    const result = await dismissBatch(noticeIds.slice(start, start + NOTICE_DISMISS_BATCH_SIZE));
+    dismissed += result.dismissed;
+    remaining = result.remaining;
+  }
+
+  return { dismissed, remaining };
+}

--- a/frontend/src/lib/queries.ts
+++ b/frontend/src/lib/queries.ts
@@ -8,6 +8,7 @@ import {
 import { removeBookFromCache, applyBookEditToCache } from './scrollCache';
 import { settleById } from './bulkResults';
 import { createEntityListQueryOptions } from './entityListQueryOptions';
+import { dismissNoticeIdsInBatches } from './noticeDismissal';
 import type { MetadataProvider, MetaSearchResponse } from './api';
 import type {
   Me, Book, BooksPage, BookDetail, EntityList, Shelf, ShelfDetail,
@@ -1469,10 +1470,13 @@ export function useDismissNotices() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (noticeIds: number[]) =>
-      apiPost<{ dismissed: number; remaining: number }>('/api/v1/notices/dismiss', {
-        notice_ids: noticeIds,
-      }),
-    onSuccess: () => void qc.invalidateQueries({ queryKey: ['notices'] }),
+      dismissNoticeIdsInBatches(noticeIds, (batch) =>
+        apiPost<{ dismissed: number; remaining: number }>('/api/v1/notices/dismiss', {
+          notice_ids: batch,
+        })),
+    // A later batch can fail after an earlier one committed. Refresh on either
+    // outcome so the banner reflects the server's actual remaining notices.
+    onSettled: () => void qc.invalidateQueries({ queryKey: ['notices'] }),
   });
 }
 

--- a/frontend/tests/unit/noticeDismissal.test.ts
+++ b/frontend/tests/unit/noticeDismissal.test.ts
@@ -1,0 +1,48 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  NOTICE_DISMISS_BATCH_SIZE,
+  dismissNoticeIdsInBatches,
+} from '../../src/lib/noticeDismissal.ts';
+
+describe('dismissNoticeIdsInBatches', () => {
+  test('keeps the normal happy path to one request', async () => {
+    const calls: number[][] = [];
+    const result = await dismissNoticeIdsInBatches([101, 102], async (ids) => {
+      calls.push(ids);
+      return { dismissed: ids.length, remaining: 0 };
+    });
+
+    assert.deepEqual(calls, [[101, 102]]);
+    assert.deepEqual(result, { dismissed: 2, remaining: 0 });
+  });
+
+  test('dismisses the reported 872-notice shape in API-safe batches', async () => {
+    const ids = Array.from({ length: 872 }, (_, index) => index + 1);
+    const calls: number[][] = [];
+    const result = await dismissNoticeIdsInBatches(ids, async (batch) => {
+      calls.push(batch);
+      return { dismissed: batch.length, remaining: ids.length - calls.flat().length };
+    });
+
+    assert.deepEqual(calls.map((batch) => batch.length), [500, 372]);
+    assert.ok(calls.every((batch) => batch.length <= NOTICE_DISMISS_BATCH_SIZE));
+    assert.deepEqual(calls.flat(), ids);
+    assert.deepEqual(result, { dismissed: 872, remaining: 0 });
+  });
+
+  test('stops after the first failed batch so later IDs are never reported as dismissed', async () => {
+    const ids = Array.from({ length: 872 }, (_, index) => index + 1);
+    let calls = 0;
+
+    await assert.rejects(
+      dismissNoticeIdsInBatches(ids, async () => {
+        calls += 1;
+        throw new Error('dismissal failed');
+      }),
+      /dismissal failed/,
+    );
+    assert.equal(calls, 1);
+  });
+});


### PR DESCRIPTION
Closes #1912. Root cause: the SPA posted every notice id in the group in one request; the API rejects >500 ids with 400, and the client swallowed the error (aria-only). Dismissals now chunk at the API cap and a failed dismissal surfaces visibly. Regression test at the reporter's 872-notice shape. Node regression 3/3, notice suites 20/20, build green.