### PR TITLE
fix(ingest): files with uppercase extensions are ingested (#1740)

### DIFF
--- a/changelog.d/1740.md
+++ b/changelog.d/1740.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- **Books with uppercase file extensions are ingested.** The startup scan and
+  live watcher now recognize supported formats such as `Book.EPUB` without
+  changing case sensitivity for unrelated watcher rules.

--- a/root/etc/s6-overlay/s6-rc.d/cwa-ingest-service/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-ingest-service/run
@@ -312,11 +312,12 @@ has_processing_markers() {
 is_supported_ingest_file() {
         local filepath="$1"
         local suf
+        local extension_path="${filepath,,}"
         for suf in $TEMP_SUFFIXES; do
                 [[ "$filepath" == *.$suf ]] && return 1
         done
         [[ "$filepath" == *.cwa.json ]] || [[ "$filepath" == *.cwa.failed.json ]] && return 1
-        [[ "$filepath" =~ $SUPPORTED_EXT_REGEX ]]
+        [[ "$extension_path" =~ $SUPPORTED_EXT_REGEX ]]
 }
 
 has_pending_ingest_files() {
@@ -605,11 +606,12 @@ handle_event() {
         done
         # ignore sidecar manifests
         if [[ "$filepath" == *.cwa.json ]] || [[ "$filepath" == *.cwa.failed.json ]]; then
-                echo "[cwa-ingest-service] Skipping sidecar manifest: $filepath (handled with data file)"
+                echo "[cwa-ingest-service] Skipping sidecar manifest event: $filepath (not a standalone ingest candidate)"
                 return 0
         fi
         # extension filter
-        if ! [[ "$filepath" =~ $SUPPORTED_EXT_REGEX ]]; then
+        local extension_path="${filepath,,}"
+        if ! [[ "$extension_path" =~ $SUPPORTED_EXT_REGEX ]]; then
                 return 0
         fi
 

--- a/tests/test_ingest_service_shell.sh
+++ b/tests/test_ingest_service_shell.sh
@@ -163,3 +163,23 @@ if [ "$(wc -l < "$post_batch_log" | tr -d ' ')" != "1" ]; then
         cat "$post_batch_log" >&2
         exit 1
 fi
+
+sidecar_path="$tmpdir/watch/metadata.cwa.json"
+output=$(handle_event "$sidecar_path" 2>&1)
+assert_contains "$output" "not a standalone ingest candidate"
+assert_processor_invocations 4
+
+# Fork #1740: the live event path must accept Calibre formats regardless of
+# extension case without changing Bash matching rules for the rest of the
+# long-running watcher.
+export PROCESSOR_EXIT_CODE=0
+uppercase_path="$tmpdir/watch/Book.EPUB"
+printf 'uppercase extension\n' > "$uppercase_path"
+output=$(handle_event "$uppercase_path" 2>&1)
+assert_contains "$output" "Starting Ingest Processor"
+assert_processor_invocations 5
+if ! grep -Fxq "$uppercase_path" "$processor_log"; then
+        printf 'Expected uppercase-extension path to reach processor stub\n' >&2
+        cat "$processor_log" >&2
+        exit 1
+fi

--- a/tests/unit/test_ingest_startup_sweep_1360.py
+++ b/tests/unit/test_ingest_startup_sweep_1360.py
@@ -178,6 +178,19 @@ def test_startup_sweep_ingests_preexisting_file(harness):
     )
 
 
+def test_startup_sweep_ingests_uppercase_extension(harness):
+    """Fork #1740: Calibre format extensions are case-insensitive on disk;
+    the startup sweep must not silently strand ``Book.EPUB``."""
+    book = harness.watch / "Book.EPUB"
+    book.write_text("a whole book")
+
+    processed = harness("startup_ingest_sweep >/dev/null 2>&1 || true")
+
+    assert str(book) in processed, (
+        "startup sweep silently ignored a supported uppercase extension (#1740)"
+    )
+
+
 def test_startup_sweep_recurses_into_subfolders(harness):
     """The watcher is recursive (`inotifywait -r`) and download clients drop
     books into per-author subfolders, so the sweep must recurse too."""


### PR DESCRIPTION
Closes #1740. Case-insensitive extension matching at both watcher call sites (startup sweep + event path), scoped so it cannot leak into unrelated matching; the misleading sidecar-skip log line now tells the truth. Shell harness extended with live uppercase-extension and sidecar cases (exit 0); watcher suites 24/24.