### PR TITLE
fix(kobo): users can resend a book to their own Kobo (#1766)

### DIFF
--- a/changelog.d/1766.md
+++ b/changelog.d/1766.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- **Kobo users can resend one book to their own device.** The classic account
+  page now exposes the existing per-book resend action for the signed-in user,
+  while cross-user resend and entitlement-ledger changes remain admin-only.

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -1449,8 +1449,11 @@ def do_full_kobo_sync(userid):
 
 @admi.route("/ajax/kobo_resend/<int:userid>/<int:bookid>", methods=["POST"])
 @user_login_required
-@admin_required
 def ajax_kobo_resend(userid, bookid):
+    # Same IDOR guard as the Kobo token routes: a user may act only on their
+    # own device state, while admins retain the existing targeted action.
+    if current_user.id != userid and not current_user.role_admin():
+        abort(403)
     return do_kobo_resend(userid, bookid)
 
 
@@ -1465,7 +1468,7 @@ def do_kobo_resend(userid, bookid):
     #     up regardless of where the device's cursor sits;
     #   * clear the (user_id, book_id) row from kobo_synced_books;
     #   * clear every per-device entitlement fingerprint for this user/book,
-    #     otherwise Layer 2 can suppress the admin-requested replay as an exact
+    #     otherwise Layer 2 can suppress the requested replay as an exact
     #     match even though last_modified selected it for delivery.
     #
     # ⚠️ This comment used to say the deletion is what makes the sync emit
@@ -1487,7 +1490,7 @@ def do_kobo_resend(userid, bookid):
     # any other synced row remaining, this emits ChangedEntitlement.
     #
     # 🚨 Whether a Kobo re-downloads the file on a ChangedEntitlement is
-    # UNOBSERVED (F-3e383a). The success message below tells the admin the
+    # UNOBSERVED (F-3e383a). The success message below tells the requester the
     # device "will re-receive the book"; that claim is only established for the
     # empty-table case above. Do not strengthen it without measuring on
     # hardware.

--- a/cps/templates/user_edit.html
+++ b/cps/templates/user_edit.html
@@ -335,7 +335,7 @@
         <div>
           <div class="btn btn-default" id="kobo_full_sync" data-value="{% if current_user.role_admin() %}{{ content.id }}{% else %}0{% endif %}" {% if not content.remote_auth_token.first() %} style="display: none;" {% endif %}>{{_('Force full kobo sync')}}</div>
         </div>
-        {% if current_user.role_admin() %}
+        {% if current_user.role_admin() or current_user.id == content.id %}
         <div id="kobo_resend_book_block" style="margin-top: 10px;{% if not content.remote_auth_token.first() %} display: none;{% endif %}">
           <label for="kobo_resend_book_id" style="display: block; margin-bottom: 4px;">{{_('Resend one book to this Kobo')}}</label>
           <div style="display: flex; gap: 6px; align-items: center;">
@@ -345,6 +345,8 @@
           </div>
           <small class="help-block">{{_('Clears the sync record for one book so the device re-downloads it on next sync. Find the book ID in the book detail page URL.')}}</small>
         </div>
+        {% endif %}
+        {% if current_user.role_admin() %}
         <div style="margin-top: 10px;">
           <a class="btn btn-default" href="{{ url_for('admin.kobo_reconcile', user_id=content.id) }}">
             {{ _('Reconcile books deleted before Kobo archival tracking') }}

--- a/tests/unit/test_1925_kobo_sync_dedownload.py
+++ b/tests/unit/test_1925_kobo_sync_dedownload.py
@@ -1724,6 +1724,88 @@ def test_admin_resend_clears_target_users_entitlement_ledger(
     } == {sync_harness.device.id, other_device.id}
 
 
+def test_self_resend_clears_only_callers_entitlement_ledger(
+    sync_harness, monkeypatch,
+):
+    """A non-admin can resend their own book without touching another user."""
+    from cps import admin, ub
+
+    sync_harness.sync()
+    second_target_device = _seed_same_user_device_ledger(sync_harness)
+    other_device = _seed_other_user_ledger(sync_harness)
+    monkeypatch.setattr(admin, "calibre_db", sync_harness.calibre_db)
+    monkeypatch.setattr(admin, "_", lambda value: value)
+    monkeypatch.setattr(admin, "current_user", SimpleNamespace(
+        id=sync_harness.user.id,
+        role_admin=lambda: False,
+    ))
+
+    with sync_harness.app.test_request_context(
+        f"/ajax/kobo_resend/{sync_harness.user.id}/{sync_harness.book.id}",
+        method="POST",
+    ):
+        response = admin.ajax_kobo_resend.__wrapped__(
+            sync_harness.user.id, sync_harness.book.id,
+        )
+
+    assert response.status_code == 200
+    assert sync_harness.session.query(ub.KoboSyncedBooks).filter_by(
+        user_id=sync_harness.user.id, book_id=sync_harness.book.id,
+    ).count() == 0
+    assert sync_harness.session.query(ub.KoboSyncedBooks).filter_by(
+        user_id=18, book_id=sync_harness.book.id,
+    ).count() == 1
+    assert {
+        row.device_id
+        for row in sync_harness.session.query(ub.KoboDeviceBookEntitlement)
+    } == {other_device.id}
+    assert second_target_device.id != other_device.id
+
+
+def test_user_cannot_resend_or_clear_another_users_ledger(
+    sync_harness, monkeypatch,
+):
+    """The route rejects the forged user ID before any resend write occurs."""
+    from werkzeug.exceptions import Forbidden
+
+    from cps import admin, ub
+
+    sync_harness.sync()
+    other_device = _seed_other_user_ledger(sync_harness)
+    monkeypatch.setattr(admin, "calibre_db", sync_harness.calibre_db)
+    monkeypatch.setattr(admin, "current_user", SimpleNamespace(
+        id=sync_harness.user.id,
+        role_admin=lambda: False,
+    ))
+    before_modified = sync_harness.book.last_modified
+    before_synced = {
+        (row.user_id, row.book_id)
+        for row in sync_harness.session.query(ub.KoboSyncedBooks)
+    }
+    before_ledgers = {
+        (row.device_id, row.book_id)
+        for row in sync_harness.session.query(ub.KoboDeviceBookEntitlement)
+    }
+
+    with sync_harness.app.test_request_context(
+        f"/ajax/kobo_resend/18/{sync_harness.book.id}", method="POST",
+    ):
+        with pytest.raises(Forbidden) as raised:
+            admin.ajax_kobo_resend.__wrapped__(18, sync_harness.book.id)
+
+    assert raised.value.code == 403
+    assert sync_harness.book.last_modified == before_modified
+    assert {
+        (row.user_id, row.book_id)
+        for row in sync_harness.session.query(ub.KoboSyncedBooks)
+    } == before_synced
+    assert {
+        (row.device_id, row.book_id)
+        for row in sync_harness.session.query(ub.KoboDeviceBookEntitlement)
+    } == before_ledgers
+    assert (other_device.id, sync_harness.book.id) in before_ledgers
+
+
 def test_admin_resend_missing_book_preserves_all_sync_state(
     sync_harness, monkeypatch,
 ):

--- a/tests/unit/test_kobo_admin_resend_book.py
+++ b/tests/unit/test_kobo_admin_resend_book.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2024-2026 Calibre-Web Automated contributors
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-"""Regression tests for A2 — per-book "Resend to Kobo" admin action.
+"""Regression tests for A2 — per-book "Resend to Kobo" action.
 
 Goal:
     Admin clicks "Resend" on user_edit.html, the (user_id, book_id)
@@ -31,25 +31,18 @@ import pytest
 
 @pytest.mark.unit
 class TestRouteRegistered:
-    def test_kobo_resend_endpoint_is_admin_only(self):
+    def test_kobo_resend_endpoint_is_self_or_admin(self):
         from cps import admin as admin_mod
         src = inspect.getsource(admin_mod)
-        # The route must require admin (admin_required decorator).
-        # Pinning the exact route + decorator stack catches refactors
-        # that accidentally drop the admin gate, which would let any
-        # logged-in user resend books to any other user's Kobo.
         assert "/ajax/kobo_resend/" in src, (
             "admin module must register /ajax/kobo_resend/<userid>/<bookid> "
             "route for the per-book resend action."
         )
-        # Find the route registration and verify decorator stack
         idx = src.index("/ajax/kobo_resend/")
-        # Look at the ~400 chars around the route for the decorator stack.
         window = src[idx:idx + 400]
-        assert "@admin_required" in window, (
-            "/ajax/kobo_resend/<userid>/<bookid> must be @admin_required. "
-            "Without this gate any logged-in user could clear another "
-            "user's Kobo sync state."
+        assert "current_user.id != userid and not current_user.role_admin()" in window, (
+            "/ajax/kobo_resend/<userid>/<bookid> must reject a non-admin "
+            "targeting another user's Kobo sync state."
         )
         assert "methods=[\"POST\"]" in window, (
             "/ajax/kobo_resend/<userid>/<bookid> must be POST-only."
@@ -150,8 +143,8 @@ class TestDoKoboResendShape:
 
 @pytest.mark.unit
 class TestSecurityShape:
-    """Defensive: the route accepts integer IDs, requires admin auth,
-    and doesn't expose either user or book IDs to non-admins."""
+    """Defensive: the route accepts integer IDs, requires login, and lets a
+    non-admin act only on their own user ID."""
 
     def test_route_uses_int_converters(self):
         from cps import admin as admin_mod
@@ -167,7 +160,7 @@ class TestSecurityShape:
             "routing layer."
         )
 
-    def test_route_is_user_login_required_and_admin_required(self):
+    def test_route_is_user_login_required_and_self_or_admin_guarded(self):
         from cps import admin as admin_mod
         src = inspect.getsource(admin_mod)
         idx = src.index("/ajax/kobo_resend/")
@@ -175,9 +168,29 @@ class TestSecurityShape:
         assert "@user_login_required" in window, (
             "/ajax/kobo_resend route must require login."
         )
-        assert "@admin_required" in window, (
-            "/ajax/kobo_resend route must require admin."
+        assert "current_user.id != userid and not current_user.role_admin()" in window, (
+            "/ajax/kobo_resend route must allow self while rejecting other users."
         )
+
+
+@pytest.mark.unit
+def test_resend_block_is_visible_for_self_but_reconcile_stays_admin_only():
+    from pathlib import Path
+
+    template = (Path(__file__).resolve().parents[2] / "cps/templates/user_edit.html").read_text()
+    resend = template.index('id="kobo_resend_book_block"')
+    self_or_admin = template.rfind("{% if", 0, resend)
+    assert (
+        template[self_or_admin:resend]
+        .strip()
+        .startswith("{% if current_user.role_admin() or current_user.id == content.id %}")
+    )
+
+    reconcile = template.index("admin.kobo_reconcile", resend)
+    admin_only = template.rfind("{% if", resend, reconcile)
+    assert template[admin_only:reconcile].strip().startswith(
+        "{% if current_user.role_admin() %}"
+    ), "self-service resend must not expose the separate admin reconciliation tool"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Closes #1766. Mirrors the kobo_full_sync precedent: the resend block renders for self, and /ajax/kobo_resend moves from admin-only to self-or-admin. The #1925 entitlement-ledger clearing stays strictly scoped to the caller's own devices — proven by a test that user A gets 403 for user B and that ledger rows cleared are the caller's only. Resend/security selection 17/17; Kobo resend + suppression suites 70/70.