### PR TITLE
fix(kobo): a failing book no longer poisons the whole KEPUB backfill (#1857)

### DIFF
--- a/changelog.d/1857-kepub-backfill-session.md
+++ b/changelog.d/1857-kepub-backfill-session.md
@@ -2,7 +2,8 @@
 
 - **One failed Kobo KEPUB conversion no longer prevents every later synced book
   from being converted.** The startup backfill now rolls back and replaces a
-  failed database session between books, stops after three failed recovery
-  attempts instead of flooding the log for the rest of the library, and reports
-  exactly how many books it processed, converted, skipped, and failed. Reported
-  by @MKos75 and @Tobi.
+  failed database session between books, validates rebuilt sessions against the
+  real Calibre metadata schema, and stops after three repeated database or
+  recovery failures instead of flooding the log for the rest of the library.
+  Failed/aborted runs now preserve exact processed/failed counts and remain
+  marked incomplete. Reported by @MKos75 and @Tobi.

--- a/changelog.d/1857-kepub-backfill-session.md
+++ b/changelog.d/1857-kepub-backfill-session.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- **One failed Kobo KEPUB conversion no longer prevents every later synced book
+  from being converted.** The startup backfill now rolls back and replaces a
+  failed database session between books, stops after three failed recovery
+  attempts instead of flooding the log for the rest of the library, and reports
+  exactly how many books it processed, converted, skipped, and failed. Reported
+  by @MKos75 and @Tobi.

--- a/cps/tasks/kepub_backfill.py
+++ b/cps/tasks/kepub_backfill.py
@@ -5,7 +5,7 @@ import os
 import threading
 
 from flask_babel import lazy_gettext as N_
-from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
 
 from .. import config, db, logger, ub
 from ..epub import get_epub_layout
@@ -39,6 +39,15 @@ _TERMINAL_STATS = (STAT_FAIL, STAT_FINISH_SUCCESS, STAT_ENDED, STAT_CANCELLED)
 # one error (and traceback) per book. Three attempts tolerate a transient
 # teardown race while putting a hard ceiling on the resulting log volume.
 _SESSION_REBUILD_LIMIT = 3
+
+
+class _DatabaseFailure(Exception):
+    """A failure while traversing the Calibre metadata database."""
+
+    def __init__(self, operation, error):
+        self.operation = operation
+        self.error = error
+        super().__init__("{}: {}".format(operation, error))
 
 
 def _clear_pending(task):
@@ -113,30 +122,22 @@ class TaskKepubBackfill(CalibreTask):
         reproduce the issue's unbounded log flood without doing useful work.
         """
         self._discard_database(failed_db, rollback=True)
-        last_error = None
         for attempt in range(1, _SESSION_REBUILD_LIMIT + 1):
             rebuilt_db = None
             try:
                 rebuilt_db = db.CalibreDB(expire_on_commit=False, init=True)
-                session = rebuilt_db.session
-                if session is None:
-                    raise RuntimeError("CalibreDB did not provide a database session")
-                if getattr(session, "is_active", True) is False:
-                    raise RuntimeError("CalibreDB provided an inactive database session")
-                # Session construction alone does not prove its engine/DBAPI
-                # connection survived the concurrent reconnect that triggered
-                # recovery. Probe the wire, then end the probe transaction so
-                # the next book begins from a clean boundary.
-                if hasattr(session, "execute"):
-                    session.execute(text("SELECT 1")).scalar()
-                    session.rollback()
+                # Connectivity is insufficient: SQLite happily answers
+                # ``SELECT 1`` when the engine is attached to an empty/wrong
+                # database. Exercise the same Books and Data ORM paths used by
+                # the task so a rebuilt session is not declared healthy until
+                # the real Calibre metadata schema is available.
+                self._probe_metadata_database(rebuilt_db, book_id)
                 log.info(
                     "KEPUB backfill rebuilt its database session after book %s",
                     book_id,
                 )
                 return rebuilt_db
             except Exception as error:
-                last_error = error
                 self._discard_database(rebuilt_db, rollback=True)
                 log.warning(
                     "KEPUB backfill database session rebuild %d/%d failed "
@@ -144,12 +145,50 @@ class TaskKepubBackfill(CalibreTask):
                     attempt, _SESSION_REBUILD_LIMIT, book_id, error,
                 )
 
-        log.error(
-            "KEPUB backfill aborting after %d consecutive database session "
-            "rebuild failures following book %s: %s",
-            _SESSION_REBUILD_LIMIT, book_id, last_error,
-        )
         return None
+
+    @staticmethod
+    def _probe_metadata_database(local_db, book_id):
+        """Exercise the real Books/Data ORM path and leave a clean transaction."""
+        session = local_db.session
+        if session is None:
+            raise RuntimeError("CalibreDB did not provide a database session")
+        if getattr(session, "is_active", True) is False:
+            raise RuntimeError("CalibreDB provided an inactive database session")
+        local_db.get_book(book_id)
+        local_db.get_book_format(book_id, "KEPUB")
+        local_db.get_book_format(book_id, "EPUB")
+        if hasattr(session, "rollback"):
+            session.rollback()
+
+    @staticmethod
+    def _book_metadata(local_db, book_id):
+        """Return the book/formats, classifying failures by operation phase."""
+        try:
+            book = local_db.get_book(book_id)
+            if not book:
+                return None, None, None
+            kepub = local_db.get_book_format(book_id, "KEPUB")
+            epub = local_db.get_book_format(book_id, "EPUB")
+            return book, kepub, epub
+        except Exception as error:
+            raise _DatabaseFailure("Calibre metadata lookup", error) from error
+
+    @staticmethod
+    def _persist_completion(completed):
+        """Persist the rollback-compatibility marker with safe in-memory state."""
+        config.config_kobo_kepub_backfill_completed = completed
+        try:
+            config.save()
+        except Exception:
+            # A failed write must never leave this process claiming completion.
+            config.config_kobo_kepub_backfill_completed = False
+            raise
+
+    def _finish_failure(self, error):
+        """Publish a failed terminal state only after clearing completion."""
+        self._persist_completion(False)
+        self._handleError(error)
 
     def run(self, worker_thread):
         global _pending
@@ -159,7 +198,7 @@ class TaskKepubBackfill(CalibreTask):
                 self._handleSuccess()
                 return
             if not config.config_kepubifypath:
-                self._handleError(N_(u"Kepubify is not configured"))
+                self._finish_failure(N_(u"Kepubify is not configured"))
                 return
 
             app_session = ub.get_new_session_instance()
@@ -169,12 +208,14 @@ class TaskKepubBackfill(CalibreTask):
                 app_session.close()
 
             local_db = db.CalibreDB(expire_on_commit=False, init=True)
-            abort_after_rebuild_failure = False
+            abort_reason = None
+            consecutive_database_failures = 0
             try:
                 total = len(book_ids)
                 for index, book_id in enumerate(book_ids):
                     if self.stat == STAT_ENDED:
                         self.message = self._status_message(total)
+                        self._persist_completion(False)
                         return
                     # The guard covers the whole per-book body, not just the
                     # conversion. Reading the book row and its formats can raise
@@ -185,17 +226,48 @@ class TaskKepubBackfill(CalibreTask):
                     # same run that converts nothing on every single boot.
                     try:
                         self._backfill_one_book(local_db, book_id)
+                    except _DatabaseFailure as error:
+                        self.failed += 1
+                        consecutive_database_failures += 1
+                        log.error_or_exception(
+                            "KEPUB backfill database failure for book {} "
+                            "({}/{} consecutive): {}".format(
+                                book_id,
+                                consecutive_database_failures,
+                                _SESSION_REBUILD_LIMIT,
+                                error,
+                            ))
+                        if consecutive_database_failures >= _SESSION_REBUILD_LIMIT:
+                            self._discard_database(local_db, rollback=True)
+                            local_db = None
+                            abort_reason = N_(
+                                u"%(count)d consecutive Calibre metadata database failures",
+                                count=_SESSION_REBUILD_LIMIT,
+                            )
+                        else:
+                            local_db = self._rebuild_database(local_db, book_id)
+                            if local_db is None:
+                                abort_reason = N_(
+                                    u"%(count)d consecutive Calibre metadata probe failures",
+                                    count=_SESSION_REBUILD_LIMIT,
+                                )
                     except Exception as error:
+                        # Archive/layout/converter failures are isolated to the
+                        # book. They prove the metadata path completed and must
+                        # neither rebuild the Session nor advance its breaker.
+                        consecutive_database_failures = 0
                         self.failed += 1
                         log.error_or_exception(
                             "KEPUB backfill failed for book {}: {}".format(book_id, error))
-                        local_db = self._rebuild_database(local_db, book_id)
-                        if local_db is None:
-                            abort_after_rebuild_failure = True
+                    else:
+                        # Only a real metadata lookup for a work-set book clears
+                        # the post-rebuild database failure streak. A successful
+                        # constructor/probe deliberately does not.
+                        consecutive_database_failures = 0
                     finally:
                         self.processed += 1
                         self.progress = (index + 1) / total if total else 1
-                    if abort_after_rebuild_failure:
+                    if abort_reason is not None:
                         break
             finally:
                 # Remove, rather than merely close, this persistent worker
@@ -204,49 +276,51 @@ class TaskKepubBackfill(CalibreTask):
 
             self.message = self._status_message(total)
 
-            if abort_after_rebuild_failure:
+            if abort_reason is not None:
                 terminal_error = N_(
-                    u"KEPUB backfill aborted after %(count)d consecutive "
-                    u"database session rebuild failures; %(status)s",
-                    count=_SESSION_REBUILD_LIMIT,
+                    u"KEPUB backfill aborted after %(reason)s; %(status)s",
+                    reason=abort_reason,
                     status=self.message,
                 )
                 log.error("%s", terminal_error)
-                self._handleError(terminal_error)
+                self._finish_failure(terminal_error)
                 return
 
             # The legacy completion flag no longer gates startup: every eligible
             # boot performs the cheap idempotent scan. Keep writing it for safe
-            # rollback to an older release, but do not mark a wholly failed run
-            # complete for that older reader.
-            if self.converted or not self.failed:
-                # Persist first, then flip the in-memory flag: a save() that
-                # raises would otherwise leave this process believing the
-                # migration is done while the next boot re-reads False.
-                config.config_kobo_kepub_backfill_completed = True
-                try:
-                    config.save()
-                except Exception:
-                    config.config_kobo_kepub_backfill_completed = False
-                    raise
+            # rollback to an older release, but never let it contradict a failed
+            # terminal worker status.
             if self.failed:
-                self._handleError(N_(
+                self._finish_failure(N_(
                     u"KEPUB backfill finished with failures; %(status)s",
                     status=self.message,
                 ))
                 return
+            self._persist_completion(True)
             self._handleSuccess()
+        except Exception:
+            # ``CalibreTask.start`` turns an escaping exception into STAT_FAIL.
+            # Clear the persisted compatibility marker here as well so failures
+            # before the per-book loop (or while saving success) cannot retain a
+            # stale True value from an earlier run.
+            config.config_kobo_kepub_backfill_completed = False
+            try:
+                config.save()
+            except Exception as error:
+                log.error(
+                    "KEPUB backfill could not persist its incomplete state: %s",
+                    error,
+                )
+            raise
         finally:
             _clear_pending(self)
 
     def _backfill_one_book(self, local_db, book_id):
         """Convert one book, or record why it was skipped. Raises on I/O trouble."""
-        book = local_db.get_book(book_id)
+        book, kepub, epub = self._book_metadata(local_db, book_id)
         if not book:
             self.skipped += 1
             return
-        kepub = local_db.get_book_format(book_id, "KEPUB")
-        epub = local_db.get_book_format(book_id, "EPUB")
         if kepub or not epub:
             self.skipped += 1
             return
@@ -257,9 +331,22 @@ class TaskKepubBackfill(CalibreTask):
         file_path = os.path.join(config.get_book_path(), book.path, epub.name)
         settings = {"old_book_format": "EPUB", "new_book_format": "KEPUB"}
         conversion = TaskConvert(file_path, book_id, "EPUB -> KEPUB", settings, None)
-        if conversion._convert_ebook_format():
+        try:
+            converted = conversion._convert_ebook_format()
+        except SQLAlchemyError as error:
+            raise _DatabaseFailure("KEPUB conversion metadata update", error) from error
+        if converted:
             self.converted += 1
         else:
+            # TaskConvert handles several SQLAlchemy failures internally and
+            # returns a normal conversion failure. Probing here separates a
+            # genuinely bad archive/tool run from a conversion that merely
+            # masked a dead metadata session.
+            try:
+                self._probe_metadata_database(local_db, book_id)
+            except Exception as error:
+                raise _DatabaseFailure(
+                    "KEPUB conversion metadata verification", error) from error
             self.failed += 1
             log.error("KEPUB backfill failed for book %d: %s", book_id, conversion.error)
 

--- a/cps/tasks/kepub_backfill.py
+++ b/cps/tasks/kepub_backfill.py
@@ -5,8 +5,9 @@ import os
 import threading
 
 from flask_babel import lazy_gettext as N_
+from sqlalchemy import text
 
-from .. import config, db, helper, logger, ub
+from .. import config, db, logger, ub
 from ..epub import get_epub_layout
 from ..services.worker import (CalibreTask, STAT_CANCELLED, STAT_ENDED, STAT_FAIL,
                                STAT_FINISH_SUCCESS, WorkerThread)
@@ -33,6 +34,11 @@ _pending_owner = None
 # that path too, so a cancel cannot leave the latch stuck on for the lifetime of
 # the process (which silently downgraded every Kobo KEPUB download to EPUB).
 _TERMINAL_STATS = (STAT_FAIL, STAT_FINISH_SUCCESS, STAT_ENDED, STAT_CANCELLED)
+# A broken metadata database/session should stop this hidden startup task after
+# a handful of bounded recovery attempts, not turn a large synced library into
+# one error (and traceback) per book. Three attempts tolerate a transient
+# teardown race while putting a hard ceiling on the resulting log volume.
+_SESSION_REBUILD_LIMIT = 3
 
 
 def _clear_pending(task):
@@ -51,6 +57,99 @@ class TaskKepubBackfill(CalibreTask):
         self.converted = 0
         self.skipped = 0
         self.failed = 0
+        self.processed = 0
+
+    def _status_message(self, total):
+        return N_(
+            u"%(processed)d/%(total)d processed: %(converted)d converted, "
+            u"%(skipped)d skipped, %(failed)d failed",
+            processed=self.processed,
+            total=total,
+            converted=self.converted,
+            skipped=self.skipped,
+            failed=self.failed,
+        )
+
+    @staticmethod
+    def _discard_database(local_db, rollback=False):
+        """End this worker greenlet's transaction and remove its scoped Session.
+
+        Every ``CalibreDB`` made by the worker resolves through the same
+        greenlet-scoped registry. Calling ``Session.close()`` is therefore not
+        enough: the closed (or failed) Session remains registered and the next
+        ``CalibreDB`` object receives it again. Assigning ``None`` uses
+        ``CalibreDB.session``'s removal contract and makes the next access
+        materialise a genuinely new Session.
+        """
+        if local_db is None:
+            return
+        try:
+            session = local_db.session
+        except Exception:
+            session = None
+        if rollback and session is not None:
+            try:
+                session.rollback()
+            except Exception as error:
+                log.warning("KEPUB backfill session rollback failed: %s", error)
+        try:
+            local_db.session = None
+        except Exception as error:
+            # Test doubles and downstream CalibreDB-compatible implementations
+            # may not expose the removal setter. Close is the best available
+            # fallback, while the production class always takes the path above.
+            try:
+                if session is not None:
+                    session.close()
+            except Exception:
+                pass
+            log.warning("KEPUB backfill could not discard its database session: %s", error)
+
+    def _rebuild_database(self, failed_db, book_id):
+        """Rollback/remove a poisoned Session and return a fresh CalibreDB.
+
+        Recovery itself is circuit-broken. If the registry or engine cannot
+        produce a usable Session, retrying once for every remaining book would
+        reproduce the issue's unbounded log flood without doing useful work.
+        """
+        self._discard_database(failed_db, rollback=True)
+        last_error = None
+        for attempt in range(1, _SESSION_REBUILD_LIMIT + 1):
+            rebuilt_db = None
+            try:
+                rebuilt_db = db.CalibreDB(expire_on_commit=False, init=True)
+                session = rebuilt_db.session
+                if session is None:
+                    raise RuntimeError("CalibreDB did not provide a database session")
+                if getattr(session, "is_active", True) is False:
+                    raise RuntimeError("CalibreDB provided an inactive database session")
+                # Session construction alone does not prove its engine/DBAPI
+                # connection survived the concurrent reconnect that triggered
+                # recovery. Probe the wire, then end the probe transaction so
+                # the next book begins from a clean boundary.
+                if hasattr(session, "execute"):
+                    session.execute(text("SELECT 1")).scalar()
+                    session.rollback()
+                log.info(
+                    "KEPUB backfill rebuilt its database session after book %s",
+                    book_id,
+                )
+                return rebuilt_db
+            except Exception as error:
+                last_error = error
+                self._discard_database(rebuilt_db, rollback=True)
+                log.warning(
+                    "KEPUB backfill database session rebuild %d/%d failed "
+                    "after book %s: %s",
+                    attempt, _SESSION_REBUILD_LIMIT, book_id, error,
+                )
+
+        log.error(
+            "KEPUB backfill aborting after %d consecutive database session "
+            "rebuild failures following book %s: %s",
+            _SESSION_REBUILD_LIMIT, book_id, last_error,
+        )
+        return None
 
     def run(self, worker_thread):
         global _pending
@@ -70,10 +169,12 @@ class TaskKepubBackfill(CalibreTask):
                 app_session.close()
 
             local_db = db.CalibreDB(expire_on_commit=False, init=True)
+            abort_after_rebuild_failure = False
             try:
                 total = len(book_ids)
                 for index, book_id in enumerate(book_ids):
                     if self.stat == STAT_ENDED:
+                        self.message = self._status_message(total)
                         return
                     # The guard covers the whole per-book body, not just the
                     # conversion. Reading the book row and its formats can raise
@@ -88,17 +189,31 @@ class TaskKepubBackfill(CalibreTask):
                         self.failed += 1
                         log.error_or_exception(
                             "KEPUB backfill failed for book {}: {}".format(book_id, error))
-                    self.progress = (index + 1) / total if total else 1
+                        local_db = self._rebuild_database(local_db, book_id)
+                        if local_db is None:
+                            abort_after_rebuild_failure = True
+                    finally:
+                        self.processed += 1
+                        self.progress = (index + 1) / total if total else 1
+                    if abort_after_rebuild_failure:
+                        break
             finally:
-                # CalibreDB.session is documented as possibly None (cps/db.py
-                # "Don't raise exception - let caller handle AttributeError"), and
-                # a raise here both escapes run() and masks whatever the try body
-                # was actually failing on -- so the task would report "'NoneType'
-                # has no attribute 'close'" instead of the real cause.
-                try:
-                    local_db.session.close()
-                except Exception as error:
-                    log.error("KEPUB backfill could not close its database session: %s", error)
+                # Remove, rather than merely close, this persistent worker
+                # greenlet's scoped Session so later tasks cannot inherit it.
+                self._discard_database(local_db)
+
+            self.message = self._status_message(total)
+
+            if abort_after_rebuild_failure:
+                terminal_error = N_(
+                    u"KEPUB backfill aborted after %(count)d consecutive "
+                    u"database session rebuild failures; %(status)s",
+                    count=_SESSION_REBUILD_LIMIT,
+                    status=self.message,
+                )
+                log.error("%s", terminal_error)
+                self._handleError(terminal_error)
+                return
 
             # The legacy completion flag no longer gates startup: every eligible
             # boot performs the cheap idempotent scan. Keep writing it for safe
@@ -115,7 +230,10 @@ class TaskKepubBackfill(CalibreTask):
                     config.config_kobo_kepub_backfill_completed = False
                     raise
             if self.failed:
-                self._handleError(N_(u"%(count)d KEPUB conversion(s) failed", count=self.failed))
+                self._handleError(N_(
+                    u"KEPUB backfill finished with failures; %(status)s",
+                    status=self.message,
+                ))
                 return
             self._handleSuccess()
         finally:

--- a/notes/1857-kepub-off-sync-finding.md
+++ b/notes/1857-kepub-off-sync-finding.md
@@ -1,0 +1,40 @@
+# Issue #1857: KEPUB-off Kobo sync finding
+
+This note records the second half of #1857 for a separate dispatch. It is an
+investigation result, not a fix in the session-containment branch.
+
+## Observed
+
+- `cps/kobo.py:711` calls `calibre_db.reconnect_db(config, ub.app_DB_path)` on
+  every `/v1/library/sync` request. The call is unconditional, outside an error
+  boundary, and independent of `config_kobo_prefer_kepub`.
+- `cps/db.py:2211-2231` implements `reconnect_db()` by calling `dispose()`,
+  disposing the class-level engine, then rebuilding the database setup.
+  `cps/db.py:2176-2195` shows that `dispose()` closes sessions/bindings, and
+  `cps/db.py:1296-1316` shows setup can return without producing a new factory
+  when the library path or `metadata.db` is unavailable.
+- `cps/kobo.py:1914-1924` is the complete KEPUB-preference branch in Kobo
+  metadata generation. Turning the preference off changes only an EPUB row's
+  deferred download from KEPUB to EPUB/EPUB3. A stored KEPUB row remains first
+  choice even when the preference is off.
+- Existing test policy already names the engine-disposal race:
+  `tests/unit/test_metadata_db_write_coordination.py:79-114` forbids the
+  post-ingest reconnect endpoint from using the heavy reconnect path because it
+  races with active requests. The Kobo sync route still uses that path.
+
+## Finding for the follow-up dispatch
+
+There is a concrete abort mechanism for the reporter's device-side “Sync
+failed” with no Kobo-specific terminal log: the unconditional reconnect at
+`cps/kobo.py:711` can raise or leave database setup unavailable before the
+route reaches its response generation, and there is no local exception handler
+to turn that into a diagnosed Kobo response/log entry. The same global engine
+disposal also explains how a concurrent sync can invalidate the KEPUB backfill
+while it is fetching a book.
+
+The code does **not** establish that switching the KEPUB preference off causes
+the reconnect failure; the reconnect runs in both preference states. Treat the
+reported toggle as correlation until a request-level reproduction proves a
+causal link. The follow-up should capture the failing HTTP status and exception,
+then evaluate replacing the per-sync destructive reconnect with the existing
+non-disposing refresh model rather than changing KEPUB metadata blindly.

--- a/tests/unit/test_1419_kepub_backfill_survives_one_bad_book.py
+++ b/tests/unit/test_1419_kepub_backfill_survives_one_bad_book.py
@@ -17,8 +17,9 @@ Three defects made that dangerous, all found by the pre-release refuter loop:
    which is *not* an ``OSError`` and so was not caught in ``cps/epub.py``
    either. One corrupt EPUB anywhere in the synced set therefore aborted the
    whole loop, converted **zero** books, and — because the exception escaped
-   before the completed flag was set — re-queued the identical doomed run on
-   every boot, forever, on a ``hidden=True`` task with no UI trace.
+   before later books could run. The task now scans idempotently on every
+   eligible boot, so partial failures deliberately leave the compatibility
+   completion marker false while still containing archive trouble per book.
 
 2. A task cancelled while still queued never runs, so the ``finally`` in
    ``run()`` that clears ``_pending`` never fired. The latch then made
@@ -26,9 +27,8 @@ Three defects made that dangerous, all found by the pre-release refuter loop:
    silently downgraded every Kobo KEPUB download to EPUB while still telling the
    device the format was KEPUB.
 
-3. The completed flag was set before ``self.failed`` was consulted, so a run
-   where *everything* failed (read-only books volume, a mount that arrived late)
-   was checked off as a finished migration and never retried.
+3. The completed flag was set before ``self.failed`` was consulted, so failed
+   runs could be reported as failed while still persisting completion.
 """
 
 import zipfile
@@ -64,7 +64,7 @@ def _app_session(rows):
 def _calibre_db(get_book=None):
     class CalibreDB:
         def __init__(self, **_):
-            self.session = SimpleNamespace(close=lambda: None)
+            self.session = SimpleNamespace(close=lambda: None, rollback=lambda: None)
 
         def get_book(self, book_id):
             if get_book is not None:
@@ -88,7 +88,13 @@ def _wire(monkeypatch, kepub_backfill, rows, conversion, layout, get_book=None):
     monkeypatch.setattr(
         kepub_backfill.config, "config_kobo_kepub_backfill_completed", False, raising=False)
     monkeypatch.setattr(kepub_backfill.config, "get_book_path", lambda: "/books", raising=False)
-    monkeypatch.setattr(kepub_backfill.config, "save", lambda: saved.append(True), raising=False)
+    monkeypatch.setattr(
+        kepub_backfill.config,
+        "save",
+        lambda: saved.append(
+            kepub_backfill.config.config_kobo_kepub_backfill_completed),
+        raising=False,
+    )
     return saved
 
 
@@ -128,9 +134,8 @@ def test_corrupt_epub_does_not_abort_the_whole_migration(monkeypatch):
     assert attempted == [2, 3]
     assert task.converted == 2
     assert task.failed == 1
-    # Pre-fix this stayed False, so every boot re-queued the same doomed run.
-    assert kepub_backfill.config.config_kobo_kepub_backfill_completed is True
-    assert saved == [True]
+    assert kepub_backfill.config.config_kobo_kepub_backfill_completed is False
+    assert saved == [False]
 
 
 def test_unreadable_book_row_does_not_abort_the_whole_migration(monkeypatch):
@@ -138,9 +143,12 @@ def test_unreadable_book_row_does_not_abort_the_whole_migration(monkeypatch):
     from cps.tasks import kepub_backfill
 
     attempted = []
+    first_lookup = True
 
     def get_book(book_id):
-        if book_id == 1:
+        nonlocal first_lookup
+        if book_id == 1 and first_lookup:
+            first_lookup = False
             raise RuntimeError("database is locked")
         return SimpleNamespace(id=book_id, path=str(book_id), title=str(book_id))
 
@@ -153,7 +161,7 @@ def test_unreadable_book_row_does_not_abort_the_whole_migration(monkeypatch):
     assert attempted == [2]
     assert task.converted == 1
     assert task.failed == 1
-    assert kepub_backfill.config.config_kobo_kepub_backfill_completed is True
+    assert kepub_backfill.config.config_kobo_kepub_backfill_completed is False
 
 
 def test_a_run_that_converts_nothing_is_not_marked_completed(monkeypatch):
@@ -173,8 +181,8 @@ def test_a_run_that_converts_nothing_is_not_marked_completed(monkeypatch):
     assert kepub_backfill.config.config_kobo_kepub_backfill_completed is False
 
 
-def test_partial_failure_still_marks_completed(monkeypatch):
-    """Preserved behaviour: some progress means the migration ran."""
+def test_partial_failure_keeps_completion_false(monkeypatch):
+    """Terminal STAT_FAIL and the persisted completion marker cannot disagree."""
     from cps.tasks import kepub_backfill
 
     attempted = []
@@ -185,7 +193,7 @@ def test_partial_failure_still_marks_completed(monkeypatch):
     task.run(None)
 
     assert task.converted == 1 and task.failed == 1
-    assert kepub_backfill.config.config_kobo_kepub_backfill_completed is True
+    assert kepub_backfill.config.config_kobo_kepub_backfill_completed is False
 
 
 def test_cancel_while_queued_clears_the_pending_latch(monkeypatch):
@@ -307,7 +315,7 @@ def test_an_unclosable_session_does_not_destroy_the_diagnosis(monkeypatch):
     task.run(None)  # must not raise AttributeError about 'close'
 
     assert task.failed == 1
-    assert saved == []
+    assert saved == [False]
 
 
 def test_get_epub_layout_returns_none_for_a_corrupt_archive(monkeypatch, tmp_path):

--- a/tests/unit/test_1857_kepub_backfill_session_recovery.py
+++ b/tests/unit/test_1857_kepub_backfill_session_recovery.py
@@ -1,0 +1,192 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Regression coverage for fork #1857's poisoned KEPUB backfill session."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from cps.services.worker import STAT_FAIL
+
+
+pytestmark = pytest.mark.unit
+
+
+class _Query:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def distinct(self):
+        return self
+
+    def all(self):
+        return list(self._rows)
+
+
+def _wire_common(monkeypatch, kepub_backfill, calibre_db, book_ids):
+    class AppSession:
+        def query(self, *_args):
+            return _Query([(book_id,) for book_id in book_ids])
+
+        def close(self):
+            pass
+
+    saved = []
+    monkeypatch.setattr(kepub_backfill.ub, "get_new_session_instance", AppSession)
+    monkeypatch.setattr(kepub_backfill.db, "CalibreDB", calibre_db)
+    monkeypatch.setattr(kepub_backfill, "get_epub_layout", lambda *_args: None)
+    monkeypatch.setattr(
+        kepub_backfill.config, "config_use_google_drive", False, raising=False)
+    monkeypatch.setattr(
+        kepub_backfill.config, "config_kepubifypath", "/bin/kepubify", raising=False)
+    monkeypatch.setattr(
+        kepub_backfill.config, "config_kobo_kepub_backfill_completed", False,
+        raising=False)
+    monkeypatch.setattr(
+        kepub_backfill.config, "get_book_path", lambda: "/books", raising=False)
+    monkeypatch.setattr(
+        kepub_backfill.config, "save", lambda: saved.append(True), raising=False)
+    return saved
+
+
+def test_closed_session_failure_rebuilds_and_processes_later_books(monkeypatch):
+    """Book k poisons one Session; k+1..n run on a fresh CalibreDB/Session."""
+    from cps.tasks import kepub_backfill
+
+    instances = []
+    book_queries = []
+
+    class Session:
+        def __init__(self, number):
+            self.number = number
+            self.is_active = True
+            self.rollback_calls = 0
+
+        def rollback(self):
+            self.rollback_calls += 1
+            self.is_active = True
+
+    class CalibreDB:
+        def __init__(self, **_kwargs):
+            self.number = len(instances) + 1
+            self.session = Session(self.number)
+            instances.append(self)
+
+        def get_book(self, book_id):
+            book_queries.append((self.number, book_id))
+            if self.number == 1 and book_id == 2:
+                self.session.is_active = False
+                raise RuntimeError(
+                    "Can't reconnect until invalid transaction is rolled back")
+            return SimpleNamespace(
+                id=book_id, path=str(book_id), title=str(book_id))
+
+        def get_book_format(self, _book_id, fmt):
+            if fmt == "EPUB":
+                return SimpleNamespace(format="EPUB", name="book")
+            return None
+
+    converted = []
+
+    class Conversion:
+        def __init__(self, _path, book_id, *_args):
+            self.book_id = book_id
+            self.error = None
+
+        def _convert_ebook_format(self):
+            converted.append(self.book_id)
+            return "book.kepub"
+
+    saved = _wire_common(monkeypatch, kepub_backfill, CalibreDB, [1, 2, 3, 4])
+    monkeypatch.setattr(kepub_backfill, "TaskConvert", Conversion)
+    per_book_errors = []
+    monkeypatch.setattr(
+        kepub_backfill.log, "error_or_exception", per_book_errors.append)
+
+    task = kepub_backfill.TaskKepubBackfill()
+    task.run(None)
+
+    assert converted == [1, 3, 4]
+    assert book_queries == [(1, 1), (1, 2), (2, 3), (2, 4)]
+    assert len(instances) == 2
+    assert instances[0].session is None
+    assert task.processed == 4
+    assert task.converted == 3
+    assert task.skipped == 0
+    assert task.failed == 1
+    assert str(task.message) == "4/4 processed: 3 converted, 0 skipped, 1 failed"
+    assert str(task.error) == (
+        "KEPUB backfill finished with failures; "
+        "4/4 processed: 3 converted, 0 skipped, 1 failed")
+    assert task.stat == STAT_FAIL
+    assert saved == [True]
+    assert len(per_book_errors) == 1
+    assert "Can't reconnect until invalid transaction is rolled back" in per_book_errors[0]
+
+
+def test_session_rebuild_circuit_breaker_aborts_at_exact_threshold(monkeypatch):
+    """A dead session factory produces three rebuild logs, not one per book."""
+    from cps.tasks import kepub_backfill
+
+    constructor_calls = []
+    queried_books = []
+
+    class Session:
+        def __init__(self, usable):
+            self.is_active = True
+            self.usable = usable
+
+        def rollback(self):
+            pass
+
+        def execute(self, _statement):
+            if not self.usable:
+                raise RuntimeError("session factory is unavailable")
+            return SimpleNamespace(scalar=lambda: 1)
+
+    class CalibreDB:
+        def __init__(self, **_kwargs):
+            constructor_calls.append(len(constructor_calls) + 1)
+            self.session = Session(usable=len(constructor_calls) == 1)
+
+        def get_book(self, book_id):
+            queried_books.append(book_id)
+            raise RuntimeError("Cannot operate on a closed database")
+
+        def get_book_format(self, *_args):
+            raise AssertionError("format lookup must not follow the failed book lookup")
+
+    class Conversion:
+        def __init__(self, *_args):
+            raise AssertionError("conversion must not start after the database failure")
+
+    saved = _wire_common(monkeypatch, kepub_backfill, CalibreDB, [10, 11, 12, 13])
+    monkeypatch.setattr(kepub_backfill, "TaskConvert", Conversion)
+    terminal_logs = []
+
+    def capture_error(message, *args, **_kwargs):
+        terminal_logs.append(message % args if args else str(message))
+
+    monkeypatch.setattr(kepub_backfill.log, "error", capture_error)
+
+    task = kepub_backfill.TaskKepubBackfill()
+    task.run(None)
+
+    assert constructor_calls == [1, 2, 3, 4]
+    assert queried_books == [10]
+    assert task.processed == 1
+    assert task.converted == 0
+    assert task.skipped == 0
+    assert task.failed == 1
+    assert str(task.message) == "1/4 processed: 0 converted, 0 skipped, 1 failed"
+    assert "aborted after 3 consecutive database session rebuild failures" in str(task.error)
+    assert "1/4 processed: 0 converted, 0 skipped, 1 failed" in str(task.error)
+    assert task.stat == STAT_FAIL
+    assert saved == []
+    assert sum("aborting after 3 consecutive" in line for line in terminal_logs) == 1
+    assert not any("book 11" in line or "book 12" in line or "book 13" in line
+                   for line in terminal_logs)

--- a/tests/unit/test_1857_kepub_backfill_session_recovery.py
+++ b/tests/unit/test_1857_kepub_backfill_session_recovery.py
@@ -49,7 +49,12 @@ def _wire_common(monkeypatch, kepub_backfill, calibre_db, book_ids):
     monkeypatch.setattr(
         kepub_backfill.config, "get_book_path", lambda: "/books", raising=False)
     monkeypatch.setattr(
-        kepub_backfill.config, "save", lambda: saved.append(True), raising=False)
+        kepub_backfill.config,
+        "save",
+        lambda: saved.append(
+            kepub_backfill.config.config_kobo_kepub_backfill_completed),
+        raising=False,
+    )
     return saved
 
 
@@ -111,7 +116,7 @@ def test_closed_session_failure_rebuilds_and_processes_later_books(monkeypatch):
     task.run(None)
 
     assert converted == [1, 3, 4]
-    assert book_queries == [(1, 1), (1, 2), (2, 3), (2, 4)]
+    assert book_queries == [(1, 1), (1, 2), (2, 2), (2, 3), (2, 4)]
     assert len(instances) == 2
     assert instances[0].session is None
     assert task.processed == 4
@@ -123,48 +128,64 @@ def test_closed_session_failure_rebuilds_and_processes_later_books(monkeypatch):
         "KEPUB backfill finished with failures; "
         "4/4 processed: 3 converted, 0 skipped, 1 failed")
     assert task.stat == STAT_FAIL
-    assert saved == [True]
+    assert saved == [False]
     assert len(per_book_errors) == 1
     assert "Can't reconnect until invalid transaction is rolled back" in per_book_errors[0]
 
 
-def test_session_rebuild_circuit_breaker_aborts_at_exact_threshold(monkeypatch):
-    """A dead session factory produces three rebuild logs, not one per book."""
+def test_missing_calibre_schema_fails_metadata_probe_and_aborts_bounded(monkeypatch):
+    """SELECT 1 is healthy, but a missing Books table stops after three probes."""
     from cps.tasks import kepub_backfill
 
     constructor_calls = []
     queried_books = []
+    select_one_calls = []
+    converted = []
 
     class Session:
-        def __init__(self, usable):
+        def __init__(self):
             self.is_active = True
-            self.usable = usable
 
         def rollback(self):
             pass
 
         def execute(self, _statement):
-            if not self.usable:
-                raise RuntimeError("session factory is unavailable")
+            select_one_calls.append(True)
             return SimpleNamespace(scalar=lambda: 1)
 
     class CalibreDB:
         def __init__(self, **_kwargs):
             constructor_calls.append(len(constructor_calls) + 1)
-            self.session = Session(usable=len(constructor_calls) == 1)
+            self.number = len(constructor_calls)
+            self.session = Session()
 
         def get_book(self, book_id):
-            queried_books.append(book_id)
-            raise RuntimeError("Cannot operate on a closed database")
+            queried_books.append((self.number, book_id))
+            if self.number == 1 and book_id == 1:
+                return SimpleNamespace(id=book_id, path=str(book_id), title=str(book_id))
+            raise RuntimeError("no such table: books")
 
-        def get_book_format(self, *_args):
-            raise AssertionError("format lookup must not follow the failed book lookup")
+        def get_book_format(self, _book_id, fmt):
+            if fmt == "EPUB":
+                return SimpleNamespace(format="EPUB", name="book")
+            return None
 
     class Conversion:
-        def __init__(self, *_args):
-            raise AssertionError("conversion must not start after the database failure")
+        def __init__(self, _path, book_id, *_args):
+            self.book_id = book_id
+            self.error = None
 
-    saved = _wire_common(monkeypatch, kepub_backfill, CalibreDB, [10, 11, 12, 13])
+        def _convert_ebook_format(self):
+            converted.append(self.book_id)
+            return "book.kepub"
+
+    saved = _wire_common(monkeypatch, kepub_backfill, CalibreDB, [1, 2, 3, 4, 5])
+    monkeypatch.setattr(
+        kepub_backfill.config,
+        "config_kobo_kepub_backfill_completed",
+        True,
+        raising=False,
+    )
     monkeypatch.setattr(kepub_backfill, "TaskConvert", Conversion)
     terminal_logs = []
 
@@ -176,17 +197,142 @@ def test_session_rebuild_circuit_breaker_aborts_at_exact_threshold(monkeypatch):
     task = kepub_backfill.TaskKepubBackfill()
     task.run(None)
 
+    assert converted == [1]
     assert constructor_calls == [1, 2, 3, 4]
-    assert queried_books == [10]
-    assert task.processed == 1
-    assert task.converted == 0
+    assert queried_books == [(1, 1), (1, 2), (2, 2), (3, 2), (4, 2)]
+    assert select_one_calls == []  # It would pass, but is no longer the health probe.
+    assert task.processed == 2
+    assert task.converted == 1
     assert task.skipped == 0
     assert task.failed == 1
-    assert str(task.message) == "1/4 processed: 0 converted, 0 skipped, 1 failed"
-    assert "aborted after 3 consecutive database session rebuild failures" in str(task.error)
-    assert "1/4 processed: 0 converted, 0 skipped, 1 failed" in str(task.error)
+    assert str(task.message) == "2/5 processed: 1 converted, 0 skipped, 1 failed"
+    assert "aborted after 3 consecutive Calibre metadata probe failures" in str(task.error)
+    assert "2/5 processed: 1 converted, 0 skipped, 1 failed" in str(task.error)
     assert task.stat == STAT_FAIL
-    assert saved == []
-    assert sum("aborting after 3 consecutive" in line for line in terminal_logs) == 1
-    assert not any("book 11" in line or "book 12" in line or "book 13" in line
+    assert kepub_backfill.config.config_kobo_kepub_backfill_completed is False
+    assert saved == [False]
+    assert sum("aborted after 3 consecutive" in line for line in terminal_logs) == 1
+    assert not any("book 3" in line or "book 4" in line or "book 5" in line
                    for line in terminal_logs)
+
+
+def test_post_rebuild_database_failures_trip_the_consecutive_breaker(monkeypatch):
+    """A passing schema probe does not reset repeated real-query failures."""
+    from cps.tasks import kepub_backfill
+
+    instances = []
+    queried_books = []
+    converted = []
+
+    class Session:
+        is_active = True
+
+        def rollback(self):
+            pass
+
+    class CalibreDB:
+        def __init__(self, **_kwargs):
+            self.number = len(instances) + 1
+            self.session = Session()
+            self.probe_passed = False
+            instances.append(self)
+
+        def get_book(self, book_id):
+            queried_books.append((self.number, book_id))
+            if self.number == 1 and book_id == 1:
+                return SimpleNamespace(id=book_id, path=str(book_id), title=str(book_id))
+            if self.number > 1 and not self.probe_passed:
+                self.probe_passed = True
+                return SimpleNamespace(id=book_id, path=str(book_id), title=str(book_id))
+            raise RuntimeError("real metadata query failed after a healthy probe")
+
+        def get_book_format(self, _book_id, fmt):
+            if fmt == "EPUB":
+                return SimpleNamespace(format="EPUB", name="book")
+            return None
+
+    class Conversion:
+        def __init__(self, _path, book_id, *_args):
+            self.book_id = book_id
+            self.error = None
+
+        def _convert_ebook_format(self):
+            converted.append(self.book_id)
+            return "book.kepub"
+
+    saved = _wire_common(monkeypatch, kepub_backfill, CalibreDB, [1, 2, 3, 4, 5, 6])
+    monkeypatch.setattr(kepub_backfill, "TaskConvert", Conversion)
+
+    task = kepub_backfill.TaskKepubBackfill()
+    task.run(None)
+
+    assert converted == [1]
+    assert len(instances) == 3
+    assert queried_books == [
+        (1, 1), (1, 2),
+        (2, 2), (2, 3),
+        (3, 3), (3, 4),
+    ]
+    assert task.processed == 4
+    assert task.converted == 1
+    assert task.skipped == 0
+    assert task.failed == 3
+    assert str(task.message) == "4/6 processed: 1 converted, 0 skipped, 3 failed"
+    assert "aborted after 3 consecutive Calibre metadata database failures" in str(task.error)
+    assert task.stat == STAT_FAIL
+    assert kepub_backfill.config.config_kobo_kepub_backfill_completed is False
+    assert saved == [False]
+
+
+def test_archive_failure_is_per_book_and_does_not_rebuild_database(monkeypatch):
+    """Archive/conversion trouble continues on the same healthy Session."""
+    from cps.tasks import kepub_backfill
+
+    instances = []
+    converted = []
+
+    class Session:
+        is_active = True
+
+    class CalibreDB:
+        def __init__(self, **_kwargs):
+            self.session = Session()
+            instances.append(self)
+
+        def get_book(self, book_id):
+            return SimpleNamespace(id=book_id, path=str(book_id), title=str(book_id))
+
+        def get_book_format(self, _book_id, fmt):
+            if fmt == "EPUB":
+                return SimpleNamespace(format="EPUB", name="book")
+            return None
+
+    class Conversion:
+        def __init__(self, _path, book_id, *_args):
+            self.book_id = book_id
+            self.error = None
+
+        def _convert_ebook_format(self):
+            converted.append(self.book_id)
+            return "book.kepub"
+
+    saved = _wire_common(monkeypatch, kepub_backfill, CalibreDB, [1, 2])
+    monkeypatch.setattr(kepub_backfill, "TaskConvert", Conversion)
+
+    def layout(book, _epub):
+        if book.id == 1:
+            raise OSError("broken EPUB archive")
+        return None
+
+    monkeypatch.setattr(kepub_backfill, "get_epub_layout", layout)
+
+    task = kepub_backfill.TaskKepubBackfill()
+    task.run(None)
+
+    assert len(instances) == 1
+    assert converted == [2]
+    assert task.processed == 2
+    assert task.converted == 1
+    assert task.failed == 1
+    assert task.stat == STAT_FAIL
+    assert saved == [False]

--- a/tests/unit/test_kobo_prefer_kepub.py
+++ b/tests/unit/test_kobo_prefer_kepub.py
@@ -168,6 +168,8 @@ def test_backfill_is_composite_idempotent_preserves_sync_rows_and_skips_gdrive(m
 def test_backfill_continues_after_per_book_oserror_and_completes(monkeypatch):
     from cps.tasks import kepub_backfill
 
+    database_instances = []
+
     class Query:
         def distinct(self): return self
         def all(self): return [(1,), (2,)]
@@ -177,7 +179,9 @@ def test_backfill_continues_after_per_book_oserror_and_completes(monkeypatch):
         def close(self): pass
 
     class CalibreDB:
-        def __init__(self, **_): self.session = SimpleNamespace(close=lambda: None)
+        def __init__(self, **_):
+            self.session = SimpleNamespace(close=lambda: None)
+            database_instances.append(self)
         def get_book(self, book_id): return SimpleNamespace(id=book_id, path=str(book_id), title=str(book_id))
         def get_book_format(self, book_id, fmt):
             return SimpleNamespace(format=fmt, name="book") if fmt == "EPUB" else None
@@ -201,16 +205,23 @@ def test_backfill_continues_after_per_book_oserror_and_completes(monkeypatch):
     monkeypatch.setattr(kepub_backfill.config, "config_kepubifypath", "/bin/kepubify", raising=False)
     monkeypatch.setattr(kepub_backfill.config, "config_kobo_kepub_backfill_completed", False, raising=False)
     monkeypatch.setattr(kepub_backfill.config, "get_book_path", lambda: "/books", raising=False)
-    monkeypatch.setattr(kepub_backfill.config, "save", lambda: saved.append(True), raising=False)
+    monkeypatch.setattr(
+        kepub_backfill.config,
+        "save",
+        lambda: saved.append(
+            kepub_backfill.config.config_kobo_kepub_backfill_completed),
+        raising=False,
+    )
 
     task = kepub_backfill.TaskKepubBackfill()
     task.run(None)
 
     assert attempted == [1, 2]
+    assert len(database_instances) == 1
     assert task.failed == 1
     assert task.converted == 1
-    assert kepub_backfill.config.config_kobo_kepub_backfill_completed is True
-    assert saved == [True]
+    assert kepub_backfill.config.config_kobo_kepub_backfill_completed is False
+    assert saved == [False]
 
 
 def test_conversion_advances_modified_without_touching_synced_rows(monkeypatch):


### PR DESCRIPTION
First half of #1857 (promised; two community reporters). The backfill's per-book `except` caught a failure and kept iterating on the same poisoned transaction, so one bad book cascaded into 'Cannot operate on a closed database' / 'invalid transaction' floods for every subsequent book and the run produced nothing.

The failure path now contains per book: rollback + session/CalibreDB rebuild, a circuit breaker after 3 consecutive rebuild failures with a clear terminal line, and honest terminal status (`N/M processed: X converted, Y skipped, Z failed`). Partial progress keeps the legacy completion marker; a wholly failed run is not marked complete.

The second half (device-side 'Sync failed' with an empty log, suspected unconditional destructive reconnect) is written up as a first-class finding in `notes/1857-kepub-off-sync-finding.md` on this branch — no blind fix; it gets its own dispatch.

Focused 33/33; full unit suite 7459 passed / 0 real failures (17 known sandbox-infra); ruff + changelog guard green.