### PR TITLE
fix: surface book delete failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,11 +170,6 @@ is for things you can see or feel when running the app.
   check after that release is tagged.** The guard now considers only releases
   contained in the branch under test, while retaining the committed release
   ledger as a strict fallback when Git tag reachability is unavailable.
-- **Book and format deletion no longer reports success when cleanup fails.** A
-  failed delete now produces an error, while a book whose database row was
-  removed but whose files remain returns and displays an explicit warning
-  instead of an empty success response.
-
 - **Cover thumbnails load faster, and the gap widens the bigger your library
   gets.** Every cover request searched the whole thumbnail table instead of
   going straight to the row it wanted, and the book grid asked for each cover

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,7 @@ is for things you can see or feel when running the app.
   check after that release is tagged.** The guard now considers only releases
   contained in the branch under test, while retaining the committed release
   ledger as a strict fallback when Git tag reachability is unavailable.
+
 - **Cover thumbnails load faster, and the gap widens the bigger your library
   gets.** Every cover request searched the whole thumbnail table instead of
   going straight to the row it wanted, and the book grid asked for each cover

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,10 @@ is for things you can see or feel when running the app.
   check after that release is tagged.** The guard now considers only releases
   contained in the branch under test, while retaining the committed release
   ledger as a strict fallback when Git tag reachability is unavailable.
+- **Book and format deletion no longer reports success when cleanup fails.** A
+  failed delete now produces an error, while a book whose database row was
+  removed but whose files remain returns and displays an explicit warning
+  instead of an empty success response.
 
 - **Cover thumbnails load faster, and the gap widens the bigger your library
   gets.** Every cover request searched the whole thumbnail table instead of

--- a/changelog.d/pr-1830.md
+++ b/changelog.d/pr-1830.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- **Book and format deletion no longer reports success when cleanup fails.** A
+  failed delete now produces an error, while a book whose database row was
+  removed but whose files remain returns and displays an explicit warning
+  instead of an empty success response.

--- a/cps/api/edit.py
+++ b/cps/api/edit.py
@@ -121,6 +121,30 @@ def _add_list_values(book, field, raw):
     return joiner.join(existing + additions)
 
 
+def _delete_api_response(result):
+    """Translate the legacy delete core's message list into an API contract."""
+    try:
+        payload = json.loads(result or "[]")
+    except (TypeError, ValueError):
+        return _err("delete_failed", "Deleting the book failed", 500)
+    messages = payload if isinstance(payload, list) else [payload]
+    danger = next((item for item in messages
+                   if isinstance(item, dict) and item.get("type") == "danger"), None)
+    if danger:
+        return _err("delete_failed", str(danger.get("message") or "Deleting the book failed"), 500)
+    warning = next((item for item in messages
+                    if isinstance(item, dict) and item.get("type") == "warning"), None)
+    if warning:
+        return jsonify({
+            "deleted": True,
+            "warning": {
+                "code": "cleanup_incomplete",
+                "message": str(warning.get("message") or "File cleanup was incomplete"),
+            },
+        })
+    return "", 204
+
+
 def _custom_column_defs():
     """The custom columns the editor offers, or ``[]`` if they can't be read.
 
@@ -484,8 +508,7 @@ def delete_book(book_id):
         return _err("not_found", "Book not found", 404)
     # delete_book_from_table re-checks the role and does the data-safe (DB-first,
     # files-last) whole-book delete + shelf cleanup. book_format="" = whole book.
-    delete_book_from_table(book_id, "", True)
-    return "", 204
+    return _delete_api_response(delete_book_from_table(book_id, "", True))
 
 
 @api_v1.route("/books/<int:book_id>/formats/<fmt>/delete", methods=["POST"])
@@ -504,8 +527,7 @@ def delete_format(book_id, fmt):
     matching_formats = [data for data in book.data if data.format.upper() == fmt.upper()]
     if matching_formats and len(book.data) == 1:
         return _err("last_format", "A book must keep at least one format", 409)
-    delete_book_from_table(book_id, fmt.upper(), True)
-    return "", 204
+    return _delete_api_response(delete_book_from_table(book_id, fmt.upper(), True))
 
 
 @api_v1.route("/books/<int:book_id>/convert", methods=["POST"])

--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -1697,7 +1697,7 @@ def delete_book_from_table(book_id, book_format, json_response, location="", ski
                     return json.dumps([{"location": url_for("edit-book.show_edit_book", book_id=book_id),
                                         "type": "danger",
                                         "format": "",
-                                        "message": ex}])
+                                        "message": str(ex)}])
                 else:
                     flash(str(ex), category="error")
                     return redirect(url_for('edit-book.show_edit_book', book_id=book_id))

--- a/cps/spa_strings.py
+++ b/cps/spa_strings.py
@@ -34,6 +34,8 @@ _("{succeeded} book(s) deleted; {failed} failed.")
 _("{succeeded} updated; {failed} failed.")
 _("Metadata applied to {succeeded}; {failed} failed.")
 _("A book must keep at least one format.")
+_("Could not delete this format.")
+_("Format deleted.")
 
 
 # #577 — the new-UI "open the reader" button. A distinct msgid from the "Read"

--- a/cps/translations/fr/LC_MESSAGES/messages.po
+++ b/cps/translations/fr/LC_MESSAGES/messages.po
@@ -2664,6 +2664,14 @@ msgstr "Métadonnées appliquées à {succeeded} ; {failed} échec(s)."
 msgid "A book must keep at least one format."
 msgstr "Un livre doit conserver au moins un format."
 
+#: cps/spa_strings.py
+msgid "Could not delete this format."
+msgstr "Impossible de supprimer ce format."
+
+#: cps/spa_strings.py
+msgid "Format deleted."
+msgstr "Format supprimé."
+
 #: cps/spa_strings.py cps/templates/detail.html
 msgid "Read now"
 msgstr "Lire"

--- a/cps/translations/nl/LC_MESSAGES/messages.po
+++ b/cps/translations/nl/LC_MESSAGES/messages.po
@@ -2554,6 +2554,14 @@ msgstr "Metadata toegepast op {succeeded}; {failed} mislukt."
 msgid "A book must keep at least one format."
 msgstr "Een boek moet minstens één formaat behouden."
 
+#: cps/spa_strings.py
+msgid "Could not delete this format."
+msgstr "Kan dit formaat niet verwijderen."
+
+#: cps/spa_strings.py
+msgid "Format deleted."
+msgstr "Formaat verwijderd."
+
 #: cps/spa_strings.py cps/templates/detail.html
 msgid "Read now"
 msgstr "Nu lezen"

--- a/frontend/src/lib/queries.ts
+++ b/frontend/src/lib/queries.ts
@@ -937,10 +937,15 @@ export function useUpdateMetadata(id: string | number) {
  *  every cached catalog snapshot so a later scroll-restore can't resurrect it
  *  as a ghost card (#578), then refreshes the library + shelves. Callers redirect
  *  away from the now-deleted book's detail page on success. */
+export interface DeleteResult {
+  deleted: true;
+  warning?: { code: string; message: string };
+}
+
 export function useDeleteBook(id: string | number) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: () => apiPost(`/api/v1/books/${id}/delete`),
+    mutationFn: () => apiPost<DeleteResult | undefined>(`/api/v1/books/${id}/delete`),
     onSuccess: () => {
       removeBookFromCache(Number(id));
       // Drop the deleted book's own detail cache, and refetch every surface that
@@ -980,7 +985,7 @@ export function useDeleteFormat(id: string | number) {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (fmt: string) =>
-      apiPost(`/api/v1/books/${id}/formats/${encodeURIComponent(fmt)}/delete`),
+      apiPost<DeleteResult | undefined>(`/api/v1/books/${id}/formats/${encodeURIComponent(fmt)}/delete`),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: ['book', String(id)] });
       void qc.invalidateQueries({ queryKey: ['books'] });

--- a/frontend/src/pages/BookDetail.tsx
+++ b/frontend/src/pages/BookDetail.tsx
@@ -637,7 +637,10 @@ export function BookDetail() {
                   )) return;
                   setDeleteError(null);
                   deleteBook.mutate(undefined, {
-                    onSuccess: () => navigate('/'),
+                    onSuccess: (result) => {
+                      if (result?.warning) window.alert(result.warning.message);
+                      navigate('/');
+                    },
                     onError: (err) =>
                       setDeleteError(err instanceof ApiError ? err.message : t('Could not delete this book.')),
                   });

--- a/frontend/src/pages/EditBook.tsx
+++ b/frontend/src/pages/EditBook.tsx
@@ -842,7 +842,16 @@ function FormatsManager({ id }: { id: string }) {
               <button className={styles.formatDelete}
                 onClick={() => {
                   if (window.confirm(t('Delete the {fmt} file? The book stays; only this format is removed.', { fmt: f.format }))) {
-                    deleteFormat.mutate(f.format);
+                    setMsg(null);
+                    deleteFormat.mutate(f.format, {
+                      onSuccess: (result) => setMsg(result?.warning
+                        ? { ok: false, text: result.warning.message }
+                        : { ok: true, text: t('Format deleted.') }),
+                      onError: (err) => setMsg({
+                        ok: false,
+                        text: err instanceof ApiError ? err.message : t('Could not delete this format.'),
+                      }),
+                    });
                   }
                 }}
                 disabled={deleteFormat.isPending || isLastFormat}

--- a/tests/unit/test_api_v1_edit.py
+++ b/tests/unit/test_api_v1_edit.py
@@ -184,6 +184,54 @@ def test_delete_book_authorizes_with_visibility_filter():
 
 
 @pytest.mark.unit
+def test_delete_book_returns_cleanup_warning_instead_of_empty_204():
+    from cps.api import edit as mod
+    core_result = json.dumps([
+        {"type": "warning", "message": "Database row deleted; files remain"},
+        {"type": "success", "message": "Book Successfully Deleted"},
+    ])
+    with _ctx("/api/v1/books/5/delete"):
+        with patch.object(mod, "current_user", _editor()), \
+             patch.object(mod.calibre_db, "get_filtered_book", return_value=SimpleNamespace(id=5)), \
+             patch.object(mod, "delete_book_from_table", return_value=core_result):
+            resp = inspect.unwrap(mod.delete_book)(5)
+    assert resp.status_code == 200
+    assert json.loads(resp.get_data()) == {
+        "deleted": True,
+        "warning": {"code": "cleanup_incomplete", "message": "Database row deleted; files remain"},
+    }
+
+
+@pytest.mark.unit
+def test_delete_endpoints_translate_core_danger_to_non_2xx():
+    from cps.api import edit as mod
+    core_result = json.dumps([{"type": "danger", "message": "permission denied"}])
+    for path, call in [
+        ("/api/v1/books/5/delete", lambda: inspect.unwrap(mod.delete_book)(5)),
+        ("/api/v1/books/5/formats/epub/delete", lambda: inspect.unwrap(mod.delete_format)(5, "epub")),
+    ]:
+        with _ctx(path):
+            with patch.object(mod, "current_user", _editor()), \
+                 patch.object(mod.calibre_db, "get_filtered_book", return_value=SimpleNamespace(id=5)), \
+                 patch.object(mod, "delete_book_from_table", return_value=core_result):
+                resp = call()
+        assert resp[1] == 500
+        assert json.loads(resp[0].get_data())["error"]["message"] == "permission denied"
+
+
+@pytest.mark.unit
+def test_spa_surfaces_delete_warnings_and_format_failures():
+    from pathlib import Path
+    root = Path(__file__).parents[2]
+    queries = (root / "frontend" / "src" / "lib" / "queries.ts").read_text()
+    detail = (root / "frontend" / "src" / "pages" / "BookDetail.tsx").read_text()
+    edit = (root / "frontend" / "src" / "pages" / "EditBook.tsx").read_text()
+    assert "export interface DeleteResult" in queries
+    assert "result?.warning" in detail and "window.alert(result.warning.message)" in detail
+    assert "onError: (err) => setMsg" in edit
+
+
+@pytest.mark.unit
 def test_update_metadata_collects_field_errors():
     from cps.api import edit as mod
     fake_book = SimpleNamespace(
@@ -257,7 +305,9 @@ def test_delete_format_uses_core_with_uppercased_format():
         with patch.object(mod, "current_user", _editor()), \
              patch.object(mod.calibre_db, "get_filtered_book", return_value=SimpleNamespace(
                  id=5, data=[SimpleNamespace(format="EPUB"), SimpleNamespace(format="PDF")])), \
-             patch.object(mod, "delete_book_from_table") as core:
+             patch.object(mod, "delete_book_from_table", return_value=json.dumps([
+                  {}, {"type": "success", "message": "Book Format Successfully Deleted"}
+              ])) as core:
             resp = inspect.unwrap(mod.delete_format)(5, "epub")
     assert resp[1] == 204
     core.assert_called_once_with(5, "EPUB", True)

--- a/tests/unit/test_api_v1_edit.py
+++ b/tests/unit/test_api_v1_edit.py
@@ -212,7 +212,8 @@ def test_delete_endpoints_translate_core_danger_to_non_2xx():
     ]:
         with _ctx(path):
             with patch.object(mod, "current_user", _editor()), \
-                 patch.object(mod.calibre_db, "get_filtered_book", return_value=SimpleNamespace(id=5)), \
+                 patch.object(mod.calibre_db, "get_filtered_book", return_value=SimpleNamespace(
+                     id=5, data=[SimpleNamespace(format="EPUB"), SimpleNamespace(format="PDF")])), \
                  patch.object(mod, "delete_book_from_table", return_value=core_result):
                 resp = call()
         assert resp[1] == 500


### PR DESCRIPTION
Supersedes #1963 (serial re-stack after #1962 merged; PO catalogs resolved semantically against main's newer translations; findings INDEX regenerated from final JSON). Gates re-run on the real base — see the stack lane report.