### PR TITLE
Keep container-backed fixtures out of the fast test lane

### DIFF
--- a/changelog.d/kosync-fixture-scope.md
+++ b/changelog.d/kosync-fixture-scope.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **The fast test lane no longer starts a Docker container for tests that don't need one.** Enabling KOReader sync for the integration suite was applied to a whole module, including a class of pure helper tests, so the quick lane quietly booted a container to run three tests that never touch it. The fast lane now refuses, by name, any quick test that depends on a container.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -645,6 +645,32 @@ def pytest_collection_modifyitems(config, items):
         if ("docker_integration" in item.keywords or "docker_e2e" in item.keywords) and not has_docker:
             item.add_marker(skip_docker_integration)
 
+    # A unit-marked test may never depend on a fixture that starts a container:
+    # requesting one turns the fast lane into a Docker lane.
+    #
+    # Enforced here rather than inside those fixtures because they are
+    # session-scoped -- their ``request.node`` is the session, which carries no
+    # markers, so a guard written there could never see the offending test.
+    #
+    # It exists because a module-level ``usefixtures("koreader_sync_enabled")``
+    # mark landed on a unit-only helper class and CI stayed GREEN: starting a
+    # container succeeds on a runner, so the fast lane simply paid for Docker in
+    # silence. Nothing failed; the lane just stopped being fast, and the only
+    # visible symptom was a container-name collision on a developer machine.
+    container_backed = {"koreader_sync_enabled", "cwa_container", "cwa_api_client"}
+    offenders = [
+        f"{item.nodeid} requests {sorted(container_backed.intersection(item.fixturenames))}"
+        for item in items
+        if item.get_closest_marker("unit") is not None
+        and container_backed.intersection(getattr(item, "fixturenames", ()))
+    ]
+    if offenders:
+        raise pytest.UsageError(
+            "unit-marked tests must not require a container-backed fixture; put "
+            "the fixture on the docker_integration classes instead of the "
+            "module:\n  " + "\n  ".join(offenders)
+        )
+
 
 # ============================================================================
 # Docker Container Fixtures (for integration/e2e tests)
@@ -925,7 +951,6 @@ def koreader_sync_enabled(container_name):
     every boolean from the submitted fields, so saving through it would silently
     switch off everything this fixture did not think to include.
     """
-    import json
     import subprocess
 
     def _set(value):

--- a/tests/integration/test_kosync_edge_cases.py
+++ b/tests/integration/test_kosync_edge_cases.py
@@ -10,12 +10,10 @@ import pytest
 import base64
 import json
 
-# Every endpoint in this file answers 503 while KOReader sync is disabled, which
-# it is by default. Without this the whole module measures one early-return.
-pytestmark = pytest.mark.usefixtures("koreader_sync_enabled")
 
 
 
+@pytest.mark.usefixtures("koreader_sync_enabled")
 @pytest.mark.docker_integration
 @pytest.mark.slow
 class TestKOSyncValidationEdgeCases:
@@ -294,6 +292,7 @@ class TestKOSyncValidationEdgeCases:
         assert response.status_code == 400, "Should reject document ID with colon"
 
 
+@pytest.mark.usefixtures("koreader_sync_enabled")
 @pytest.mark.docker_integration
 @pytest.mark.slow
 class TestKOSyncAuthenticationEdgeCases:

--- a/tests/integration/test_kosync_update_read_status.py
+++ b/tests/integration/test_kosync_update_read_status.py
@@ -16,9 +16,6 @@ import sys
 import base64
 from pathlib import Path
 
-# Every endpoint in this file answers 503 while KOReader sync is disabled, which
-# it is by default. Without this the whole module measures one early-return.
-pytestmark = pytest.mark.usefixtures("koreader_sync_enabled")
 
 
 # Add project root to path
@@ -26,6 +23,7 @@ project_root = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(project_root))
 
 
+@pytest.mark.usefixtures("koreader_sync_enabled")
 @pytest.mark.docker_integration
 @pytest.mark.slow
 class TestUpdateBookReadStatusThresholds:
@@ -149,6 +147,7 @@ class TestUpdateBookReadStatusThresholds:
         assert response.status_code == 200
 
 
+@pytest.mark.usefixtures("koreader_sync_enabled")
 @pytest.mark.docker_integration
 @pytest.mark.slow
 class TestUpdateBookReadStatusRecordManagement:
@@ -217,6 +216,7 @@ class TestUpdateBookReadStatusRecordManagement:
         assert float(data['percentage']) == 0.60  # Returns as decimal
 
 
+@pytest.mark.usefixtures("koreader_sync_enabled")
 @pytest.mark.docker_integration
 @pytest.mark.slow
 class TestUpdateBookReadStatusEdgeCases:

--- a/tests/integration/test_progress_syncing_kosync.py
+++ b/tests/integration/test_progress_syncing_kosync.py
@@ -19,9 +19,6 @@ import json
 import base64
 from pathlib import Path
 
-# Every endpoint in this file answers 503 while KOReader sync is disabled, which
-# it is by default. Without this the whole module measures one early-return.
-pytestmark = pytest.mark.usefixtures("koreader_sync_enabled")
 
 
 # Add project root to path
@@ -29,6 +26,7 @@ project_root = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(project_root))
 
 
+@pytest.mark.usefixtures("koreader_sync_enabled")
 @pytest.mark.docker_integration
 @pytest.mark.slow
 class TestKOSyncChecksumLookup:
@@ -146,6 +144,7 @@ class TestKOSyncChecksumLookup:
         assert float(data['percentage']) == 0.75, "Percentage should be persisted correctly"
 
 
+@pytest.mark.usefixtures("koreader_sync_enabled")
 @pytest.mark.docker_integration
 @pytest.mark.slow
 class TestKOSyncBookEnrichment:
@@ -261,6 +260,7 @@ class TestKOSyncHelperFunctions:
         assert callable(enrich_response_with_book_info)
 
 
+@pytest.mark.usefixtures("koreader_sync_enabled")
 @pytest.mark.docker_integration
 @pytest.mark.slow
 class TestKOSyncAuthentication:
@@ -304,6 +304,7 @@ class TestKOSyncAuthentication:
             assert response.status_code in [401, 403, 404]
 
 
+@pytest.mark.usefixtures("koreader_sync_enabled")
 @pytest.mark.docker_integration
 @pytest.mark.slow
 class TestKOSyncDataValidation:


### PR DESCRIPTION
The fast test lane started booting a Docker container for three tests that never touch one. I introduced this in #1969 and it reached main.

## What happened

#1969 enabled KOReader sync for the integration suite, because while sync is off every `/kosync` endpoint answers 503 before any handler runs. That mark was applied at **module** level — which also caught `TestKOSyncHelperFunctions`, a `@pytest.mark.unit` class of pure helper tests. Those three then pulled in `cwa_container` and started Docker.

**CI stayed green, which is exactly why this needed catching on purpose.** Starting a container *succeeds* on a runner, so the fast lane simply paid for Docker in silence — nothing failed, the lane just stopped being fast. The only visible symptom was on a developer machine, where the container name collided with an existing one and the tests errored.

## The fix

The mark now sits on the `docker_integration` classes that actually need a server, in all three kosync modules.

## The guard, which is the more important half

A collection-time check refuses any `unit`-marked test that depends on a container-backed fixture, naming the tests and the fixtures:

```
ERROR: unit-marked tests must not require a container-backed fixture; put the
fixture on the docker_integration classes instead of the module:
  ...TestKOSyncHelperFunctions::test_get_book_by_checksum_function_exists
     requests ['cwa_container', 'koreader_sync_enabled']
```

Two placements were rejected along the way, both worth recording:

**Not inside the fixtures.** They are session-scoped, so `request.node` is the session and carries no markers — a guard written there can never see the offending test. It would have looked like protection and done nothing.

**Not as a second `pytest_collection_modifyitems`.** One already exists, and a second `def` in the same module silently shadows the first. That hook's own docstring explains that losing its lane assignment puts ~970 tests quiet behind a green board — so adding a guard against silent test loss would have caused a much larger silent test loss. It is integrated into the existing hook instead.

## Verification

- Proven to fire: restoring the module-level mark produces the error above.
- Fixed lane: `3 passed in 1.47s`, no container started.
- Full unit lane: **7490 passed, 107 skipped, 0 errors** (was 3 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xc6tdQ4uwXEzUezFFG2LgG
