### PR TITLE
fix(ci): stop cancelling main's queued Test Suite runs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,12 @@ on:
 # Cancel in-progress runs when new commit pushed
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # On a PR branch only the newest head matters, so a new push cancels the
+  # running verification. On main every landed commit must be verified:
+  # cancelling there let ~80% of main's runs die before dispatch under a high
+  # merge rate while Build & Push - Dev published those same commits
+  # (F-493b49). Runs on main queue behind each other instead.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   # ============================================================================

--- a/changelog.d/1992-main-ci-coverage.md
+++ b/changelog.d/1992-main-ci-coverage.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Every commit that lands on the main branch is verified by CI again.** A new push used to cancel the still-queued test run of the previous commit, so under a busy merge rate most main commits were never tested while development images still published from them.


### PR DESCRIPTION
Implements F-493b49's fix shape 1 (finding recorded in #1993, measured by another session: 16 of main's last 20 Test Suite runs cancelled with zero jobs while `:dev` published those commits).

`cancel-in-progress` becomes `${{ github.ref != 'refs/heads/main' }}`: PR refs keep newest-head-wins; main's runs queue and every landed commit gets verified. One line + comment + changelog fragment; YAML validated.