### PR TITLE
test(frontend): the Node unit harness could not load any source module with an extensionless import

### DIFF
--- a/frontend/tests/unit/libModuleResolution.test.ts
+++ b/frontend/tests/unit/libModuleResolution.test.ts
@@ -1,0 +1,10 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { apiUrl } from '../../src/lib/api.ts';
+
+describe('frontend source module resolution', () => {
+  test('loads api.ts through its extensionless source imports', () => {
+    assert.equal(apiUrl('/api/v1/books'), '/api/v1/books');
+  });
+});

--- a/frontend/tests/unit/registerTypeScriptResolution.mjs
+++ b/frontend/tests/unit/registerTypeScriptResolution.mjs
@@ -1,0 +1,40 @@
+import { registerHooks } from 'node:module';
+
+const FRONTEND_SRC_URL = new URL('../../src/', import.meta.url).href;
+const TYPESCRIPT_CANDIDATE_SUFFIXES = ['.ts', '.tsx', '/index.ts', '/index.tsx'];
+
+function isRelativeSpecifier(specifier) {
+  return specifier.startsWith('./') || specifier.startsWith('../');
+}
+
+function isUnresolvedRelativeImport(error) {
+  return error?.code === 'ERR_MODULE_NOT_FOUND'
+    || error?.code === 'ERR_UNSUPPORTED_DIR_IMPORT';
+}
+
+function resolve(specifier, context, nextResolve) {
+  if (!context.parentURL || !isRelativeSpecifier(specifier)) {
+    return nextResolve(specifier, context);
+  }
+
+  try {
+    return nextResolve(specifier, context);
+  } catch (originalError) {
+    if (!isUnresolvedRelativeImport(originalError)) throw originalError;
+
+    for (const suffix of TYPESCRIPT_CANDIDATE_SUFFIXES) {
+      const candidate = new URL(specifier + suffix, context.parentURL);
+      if (!candidate.href.startsWith(FRONTEND_SRC_URL)) continue;
+
+      try {
+        return nextResolve(candidate.href, context);
+      } catch (candidateError) {
+        if (!isUnresolvedRelativeImport(candidateError)) throw candidateError;
+      }
+    }
+
+    throw originalError;
+  }
+}
+
+registerHooks({ resolve });

--- a/scripts/check_changelog_diff.py
+++ b/scripts/check_changelog_diff.py
@@ -24,6 +24,10 @@ NON_SHIPPING_PATH_PREFIXES = (
     "examples/",
     "findings/",
     "frontend/e2e/",
+    # The runtime image deletes frontend/ and copies only the Vite-built bundle
+    # from cps/static/app, so frontend test sources never ship (Dockerfile
+    # steps 6 and 6.1).
+    "frontend/tests/",
     "notes/",
     "tests/",
     "wiki-src/",

--- a/tests/unit/test_changelog_diff_guard.py
+++ b/tests/unit/test_changelog_diff_guard.py
@@ -169,6 +169,23 @@ def test_mixing_frontend_e2e_with_shipping_frontend_still_requires_an_entry():
     assert "shipping paths" in errors[0]
 
 
+def test_frontend_unit_tests_only_pr_does_not_require_a_changelog_entry():
+    assert changelog_requirement_errors(
+        ["frontend/tests/unit/libModuleResolution.test.ts"]
+    ) == []
+
+
+def test_mixing_frontend_tests_with_shipping_frontend_still_requires_an_entry():
+    errors = changelog_requirement_errors(
+        [
+            "frontend/tests/unit/libModuleResolution.test.ts",
+            "frontend/src/lib/api.ts",
+        ]
+    )
+    assert len(errors) == 1
+    assert "shipping paths" in errors[0]
+
+
 def test_translation_only_pr_does_not_require_a_changelog_entry():
     assert changelog_requirement_errors(
         ["cps/translations/ru/LC_MESSAGES/messages.po", "messages.pot"]

--- a/tests/unit/test_frontend_unit_suites_run.py
+++ b/tests/unit/test_frontend_unit_suites_run.py
@@ -32,6 +32,7 @@ pytestmark = pytest.mark.unit
 REPO = Path(__file__).resolve().parents[2]
 SUITE_DIR = REPO / "frontend" / "tests" / "unit"
 NODE_MODULES = REPO / "frontend" / "node_modules"
+TYPESCRIPT_RESOLUTION_REGISTER = SUITE_DIR / "registerTypeScriptResolution.mjs"
 # Explicit file paths, never the directory. `node --test <dir>` fails to apply
 # type stripping to the .ts files it discovers and reports a bare "test failed"
 # with no assertion behind it, while `node --test <file>` on the same suite
@@ -74,14 +75,22 @@ def test_frontend_unit_suite_passes(suite: Path):
             "the frontend Node unit suites"
         )
 
-    # Type stripping is unflagged only from Node 23.6 and CI pins 22, so the
-    # flag has to be supplied -- but it must go through NODE_OPTIONS, not argv.
-    # `node --test` runs each file in a CHILD process, and a flag passed on the
-    # parent's command line is not inherited: on real Node 22.22 that yields
-    # "tests 0, pass 0, fail 0" and exit code 0. Measured both ways rather than
-    # reasoned about, after CI produced exactly that empty run.
+    # Type stripping is unflagged only from Node 23.6 and CI pins 22. The
+    # resolution register gives Node the same extensionless relative-import
+    # convention that Vite/tsc apply inside frontend/src. Both have to be
+    # supplied through NODE_OPTIONS, not argv: `node --test` runs each file in
+    # a CHILD process, and a flag passed on the parent's command line is not
+    # inherited. On real Node 22.22, argv-only type stripping yields "tests 0,
+    # pass 0, fail 0" and exit code 0. Measured both ways rather than reasoned
+    # about, after CI produced exactly that empty run.
     env = dict(os.environ)
-    env["NODE_OPTIONS"] = (env.get("NODE_OPTIONS", "") + " --experimental-strip-types").strip()
+    required_node_options = (
+        f"--import={TYPESCRIPT_RESOLUTION_REGISTER.as_uri()} "
+        "--experimental-strip-types"
+    )
+    env["NODE_OPTIONS"] = (
+        env.get("NODE_OPTIONS", "") + " " + required_node_options
+    ).strip()
     result = subprocess.run(
         [node, "--test", str(suite)],
         cwd=REPO,


### PR DESCRIPTION
The frontend Node unit harness could not load any source module that used an extensionless relative import — the convention Vite and tsc apply throughout `frontend/src`. Every attempt to unit-test real source (rather than a self-contained fixture) died with `ERR_MODULE_NOT_FOUND` before a single assertion ran, so the suite's coverage was structurally capped at code with no internal imports.

`frontend/tests/unit/registerTypeScriptResolution.mjs` installs a `node:module` `registerHooks` resolver that retries an unresolved relative specifier with `.ts`, `.tsx`, `/index.ts` and `/index.tsx`, scoped to `frontend/src`. It is supplied through `NODE_OPTIONS` alongside `--experimental-strip-types`, because `node --test` runs each file in a child process that does not inherit parent argv flags.

`frontend/tests/unit/libModuleResolution.test.ts` is the regression test: it imports `../../src/lib/api.ts`, which reaches real source through extensionless imports.

`scripts/check_changelog_diff.py` gains `frontend/tests/` to its non-shipping exemptions, matching the `frontend/e2e/` entry already there — the runtime image deletes `frontend/` and copies only the Vite-built bundle from `cps/static/app`, so frontend test sources never ship. A PR that mixes `frontend/tests/` with shipping `frontend/src` still requires a changelog entry, and that is asserted.

Verification (manager leg, at this head):
- GREEN — `tests/unit/test_frontend_unit_suites_run.py` + `tests/unit/test_changelog_diff_guard.py`: 45 passed.
- RED at choke point 1 — drop `--import=…registerTypeScriptResolution.mjs` from `NODE_OPTIONS`: `libModuleResolution.test.ts` fails.
- RED at choke point 2 — drop `"frontend/tests/"` from the exemption list: `test_frontend_unit_tests_only_pr_does_not_require_a_changelog_entry` fails.

No runtime code, no new dependencies (`node:module` is a builtin), no license or external-URL change.
