### PR TITLE
Book detail: the delete region loses its redundant heading (#1862)

### DIFF
--- a/changelog.d/1862-delete-label.md
+++ b/changelog.d/1862-delete-label.md
@@ -1,0 +1,6 @@
+### Changed
+
+- **Whole-book deletion no longer has a redundant heading on book details.**
+  “Delete from the global library” now appears directly on the button, while
+  the destructive action keeps its quiet separation and accessible context.
+  Reported by @chloeroform.

--- a/frontend/e2e/book-detail-delete-prominence.spec.ts
+++ b/frontend/e2e/book-detail-delete-prominence.spec.ts
@@ -37,18 +37,17 @@ test('book-detail deletion remains visible and accessible with delete permission
   await setDeletePermission(page, true);
   await page.goto(`/app/book/${book.id}`, { waitUntil: 'domcontentloaded' });
 
-  // #1939 renamed this region's heading and the button's accessible name from
-  // "Delete book" to "Delete from the global library". The rename is the point:
-  // once a user can also *remove a book from their own library*, "Delete book"
-  // no longer says which of the two you are about to do, and only one of them is
-  // irreversible for everyone. What #1862 guards is unchanged and still asserted
-  // below - the region is present, has an accessible name, and exposes a
-  // reachable delete control - so this is a re-expression, not a relaxation.
+  // #1939's disambiguating wording remains load-bearing, but the redundant
+  // heading row does not: the region and the control now carry the wording.
   const region = page.getByTestId('book-destructive-actions');
   await expect(region).toBeVisible();
   await expect(region).toHaveAccessibleName('Delete from the global library');
-  await expect(region.getByRole('heading', { name: 'Delete from the global library' })).toBeVisible();
-  await expect(region.getByRole('button', { name: 'Delete from the global library' })).toBeVisible();
+  await expect(region).toHaveAttribute('aria-label', 'Delete from the global library');
+  await expect(region.getByRole('heading')).toHaveCount(0);
+  const deleteButton = region.getByRole('button', { name: 'Delete from the global library' });
+  await expect(deleteButton).toHaveCount(1);
+  await expect(deleteButton).toBeVisible();
+  await expect(deleteButton).toHaveText('Delete from the global library');
 });
 
 test('book-detail deletion remains absent without delete permission (#1862)', async ({ page }) => {
@@ -79,8 +78,6 @@ test('dismissing book-detail deletion confirmation never calls the endpoint (#18
   });
 
   await page.goto(`/app/book/${book.id}`, { waitUntil: 'domcontentloaded' });
-  // Accessible name, not visible text: the button reads "Delete" and carries
-  // aria-label "Delete from the global library" (#1939).
   const deleteButton = page.getByTestId('book-destructive-actions')
     .getByRole('button', { name: 'Delete from the global library' });
   await expect(deleteButton).toBeVisible();
@@ -112,13 +109,9 @@ test('book-detail deletion is a quiet region in light and dark themes (#1862)', 
     await page.locator('html').evaluate((html, value) => html.setAttribute('data-theme', value), theme);
     const appearance = await region.evaluate((element) => {
       const style = getComputedStyle(element);
-      const label = element.querySelector('h2');
       const button = element.querySelector('button');
-      const pageTitle = document.querySelector('h1');
-      if (!(label instanceof HTMLElement)
-        || !(button instanceof HTMLElement)
-        || !(pageTitle instanceof HTMLElement)) {
-        throw new Error('destructive region and page title must retain their semantic structure');
+      if (!(button instanceof HTMLElement)) {
+        throw new Error('destructive region must retain its delete control');
       }
 
       const dangerProbe = document.createElement('span');
@@ -127,9 +120,7 @@ test('book-detail deletion is a quiet region in light and dark themes (#1862)', 
       const dangerColor = getComputedStyle(dangerProbe).color;
       dangerProbe.remove();
 
-      const labelStyle = getComputedStyle(label);
       const buttonStyle = getComputedStyle(button);
-      const pageTitleStyle = getComputedStyle(pageTitle);
       return {
         backgroundColor: style.backgroundColor,
         borderLeftStyle: style.borderLeftStyle,
@@ -141,13 +132,8 @@ test('book-detail deletion is a quiet region in light and dark themes (#1862)', 
         outlineStyle: style.outlineStyle,
         boxShadow: style.boxShadow,
         dangerColor,
-        labelColor: labelStyle.color,
-        labelFontSize: labelStyle.fontSize,
-        labelFontWeight: labelStyle.fontWeight,
-        pageTitleFontSize: pageTitleStyle.fontSize,
         buttonColor: buttonStyle.color,
         buttonBorderColor: buttonStyle.borderColor,
-        buttonFontWeight: buttonStyle.fontWeight,
       };
     });
 
@@ -157,17 +143,6 @@ test('book-detail deletion is a quiet region in light and dark themes (#1862)', 
       usesDangerColor: appearance.borderTopColor === appearance.dangerColor,
     }, `${theme} theme must retain a neutral top divider`).toEqual({
       hasTopDivider: true,
-      usesDangerColor: false,
-    });
-    expect.soft({
-      isPageTitleSized: Number.parseFloat(appearance.labelFontSize)
-        >= Number.parseFloat(appearance.pageTitleFontSize),
-      isAtLeastButtonWeight: Number.parseFloat(appearance.labelFontWeight)
-        >= Number.parseFloat(appearance.buttonFontWeight),
-      usesDangerColor: appearance.labelColor === appearance.dangerColor,
-    }, `${theme} theme must keep the region label subdued`).toEqual({
-      isPageTitleSized: false,
-      isAtLeastButtonWeight: false,
       usesDangerColor: false,
     });
     expect.soft({

--- a/frontend/e2e/delete-book-discoverability.spec.ts
+++ b/frontend/e2e/delete-book-discoverability.spec.ts
@@ -113,10 +113,13 @@ test('book-detail deletion is grouped outside the ordinary action chips (#1046)'
   const destructiveActions = page.getByTestId('book-destructive-actions');
   await expect(ordinaryActions).toBeVisible();
   await expect(destructiveActions).toBeVisible();
-  // #1939: this surface's heading and button accessible name are now
-  // "Delete from the global library". The edit page's own delete button keeps
-  // "Delete book" and is asserted separately above - two different surfaces.
-  await expect(destructiveActions.getByRole('heading', { name: 'Delete from the global library' })).toBeVisible();
-  await expect(destructiveActions.getByRole('button', { name: 'Delete from the global library' })).toBeVisible();
+  // #1939's wording stays on the book-detail region and control. The edit
+  // page's separate "Delete book" button remains asserted above.
+  await expect(destructiveActions).toHaveAccessibleName('Delete from the global library');
+  await expect(destructiveActions.getByRole('heading')).toHaveCount(0);
+  const deleteButton = destructiveActions
+    .getByRole('button', { name: 'Delete from the global library' });
+  await expect(deleteButton).toBeVisible();
+  await expect(deleteButton).toHaveText('Delete from the global library');
   await expect(ordinaryActions.getByRole('button', { name: 'Delete from the global library' })).toHaveCount(0);
 });

--- a/frontend/src/pages/BookDetail.module.css
+++ b/frontend/src/pages/BookDetail.module.css
@@ -450,14 +450,6 @@
   background: transparent;
 }
 
-.dangerZoneTitle {
-  margin: 0;
-  color: var(--text-muted);
-  font-family: var(--font-body);
-  font-size: var(--fs-sm);
-  font-weight: var(--fw-medium);
-}
-
 .actionDanger {
   display: inline-flex;
   align-items: center;

--- a/frontend/src/pages/BookDetail.tsx
+++ b/frontend/src/pages/BookDetail.tsx
@@ -685,10 +685,7 @@ export function BookDetail() {
               this gate and grouping are the discoverability/UX layer. */}
           {me?.role?.delete_books && me?.role?.edit && (
             <section className={styles.dangerZone} data-testid="book-destructive-actions"
-              aria-labelledby={`delete-book-heading-${book.id}`}>
-              <h2 id={`delete-book-heading-${book.id}`} className={styles.dangerZoneTitle}>
-                {t('Delete from the global library')}
-              </h2>
+              aria-label={t('Delete from the global library')}>
               <button
                 type="button"
                 className={styles.actionDanger}
@@ -711,7 +708,7 @@ export function BookDetail() {
                 }}
               >
                 <Trash2 size={14} aria-hidden="true" focusable={false} />
-                {deleteBook.isPending ? t('Deleting…') : t('Delete')}
+                {deleteBook.isPending ? t('Deleting…') : t('Delete from the global library')}
               </button>
               {deleteError && <p className={styles.deleteErr} role="alert">{deleteError}</p>}
             </section>


### PR DESCRIPTION
Closes #1862 (follow-up round).

@chloeroform, after v4.1.42: *"It's better but the 'quiet label' is completely useless, and I am not convinced we need to separate the 'Delete' button from the others."*

Half of that is right, and this takes it.

The label was doing one real job — #1939 gave the region the wording **"Delete from the global library"** because the same page also offers **"Remove from my library"**, and those are very different actions. But it was doing that job in the wrong place: a heading nobody reads, above a button that just said "Delete". So the heading row is gone and the wording moved onto the control itself. The button now reads "Delete from the global library"; the section keeps its accessible name directly via `aria-label`.

The separation stays, and it is now only a hairline rule plus the space above it — no heading, no fill, no red box. That is what #1046 asked for: deletion not sitting inside the row of everyday chips. Danger colour remains on the button alone.

### Verification (all OBSERVED, against the running `cwn-local` container, desktop project)

| | |
|---|---|
| **Red** — `origin/main`'s component, new specs | **2 failed / 7 passed**. `getByTestId('book-destructive-actions').getByRole('heading')` expected 0, received 1; button visible text was `Delete`, not the full phrase. |
| **Green** — this branch | **9 passed / 0 failed** (same two spec files, same container). |

The specs pin what must not move with the heading: the region's accessible name, exactly one reachable delete control named "Delete from the global library", the delete control absent without permission, a dismissed `window.confirm` issuing no request, the delete control never rendering inside the ordinary-actions row, and the region staying unfilled with non-danger borders in **both light and dark**.

`npm run build` (`tsc -b` + Vite) clean. No dependency, license or external-URL change; no server-side change at all.
