### PR TITLE
fix(annotations): a batch with an id-less annotation no longer reports full success (#1889)

### DIFF
--- a/changelog.d/1889.md
+++ b/changelog.d/1889.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- **Kobo annotation batches no longer acknowledge id-less highlights as stored.**
+  A malformed member now makes the batch incomplete while valid highlights in
+  the same upload are still preserved, allowing the device to retry safely.

--- a/cps/services/annotation_sync/__init__.py
+++ b/cps/services/annotation_sync/__init__.py
@@ -715,12 +715,21 @@ def dispatch_annotation_sync(payload_annotations, book, user, *, origin_device_i
             )
             all_persisted = False
             continue
+        if not payload.get("id"):
+            log.warning(
+                "Skipping annotation without an id at updatedAnnotations[%d]", index,
+            )
+            all_persisted = False
+            continue
         pending_job = None
         try:
             ann = _upsert_annotation(
                 ub.session, payload, book, user, origin_device_id=origin_device_id,
             )
             if ann is None:
+                # The malformed shapes that cannot be addressed on a retry were
+                # rejected above. None here is a persisted row's legitimate
+                # stale/idempotent no-op and therefore does not fail the batch.
                 continue
             raw_record = None
             if raw_materializations is not None and index < len(raw_materializations):

--- a/tests/unit/test_annotation_sync_dispatcher.py
+++ b/tests/unit/test_annotation_sync_dispatcher.py
@@ -291,12 +291,30 @@ def test_non_object_annotation_member_is_skipped_without_dropping_later_members(
 ):
     s, user = patched_session
 
-    dispatch_annotation_sync([
+    result = dispatch_annotation_sync([
         _payload("uuid-before", text_="before"),
         "not-an-annotation-object",
         _payload("uuid-after", text_="after"),
     ], _book(), user)
 
+    assert result is False
+    assert [row.annotation_id for row in s.query(ub.Annotation).order_by(ub.Annotation.id)] == [
+        "uuid-before", "uuid-after",
+    ]
+
+
+def test_idless_annotation_member_makes_batch_incomplete_without_dropping_later_members(
+    patched_session,
+):
+    s, user = patched_session
+
+    result = dispatch_annotation_sync([
+        _payload("uuid-before", text_="before"),
+        {"highlightedText": "cannot be addressed or retried after acknowledgement"},
+        _payload("uuid-after", text_="after"),
+    ], _book(), user)
+
+    assert result is False
     assert [row.annotation_id for row in s.query(ub.Annotation).order_by(ub.Annotation.id)] == [
         "uuid-before", "uuid-after",
     ]


### PR DESCRIPTION
Closes #1889. `_upsert_annotation()` returned None for both an unaddressable id-less member and a legitimate stale no-op, and the dispatcher's `continue` conflated them — the malformed member was dropped while the batch acked as fully persisted upstream (so it was never stored anywhere). The dispatcher now rejects a missing id before the upsert, sets `all_persisted=False`, logs the member index, and keeps processing the valid members; genuine no-ops keep succeeding. Full `continue` audit of the loop done. Reproduced red-then-green (batch valid/id-less/valid asserted True pre-fix); dispatcher suite 22/22, total 32/32.