### PR TITLE
fix(auth): trusted reverse-proxy hop counts are configurable (#1821)

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,7 +521,22 @@ Behind multiple proxies (e.g. Cloudflare Tunnel then nginx then CWA), set the pr
 - TRUSTED_PROXY_COUNT=2
 ```
 
-Without this, CWA may see different client IPs across requests and trigger Session Protection warnings, forcing re-login on every page load. Default is `1`.
+Without this, CWA may see different client IPs across requests and trigger Session Protection warnings, forcing re-login on every page load. It can also mistake an externally secure OIDC callback for plain HTTP. Default is `1`.
+
+`TRUSTED_PROXY_COUNT` applies one trust depth to `X-Forwarded-For`,
+`X-Forwarded-Proto`, `X-Forwarded-Host`, and `X-Forwarded-Prefix`. If your
+proxy chain appends or replaces those headers at different layers, override the
+first three independently; each falls back to `TRUSTED_PROXY_COUNT`, then `1`:
+
+```yaml
+- PROXYFIX_X_FOR=2
+- PROXYFIX_X_PROTO=1
+- PROXYFIX_X_HOST=1
+```
+
+The corresponding ProxyFix arguments are `x_for`, `x_proto`, and `x_host`.
+Count only proxies you control and that overwrite or sanitize the corresponding
+header.
 
 ### Hardcover metadata provider
 

--- a/changelog.d/1821.md
+++ b/changelog.d/1821.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- **Login and OIDC callbacks now support reverse-proxy headers with different hop counts.**
+  Deployments can configure trusted `X-Forwarded-For`, `X-Forwarded-Proto`,
+  and `X-Forwarded-Host` depths independently while existing single-count and
+  single-proxy configurations keep their current behavior.

--- a/cps/__init__.py
+++ b/cps/__init__.py
@@ -98,11 +98,25 @@ def protect_user_specific_catalog_responses(response):
 
 # Fix for running behind reverse proxy (e.g. nginx, apache, caddy, ...)
 # Without it, url_for will generate http:// urls even if https:// is used
-# Set TRUSTED_PROXY_COUNT to the number of proxies in your chain (default: 1)
-# For CF Tunnel + reverse proxy, use TRUSTED_PROXY_COUNT=2
+# Set TRUSTED_PROXY_COUNT to the number of proxies in your chain (default: 1).
+# PROXYFIX_X_FOR / _X_PROTO / _X_HOST override it for header-specific chains.
 num_proxies = int(os.environ.get('TRUSTED_PROXY_COUNT', '1'))
-app.wsgi_app = ProxyFix(app.wsgi_app, x_for=num_proxies, x_proto=num_proxies, x_host=num_proxies, x_prefix=num_proxies)
-log.info(f'ProxyFix configured to trust {num_proxies} proxy(ies) for X-Forwarded-* headers')
+proxyfix_hops = {
+    'x_for': int(os.environ.get('PROXYFIX_X_FOR', num_proxies)),
+    'x_proto': int(os.environ.get('PROXYFIX_X_PROTO', num_proxies)),
+    'x_host': int(os.environ.get('PROXYFIX_X_HOST', num_proxies)),
+    # Preserve the existing shared-count behavior for X-Forwarded-Prefix.
+    'x_prefix': num_proxies,
+}
+app.wsgi_app = ProxyFix(app.wsgi_app, **proxyfix_hops)
+if len(set(proxyfix_hops.values())) == 1:
+    log.info(f'ProxyFix configured to trust {num_proxies} proxy(ies) for X-Forwarded-* headers')
+else:
+    log.info(
+        'ProxyFix configured with trusted proxy hops: '
+        f'x_for={proxyfix_hops["x_for"]}, x_proto={proxyfix_hops["x_proto"]}, '
+        f'x_host={proxyfix_hops["x_host"]}, x_prefix={proxyfix_hops["x_prefix"]}'
+    )
 
 lm = MyLoginManager()
 

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -28,6 +28,11 @@ NETWORK_SHARE_MODE=false
 # Trusted reverse-proxy hops. Default: 1.
 # Change this if CWNG is running behind multiple proxies (e.g., Cloudflare Tunnel + reverse proxy).
 # TRUSTED_PROXY_COUNT=1
+# If different proxies append or replace different X-Forwarded-* headers, override
+# their trust depths independently. Each defaults to TRUSTED_PROXY_COUNT (or 1).
+# PROXYFIX_X_FOR=1
+# PROXYFIX_X_PROTO=1
+# PROXYFIX_X_HOST=1
 
 # Path where CWNG is installed. Default: the parent of scripts/app_paths.py.
 # Set when a packager separates the installed application tree from this layout.

--- a/tests/unit/test_1821_proxyfix_hops.py
+++ b/tests/unit/test_1821_proxyfix_hops.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Regression coverage for independently trusted ProxyFix header chains."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROXY_ENV_VARS = (
+    "TRUSTED_PROXY_COUNT",
+    "PROXYFIX_X_FOR",
+    "PROXYFIX_X_PROTO",
+    "PROXYFIX_X_HOST",
+)
+
+
+def _constructed_proxyfix_args(overrides=None):
+    env = os.environ.copy()
+    for name in PROXY_ENV_VARS:
+        env.pop(name, None)
+    env.update(overrides or {})
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(REPO_ROOT), env.get("PYTHONPATH", "")]
+    ).rstrip(os.pathsep)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import json; import cps; middleware = cps.app.wsgi_app; "
+                "print(json.dumps({name: getattr(middleware, name) for name in "
+                "('x_for', 'x_proto', 'x_host', 'x_prefix')}))"
+            ),
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+def test_proxyfix_defaults_are_identical_to_the_existing_single_hop_behavior():
+    assert _constructed_proxyfix_args() == {
+        "x_for": 1,
+        "x_proto": 1,
+        "x_host": 1,
+        "x_prefix": 1,
+    }
+
+
+def test_per_header_env_vars_change_the_proxyfix_construction_args():
+    assert _constructed_proxyfix_args({
+        "PROXYFIX_X_FOR": "2",
+        "PROXYFIX_X_PROTO": "3",
+        "PROXYFIX_X_HOST": "4",
+    }) == {
+        "x_for": 2,
+        "x_proto": 3,
+        "x_host": 4,
+        "x_prefix": 1,
+    }
+
+
+def test_per_header_values_override_the_backward_compatible_shared_count():
+    assert _constructed_proxyfix_args({
+        "TRUSTED_PROXY_COUNT": "2",
+        "PROXYFIX_X_PROTO": "3",
+    }) == {
+        "x_for": 2,
+        "x_proto": 3,
+        "x_host": 2,
+        "x_prefix": 2,
+    }


### PR DESCRIPTION
Closes #1821. ProxyFix was hardcoded to trust one hop, so multi-hop deployments (reporter-confirmed) saw `InsecureTransportError` on OIDC callbacks and classic-login rejects unless they resorted to `OAUTHLIB_INSECURE_TRANSPORT`. Trusted hop counts (`x_for`/`x_proto`/`x_host`) are now env-configurable with defaults byte-identical to today, documented in the canonical env reference. Proxy suite 99/99; env-reference guards 34/34.