### PR TITLE
test(kobo): fixtures model the real device; wire-delivered annotations match again (#1866, #1886)

### DIFF
--- a/changelog.d/1866.md
+++ b/changelog.d/1866.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- **Kobo annotation regressions are now tested against the shapes a real Clara
+  writes.** Recovery fixtures use device ContentIDs, typed bookmark rows,
+  millisecond creation clocks, selector sentinels, and the matching OEBPS spine
+  instead of a server-shaped database that could let incompatible changes pass.

--- a/changelog.d/1886.md
+++ b/changelog.d/1886.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- **Importing a Kobo database no longer reports unchanged cloud-delivered
+  highlights as newer server conflicts.** Equivalent `NULL` and `-99` KoboSpan
+  selector markers are matched before deciding whether recovery data differs.

--- a/cps/annotations.py
+++ b/cps/annotations.py
@@ -605,6 +605,30 @@ def _device_edit_is_newer(device_modified_at, existing) -> bool:
     return watermark is None or device_modified_at > watermark
 
 
+def _matching_container_child_index(value):
+    """Collapse the two equivalent KoboSpan selector sentinels for equality.
+
+    Nickel persists ``-99`` in KoboReader.sqlite while its wire annotation omits
+    the child-index fields, which stores as ``NULL``.  Both the position
+    converter and the web-reader locator consume either spelling as "use the
+    selector path", so the recovery comparator must not invent a content
+    conflict from that structural transport difference.
+    """
+    from .services.kobo_position import KOBO_SELECTOR_SENTINEL
+
+    if value is None or value == KOBO_SELECTOR_SENTINEL:
+        return None
+    return value
+
+
+def _matching_annotation_values(values):
+    """Return comparator-only values with equivalent child sentinels folded."""
+    values = list(values)
+    for index in (5, 8):
+        values[index] = _matching_container_child_index(values[index])
+    return tuple(values)
+
+
 def _bookmark_values(bm, content_id):
     return (
         bm.text,
@@ -642,7 +666,11 @@ def _annotation_values(row):
 
 
 def _bookmark_matches_annotation(bm, content_id, row) -> bool:
-    return not bool(row.hidden) and _bookmark_values(bm, content_id) == _annotation_values(row)
+    return (
+        not bool(row.hidden)
+        and _matching_annotation_values(_bookmark_values(bm, content_id))
+        == _matching_annotation_values(_annotation_values(row))
+    )
 
 
 def _apply_imported_bookmark(row, bm, content_id, *, device_modified_at,

--- a/tests/fixtures/kepub_fixture.py
+++ b/tests/fixtures/kepub_fixture.py
@@ -150,7 +150,7 @@ def build_synthetic_kepub(dest: Path, book_uuid: str = "00000000-0000-0000-0000-
     for i, fname in enumerate(chapters.keys(), 1):
         idref = f"ch{i}"
         manifest_lines.append(
-            f'    <item id="{idref}" href="{fname}" media-type="application/xhtml+xml"/>'
+            f'    <item id="{idref}" href="OEBPS/{fname}" media-type="application/xhtml+xml"/>'
         )
         spine_lines.append(f'    <itemref idref="{idref}"/>')
 

--- a/tests/fixtures/kobo_reader_sqlite.py
+++ b/tests/fixtures/kobo_reader_sqlite.py
@@ -69,60 +69,85 @@ def build_synthetic_kobo_db(
     if path.exists():
         path.unlink()
     conn = sqlite3.connect(path)
-    conn.executescript(BOOKMARK_DDL)
+    # The canonical fixture models the current Clara schema.  A deliberately
+    # untyped compatibility fixture lives in
+    # ``build_kobo_db_without_bookmark_type`` below.
+    conn.executescript(BOOKMARK_DDL_WITH_TYPE)
 
     rows = [
-        # bm_id, volume_id, content_id, sp, sci, so, ep, eci, eo, text, ann, color, ctx, prog, dcreated, dmod, hidden
+        # bm_id, volume_id, content_id, sp, sci, so, ep, eci, eo, text,
+        # ann, color, ctx, prog, dcreated, dmod, hidden, type
         # Hidden is the STRING 'true'/'false' — that is what a real Kobo writes,
         # measured on firmware 4.45.23792 where typeof(Hidden) is 'text' for every
         # row. The column is declared BOOL (NUMERIC affinity) but neither word
         # converts to a number, so SQLite keeps them as TEXT. Do NOT "fix" these
         # back to 0/1: bool('false') is True, and a fixture using integers cannot
         # detect the coercion bug that silently skipped every row on import.
-        ("bm-001", book_uuid, f"{book_uuid}!!chapter1.html",
+        ("bm-001", book_uuid, f"{book_uuid}!OEBPS!chapter1.html",
          "span#kobo\\.1\\.1", -99, 0, "span#kobo\\.1\\.1", -99, 15,
          "All animals are equal.", None, 0, "... All animals are equal. But ...",
-         0.01, "2026-01-01T10:00:00.000", "2026-01-01T10:00:00Z", "false"),
-        ("bm-002", book_uuid, f"{book_uuid}!!chapter1.html",
+         0.01, "2026-01-01T10:00:00.000", "2026-01-01T10:00:00Z", "false", "highlight"),
+        ("bm-002", book_uuid, f"{book_uuid}!OEBPS!chapter1.html",
          "span#kobo\\.1\\.2", -99, 0, "span#kobo\\.1\\.3", -99, 21,
          "Four legs good, two legs bad.", "my favorite line", 1,
          "Four legs good, two legs bad.", 0.024, "2026-01-01T10:05:00.123",
-         "2026-01-01T10:05:00Z", "false"),
-        ("bm-003", book_uuid, f"{book_uuid}!!chapter2.html",
+         "2026-01-01T10:05:00Z", "false", "highlight"),
+        ("bm-003", book_uuid, f"{book_uuid}!OEBPS!chapter2.html",
          "span#kobo\\.2\\.1", -99, 8, "span#kobo\\.2\\.1", -99, 17,
          "Comrade Napoleon", None, 2, "...Comrade Napoleon is always right...",
-         0.5, "2026-01-02T10:00:00.000", "2026-01-02T10:00:00Z", "false"),
+         0.5, "2026-01-02T10:00:00.000", "2026-01-02T10:00:00Z", "false", "highlight"),
         # sideloaded — must be skipped
-        ("bm-004", sideloaded_uri, "sideloaded!!ch1.html",
+        ("bm-004", sideloaded_uri, "sideloaded!OEBPS!ch1.html",
          "span#kobo\\.4\\.1", -99, 0, "span#kobo\\.4\\.1", -99, 10,
          "sideloaded text", None, 0, None, 0.1,
-         "2026-01-03T10:00:00.000", "2026-01-03T10:00:00Z", "false"),
+         "2026-01-03T10:00:00.000", "2026-01-03T10:00:00Z", "false", "highlight"),
         # hidden — must be skipped
-        ("bm-005", book_uuid, f"{book_uuid}!!chapter1.html",
+        ("bm-005", book_uuid, f"{book_uuid}!OEBPS!chapter1.html",
          "span#kobo\\.1\\.4", -99, 0, "span#kobo\\.1\\.4", -99, 30,
          "deleted on device", None, 0, None, 0.05,
-         "2026-01-04T10:00:00.000", "2026-01-04T10:00:00Z", "true"),
+         "2026-01-04T10:00:00.000", "2026-01-04T10:00:00Z", "true", "highlight"),
         # unrelated UUID — must be skipped (no CW book matches)
-        ("bm-006", extra_book_uuid, f"{extra_book_uuid}!!intro.html",
+        ("bm-006", extra_book_uuid, f"{extra_book_uuid}!OEBPS!intro.html",
          "span#kobo\\.5\\.1", -99, 0, "span#kobo\\.5\\.1", -99, 12,
          "orphan highlight", None, 3, None, 0.0,
-         "2026-01-05T10:00:00.000", "2026-01-05T10:00:00Z", "false"),
+         "2026-01-05T10:00:00.000", "2026-01-05T10:00:00Z", "false", "highlight"),
         # malformed: empty BookmarkID — must be skipped silently
         ("", book_uuid, None, None, None, None, None, None, None,
-         "malformed", None, 0, None, None, None, None, "false"),
-        # empty text — must be skipped (parser WHERE clause filters)
-        ("bm-008", book_uuid, f"{book_uuid}!!chapter1.html",
+         "malformed", None, 0, None, None, None, None, "false", None),
+        # no annotation evidence — must be skipped by the ingest classifier
+        ("bm-008", book_uuid, f"{book_uuid}!OEBPS!chapter1.html",
          "span#kobo\\.1\\.7", -99, 0, "span#kobo\\.1\\.7", -99, 5,
          "", None, 0, None, 0.0,
-         "2026-01-06T10:00:00.000", "2026-01-06T10:00:00Z", "false"),
+         "2026-01-06T10:00:00.000", "2026-01-06T10:00:00Z", "false", None),
     ]
 
     conn.executemany(
-        "INSERT INTO Bookmark VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO Bookmark VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         rows,
     )
     conn.commit()
     conn.close()
+    return path
+
+
+def build_kobo_db_without_bookmark_type(
+    path: Path,
+    book_uuid: str = "b3d1b38b-74fd-43b7-a796-996e5a6a8b04",
+) -> Path:
+    """Build the canonical rows with an older schema that lacks ``Type``.
+
+    This is intentionally not the canonical fixture: current Clara firmware
+    has the column.  It exists only to preserve the importer's compatibility
+    guard for older databases without making every current-device test blind
+    to ``Bookmark.Type``.
+    """
+    path = build_synthetic_kobo_db(path, book_uuid=book_uuid)
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute("ALTER TABLE Bookmark DROP COLUMN Type")
+        conn.commit()
+    finally:
+        conn.close()
     return path
 
 
@@ -146,18 +171,18 @@ def build_kobo_db_with_colors(
     if path.exists():
         path.unlink()
     conn = sqlite3.connect(path)
-    conn.executescript(BOOKMARK_DDL)
+    conn.executescript(BOOKMARK_DDL_WITH_TYPE)
     rows = []
     for index, color in enumerate(colors):
         rows.append((
-            f"clr-{index}", book_uuid, f"{book_uuid}!!chapter1.html",
+            f"clr-{index}", book_uuid, f"{book_uuid}!OEBPS!chapter1.html",
             "span#kobo\\.1\\.{}".format(index), -99, 0,
             "span#kobo\\.1\\.{}".format(index), -99, 10,
             f"passage {index}", None, color, None, 0.1,
-            "2026-01-01T10:00:00.000", "2026-01-01T10:00:00Z", 0,
+            "2026-01-01T10:00:00.000", "2026-01-01T10:00:00Z", "false", "highlight",
         ))
     conn.executemany(
-        "INSERT INTO Bookmark VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO Bookmark VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         rows,
     )
     conn.commit()
@@ -189,22 +214,22 @@ def build_kobo_db_with_bookmark_type(
 ) -> Path:
     """A Bookmark table that carries the ``Type`` column, as current firmware does.
 
-    ``build_synthetic_kobo_db`` above deliberately omits ``Type`` — it models an
-    older schema, and the importer must keep working there. This one models the
-    schema a current device actually has, so the two together cover both sides of
-    the capability check in ``parse_kobo_bookmarks``.
+    Kept as a focused vocabulary fixture even though the canonical builder now
+    also carries ``Type``.  ``build_kobo_db_without_bookmark_type`` covers the
+    older-schema capability branch in ``parse_kobo_bookmarks``.
 
-    ``dogear`` rows carry no ``Text`` on a real device and so cannot reach the
-    importer, whose SELECT filters them out. One is included anyway, with text,
-    precisely so a test can prove the importer stores whatever word the device
-    used rather than assuming everything it sees is a highlight.
+    ``dogear`` rows normally carry no ``Text`` on a real device. One is included
+    here with text so the focused vocabulary test proves the importer stores
+    whatever word the device used rather than assuming every populated row is a
+    highlight; empty-text recovery is covered by
+    ``build_kobo_db_with_recovery_rows``.
     """
     import sqlite3
 
     conn = sqlite3.connect(path)
     conn.executescript(BOOKMARK_DDL_WITH_TYPE)
-    chapter1 = "{}!!chapter1.html".format(book_uuid)
-    chapter2 = "{}!!chapter2.html".format(book_uuid)
+    chapter1 = "{}!OEBPS!chapter1.html".format(book_uuid)
+    chapter2 = "{}!OEBPS!chapter2.html".format(book_uuid)
     rows = [
         ("bt-001", book_uuid, chapter1, "span#kobo\\.1\\.1", -99, 0,
          "span#kobo\\.1\\.2", -99, 5, "a highlight", None, 0, "ctx", 0.1,
@@ -246,7 +271,7 @@ def build_kobo_db_with_recovery_rows(
         path.unlink()
     conn = sqlite3.connect(path)
     conn.executescript(BOOKMARK_DDL_WITH_TYPE)
-    chapter = f"{book_uuid}!!chapter1.html"
+    chapter = f"{book_uuid}!OEBPS!chapter1.html"
     rows = [
         (
             "recover-dogear", book_uuid, chapter,

--- a/tests/unit/test_annotations_import_endpoint.py
+++ b/tests/unit/test_annotations_import_endpoint.py
@@ -215,6 +215,73 @@ class TestIngestCounts:
 
 
 @pytest.mark.unit
+class TestWireAndDatabaseSentinelEquivalence:
+    def test_wire_delivered_annotation_is_already_present(
+        self, memory_db, synthetic_db, monkeypatch,
+    ):
+        """NULL on the wire and -99 in SQLite describe one KoboSpan selector."""
+        from cps import ub
+        from cps.annotations import ingest_bookmarks
+        from cps.services.annotation_sync import (
+            dispatch_annotation_sync,
+            reset_registry_for_testing,
+            set_remote_enqueue,
+        )
+
+        session, _, _ = memory_db
+
+        def commit():
+            session.commit()
+            return True
+
+        monkeypatch.setattr(ub, "session", session)
+        monkeypatch.setattr(ub, "session_commit", commit)
+        reset_registry_for_testing()
+        set_remote_enqueue(None)
+        book_uuid = "b3d1b38b-74fd-43b7-a796-996e5a6a8b04"
+        book = SimpleNamespace(id=348, uuid=book_uuid, title="Animal Farm")
+        user = SimpleNamespace(id=7)
+        payload = {
+            "id": "bm-001",
+            "highlightedText": "All animals are equal.",
+            "noteText": None,
+            "highlightColor": "#F6F3B3",
+            "type": "highlight",
+            "clientLastModifiedUtc": "2026-01-01T10:00:00Z",
+            "location": {"span": {
+                "chapterFilename": "OEBPS/chapter1.html",
+                "startPath": "span#kobo\\.1\\.1",
+                "startChar": 0,
+                "endPath": "span#kobo\\.1\\.1",
+                "endChar": 15,
+                "contextString": "... All animals are equal. But ...",
+                "chapterProgress": 0.01,
+            }},
+        }
+
+        assert dispatch_annotation_sync([payload], book, user) is True
+        wire_row = session.query(ub.Annotation).filter_by(
+            annotation_id="bm-001",
+        ).one()
+        assert wire_row.start_container_child_index is None
+        assert wire_row.end_container_child_index is None
+
+        result = ingest_bookmarks(
+            synthetic_db,
+            user_id=7,
+            session=session,
+            book_lookup=_make_book_lookup({book_uuid: 348}),
+            commit=commit,
+        )
+
+        assert result["skipped_existing"] == 1, result
+        assert result["skipped_newer_server"] == 0, result
+        assert session.query(ub.Annotation).filter_by(
+            user_id=7, book_id=348, annotation_id="bm-001",
+        ).count() == 1
+
+
+@pytest.mark.unit
 class TestKoboDeviceContentId:
     BOOK_UUID = "b3d1b38b-74fd-43b7-a796-996e5a6a8b04"
 

--- a/tests/unit/test_imported_annotation_records_its_type.py
+++ b/tests/unit/test_imported_annotation_records_its_type.py
@@ -26,7 +26,7 @@ from sqlalchemy.orm import sessionmaker
 
 from tests.fixtures.kobo_reader_sqlite import (
     build_kobo_db_with_bookmark_type,
-    build_synthetic_kobo_db,
+    build_kobo_db_without_bookmark_type,
 )
 
 pytestmark = pytest.mark.unit
@@ -89,7 +89,10 @@ def test_an_empty_device_word_is_stored_as_null(memory_db, tmp_path):
 
 def test_an_older_schema_still_imports_and_stores_null(memory_db, tmp_path):
     """No Type column on the device is not an error, and must not lose rows."""
-    rows = _import(memory_db, build_synthetic_kobo_db(tmp_path / "old.sqlite"))
+    rows = _import(
+        memory_db,
+        build_kobo_db_without_bookmark_type(tmp_path / "old.sqlite"),
+    )
     assert len(rows) >= 3, "the older-schema import lost rows"
     assert {r.annotation_type for r in rows.values()} == {None}
 

--- a/tests/unit/test_kobo_import_parser.py
+++ b/tests/unit/test_kobo_import_parser.py
@@ -26,6 +26,7 @@ from pathlib import Path
 import pytest
 
 from tests.fixtures.kobo_reader_sqlite import (
+    build_kobo_db_without_bookmark_type,
     build_synthetic_kobo_db,
     build_empty_sqlite_no_bookmark_table,
     build_not_sqlite,
@@ -144,6 +145,38 @@ class TestParseKoboBookmarks:
         rows = {r.bookmark_id: r for r in parse_kobo_bookmarks(p)}
         assert rows["bm-004"].volume_id.startswith("file:///")
 
+    def test_canonical_fixture_carries_measured_clara_shapes(self, tmp_path):
+        """The default fixture is the current device, not a server-shaped fake."""
+        import sqlite3
+
+        p = build_synthetic_kobo_db(tmp_path / "k.sqlite")
+        connection = sqlite3.connect(p)
+        try:
+            columns = {
+                row[1] for row in connection.execute("PRAGMA table_info(Bookmark)")
+            }
+            row = connection.execute(
+                """
+                SELECT ContentID, StartContainerChildIndex,
+                       EndContainerChildIndex, DateCreated, Hidden,
+                       typeof(Hidden), Type
+                FROM Bookmark WHERE BookmarkID = 'bm-001'
+                """
+            ).fetchone()
+        finally:
+            connection.close()
+
+        assert "Type" in columns
+        assert row == (
+            "b3d1b38b-74fd-43b7-a796-996e5a6a8b04!OEBPS!chapter1.html",
+            -99,
+            -99,
+            "2026-01-01T10:00:00.000",
+            "false",
+            "text",
+            "highlight",
+        )
+
 
 @pytest.mark.unit
 class TestParserEdgeCases:
@@ -230,9 +263,7 @@ class TestBookmarkTypeIsRecovered:
         their type is None rather than a fabricated default.
         """
         from cps.services.kobo_import import parse_kobo_bookmarks
-        from tests.fixtures.kobo_reader_sqlite import build_synthetic_kobo_db
-
-        p = build_synthetic_kobo_db(tmp_path / "old.sqlite")
+        p = build_kobo_db_without_bookmark_type(tmp_path / "old.sqlite")
         rows = list(parse_kobo_bookmarks(p))
         assert len(rows) >= 6, "the older-schema import lost rows"
         assert {r.annotation_type for r in rows} == {None}
@@ -247,7 +278,7 @@ class TestBookmarkTypeIsRecovered:
 
         from tests.fixtures.kobo_reader_sqlite import (
             build_kobo_db_with_bookmark_type,
-            build_synthetic_kobo_db,
+            build_kobo_db_without_bookmark_type,
         )
 
         def columns(path):
@@ -258,4 +289,6 @@ class TestBookmarkTypeIsRecovered:
                 conn.close()
 
         assert "Type" in columns(build_kobo_db_with_bookmark_type(tmp_path / "new.sqlite"))
-        assert "Type" not in columns(build_synthetic_kobo_db(tmp_path / "old.sqlite"))
+        assert "Type" not in columns(
+            build_kobo_db_without_bookmark_type(tmp_path / "old.sqlite")
+        )

--- a/tests/unit/test_kobo_position_converter.py
+++ b/tests/unit/test_kobo_position_converter.py
@@ -68,7 +68,11 @@ class TestSpineParse:
         from cps.services.kobo_position import parse_spine
 
         spine = parse_spine(synthetic_kepub)
-        assert spine == ["chapter1.html", "chapter2.html", "chapter3.html"]
+        assert spine == [
+            "OEBPS/chapter1.html",
+            "OEBPS/chapter2.html",
+            "OEBPS/chapter3.html",
+        ]
 
     def test_spine_empty_for_nonexistent_file(self, tmp_path):
         from cps.services.kobo_position import parse_spine
@@ -116,7 +120,7 @@ class TestComputeCfiRangeKepub:
         from cps.services.kobo_position import KoboPosition, compute_cfi_range
 
         pos = KoboPosition(
-            content_id="00000000-0000-0000-0000-deadbeefcafe!!chapter1.html",
+            content_id="00000000-0000-0000-0000-deadbeefcafe!!OEBPS/chapter1.html",
             start_container_path="span#kobo\\.1\\.1",
             start_container_child_index=-99,
             start_offset=0,
@@ -291,7 +295,7 @@ class TestCfiRoundTrip:
         # epubcfi(common,start,end) — common reaches the span.
         common = cfi[len("epubcfi("):-1].split(",")[0].split("!", 1)[1]
         cache_key = (str(synthetic_kepub), synthetic_kepub.stat().st_mtime_ns)
-        tree = _get_chapter_dom(cache_key, synthetic_kepub, "chapter1.html")
+        tree = _get_chapter_dom(cache_key, synthetic_kepub, "OEBPS/chapter1.html")
         span = _walk_cfi_element_path(tree, common)
         assert span.get("id") == "kobo.1.1"
         # /1:0 .. /1:15 over the span's text → the exact highlighted run.
@@ -303,7 +307,7 @@ class TestCfiRoundTrip:
         )
 
         pos = KoboPosition(
-            content_id="00000000-0000-0000-0000-deadbeefcafe!!chapter1.html",
+            content_id="00000000-0000-0000-0000-deadbeefcafe!!OEBPS/chapter1.html",
             start_container_path="span#kobo\\.1\\.1",
             start_container_child_index=-99,
             start_offset=0,
@@ -315,7 +319,7 @@ class TestCfiRoundTrip:
         parts = cfi[len("epubcfi("):-1].split(",")
         common = parts[0].split("!", 1)[1]
         cache_key = (str(synthetic_kepub), synthetic_kepub.stat().st_mtime_ns)
-        tree = _get_chapter_dom(cache_key, synthetic_kepub, "chapter1.html")
+        tree = _get_chapter_dom(cache_key, synthetic_kepub, "OEBPS/chapter1.html")
         # Common ancestor is the <p>; start/end paths are relative to it.
         common_el = _walk_cfi_element_path(tree, common)
         assert common_el.tag == "p"
@@ -438,7 +442,11 @@ class TestCacheInvalidation:
         build_synthetic_kepub(epub)
 
         spine_v1 = parse_spine(epub)
-        assert spine_v1 == ["chapter1.html", "chapter2.html", "chapter3.html"]
+        assert spine_v1 == [
+            "OEBPS/chapter1.html",
+            "OEBPS/chapter2.html",
+            "OEBPS/chapter3.html",
+        ]
 
         # Wait at least one filesystem tick + replace with the minimal
         # fixture (single chapter) so the cache key changes.


### PR DESCRIPTION
Closes #1866 and #1886 (the latter was gated on the former — a fix without real-device fixtures ships untested).

**#1866:** `tests/fixtures/kobo_reader_sqlite.py` now models the real Clara: single-bang ContentID, naive+milliseconds `DateCreated`, the `Type` column present; `kepub_fixture.py`'s spine re-anchored so `!OEBPS!` resolves. 12 assertions flipped under the corrected shapes and were re-grounded without weakening product code.

**#1886:** `_bookmark_matches_annotation` compared container child indices that are structurally `-99` (device) vs `NULL` (wire), so a wire-delivered annotation could never match and every one reported `skipped_newer_server`. Sentinels are normalized before comparison; regression proves a wire-delivered annotation is recognized as present and fails on the old comparator.

Full unit suite **7747 passed / 0 failed**.