### PR TITLE
fix(paths): /config literals resolve through the directory resolver — bare-metal installs work (#1883)

### DIFF
--- a/changelog.d/1883.md
+++ b/changelog.d/1883.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Bare-metal installs now keep processed-book backups, conversion logs and the metadata write lock under their configured data directory.** Full-library conversion, ingest recovery, EPUB fixing, auto-zipping and duplicate resolution all follow `CALIBRE_DBPATH` instead of trying to read or create Docker's `/config` paths; the affected admin pages show the effective locations too.

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -3096,6 +3096,7 @@ def _db_configuration_result(error_flash=None, gdrive_error=None):
 
     return render_title_template("config_db.html",
                                  config=config,
+                                 backup_root=constants.config_path("backup"),
                                  show_authenticate_google_drive=gdrive_authenticate,
                                  gdriveError=gdrive_error,
                                  gdrivefolders=gdrivefolders,
@@ -3681,7 +3682,11 @@ def restore_calibre_db():
             flash(_("Restore failed: metadata.db not found at %(path)s", path=metadata_path), category="error")
             return redirect(url_for("admin.db_configuration"))
 
-        app_db_path = ub.app_DB_path or cli_param.settings_path or "/config/app.db"
+        app_db_path = (
+            ub.app_DB_path
+            or cli_param.settings_path
+            or constants.config_path("app.db")
+        )
         if not os.path.exists(app_db_path):
             flash(_("Restore failed: app.db not found at %(path)s", path=app_db_path), category="error")
             return redirect(url_for("admin.db_configuration"))
@@ -3696,7 +3701,9 @@ def restore_calibre_db():
         lock_handles.extend(service_lock_handles)
 
         # 1. Backup both DBs
-        backup_dir = f"/config/backup/restore_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+        backup_dir = constants.config_path(
+            "backup", f"restore_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+        )
         os.makedirs(backup_dir, exist_ok=True)
         copy_sqlite_database(metadata_path, os.path.join(backup_dir, "metadata.db.bak"))
         copy_sqlite_database(app_db_path, os.path.join(backup_dir, "app.db.bak"))

--- a/cps/calibre_init.py
+++ b/cps/calibre_init.py
@@ -7,7 +7,7 @@
 import os
 import sqlite3
 
-from cps import db, logger
+from cps import constants, db, logger
 
 log = logger.create()
 
@@ -51,7 +51,7 @@ def init_calibre_db_from_config(config, settings_path):
 def init_calibre_db_from_app_db(app_db_path=None):
     """Initialize CalibreDB by reading config from app.db (for background workers)."""
     if app_db_path is None:
-        base_path = os.environ.get("CALIBRE_DBPATH", "/config")
+        base_path = constants.CONFIG_DIR
         if base_path.endswith(".db"):
             if os.path.basename(base_path) != "app.db":
                 app_db_path = os.path.join(os.path.dirname(base_path), "app.db")

--- a/cps/constants.py
+++ b/cps/constants.py
@@ -155,6 +155,16 @@ else:
     if getattr(sys, 'frozen', False):
         CONFIG_DIR = os.path.abspath(os.path.join(CONFIG_DIR, os.pardir))
 
+
+def config_path(*parts, _join=os.path.join):
+    """Return a path beneath the resolved writable config root."""
+    return _join(CONFIG_DIR, *parts)
+
+
+def processed_books_dir():
+    """Root for retained originals, failed conversions and backup archives."""
+    return config_path("processed_books")
+
 # Where the metadata/cover enforcer (scripts/cover_enforcer.py, driven by the
 # metadata-change-detector s6 service) watches for change logs. Env-overridable
 # for tests.

--- a/cps/cwa_functions.py
+++ b/cps/cwa_functions.py
@@ -219,7 +219,11 @@ def get_ingest_dir():
 def get_ingest_status():
     """Read the current ingest service status"""
     try:
-        with open('/config/cwa_ingest_status', 'r') as f:
+        status_path = os.environ.get(
+            "CWA_INGEST_STATUS_FILE",
+            constants.config_path("cwa_ingest_status"),
+        )
+        with open(status_path, 'r') as f:
             status_line = f.read().strip()
             if ':' in status_line:
                 parts = status_line.split(':')
@@ -253,7 +257,11 @@ def _coerce_book_ids(raw_book_ids):
 def get_ingest_queue_size():
     """Get the number of files in the retry queue"""
     try:
-        with open('/config/cwa_ingest_retry_queue', 'r') as f:
+        queue_path = os.environ.get(
+            "CWA_INGEST_RETRY_QUEUE",
+            constants.config_path("cwa_ingest_retry_queue"),
+        )
+        with open(queue_path, 'r') as f:
             return len([line for line in f if line.strip()])
     except (FileNotFoundError, IOError):
         return 0
@@ -1124,7 +1132,9 @@ def set_cwa_settings():
                                     cwa_settings=cwa_settings, ignorable_formats=ignorable_formats, target_formats=target_formats,
                                     automerge_options=automerge_options, autoingest_options=autoingest_options,
                                     hardcover_token_available=hardcover_token_available,
-                                    next_duplicate_scan_run=next_scan_run, config=config)
+                                    next_duplicate_scan_run=next_scan_run,
+                                    processed_books_dir=constants.processed_books_dir(),
+                                    config=config)
 
 
 def get_next_duplicate_scan_run(settings):
@@ -1958,6 +1968,11 @@ def get_log_dates(logs) -> dict[str,str]:
                             "time":log_time}}
     return log_dates
 
+
+def _service_log_path(filename: str) -> str:
+    """Resolve a service log beneath the active config directory."""
+    return constants.config_path(filename)
+
 ##———————————————————END OF SHARED VARIABLES & FUNCTIONS———————————————————————##
 
 def convert_library_start(queue):
@@ -1978,7 +1993,7 @@ def empty_tmp_con_dir(tmp_conversion_dir) -> None:
         print(f"[cwa-functions]: An error occurred while emptying {tmp_conversion_dir}. See the following error: {e}")
 
 def is_convert_library_finished() -> bool:
-    log_path = "/config/convert-library.log"
+    log_path = _service_log_path("convert-library.log")
     with open(log_path, 'r') as log:
         if "NextGen Convert Library Service - Run Ended: " in log.read():
             return True
@@ -1987,7 +2002,7 @@ def is_convert_library_finished() -> bool:
 
 def kill_convert_library(queue):
     trigger_file = Path(tempfile.gettempdir() + "/.kill_convert_library_trigger")
-    log_path = "/config/convert-library.log"
+    log_path = _service_log_path("convert-library.log")
     while True:
         sleep(0.05) # Required to prevent high cpu usage
         if trigger_file.exists():
@@ -2056,7 +2071,7 @@ def show_convert_library_logs():
 @admin_required
 def download_current_log(log_filename):
     log_filename = "convert-library.log"
-    LOG_DIR = "/config"
+    LOG_DIR = constants.CONFIG_DIR
     try:
         # Secure the filename to prevent directory traversal (e.g., '..')
         safe_filename = secure_filename(log_filename)
@@ -2084,7 +2099,7 @@ def download_current_log(log_filename):
 @admin_required
 def start_conversion():
     # Wipe conversion log from previous runs
-    open('/config/convert-library.log', 'w').close()
+    open(_service_log_path("convert-library.log"), 'w').close()
     # Remove any left over kill file
     try:
         os.remove(tempfile.gettempdir() + "/.kill_convert_library_trigger")
@@ -2112,7 +2127,7 @@ def cancel_convert_library():
 @login_required_if_no_ano
 @admin_required
 def get_status():
-    with open("/config/convert-library.log", 'r') as f:
+    with open(_service_log_path("convert-library.log"), 'r') as f:
         status = f.read()
     progress = extract_progress(status)
     statusList = {'status':status,
@@ -2134,7 +2149,7 @@ def epub_fixer_start(queue, input_file: str | None = None):
     queue.put(ef_process)
 
 def is_epub_fixer_finished() -> bool:
-    log_path = "/config/epub-fixer.log"
+    log_path = _service_log_path("epub-fixer.log")
     with open(log_path, 'r') as log:
         if "NextGen Kindle EPUB Fixer Service - Run Ended: " in log.read():
             return True
@@ -2143,7 +2158,7 @@ def is_epub_fixer_finished() -> bool:
 
 def kill_epub_fixer(queue):
     trigger_file = Path(tempfile.gettempdir() + "/.kill_epub_fixer_trigger")
-    log_path = "/config/epub-fixer.log"
+    log_path = _service_log_path("epub-fixer.log")
     while True:
         sleep(0.05) # Required to prevent high cpu usage
         if trigger_file.exists():
@@ -2208,7 +2223,7 @@ def show_epub_fixer_logs():
 @admin_required
 def download_current_log(log_filename):
     log_filename = "epub-fixer.log"
-    LOG_DIR = "/config"
+    LOG_DIR = constants.CONFIG_DIR
     try:
         # Secure the filename to prevent directory traversal (e.g., '..')
         safe_filename = secure_filename(log_filename)
@@ -2236,7 +2251,7 @@ def download_current_log(log_filename):
 @admin_required
 def start_epub_fixer():
     # Wipe conversion log from previous runs
-    open('/config/epub-fixer.log', 'w').close()
+    open(_service_log_path("epub-fixer.log"), 'w').close()
     # Remove any left over kill file
     try:
         os.remove(tempfile.gettempdir() + "/.kill_epub_fixer_trigger")
@@ -2284,7 +2299,7 @@ def run_epub_fixer_for_book():
             return jsonify({"success": False, "error": _("EPUB file not found on disk.")}), 404
 
         # Wipe conversion log from previous runs
-        open('/config/epub-fixer.log', 'w').close()
+        open(_service_log_path("epub-fixer.log"), 'w').close()
         # Remove any left over kill file
         try:
             os.remove(tempfile.gettempdir() + "/.kill_epub_fixer_trigger")
@@ -2321,7 +2336,7 @@ def cancel_epub_fixer():
 @login_required_if_no_ano
 @admin_required
 def get_status():
-    with open("/config/epub-fixer.log", 'r') as f:
+    with open(_service_log_path("epub-fixer.log"), 'r') as f:
         status = f.read()
     progress = extract_progress(status)
     statusList = {'status':status,
@@ -2390,7 +2405,7 @@ def cover_enforcer_start(queue):
         # O_APPEND makes every write go to the current end of file for both writers.
         # Popen dups the fd into the child, so closing the parent copy here is safe and
         # avoids leaking one descriptor per run.
-        log_file = open('/config/cover-enforcer.log', 'a')
+        log_file = open(_service_log_path("cover-enforcer.log"), 'a')
         ce_process = subprocess.Popen(['python3', os.path.join(constants.SCRIPTS_DIR, 'cover_enforcer.py'), '-all'], stdout=log_file, stderr=subprocess.STDOUT)
     except Exception as e:
         # Nothing was ever put on the queue, so the watcher blocked forever at queue.get()
@@ -2398,7 +2413,7 @@ def cover_enforcer_start(queue):
         # so the poller stops and the admin sees why, and hand the watcher a sentinel.
         log.error(f"Failed to start cover enforcer: {e}")
         try:
-            with open('/config/cover-enforcer.log', 'a') as f:
+            with open(_service_log_path("cover-enforcer.log"), 'a') as f:
                 f.write(f"\nFailed to start the enforcement run: {e}")
                 f.write(f"\nNextGen Cover & Metadata Enforcement Service - Run Ended: {datetime.now()}")
         except Exception as log_exc:
@@ -2444,7 +2459,7 @@ def is_cover_enforcer_finished() -> bool:
     # the whole file to find it was re-reading the entire log 20 times a second for the
     # duration of every run.
     return "NextGen Cover & Metadata Enforcement Service - Run Ended: " in _read_log_tail(
-        "/config/cover-enforcer.log")
+        _service_log_path("cover-enforcer.log"))
 
 def kill_cover_enforcer(queue):
     # Wrapped so the run is released on EVERY exit path, including an unexpected
@@ -2457,7 +2472,7 @@ def kill_cover_enforcer(queue):
 
 def _watch_cover_enforcer(queue):
     trigger_file = Path(tempfile.gettempdir() + "/.kill_cover_enforcer_trigger")
-    log_path = "/config/cover-enforcer.log"
+    log_path = _service_log_path("cover-enforcer.log")
     # The run this watcher owns, once cover_enforcer_start() publishes it. Held so the
     # loop can key termination on the PROCESS rather than only on a string in the log:
     # a child that dies without printing the marker - an import error, a fatal signal, a
@@ -2598,7 +2613,7 @@ def show_cover_enforcer_logs():
 @admin_required
 def download_current_log(log_filename):
     log_filename = "cover-enforcer.log"
-    LOG_DIR = "/config"
+    LOG_DIR = constants.CONFIG_DIR
     try:
         # Secure the filename to prevent directory traversal (e.g., '..')
         safe_filename = secure_filename(log_filename)
@@ -2645,7 +2660,7 @@ def start_cover_enforcer():
         _cover_enforcer_run['active'] = True
     try:
         # Wipe enforcement log from previous runs
-        open('/config/cover-enforcer.log', 'w').close()
+        open(_service_log_path("cover-enforcer.log"), 'w').close()
         # Remove any left over kill file
         try:
             os.remove(tempfile.gettempdir() + "/.kill_cover_enforcer_trigger")
@@ -2684,7 +2699,7 @@ def cancel_cover_enforcer():
 @login_required_if_no_ano
 @admin_required
 def get_status():
-    log_path = "/config/cover-enforcer.log"
+    log_path = _service_log_path("cover-enforcer.log")
     # Bounded tail, not the whole file - see COVER_ENFORCER_STATUS_TAIL_BYTES. Returns ""
     # when the log does not exist yet, so a first-ever page load still gets valid JSON.
     status = _read_log_tail(log_path)

--- a/cps/duplicates.py
+++ b/cps/duplicates.py
@@ -20,7 +20,7 @@ import threading
 import time
 from shutil import copyfile
 
-from . import db, calibre_db, logger, ub, csrf, config, helper, user_book_data
+from . import db, calibre_db, logger, ub, csrf, config, constants, helper, user_book_data
 from .services.worker import WorkerThread, STAT_FINISH_SUCCESS, STAT_FAIL, STAT_ENDED, STAT_CANCELLED
 from .admin import admin_required  
 from .usermanagement import login_required_if_no_ano
@@ -54,6 +54,24 @@ log = logger.create()
 # request) for the holder's entire run. Preview (dry_run=True) is read-only and
 # never acquires this lock.
 _AUTO_RESOLVE_LOCK = threading.Lock()
+
+
+def duplicate_resolution_root():
+    """Directory where destructive duplicate resolution retains originals."""
+    config_root = getattr(constants, "CONFIG_DIR", None)
+    if not config_root:
+        configured = (os.environ.get("CALIBRE_DBPATH") or "").strip()
+        if configured:
+            config_root = (
+                os.path.dirname(configured)
+                if configured.endswith(".db")
+                else configured
+            )
+        else:
+            config_root = os.path.dirname(os.path.dirname(__file__))
+    return os.path.join(
+        config_root, "processed_books", "duplicate_resolutions"
+    )
 
 
 class _DeletedBookFileRef:
@@ -599,6 +617,7 @@ def show_duplicates():
                                      duplicate_groups=duplicate_groups,
                                      duplicate_index_needs_full_scan=duplicate_index_needs_full_scan,
                                      next_scan_run=next_scan_run,
+                                     duplicate_backup_dir=f"{duplicate_resolution_root()}{os.sep}",
                                      title=_("Duplicate Books"), 
                                      page="duplicates")
                                      
@@ -610,6 +629,7 @@ def show_duplicates():
                                      duplicate_groups=[],
                                      duplicate_index_needs_full_scan=False,
                                      next_scan_run=None,
+                                     duplicate_backup_dir=f"{duplicate_resolution_root()}{os.sep}",
                                      title=_("Duplicate Books"), 
                                      page="duplicates")
 
@@ -1874,7 +1894,10 @@ def auto_resolve_duplicates(strategy='newest', dry_run=False, user_id=None, trig
                 book_to_keep = book_to_keep_ref
 
                 deleted_ids = []
-                backup_dir = f"/config/processed_books/duplicate_resolutions/{datetime.now().strftime('%Y%m%d_%H%M%S')}_group_{group['group_hash'][:8]}"
+                backup_dir = os.path.join(
+                    duplicate_resolution_root(),
+                    f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_group_{group['group_hash'][:8]}",
+                )
                 os.makedirs(backup_dir, exist_ok=True)
 
                 if strategy == 'merge':

--- a/cps/services/calibre_db_lock.py
+++ b/cps/services/calibre_db_lock.py
@@ -33,6 +33,7 @@ import errno
 import os
 import time
 from contextlib import contextmanager
+from pathlib import Path
 
 try:
     from .parallel import cooperative_sleep
@@ -61,13 +62,29 @@ except ImportError:  # pragma: no cover — Windows
     HAS_FCNTL = False
 
 
-DEFAULT_LOCK_DIR = "/config"
 DEFAULT_LOCK_BASENAME = ".cwa-metadata-write.lock"
 DEFAULT_TIMEOUT_SECONDS = 120.0
 
 
+def _resolved_config_dir() -> str:
+    """Mirror the dependency-free config resolver used by scripts.app_paths."""
+    override = (os.environ.get("CALIBRE_DBPATH") or "").strip()
+    if override:
+        configured = Path(override)
+        return str(configured.parent if configured.suffix == ".db" else configured)
+
+    cps_dir = Path(__file__).resolve().parents[1]
+    if (cps_dir / ".HOMEDIR").is_file():
+        return str(Path(os.path.expanduser("~")) / ".calibre-web-automated")
+    return str(cps_dir.parent)
+
+
 def _resolve_lock_path(lock_dir: str | None) -> str:
-    base = lock_dir or os.environ.get("CWA_METADATA_LOCK_DIR") or DEFAULT_LOCK_DIR
+    base = (
+        lock_dir
+        or os.environ.get("CWA_METADATA_LOCK_DIR")
+        or _resolved_config_dir()
+    )
     return os.path.join(base, DEFAULT_LOCK_BASENAME)
 
 
@@ -82,9 +99,9 @@ def metadata_db_write_lock(
     Parameters
     ----------
     lock_dir
-        Directory to place the lock file in. Defaults to /config, the
-        local Docker volume that always supports fcntl. Override via
-        the ``CWA_METADATA_LOCK_DIR`` env var or for tests.
+        Directory to place the lock file in. Defaults to the resolved config
+        directory (``/config`` in the image). Override via the
+        ``CWA_METADATA_LOCK_DIR`` env var or for tests.
     timeout
         Seconds to wait for the lock before raising ``TimeoutError``.
         Default 120s — long enough to ride out the kindle-epub-fixer
@@ -104,7 +121,7 @@ def metadata_db_write_lock(
 
     # The directory must exist. We deliberately do NOT create the lock
     # directory on demand — that would mask a misconfiguration (e.g.
-    # /config not mounted). If the directory is missing, the
+    # configured directory not mounted). If the directory is missing, the
     # ENOENT-from-open below surfaces clearly.
     fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o644)
     try:

--- a/cps/services/cover_preview_cache.py
+++ b/cps/services/cover_preview_cache.py
@@ -82,11 +82,13 @@ import threading
 from pathlib import Path
 from typing import Dict, Optional
 
+from cps import constants
+
 log = logging.getLogger(__name__)
 
 # Default production cache root. Module-level (not constant) so tests can
 # `monkeypatch.setattr(mod, "CACHE_ROOT", tmp_path / ".cwa-preview-cache")`.
-CACHE_ROOT: Path = Path("/config/.cwa-preview-cache")
+CACHE_ROOT: Path = Path(constants.CONFIG_DIR) / ".cwa-preview-cache"
 
 # 16 hex chars = 64 bits of key space. Birthday-collision probability is
 # ~1 in 2^32 at 4 billion entries; we're nowhere near that scale

--- a/cps/tasks/ops.py
+++ b/cps/tasks/ops.py
@@ -12,7 +12,7 @@ import re
 from flask_babel import lazy_gettext as N_
 
 from cps.services.worker import CalibreTask, STAT_CANCELLED, STAT_ENDED
-from cps import logger, helper
+from cps import constants, logger, helper
 
 log = logger.create()
 
@@ -26,7 +26,7 @@ class TaskConvertLibraryRun(CalibreTask):
 
     def __init__(self):
         super(TaskConvertLibraryRun, self).__init__(N_(u"Convert Library – full run"))
-        self.log_path = "/config/convert-library.log"
+        self.log_path = constants.config_path("convert-library.log")
         self._finished_marker = "NextGen Convert Library Service - Run Ended: "
 
     def run(self, worker_thread):
@@ -93,7 +93,7 @@ class TaskEpubFixerRun(CalibreTask):
 
     def __init__(self):
         super(TaskEpubFixerRun, self).__init__(N_(u"EPUB Fixer – full run"))
-        self.log_path = "/config/epub-fixer.log"
+        self.log_path = constants.config_path("epub-fixer.log")
         self._finished_marker = "NextGen Kindle EPUB Fixer Service - Run Ended: "
 
     def run(self, worker_thread):

--- a/cps/templates/config_db.html
+++ b/cps/templates/config_db.html
@@ -121,7 +121,7 @@
 
     <div style="margin-top: 2rem;">
       <h2>{{ _('Last Resort: Restore Calibre Database (experimental)') }}</h2>
-      <p style="font-size: 14px; margin-top: 4rem; margin-bottom: 4rem;">{{ _('If your Calibre library is corrupted and cannot be opened, you can attempt to restore it from the OPF files in your library. This will <b>erase all per-book data</b> (reading progress, bookmarks, shelf links, downloads, etc.) in the app database, but will not affect user accounts or settings. <b>Both databases will be automatically backed up in /config/backup before any destructive action.</b> A restore log will be saved alongside the backups.') | safe }}</p>
+      <p style="font-size: 14px; margin-top: 4rem; margin-bottom: 4rem;">{{ _('If your Calibre library is corrupted and cannot be opened, you can attempt to restore it from the OPF files in your library. This will <b>erase all per-book data</b> (reading progress, bookmarks, shelf links, downloads, etc.) in the app database, but will not affect user accounts or settings.') | safe }} <b>{{ _('Both databases will be automatically backed up in %(path)s before any destructive action.', path=backup_root) }}</b> {{ _('A restore log will be saved alongside the backups.') }}</p>
       <form method="POST" action="{{ url_for('admin.restore_calibre_db') }}" style="display:inline;">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <button type="submit" class="btn btn-danger" data-confirm="{{ _('Are you sure? This cannot be undone.') }}" onclick="return confirm(this.dataset.confirm);">{{ _('Restore Calibre Database (Last Resort)') }}</button>

--- a/cps/templates/cwa_settings.html
+++ b/cps/templates/cwa_settings.html
@@ -828,7 +828,7 @@
       {% endif %}
       <label for="auto_backup_imports" style="padding-left: 10px;">{{_('Enable NextGen Import Auto-Backup')}}</label><br>
       <p class="cwa-settings-tooltip">
-        {{_('When active, a copy of all imported files will be stored in <i>/config/processed_books/imported</i>') | safe }}
+        {{_('When active, a copy of all imported files will be stored in')}} <code>{{ processed_books_dir }}/imported</code>
       </p>
 
       {% if cwa_settings['auto_backup_conversions'] %}
@@ -838,7 +838,7 @@
       {% endif %}
       <label for="auto_backup_conversions" style="padding-left: 10px;">{{_('Enable NextGen Conversion Auto-Backup')}}</label><br>
       <p class="cwa-settings-tooltip">
-        {{_('When active, the originals of ingested files that undergo conversion will be stored in /config/processed_books/converted')}}
+        {{_('When active, the originals of ingested files that undergo conversion will be stored in')}} <code>{{ processed_books_dir }}/converted</code>
       </p>
 
       {% if cwa_settings['auto_backup_epub_fixes'] %}
@@ -848,7 +848,7 @@
       {% endif %}
       <label for="auto_backup_epub_fixes" style="padding-left: 10px;">{{_('Enable NextGen EPUB Fixer Auto-Backup')}}</label><br>
       <p class="cwa-settings-tooltip">
-        {{_('When active, the originals of EPUBs processed by the NextGen Kindle EPUB Fixer service will be stored in /config/processed_books/fixed_originals')}}
+        {{_('When active, the originals of EPUBs processed by the NextGen Kindle EPUB Fixer service will be stored in')}} <code>{{ processed_books_dir }}/fixed_originals</code>
       </p>
 
       <hr class="settings-divider">
@@ -860,7 +860,7 @@
       {% endif %}
       <label for="auto_zip_backups" style="padding-left: 10px;">{{_('Enable NextGen Auto-Zip Backups')}}</label><br>
       <p class="cwa-settings-tooltip">
-        {{_('When active, just before midnight each day, the cwa-auto-zipper service will make zip archives of all the backed up converted, imported and failed files from that day. This is to help keep the subdirectories of /config/processed_books organised and to minimise disk space usage.')}}
+        {{_('When active, just before midnight each day, the cwa-auto-zipper service will make zip archives of all the backed up converted, imported and failed files from that day. This helps keep the backup subdirectories organised and minimises disk space usage.')}} <code>{{ processed_books_dir }}</code>
       </p>
     </div>
     
@@ -1207,7 +1207,7 @@
         <label for="duplicate_auto_resolve_enabled" style="margin-left: 1rem;">{{_('Enable Automatic Duplicate Resolution')}} ⚠️</label>
       </div>
       <p class="cwa-settings-tip" style="background: #e74c3c57; border-color: #e74c3c; font-size: small;">
-        <strong>{{_('Warning:')}}</strong> {{_('This will automatically delete books based on the strategy below. Original files will be backed up to')}} <code>/config/processed_books/</code>
+        <strong>{{_('Warning:')}}</strong> {{_('This will automatically delete books based on the strategy below. Original files will be backed up to')}} <code>{{ processed_books_dir }}/</code>
       </p>
 
       <div class="form-group" style="padding: 2rem 3rem 2rem 3rem; background: #151e2680;">

--- a/cps/templates/duplicates.html
+++ b/cps/templates/duplicates.html
@@ -591,7 +591,7 @@
           
           <div class="cwa-settings-tip" style="margin-top: 15px; background: rgba(231, 76, 60, 0.15); border-left: 3px solid #e74c3c; padding: 12px; border-radius: 4px;">
             <strong style="color: #e74c3c;">⚠️ {{_('Warning:')}}</strong>
-            <span style="color: #ddd;">{{_('This will permanently delete books. Original files will be backed up to')}} <code style="background: #2a3441; padding: 2px 6px; border-radius: 3px; color: #f39c12; line-break: anywhere;">/config/processed_books/duplicate_resolutions/</code></span>
+            <span style="color: #ddd;">{{_('This will permanently delete books. Original files will be backed up to')}} <code style="background: #2a3441; padding: 2px 6px; border-radius: 3px; color: #f39c12; line-break: anywhere;">{{ duplicate_backup_dir }}</code></span>
           </div>
         </div>
 

--- a/scripts/app_paths.py
+++ b/scripts/app_paths.py
@@ -78,6 +78,8 @@ from pathlib import Path
 __all__ = [
     "app_root",
     "config_dir",
+    "config_path",
+    "processed_books_dir",
     "stray_legacy_config_dir",
     "dirs_json",
     "ingest_folder",
@@ -212,6 +214,16 @@ def config_dir():
     if override.suffix == ".db":
         return override.parent
     return override
+
+
+def config_path(*parts):
+    """A file or directory beneath the resolved writable config root."""
+    return config_dir().joinpath(*parts)
+
+
+def processed_books_dir():
+    """Root for retained originals, failed conversions and backup archives."""
+    return config_path("processed_books")
 
 
 def _default_config_dir():

--- a/scripts/auto_library.py
+++ b/scripts/auto_library.py
@@ -478,7 +478,7 @@ class AutoLibrary:
                 "[cwa-auto-library] CWA_CALIBRE_USER_PLUGINS is enabled but "
                 "the plugins directory could not be created (permission "
                 "error). Create it manually: "
-                f"mkdir -p /config/.config/calibre/plugins",
+                f"mkdir -p {app_paths.config_dir() / '.config' / 'calibre' / 'plugins'}",
                 flush=True,
             )
             return

--- a/scripts/auto_zip.py
+++ b/scripts/auto_zip.py
@@ -11,11 +11,12 @@ from datetime import datetime
 import pathlib
 from zipfile import ZipFile 
 
+import app_paths
 from cwa_db import CWA_DB
 
 class AutoZipper:
     def __init__(self):
-        self.archive_dirs_stem = "/config/processed_books/"
+        self.archive_dirs_stem = f"{app_paths.processed_books_dir()}{os.sep}"
         self.converted_dir = self.archive_dirs_stem + "converted/"
         self.failed_dir = self.archive_dirs_stem + "failed/"
         self.imported_dir = self.archive_dirs_stem + "imported/"

--- a/scripts/convert_library.py
+++ b/scripts/convert_library.py
@@ -24,7 +24,7 @@ from cwa_db import CWA_DB
 from kindle_epub_fixer import EPUBFixer
 
 ### Global Variables
-convert_library_log_file = str(app_paths.config_dir() / "convert-library.log")
+convert_library_log_file = str(app_paths.config_path("convert-library.log"))
 
 # Define the logger
 logger = logging.getLogger(__name__)
@@ -80,15 +80,32 @@ def _acquire_lock_or_exit():
     atexit.register(removeLock)
 
 
-try:
-    backup_destinations = {
+def _load_backup_destinations():
+    processed_root = app_paths.processed_books_dir()
+    try:
+        for name in ("converted", "imported", "fixed_originals", "failed"):
+            (processed_root / name).mkdir(parents=True, exist_ok=True)
+        return {
             entry.name: entry.path
-            for entry in os.scandir("/config/processed_books")
+            for entry in os.scandir(processed_root)
             if entry.is_dir()
         }
-except FileNotFoundError:
-    # Fallback for test environments where /config might not exist
-    backup_destinations = {}
+    except OSError as error:
+        print_and_log(
+            f"[convert-library]: WARN - Could not prepare backup directories "
+            f"under {processed_root}: {error}"
+        )
+        return {}
+
+
+backup_destinations = _load_backup_destinations()
+
+
+def failed_backup_dir() -> str:
+    """Resolved destination for converted files that could not be imported."""
+    return backup_destinations.get("failed") or str(
+        app_paths.processed_books_dir() / "failed"
+    )
 
 
 class LibraryConverter:
@@ -356,8 +373,11 @@ class LibraryConverter:
 
 
     def backup(self, input_file, backup_type):
+        output_path = backup_destinations.get(backup_type) or str(
+            app_paths.processed_books_dir() / backup_type
+        )
         try:
-            output_path = backup_destinations[backup_type]
+            os.makedirs(output_path, exist_ok=True)
             shutil.copy2(input_file, output_path)
         except Exception as e:
             print_and_log(f"[convert-library]: ERROR - The following error occurred when trying to copy {input_file} to {output_path}:\n{e}")
@@ -453,9 +473,11 @@ class LibraryConverter:
 
                 print_and_log(f"[convert-library]: ({self.current_book}/{len(self.to_convert)}) Import of {os.path.basename(target_filepath)} successfully completed!")
             except subprocess.CalledProcessError as e:
-                print_and_log(f"[convert-library]: ({self.current_book}/{len(self.to_convert)}) Import of {os.path.basename(target_filepath)} was not successfully completed. Converted file moved to /config/processed_books/failed/{os.path.basename(target_filepath)}. See the following error:\n{e}")
+                output_path = os.path.join(
+                    failed_backup_dir(), os.path.basename(target_filepath)
+                )
+                print_and_log(f"[convert-library]: ({self.current_book}/{len(self.to_convert)}) Import of {os.path.basename(target_filepath)} was not successfully completed. Converted file moved to {output_path}. See the following error:\n{e}")
                 try:
-                    output_path = f"/config/processed_books/failed/{os.path.basename(target_filepath)}"
                     shutil.move(target_filepath, output_path)
                 except Exception as e:
                     print_and_log(f"[convert-library]: ERROR - The following error occurred when trying to copy {file} to {output_path}:\n{e}")

--- a/scripts/cover_enforcer.py
+++ b/scripts/cover_enforcer.py
@@ -37,7 +37,7 @@ except Exception:
     # environment where the Flask stack it drags in is not importable -- that is what the
     # inline sanitizer fallback below exists for, and hard-failing here would take it out.
     # Resolve through the same two knobs, in the same order, as cps/constants.py.
-    _config_root = os.environ.get("CALIBRE_DBPATH", "/config")
+    _config_root = str(app_paths.config_dir())
     _CHANGE_LOGS_DIR = os.environ.get(
         "CWA_METADATA_CHANGE_LOGS_DIR", os.path.join(_config_root, "metadata_change_logs"))
     _METADATA_TEMP_DIR = os.environ.get(

--- a/scripts/generate_book_checksums.py
+++ b/scripts/generate_book_checksums.py
@@ -60,7 +60,7 @@ def _check_koreader_sync_enabled_lightweight() -> bool:
     Falls back to False on any error — matches the production
     is_koreader_sync_enabled() fail-closed behavior.
     """
-    cwa_db_dir = os.environ.get("CWA_DB_PATH", "/config/")
+    cwa_db_dir = os.environ.get("CWA_DB_PATH", str(app_paths.config_dir()))
     if not cwa_db_dir.endswith("/"):
         cwa_db_dir += "/"
     cwa_db_path = cwa_db_dir + "cwa.db"

--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -389,7 +389,7 @@ def _load_optional_cps_modules() -> None:
 def _ensure_processed_books_dirs() -> None:
     """Ensure processed backups directory structure exists so backups never crash on missing folders."""
     try:
-        processed_root = "/config/processed_books"
+        processed_root = str(app_paths.processed_books_dir())
         os.makedirs(processed_root, exist_ok=True)
         for name in ("converted", "imported", "fixed_originals", "failed"):
             os.makedirs(os.path.join(processed_root, name), exist_ok=True)
@@ -447,9 +447,12 @@ def failed_backup_dir() -> str:
     """Absolute path of the folder holding files that failed to convert.
 
     cwa-init creates it, so the scandir in _load_backup_destinations() normally
-    finds it; the literal is the fallback for a container where it is missing.
+    finds it. Bare-metal installs derive the fallback from their resolved
+    config root instead of silently writing at the filesystem root.
     """
-    return backup_destinations.get("failed") or "/config/processed_books/failed"
+    return backup_destinations.get("failed") or str(
+        app_paths.processed_books_dir() / "failed"
+    )
 
 
 def _load_backup_destinations() -> None:
@@ -457,7 +460,7 @@ def _load_backup_destinations() -> None:
     try:
         backup_destinations = {
             entry.name: entry.path
-            for entry in os.scandir("/config/processed_books")
+            for entry in os.scandir(app_paths.processed_books_dir())
             if entry.is_dir()
         }
     except FileNotFoundError:

--- a/scripts/kindle_epub_fixer.py
+++ b/scripts/kindle_epub_fixer.py
@@ -433,6 +433,7 @@ class EPUBFixer:
                 output_path = str(
                     app_paths.processed_books_dir() / "fixed_originals"
                 )
+                os.makedirs(output_path, exist_ok=True)
                 shutil.copy2(epub_path, output_path)
             except Exception as e:
                 print_and_log(f"[cwa-kindle-epub-fixer] ERROR - Error occurred when backing up {epub_path} to {output_path}:\n{e}", log=self.manually_triggered)

--- a/scripts/kindle_epub_fixer.py
+++ b/scripts/kindle_epub_fixer.py
@@ -430,7 +430,9 @@ class EPUBFixer:
         """Backup original file"""
         if self.cwa_settings['auto_backup_epub_fixes']:
             try:
-                output_path = f"/config/processed_books/fixed_originals/"
+                output_path = str(
+                    app_paths.processed_books_dir() / "fixed_originals"
+                )
                 shutil.copy2(epub_path, output_path)
             except Exception as e:
                 print_and_log(f"[cwa-kindle-epub-fixer] ERROR - Error occurred when backing up {epub_path} to {output_path}:\n{e}", log=self.manually_triggered)

--- a/tests/unit/test_1883_config_paths.py
+++ b/tests/unit/test_1883_config_paths.py
@@ -1,0 +1,205 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Regression coverage for #1883's config-root path resolution."""
+
+from __future__ import annotations
+
+import importlib
+import os
+from pathlib import Path
+import sys
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+@pytest.fixture()
+def script_config_root(monkeypatch, tmp_path):
+    """Point the dependency-free scripts resolver at a bare-metal config."""
+    config_root = tmp_path / "bare-metal-config"
+    config_root.mkdir()
+    monkeypatch.setenv("CALIBRE_DBPATH", str(config_root))
+    app_paths = importlib.reload(importlib.import_module("app_paths"))
+    return app_paths, config_root
+
+
+def test_scripts_config_helpers_honour_calibre_dbpath(script_config_root):
+    app_paths, config_root = script_config_root
+
+    assert app_paths.config_path("convert-library.log") == (
+        config_root / "convert-library.log"
+    )
+    assert app_paths.processed_books_dir() == config_root / "processed_books"
+
+
+def test_ingest_processed_books_calls_use_resolved_root(
+    script_config_root, monkeypatch
+):
+    _app_paths, config_root = script_config_root
+    ingest_processor = importlib.import_module("ingest_processor")
+    monkeypatch.setattr(ingest_processor, "backup_destinations", {})
+
+    ingest_processor._ensure_processed_books_dirs()
+    processed_root = config_root / "processed_books"
+    assert {
+        child.name for child in processed_root.iterdir() if child.is_dir()
+    } == {"converted", "imported", "fixed_originals", "failed"}
+
+    ingest_processor._load_backup_destinations()
+    assert ingest_processor.backup_destinations["failed"] == str(
+        processed_root / "failed"
+    )
+    assert ingest_processor.failed_backup_dir() == str(processed_root / "failed")
+
+
+def test_convert_library_calls_use_resolved_root(
+    script_config_root, monkeypatch
+):
+    _app_paths, config_root = script_config_root
+    convert_library = importlib.reload(importlib.import_module("convert_library"))
+    processed_root = config_root / "processed_books"
+    failed_root = processed_root / "failed"
+
+    monkeypatch.setattr(
+        convert_library,
+        "backup_destinations",
+        convert_library._load_backup_destinations(),
+    )
+
+    assert convert_library.convert_library_log_file == str(
+        config_root / "convert-library.log"
+    )
+    assert convert_library.backup_destinations["failed"] == str(failed_root)
+    assert convert_library.failed_backup_dir() == str(failed_root)
+
+    source = config_root / "source.epub"
+    source.write_bytes(b"book")
+    monkeypatch.setattr(convert_library, "backup_destinations", {})
+    converter = object.__new__(convert_library.LibraryConverter)
+    converter.backup(str(source), "converted")
+    assert (processed_root / "converted" / source.name).read_bytes() == b"book"
+
+
+def test_auto_zip_uses_resolved_processed_books_root(
+    script_config_root, monkeypatch
+):
+    _app_paths, config_root = script_config_root
+    auto_zip = importlib.import_module("auto_zip")
+
+    class _FakeDB:
+        cwa_settings = {"auto_zip_backups": True}
+
+    monkeypatch.setattr(auto_zip, "CWA_DB", _FakeDB)
+    monkeypatch.setattr(auto_zip.AutoZipper, "get_books_to_zip", lambda self: {})
+
+    zipper = auto_zip.AutoZipper()
+    expected = f"{config_root / 'processed_books'}{os.sep}"
+    assert zipper.archive_dirs_stem == expected
+    assert zipper.failed_dir == f"{expected}failed/"
+
+
+def test_kindle_fixer_backup_uses_resolved_processed_books_root(
+    script_config_root, monkeypatch
+):
+    _app_paths, config_root = script_config_root
+    kindle_epub_fixer = importlib.import_module("kindle_epub_fixer")
+    copied = []
+    monkeypatch.setattr(
+        kindle_epub_fixer.shutil,
+        "copy2",
+        lambda source, destination: copied.append((source, destination)),
+    )
+
+    fixer = object.__new__(kindle_epub_fixer.EPUBFixer)
+    fixer.cwa_settings = {"auto_backup_epub_fixes": True}
+    fixer.manually_triggered = False
+    fixer.backup_original_file("/library/book.epub")
+
+    assert copied == [(
+        "/library/book.epub",
+        str(config_root / "processed_books" / "fixed_originals"),
+    )]
+
+
+def test_cps_call_sites_follow_resolved_config_root(monkeypatch, tmp_path):
+    from cps import constants, cwa_functions, duplicates
+    from cps.tasks import ops
+
+    config_root = tmp_path / "cps-config"
+    monkeypatch.setattr(constants, "CONFIG_DIR", str(config_root))
+
+    assert constants.processed_books_dir() == str(config_root / "processed_books")
+    assert duplicates.duplicate_resolution_root() == str(
+        config_root / "processed_books" / "duplicate_resolutions"
+    )
+    assert cwa_functions._service_log_path("convert-library.log") == str(
+        config_root / "convert-library.log"
+    )
+    assert ops.TaskConvertLibraryRun().log_path == str(
+        config_root / "convert-library.log"
+    )
+    assert ops.TaskEpubFixerRun().log_path == str(
+        config_root / "epub-fixer.log"
+    )
+
+
+def test_metadata_lock_default_follows_config_resolver(monkeypatch, tmp_path):
+    from cps.services import calibre_db_lock
+
+    config_root = tmp_path / "lock-config"
+    monkeypatch.delenv("CWA_METADATA_LOCK_DIR", raising=False)
+    monkeypatch.setenv("CALIBRE_DBPATH", str(config_root / "app.db"))
+    assert calibre_db_lock._resolve_lock_path(None) == str(
+        config_root / calibre_db_lock.DEFAULT_LOCK_BASENAME
+    )
+
+    explicit = tmp_path / "explicit-locks"
+    monkeypatch.setenv("CWA_METADATA_LOCK_DIR", str(explicit))
+    assert calibre_db_lock._resolve_lock_path(None) == str(
+        explicit / calibre_db_lock.DEFAULT_LOCK_BASENAME
+    )
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    (
+        "scripts/ingest_processor.py",
+        "scripts/convert_library.py",
+        "scripts/auto_zip.py",
+        "scripts/kindle_epub_fixer.py",
+        "cps/duplicates.py",
+        "cps/templates/duplicates.html",
+        "cps/templates/cwa_settings.html",
+    ),
+)
+def test_processed_books_sites_do_not_restore_container_literal(relative_path):
+    source = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+    assert "/config/processed_books" not in source
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    (
+        "scripts/convert_library.py",
+        "cps/cwa_functions.py",
+        "cps/tasks/ops.py",
+    ),
+)
+def test_convert_log_sites_do_not_restore_container_literal(relative_path):
+    source = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+    assert "/config/convert-library.log" not in source
+
+
+def test_metadata_lock_has_no_container_default_literal():
+    source = (
+        REPO_ROOT / "cps/services/calibre_db_lock.py"
+    ).read_text(encoding="utf-8")
+    assert "DEFAULT_LOCK_DIR" not in source

--- a/tests/unit/test_1883_config_paths.py
+++ b/tests/unit/test_1883_config_paths.py
@@ -129,6 +129,25 @@ def test_kindle_fixer_backup_uses_resolved_processed_books_root(
     )]
 
 
+def test_kindle_fixer_creates_missing_backup_directory(script_config_root):
+    _app_paths, config_root = script_config_root
+    kindle_epub_fixer = importlib.import_module("kindle_epub_fixer")
+    source = config_root / "book.epub"
+    source.write_bytes(b"original book")
+    (config_root / "processed_books").mkdir()
+    backup_dir = config_root / "processed_books" / "fixed_originals"
+
+    assert not backup_dir.exists()
+
+    fixer = object.__new__(kindle_epub_fixer.EPUBFixer)
+    fixer.cwa_settings = {"auto_backup_epub_fixes": True}
+    fixer.manually_triggered = False
+    fixer.backup_original_file(str(source))
+
+    assert backup_dir.is_dir()
+    assert (backup_dir / source.name).read_bytes() == b"original book"
+
+
 def test_cps_call_sites_follow_resolved_config_root(monkeypatch, tmp_path):
     from cps import constants, cwa_functions, duplicates
     from cps.tasks import ops


### PR DESCRIPTION
Closes #1883.

Extends the #1885 resolver (env → dirs.json → compiled default) over the remaining hardcoded `/config` literals: `processed_books` across the ingest/convert/zip/fixer scripts and `cps/duplicates.py`, the service log paths (`convert-library.log`, `epub-fixer.log`, `cover-enforcer.log`), the metadata write-lock default, the restore backup root, and the cover-preview cache. The admin pages that name these locations now show the effective path instead of a hardcoded `/config/...` string.

Container deployments keep byte-identical behavior — the image sets `ENV CALIBRE_DBPATH=/config` (Dockerfile) and both `cwa-init` and `svc-calibre-web-automated` export it, so every resolver returns the same paths it returned before. Bare-metal installs stop failing on paths that do not exist.

**Evidence**
- `tests/unit/test_1883_config_paths.py`: 17 fail / 1 pass on the merge base with the test file overlaid → 19/19 pass on this head. The single pre-fix pass is the `convert_library.py` source-scan case, which was already literal-free before this branch and is therefore not counted as evidence.
- Manager review of the first commit found a regression it introduced: `kindle_epub_fixer` lost the trailing separator on its backup destination, so `shutil.copy2` into a *missing* `fixed_originals` silently created a regular file that every later backup would overwrite. Fixed in `b37677a` with a regression test that fails without it.
- Container invariant checked by execution: with `CALIBRE_DBPATH=/config`, `scripts.app_paths.processed_books_dir()` and `cps.constants.processed_books_dir()` both resolve to `/config/processed_books`.
- `cps/services/cover_preview_cache.py` now imports `cps.constants` at module scope; both the direct import and the `cps.main` application path were exercised from cold interpreters with no partially-initialised package.

**Known limitation:** the admin-page copy changes retire a handful of translated msgids, which will show English until the catalogues are updated.
