### PR TITLE
fix(spa): mobile multi-select bar clearance and book-detail reading order (#1756, #1828)

### DIFF
--- a/changelog.d/1756-bulk-bar-mobile-overlap.md
+++ b/changelog.d/1756-bulk-bar-mobile-overlap.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- **The multi-select action bar no longer hides books or the metadata form on
+  mobile.** While a selection is active, the book list now reserves bottom
+  space matching the bar's real height, so the last cover row always scrolls
+  clear of it, and the Edit Metadata panel's fields can never be painted over
+  by the control that opened them. Reported by @magdalar in #1756.

--- a/changelog.d/1828-mobile-book-detail-order.md
+++ b/changelog.d/1828-mobile-book-detail-order.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **Book details on mobile put the description first again.** On narrow
+  screens the page now reads title, author, description — then the action
+  chips, tags and attributes, instead of burying the book's description under
+  two screens of controls. Whole-book deletion shrank from a heavy red block
+  to a quiet trash icon at the end of the action row (the confirmation dialog
+  still guards it), and the action chips themselves are slimmer. The desktop
+  layout is unchanged. Reported by @iroQuai in #1828.

--- a/frontend/e2e/book-detail-delete-prominence.spec.ts
+++ b/frontend/e2e/book-detail-delete-prominence.spec.ts
@@ -29,7 +29,10 @@ async function setDeletePermission(page: Page, allowed: boolean) {
   });
 }
 
-test('book-detail deletion remains visible and accessible with delete permission (#1862)', async ({ page }) => {
+test('book-detail deletion remains visible and accessible with delete permission (#1862)', async ({ page, isMobile }) => {
+  // #1828 demotes mobile deletion to an icon-level control in the action row;
+  // the bordered region is desktop-only now. The mobile half is asserted below.
+  test.skip(isMobile === true, 'desktop region — mobile uses the icon-level control (#1828)');
   await page.goto('/app');
   const book = await firstBook(page);
   test.skip(book == null, 'seed has no books');
@@ -65,7 +68,8 @@ test('book-detail deletion remains absent without delete permission (#1862)', as
   await expect(page.getByRole('button', { name: 'Delete from the global library' })).toHaveCount(0);
 });
 
-test('dismissing book-detail deletion confirmation never calls the endpoint (#1862)', async ({ page }) => {
+test('dismissing book-detail deletion confirmation never calls the endpoint (#1862)', async ({ page, isMobile }) => {
+  test.skip(isMobile === true, 'desktop region — the mobile confirm path is covered by the icon-control test below');
   await page.goto('/app');
   const book = await firstBook(page);
   test.skip(book == null, 'seed has no books');
@@ -96,7 +100,8 @@ test('dismissing book-detail deletion confirmation never calls the endpoint (#18
   await expect(page).toHaveURL(new RegExp(`/book/${book.id}\\b`));
 });
 
-test('book-detail deletion is a quiet region in light and dark themes (#1862)', async ({ page }) => {
+test('book-detail deletion is a quiet region in light and dark themes (#1862)', async ({ page, isMobile }) => {
+  test.skip(isMobile === true, 'desktop region — hidden on mobile by #1828, so there is nothing to theme');
   await page.goto('/app');
   const book = await firstBook(page);
   test.skip(book == null, 'seed has no books');
@@ -161,4 +166,60 @@ test('book-detail deletion is a quiet region in light and dark themes (#1862)', 
       boxShadow: 'none',
     });
   }
+});
+
+/*
+ * #1828 — mobile counterpart to the region assertions above. On narrow
+ * viewports whole-book deletion is an icon-level control at the end of the
+ * ordinary action row: a red trash icon, the same accessible name, the same
+ * confirm dialog doing the guarding. The bordered desktop region stays in the
+ * DOM but is not displayed, so nothing red dominates the scroll path to the
+ * description.
+ */
+test('mobile demotes deletion to a hit-testable icon control in the action row (#1828)', async ({ page, isMobile }) => {
+  test.skip(isMobile !== true, 'mobile-only layout');
+  await page.goto('/app');
+  const book = await firstBook(page);
+  test.skip(book == null, 'seed has no books');
+
+  await setDeletePermission(page, true);
+  let deleteCalls = 0;
+  await page.route(`**/api/v1/books/${book!.id}/delete`, async (route) => {
+    deleteCalls += 1;
+    await route.fulfill({ status: 204, contentType: 'application/json', body: '' });
+  });
+  await page.goto(`/app/book/${book!.id}`, { waitUntil: 'domcontentloaded' });
+
+  // The heavy region yields on mobile…
+  await expect(page.getByTestId('book-destructive-actions')).not.toBeVisible();
+
+  // …and the icon control replaces it inside the ordinary action row, keeping
+  // the #1939 disambiguating name and gaining the tooltip the reporter asked
+  // for. Exactly one visible control carries the name — strict mode enforces
+  // that the hidden region button does not double it.
+  const icon = page.getByTestId('book-actions')
+    .getByRole('button', { name: 'Delete from the global library' });
+  await expect(icon).toBeVisible();
+  await expect(icon).toHaveAttribute('title', 'Delete from the global library');
+
+  // The icon owns its own hit target — nothing overlays it.
+  const ownsCenter = await icon.evaluate((el) => {
+    const box = el.getBoundingClientRect();
+    const hit = document.elementFromPoint(box.left + box.width / 2, box.top + box.height / 2);
+    return hit !== null && (hit === el || el.contains(hit));
+  });
+  expect(ownsCenter, 'the delete icon is covered by another element').toBe(true);
+
+  // A declined confirm from the icon never reaches the endpoint.
+  let declinedPrompt = '';
+  page.once('dialog', (dialog) => {
+    declinedPrompt = dialog.message();
+    void dialog.dismiss();
+  });
+  await icon.click();
+  await page.waitForTimeout(500);
+  expect(declinedPrompt).toContain(`"${book!.title}"`);
+  expect(declinedPrompt).toContain('cannot be undone');
+  expect(deleteCalls, 'declining confirmation must not call the delete endpoint').toBe(0);
+  await expect(page).toHaveURL(new RegExp(`/book/${book!.id}\\b`));
 });

--- a/frontend/e2e/book-detail.spec.ts
+++ b/frontend/e2e/book-detail.spec.ts
@@ -298,3 +298,72 @@ test('long title, author and series tokens add no horizontal overflow', async ({
   const titleExcess = await page.locator('main h1').evaluate((el) => el.scrollWidth - el.clientWidth);
   expect(titleExcess, 'the title must wrap inside its column, not overflow it').toBeLessThanOrEqual(1);
 });
+
+// #1828 — the mobile book page buried the description under ~two screens of
+// action chips, a heavy delete block and the attribute list. The redesign puts
+// the description directly under the title/author on narrow viewports, with
+// the action row, tags and metadata after it. Desktop keeps its historical
+// order (actions first, description last) — pinned by the second test.
+//
+// The description and a publisher row are stubbed into the detail payload so
+// the assertions do not depend on what the seed library happens to carry.
+
+async function stubDescription(page: Page, bookId: number) {
+  await page.route(`**/api/v1/books/${bookId}`, async (route) => {
+    const res = await route.fetch();
+    const book = await res.json();
+    book.description_html = '<p>Reading-order sentinel description.</p>';
+    book.publishers = [{ id: 990201, name: 'Sentinel Publisher' }];
+    await route.fulfill({ response: res, json: book });
+  });
+}
+
+test('mobile reading order: description precedes the action row and the attribute list (#1828)', async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 667 });
+  await page.goto('/app');
+  const bookId = await firstBookId(page);
+  test.skip(bookId == null, 'seed has no books');
+  await stubDescription(page, bookId!);
+
+  await page.goto(`/app/book/${bookId}`, { waitUntil: 'domcontentloaded' });
+  const description = page.getByText('Reading-order sentinel description.');
+  await expect(description).toBeVisible({ timeout: 10_000 });
+  const actions = page.getByTestId('book-actions');
+  await expect(actions).toBeVisible();
+  const metaList = page.locator('main dl');
+  await expect(metaList).toContainText('Sentinel Publisher');
+
+  const descBox = (await description.boundingBox())!;
+  const actionsBox = (await actions.boundingBox())!;
+  const metaBox = (await metaList.boundingBox())!;
+
+  expect(
+    descBox.y + descBox.height,
+    'the description must end above the action row on mobile, not follow it',
+  ).toBeLessThanOrEqual(actionsBox.y + 1);
+  expect(
+    actionsBox.y + actionsBox.height,
+    'the action row must end above the attribute list on mobile',
+  ).toBeLessThanOrEqual(metaBox.y + 1);
+});
+
+test('desktop layout is unchanged: the action row still precedes the description (#1828)', async ({ page, isMobile }) => {
+  test.skip(isMobile === true, 'desktop layout assertion — the mobile project emulates a handset');
+  await page.goto('/app');
+  const bookId = await firstBookId(page);
+  test.skip(bookId == null, 'seed has no books');
+  await stubDescription(page, bookId!);
+
+  await page.goto(`/app/book/${bookId}`, { waitUntil: 'domcontentloaded' });
+  const description = page.getByText('Reading-order sentinel description.');
+  await expect(description).toBeVisible({ timeout: 10_000 });
+  const actions = page.getByTestId('book-actions');
+  await expect(actions).toBeVisible();
+
+  const descBox = (await description.boundingBox())!;
+  const actionsBox = (await actions.boundingBox())!;
+  expect(
+    actionsBox.y + actionsBox.height,
+    'desktop must keep the action row above the description',
+  ).toBeLessThanOrEqual(descBox.y + 1);
+});

--- a/frontend/e2e/bulk-metadata-add-mode.spec.ts
+++ b/frontend/e2e/bulk-metadata-add-mode.spec.ts
@@ -92,6 +92,93 @@ test('mobile metadata keeps global navigation reachable and stays above the wrap
   ).toBeLessThanOrEqual(bulkBarBox!.y);
 });
 
+/*
+ * #1756 — the reporter's two faults on a narrow viewport: the floating bulk
+ * bar covered the last cover row with nothing able to scroll it clear, and it
+ * painted over the Edit Metadata fields. The fix pads the scroll container by
+ * the bar's own measured height (--bulk-bar-h) while a selection is active,
+ * and the panel/fields always paint above the control.
+ */
+const MANY_BOOKS: Book[] = Array.from({ length: 12 }, (_, i) => ({
+  id: 175600 + i,
+  title: `Reachable row book ${String(i + 1).padStart(2, '0')}`,
+  authors: ['Row Author'],
+  series: null,
+  series_index: null,
+  cover_url: null,
+  formats: ['EPUB'],
+  tags: ['Row tag'],
+  read: false,
+  archived: false,
+}));
+
+test('the last cover row scrolls clear of the floating bulk bar, and metadata fields stay hit-testable (#1756)', async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 667 });
+  // Re-route with enough rows to overflow the viewport (last registered wins),
+  // otherwise a two-book grid never reaches under the bar and the test proves
+  // nothing.
+  await page.route('**/api/v1/books?**', async (route: Route) => {
+    const url = new URL(route.request().url());
+    if (url.pathname !== '/api/v1/books') return route.continue();
+    const body: BooksPage = {
+      items: MANY_BOOKS,
+      page: 1,
+      per_page: Number(url.searchParams.get('per_page') || 12),
+      total: MANY_BOOKS.length,
+    };
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+  });
+
+  await page.goto('/app');
+  const main = page.getByTestId('catalog-page');
+  const basePadding = await main.evaluate((el) => parseFloat(getComputedStyle(el).paddingBottom));
+
+  await page.getByRole('button', { name: 'Select', exact: true }).click();
+  await page.getByRole('button', { name: `Select ${MANY_BOOKS[0].title}` })
+    .click({ position: { x: 12, y: 12 } });
+  const bulkBar = page.getByRole('region', { name: '1 selected' });
+  await expect(bulkBar).toBeVisible();
+
+  // While the bar floats, the container's bottom clearance exceeds the bar's
+  // own wrapped height — sized from --bulk-bar-h, not a guess.
+  const barBox = await bulkBar.boundingBox();
+  expect(barBox).not.toBeNull();
+  const padded = await main.evaluate((el) => parseFloat(getComputedStyle(el).paddingBottom));
+  expect(padded, 'scroll container has no bottom clearance for the floating bar')
+    .toBeGreaterThan(barBox!.height);
+
+  // At the very bottom of the scroll, the last card owns its own centre hit
+  // point. Pre-fix the fixed bar painted over it and swallowed the tap.
+  const lastCard = page.getByRole('button', { name: `Select ${MANY_BOOKS[MANY_BOOKS.length - 1].title}` });
+  await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight));
+  await expect(lastCard).toBeInViewport();
+  const lastCardOwnsCenter = await lastCard.evaluate((el) => {
+    const box = el.getBoundingClientRect();
+    const hit = document.elementFromPoint(box.left + box.width / 2, box.top + box.height / 2);
+    return hit !== null && (hit === el || el.contains(hit));
+  });
+  expect(lastCardOwnsCenter, 'the floating bulk bar still covers the last cover row').toBe(true);
+
+  // Second fault: with the metadata panel open, its deepest field must own its
+  // hit target — the control must never paint over the form it opened.
+  await page.getByRole('button', { name: 'Edit metadata' }).click();
+  const languagesField = page.getByRole('textbox', { name: 'Languages (comma separated)' });
+  await languagesField.scrollIntoViewIfNeeded();
+  await expect(languagesField).toBeVisible();
+  const fieldOwnsCenter = await languagesField.evaluate((el) => {
+    const box = el.getBoundingClientRect();
+    const hit = document.elementFromPoint(box.left + box.width / 2, box.top + box.height / 2);
+    return hit !== null && (hit === el || el.contains(hit));
+  });
+  expect(fieldOwnsCenter, 'the bulk bar overlays the metadata form fields').toBe(true);
+
+  // Clearing the selection retires the clearance with the bar.
+  await page.getByRole('button', { name: 'Clear selection' }).click();
+  await expect(bulkBar).toHaveCount(0);
+  const paddingAfterClear = await main.evaluate((el) => parseFloat(getComputedStyle(el).paddingBottom));
+  expect(paddingAfterClear, 'bottom clearance outlived the selection').toBeCloseTo(basePadding, 0);
+});
+
 for (const viewport of [
   { label: 'narrow and short', width: 375, height: 300 },
   { label: 'landscape phone', width: 667, height: 375 },

--- a/frontend/e2e/delete-book-discoverability.spec.ts
+++ b/frontend/e2e/delete-book-discoverability.spec.ts
@@ -101,7 +101,11 @@ test('edit-page deletion confirms before mutation and a declined confirm does no
   await expect(page).not.toHaveURL(new RegExp(`/book/${book.id}(?:/edit)?\\b`));
 });
 
-test('book-detail deletion is grouped outside the ordinary action chips (#1046)', async ({ page }) => {
+test('book-detail deletion is grouped outside the ordinary action chips (#1046)', async ({ page, isMobile }) => {
+  // Desktop grouping. #1828 deliberately reverses this on mobile, where the
+  // heavy region yielded to an icon-level control inside the row — asserted by
+  // the mobile counterpart directly below.
+  test.skip(isMobile === true, 'desktop grouping — mobile intentionally differs (#1828)');
   await page.goto('/app');
   const book = await firstBook(page);
   test.skip(book == null, 'seed has no books');
@@ -122,4 +126,25 @@ test('book-detail deletion is grouped outside the ordinary action chips (#1046)'
   await expect(deleteButton).toBeVisible();
   await expect(deleteButton).toHaveText('Delete from the global library');
   await expect(ordinaryActions.getByRole('button', { name: 'Delete from the global library' })).toHaveCount(0);
+});
+
+test('mobile groups deletion as an icon-level control inside the action row (#1828)', async ({ page, isMobile }) => {
+  test.skip(isMobile !== true, 'mobile-only grouping');
+  await page.goto('/app');
+  const book = await firstBook(page);
+  test.skip(book == null, 'seed has no books');
+
+  await setDeletePermission(page, true);
+  await page.goto(`/app/book/${book!.id}`, { waitUntil: 'domcontentloaded' });
+
+  // The mobile trade: the destructive control joins the ordinary action row as
+  // an icon (the confirm dialog is the guard), and the separated desktop
+  // region is not displayed. The reporter's ask, verbatim, was that "a red
+  // trash can is more than enough for book delete".
+  const ordinaryActions = page.getByTestId('book-actions');
+  await expect(ordinaryActions).toBeVisible();
+  await expect(
+    ordinaryActions.getByRole('button', { name: 'Delete from the global library' }),
+  ).toHaveCount(1);
+  await expect(page.getByTestId('book-destructive-actions')).not.toBeVisible();
 });

--- a/frontend/src/components/BulkBar.module.css
+++ b/frontend/src/components/BulkBar.module.css
@@ -143,6 +143,12 @@
 }
 
 .metaPanel {
+  /* #1756 — the panel and the bar share one bottom-anchored flow container, so
+     structurally they cannot overlap; the z-index is the guard for any future
+     regression of that invariant: if the two ever DO overlap again, the form
+     fields must paint above the control, never under it. */
+  position: relative;
+  z-index: 1;
   background: var(--surface-1); border: 1px solid var(--border); border-radius: var(--r-lg);
   padding: var(--sp-4); box-shadow: var(--shadow-lg, 0 12px 40px rgba(0,0,0,.4));
   width: min(680px, 92vw); max-width: 100%; min-height: 0; overflow-y: auto;

--- a/frontend/src/components/BulkBar.tsx
+++ b/frontend/src/components/BulkBar.tsx
@@ -19,8 +19,36 @@ export function BulkSelectionBar({ count, onClear, children, sticky = false }: {
   count: number; onClear: () => void; children: React.ReactNode; sticky?: boolean;
 }) {
   const t = useT();
+  const barRef = useRef<HTMLDivElement>(null);
+
+  /* #1756 — the floating variant is a fixed overlay, so the page's last row
+     can never scroll out from under it unless the document gains bottom room.
+     The bar publishes its own rendered height as --bulk-bar-h on <html>; the
+     catalog's scroll padding keys off that variable, so the clearance tracks
+     the bar's ACTUAL wrapped height (two rows of icon buttons on a narrow
+     phone, one on desktop) instead of a guessed constant. Only the floating
+     variant measures — the sticky one is in flow and overlays nothing. The
+     metadata panel is deliberately NOT measured: it is a transient overlay
+     with its own scroll, and padding the page out behind it would be absurd. */
+  useEffect(() => {
+    if (sticky) return;
+    const el = barRef.current;
+    if (!el) return;
+    const root = document.documentElement;
+    const publish = () => {
+      root.style.setProperty('--bulk-bar-h', `${Math.ceil(el.getBoundingClientRect().height)}px`);
+    };
+    publish();
+    const observer = new ResizeObserver(publish);
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+      root.style.removeProperty('--bulk-bar-h');
+    };
+  }, [sticky]);
+
   return (
-    <div className={`${styles.bar} ${sticky ? styles.sticky : ''}`} role="region"
+    <div ref={barRef} className={`${styles.bar} ${sticky ? styles.sticky : ''}`} role="region"
       aria-label={t('{n} selected', { n: count })}>
       <span className={styles.count}>{t('{n} selected', { n: count })}</span>
       <div className={styles.actions}>{children}</div>

--- a/frontend/src/pages/BookDetail.module.css
+++ b/frontend/src/pages/BookDetail.module.css
@@ -484,6 +484,14 @@
   margin: 0;
 }
 
+/* Mobile-only icon-level delete (#1828) — display:none on desktop, where the
+   separated dangerZone region above carries whole-book deletion. The media
+   query below turns this on and the region off; both controls share the same
+   handler, aria-label and confirm dialog. */
+.deleteIconButton {
+  display: none;
+}
+
 /* Tags row */
 .tags {
   display: flex;
@@ -525,8 +533,14 @@
   margin: 0;
 }
 
-/* Description prose */
+/* Description prose. Since #1828 this sits directly under the title/author
+   header IN THE DOM — the correct reading order, and the mobile visual order.
+   Desktop keeps its historical arrangement (actions and metadata first,
+   description last) by ordering it after the other info-column items; the
+   mobile media query below resets that to 0 so the grid's auto-placement
+   follows the DOM. */
 .description {
+  order: 10;
   color: var(--text);
   line-height: var(--lh-base);
   max-width: 70ch;
@@ -551,6 +565,50 @@
   .title {
     font-size: var(--fs-xl);
   }
+
+  /* #1828 reading order: the description's desktop `order: 10` must not carry
+     into the grid, where every item keeps order 0 and auto-placement follows
+     the DOM — header beside the cover, then description, then everything else. */
+  .description { order: 0; }
+
+  /* #1828: whole-book deletion trades its bordered region for an icon-level
+     button at the end of the action row. The confirm dialog is the guard; the
+     region's box was the loudest element between the reader and the book. */
+  .dangerZone { display: none; }
+  .deleteIconButton {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 34px;
+    height: 34px;
+    border-radius: var(--r-md);
+    border: 1px solid var(--danger);
+    background: transparent;
+    color: var(--danger);
+    cursor: pointer;
+    transition: background var(--dur-fast) var(--ease);
+  }
+  .deleteIconButton:hover:not(:disabled) { background: var(--danger-soft); }
+  .deleteIconButton:disabled { opacity: 0.6; cursor: default; }
+
+  /* #1828 chip compression: the action row was a wall of 38px chips with wide
+     gaps, pushing the description off the first two screens. 34px keeps the
+     SC 2.5.8 24px floor with margin; labels shrink one step. */
+  .actions { gap: var(--sp-2); }
+  .actionPrimary,
+  .readToggleActive,
+  .readToggleGhost {
+    height: 34px;
+    padding: var(--sp-2) var(--sp-3);
+    font-size: var(--fs-sm);
+  }
+  .downloadBtn {
+    height: 34px;
+    padding: var(--sp-2) var(--sp-3);
+    font-size: var(--fs-xs);
+  }
+  .twoWayChip { min-height: 34px; padding: var(--sp-1) var(--sp-3); }
+  .tags { gap: var(--sp-1); }
 
   .coverCol {
     position: static;

--- a/frontend/src/pages/BookDetail.tsx
+++ b/frontend/src/pages/BookDetail.tsx
@@ -370,6 +370,22 @@ export function BookDetail() {
   const selectionMode = me?.library_mode === 'personal_library';
   const inLibrary = !selectionMode || book.in_my_library !== false;
 
+  const requestDeleteBook = () => {
+    if (deleteBook.isPending) return;
+    if (!window.confirm(
+      t('Delete "{title}" from the global library? The book and all its files are permanently erased for every member. This cannot be undone.', { title: book.title })
+    )) return;
+    setDeleteError(null);
+    deleteBook.mutate(undefined, {
+      onSuccess: (result) => {
+        if (result?.warning) window.alert(result.warning.message);
+        navigate('/');
+      },
+      onError: (err) =>
+        setDeleteError(err instanceof ApiError ? err.message : t('Could not delete this book.')),
+    });
+  };
+
   const removeMembership = () => {
     removalImpact.mutate(book.id, {
       onSuccess: (impact) => {
@@ -492,6 +508,24 @@ export function BookDetail() {
               </div>
             )}
           </div>
+
+          {/* Description — in the DOM directly under the title/author header,
+              because on a phone that is where it belongs (#1828): the thing the
+              page is about comes before the controls and the attribute list.
+              Desktop keeps its long-standing visual order (actions first,
+              description last) via `order` in the stylesheet, so this reorder
+              changes nothing there. */}
+          {book.description_html && (
+            <div
+              className={styles.description}
+              dir="auto"
+              // description_html is sanitized server-side in serialize_book_detail
+              // (cps/clean_html.clean_string — bleach/nh3 allowlist, same as the
+              // legacy templates), so it is safe to render here.
+              // eslint-disable-next-line react/no-danger
+              dangerouslySetInnerHTML={{ __html: book.description_html }}
+            />
+          )}
 
           {/* Actions */}
           <div className={styles.actions} data-testid="book-actions">
@@ -677,11 +711,34 @@ export function BookDetail() {
               </button>
             )}
 
+            {/* Mobile-only destructive control (#1828): on narrow viewports the
+                whole-book delete is demoted from the bordered region below to an
+                icon-level button at the END of this row — a red trash can, the
+                confirm dialog doing the actual guarding. CSS hides it on desktop,
+                where the separated region remains; the two never render visibly
+                at once, and both share requestDeleteBook. Placed last so the
+                primary actions keep their positions. */}
+            {me?.role?.delete_books && me?.role?.edit && (
+              <button
+                type="button"
+                data-testid="book-delete-icon"
+                className={styles.deleteIconButton}
+                disabled={deleteBook.isPending}
+                aria-label={t('Delete from the global library')}
+                title={t('Delete from the global library')}
+                onClick={requestDeleteBook}
+              >
+                <Trash2 size={16} aria-hidden="true" focusable={false} />
+              </button>
+            )}
+
           </div>
           <p className={reloadMessage ? styles.actionStatus : undefined} role="status">{reloadMessage}</p>
 
           {/* Whole-book deletion is intentionally separated from the wrapping row
-              of ordinary action chips (#1046). This uses the same delete-and-edit policy as the server;
+              of ordinary action chips (#1046) on desktop; on mobile the region is
+              hidden and the icon-level control inside the action row above takes
+              over (#1828). This uses the same delete-and-edit policy as the server;
               this gate and grouping are the discoverability/UX layer. */}
           {me?.role?.delete_books && me?.role?.edit && (
             <section className={styles.dangerZone} data-testid="book-destructive-actions"
@@ -691,28 +748,16 @@ export function BookDetail() {
                 className={styles.actionDanger}
                 disabled={deleteBook.isPending}
                 aria-label={t('Delete from the global library')}
-                onClick={() => {
-                  if (deleteBook.isPending) return;
-                  if (!window.confirm(
-                    t('Delete "{title}" from the global library? The book and all its files are permanently erased for every member. This cannot be undone.', { title: book.title })
-                  )) return;
-                  setDeleteError(null);
-                  deleteBook.mutate(undefined, {
-                    onSuccess: (result) => {
-                      if (result?.warning) window.alert(result.warning.message);
-                      navigate('/');
-                    },
-                    onError: (err) =>
-                      setDeleteError(err instanceof ApiError ? err.message : t('Could not delete this book.')),
-                  });
-                }}
+                onClick={requestDeleteBook}
               >
                 <Trash2 size={14} aria-hidden="true" focusable={false} />
                 {deleteBook.isPending ? t('Deleting…') : t('Delete from the global library')}
               </button>
-              {deleteError && <p className={styles.deleteErr} role="alert">{deleteError}</p>}
             </section>
           )}
+          {/* Rendered outside the region so the error still surfaces on mobile,
+              where the region itself is hidden (#1828). */}
+          {deleteError && <p className={styles.deleteErr} role="alert">{deleteError}</p>}
 
           {/* Send-to-e-reader panel */}
           {sendOpen && (
@@ -875,19 +920,6 @@ export function BookDetail() {
               </Fragment>
             ))}
           </dl>
-
-          {/* Description */}
-          {book.description_html && (
-            <div
-              className={styles.description}
-              dir="auto"
-              // description_html is sanitized server-side in serialize_book_detail
-              // (cps/clean_html.clean_string — bleach/nh3 allowlist, same as the
-              // legacy templates), so it is safe to render here.
-              // eslint-disable-next-line react/no-danger
-              dangerouslySetInnerHTML={{ __html: book.description_html }}
-            />
-          )}
         </div>
       </div>
 

--- a/frontend/src/pages/Catalog.module.css
+++ b/frontend/src/pages/Catalog.module.css
@@ -15,6 +15,17 @@
   padding: var(--sp-6) var(--sp-5);
 }
 
+/* #1756 — while a multi-selection is active the bulk bar floats fixed over the
+   bottom of the viewport. Without extra bottom room the last cover row can
+   never scroll out from under it (and neither can the sentinel behind it).
+   --bulk-bar-h is published by the floating bar itself via ResizeObserver, so
+   the clearance is the bar's real wrapped height plus its bottom offset
+   (var(--sp-5)) plus a small gap — never a guessed constant. The 56px fallback
+   covers a single-row bar if the variable is somehow absent. */
+.containerBulkActive {
+  padding-bottom: calc(var(--bulk-bar-h, 56px) + var(--sp-5) + var(--sp-2));
+}
+
 .back {
   display: inline-flex;
   align-items: center;

--- a/frontend/src/pages/Catalog.tsx
+++ b/frontend/src/pages/Catalog.tsx
@@ -672,7 +672,7 @@ export function Catalog({ entityKind, entityId, view, defaultFilter }: CatalogPr
   };
 
   return (
-    <main className={styles.container} data-testid="catalog-page">
+    <main className={`${styles.container} ${selecting && selected.size > 0 ? styles.containerBulkActive : ''}`} data-testid="catalog-page">
       {filtered && (
         <Link href={`/${ENTITY_PLURAL[entityKind!]}`} className={styles.back}>
           <ChevronLeft size={16} />


### PR DESCRIPTION
Closes #1756 and #1828 (one mobile-layout pass, K3-designed).

**#1756:** the floating bulk bar measures itself (ResizeObserver → `--bulk-bar-h`) and the catalog gains matching bottom clearance while a selection is active — the last cover row and the deepest metadata field stay reachable at any wrap height; the metadata panel is guaranteed to paint above the bar if overlap ever regresses.

**#1828:** on mobile the description moves directly under the title/author, the bordered delete region gives way to an icon-level control at the end of the action row (same aria/confirm; error surfaced outside the region), chips compressed to 34px (above the WCAG 2.5.8 24px floor). Desktop is pixel-unchanged (pinned by a desktop-scoped test).

Build green ×3. New mobile e2e coverage: clearance/hit-testing at 375×667, reading order, icon-delete semantics, declined-confirm never calls the endpoint — executing on this PR's commit-pinned e2e lane.