### PR TITLE
fix(paths): create the Kindle backup destination directory before copying (#1883 follow-up)

### DIFF
--- a/changelog.d/1883-kindle-backup-dir.md
+++ b/changelog.d/1883-kindle-backup-dir.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **The Kindle EPUB Fixer's backup of an original file no longer collapses into a single overwritten file** when its `processed_books/fixed_originals` folder does not exist yet. The destination directory is created before the copy, so every retained original is kept under its own name.

--- a/scripts/kindle_epub_fixer.py
+++ b/scripts/kindle_epub_fixer.py
@@ -433,6 +433,7 @@ class EPUBFixer:
                 output_path = str(
                     app_paths.processed_books_dir() / "fixed_originals"
                 )
+                os.makedirs(output_path, exist_ok=True)
                 shutil.copy2(epub_path, output_path)
             except Exception as e:
                 print_and_log(f"[cwa-kindle-epub-fixer] ERROR - Error occurred when backing up {epub_path} to {output_path}:\n{e}", log=self.manually_triggered)

--- a/tests/unit/test_1883_config_paths.py
+++ b/tests/unit/test_1883_config_paths.py
@@ -129,6 +129,25 @@ def test_kindle_fixer_backup_uses_resolved_processed_books_root(
     )]
 
 
+def test_kindle_fixer_creates_missing_backup_directory(script_config_root):
+    _app_paths, config_root = script_config_root
+    kindle_epub_fixer = importlib.import_module("kindle_epub_fixer")
+    source = config_root / "book.epub"
+    source.write_bytes(b"original book")
+    (config_root / "processed_books").mkdir()
+    backup_dir = config_root / "processed_books" / "fixed_originals"
+
+    assert not backup_dir.exists()
+
+    fixer = object.__new__(kindle_epub_fixer.EPUBFixer)
+    fixer.cwa_settings = {"auto_backup_epub_fixes": True}
+    fixer.manually_triggered = False
+    fixer.backup_original_file(str(source))
+
+    assert backup_dir.is_dir()
+    assert (backup_dir / source.name).read_bytes() == b"original book"
+
+
 def test_cps_call_sites_follow_resolved_config_root(monkeypatch, tmp_path):
     from cps import constants, cwa_functions, duplicates
     from cps.tasks import ops


### PR DESCRIPTION
Follow-up to #2004 (#1883).

#2004 replaced the trailing-slash literal `"/config/processed_books/fixed_originals/"` in `scripts/kindle_epub_fixer.py` with a resolver-derived path that has **no** trailing separator. `shutil.copy2` into a *missing* directory therefore stopped raising and started silently creating a regular file at that path — so on an install whose backup tree was never created, the first EPUB-fixer backup becomes a file named `fixed_originals` and every later backup overwrites it. The old literal failed loudly instead.

This creates the destination directory before copying, restoring copy-into-a-directory semantics on every install shape.

**Evidence (OBSERVED)**
- The regression test in `tests/unit/test_1883_config_paths.py` creates `processed_books/` without `fixed_originals/`, runs the real backup method, and requires `fixed_originals` to be a directory holding the copied EPUB: **1 failed** without the one-line change (at `assert backup_dir.is_dir()` — `copy2` had returned successfully after creating a regular file), **1 passed** with it.
- Whole file on this head: **19 passed / 0 failed** (`.venv/bin/python -m pytest tests/unit/test_1883_config_paths.py`), run independently by the manager as well as by the implementing leg.
- Container behaviour unchanged: with `CALIBRE_DBPATH=/config` (set at `Dockerfile:288` and exported by both `cwa-init` and `svc-calibre-web-automated`), the destination remains `/config/processed_books/fixed_originals`, which `cwa-init` already creates — so this only changes the path that was previously broken.

No dependency, license or external-URL changes.
