### PR TITLE
fix(tests): the unit suite is deterministic under xdist (#1868)

### DIFF
--- a/changelog.d/1868-xdist-determinism.md
+++ b/changelog.d/1868-xdist-determinism.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **The parallel unit suite now tears down Kobo recovery-retention workers
+  deterministically.** A retention timer or startup sweep that had already
+  begun could outlive its test, contend on shared locks, and reschedule itself
+  after the test fixture only cancelled its registered timer. Teardown now
+  invalidates that maintenance generation and joins every timer and startup
+  thread before the next test starts. Translation-context tests also compile
+  into test-owned temporary storage, so a clean run no longer changes how many
+  tests execute on the following run (#1868).

--- a/cps/services/kobo_patch_spool.py
+++ b/cps/services/kobo_patch_spool.py
@@ -44,6 +44,9 @@ from gevent import Timeout, get_hub
 from .. import constants
 
 
+_current_thread = threading.current_thread
+
+
 log = logging.getLogger(__name__)
 
 MAX_BODY_BYTES = 16 * 1024 * 1024
@@ -69,7 +72,10 @@ _REPLAY_IDENTITY_FIELDS = (
 )
 _RETENTION_TIMERS_LOCK = threading.Lock()
 _RETENTION_TIMERS = {}
+_RETENTION_THREADS = {}
 _RETENTION_STARTED = False
+_RETENTION_GENERATION = 0
+_RETENTION_BOOTSTRAP_THREAD = None
 
 
 class _SpoolNoRoom(Exception):
@@ -872,73 +878,160 @@ def _expire_root_blocking(root, max_age_seconds):
             return min(item["mtime"] + max_age_seconds for item in survivors)
 
 
-def _retention_timer_fired(root, deadline, max_age_seconds):
+def _retention_timer_fired(
+    root, deadline, max_age_seconds, generation, lifecycle_token,
+):
     key = str(Path(root))
     with _RETENTION_TIMERS_LOCK:
         current = _RETENTION_TIMERS.get(key)
-        if current is not None and current[0] == deadline:
+        owner = _RETENTION_THREADS.get(lifecycle_token)
+        if (
+            current is not None
+            and current[0] == deadline
+            and current[1] is owner
+        ):
             _RETENTION_TIMERS.pop(key, None)
     try:
         next_deadline = _expire_root_blocking(root, max_age_seconds)
     except Exception:
         log.error("Kobo PATCH recovery age maintenance failed", exc_info=True)
         next_deadline = time.time() + 1.0
-    if next_deadline is not None:
-        _schedule_retention(root, next_deadline, max_age_seconds)
+    try:
+        if next_deadline is not None:
+            _schedule_retention(
+                root,
+                next_deadline,
+                max_age_seconds,
+                generation=generation,
+            )
+    finally:
+        with _RETENTION_TIMERS_LOCK:
+            _RETENTION_THREADS.pop(lifecycle_token, None)
 
 
-def _schedule_retention(root, deadline, max_age_seconds):
+def _schedule_retention(root, deadline, max_age_seconds, *, generation=None):
     root = Path(root)
     key = str(root)
     with _RETENTION_TIMERS_LOCK:
+        if generation is None:
+            generation = _RETENTION_GENERATION
+        elif generation != _RETENTION_GENERATION:
+            return False
         current = _RETENTION_TIMERS.get(key)
         if current is not None and current[0] <= deadline:
-            return
+            return True
         if current is not None:
             current[1].cancel()
+        lifecycle_token = object()
         timer = threading.Timer(
             max(0.001, deadline - time.time()),
             _retention_timer_fired,
-            args=(root, deadline, max_age_seconds),
+            args=(
+                root,
+                deadline,
+                max_age_seconds,
+                generation,
+                lifecycle_token,
+            ),
         )
         timer.daemon = True
         _RETENTION_TIMERS[key] = (deadline, timer)
-        timer.start()
+        _RETENTION_THREADS[lifecycle_token] = timer
+        try:
+            timer.start()
+        except BaseException:
+            _RETENTION_TIMERS.pop(key, None)
+            _RETENTION_THREADS.pop(lifecycle_token, None)
+            raise
+        return True
 
 
-def _bootstrap_retention(root, max_age_seconds):
+def _bootstrap_retention(root, max_age_seconds, generation):
     try:
         next_deadline = _expire_root_blocking(root, max_age_seconds)
     except Exception:
         log.error("Kobo PATCH recovery startup maintenance failed", exc_info=True)
         return
     if next_deadline is not None:
-        _schedule_retention(root, next_deadline, max_age_seconds)
+        _schedule_retention(
+            root,
+            next_deadline,
+            max_age_seconds,
+            generation=generation,
+        )
 
 
 def start_retention_maintenance():
     """Start startup expiry once per process without delaying app startup."""
-    global _RETENTION_STARTED
+    global _RETENTION_BOOTSTRAP_THREAD, _RETENTION_STARTED
     with _RETENTION_TIMERS_LOCK:
         if _RETENTION_STARTED:
             return True
         root = _spool_root()
         max_age_seconds = MAX_AGE_SECONDS
+        generation = _RETENTION_GENERATION
         thread = threading.Thread(
             target=_bootstrap_retention,
-            args=(root, max_age_seconds),
+            args=(root, max_age_seconds, generation),
             name="kobo-patch-spool-retention-bootstrap",
             daemon=True,
         )
+        _RETENTION_BOOTSTRAP_THREAD = thread
         try:
             thread.start()
         except Exception:
+            _RETENTION_BOOTSTRAP_THREAD = None
             log.error(
                 "Kobo PATCH recovery maintenance could not start", exc_info=True,
             )
             return False
         _RETENTION_STARTED = True
         return True
+
+
+def stop_retention_maintenance(timeout=None):
+    """Cancel and join every retention owner from the current lifecycle.
+
+    Incrementing the generation invalidates callbacks that already passed
+    ``Timer.cancel()`` and are running inside expiry. Joining both those timers
+    and the startup sweeper gives tests and process shutdown a real lifecycle
+    boundary: once this returns successfully, old work cannot reschedule itself.
+    """
+    global _RETENTION_BOOTSTRAP_THREAD
+    global _RETENTION_GENERATION, _RETENTION_STARTED
+
+    with _RETENTION_TIMERS_LOCK:
+        _RETENTION_GENERATION += 1
+        timers = list(_RETENTION_THREADS.values())
+        bootstrap = _RETENTION_BOOTSTRAP_THREAD
+        _RETENTION_TIMERS.clear()
+        _RETENTION_THREADS.clear()
+        _RETENTION_BOOTSTRAP_THREAD = None
+        _RETENTION_STARTED = False
+
+    for timer in timers:
+        timer.cancel()
+
+    threads = timers + ([bootstrap] if bootstrap is not None else [])
+    current = _current_thread()
+    deadline = None if timeout is None else time.monotonic() + timeout
+    for thread in threads:
+        if thread is current:
+            continue
+        join = getattr(thread, "join", None)
+        if join is None:
+            continue
+        remaining = None
+        if deadline is not None:
+            remaining = max(0.0, deadline - time.monotonic())
+        join(remaining)
+
+    return all(
+        thread is current
+        or not callable(getattr(thread, "is_alive", None))
+        or not thread.is_alive()
+        for thread in threads
+    )
 
 
 def iter_replay_candidates():

--- a/tests/unit/test_f5c1146_kobo_patch_recovery_spool.py
+++ b/tests/unit/test_f5c1146_kobo_patch_recovery_spool.py
@@ -88,16 +88,13 @@ def _isolate_request_io_capacity():
 
 
 @pytest.fixture(autouse=True)
-def _cancel_spool_retention_timers_after_test():
-    """Secondary test isolation; production dependency capture is the fix."""
+def _stop_spool_retention_threads_after_test():
+    """Finish every retention owner before monkeypatch restores global state."""
     yield
     spool = _module()
-    with spool._RETENTION_TIMERS_LOCK:
-        timers = [timer for _deadline, timer in spool._RETENTION_TIMERS.values()]
-        spool._RETENTION_TIMERS.clear()
-        spool._RETENTION_STARTED = False
-    for timer in timers:
-        timer.cancel()
+    assert spool.stop_retention_maintenance(timeout=5), (
+        "Kobo PATCH retention maintenance survived deterministic test teardown"
+    )
 
 
 def _hold_advisory_lock(lock_path, ready, release):
@@ -959,6 +956,85 @@ def test_startup_retention_expires_records_before_any_new_patch(monkeypatch, tmp
 
 
 @pytest.mark.unit
+def test_stop_retention_maintenance_joins_running_timer_and_prevents_reschedule(
+    monkeypatch, tmp_path,
+):
+    """A timer already in its callback cannot escape into the next test."""
+    spool, root = _root(monkeypatch, tmp_path)
+    callback_entered = threading.Event()
+    release_callback = threading.Event()
+    stop_result = []
+
+    def _blocked_expiry(captured_root, captured_age):
+        assert captured_root == root
+        assert captured_age == 60
+        callback_entered.set()
+        assert release_callback.wait(5), "test did not release retention callback"
+        return time.time() + 60
+
+    monkeypatch.setattr(spool, "_expire_root_blocking", _blocked_expiry)
+    spool._schedule_retention(root, time.time(), 60)
+    assert callback_entered.wait(2), "retention callback never started"
+
+    stopper = threading.Thread(
+        target=lambda: stop_result.append(
+            spool.stop_retention_maintenance(timeout=5)
+        ),
+        daemon=True,
+    )
+    stopper.start()
+    time.sleep(0.05)
+    assert stopper.is_alive(), "teardown returned without joining the live callback"
+    release_callback.set()
+    stopper.join(2)
+
+    assert not stopper.is_alive()
+    assert stop_result == [True]
+    assert spool._RETENTION_TIMERS == {}
+
+
+@pytest.mark.unit
+def test_stop_retention_maintenance_joins_running_startup_thread(
+    monkeypatch, tmp_path,
+):
+    """The startup sweeper is tracked just like scheduled timers."""
+    spool, root = _root(monkeypatch, tmp_path)
+    bootstrap_entered = threading.Event()
+    release_bootstrap = threading.Event()
+    stop_result = []
+
+    def _blocked_expiry(captured_root, captured_age):
+        assert captured_root == root
+        assert captured_age == 60
+        bootstrap_entered.set()
+        assert release_bootstrap.wait(5), "test did not release startup retention"
+        return None
+
+    monkeypatch.setattr(spool, "MAX_AGE_SECONDS", 60)
+    monkeypatch.setattr(spool, "_RETENTION_STARTED", False)
+    monkeypatch.setattr(spool, "_expire_root_blocking", _blocked_expiry)
+    assert spool.start_retention_maintenance() is True
+    assert bootstrap_entered.wait(2), "startup retention thread never started"
+
+    stopper = threading.Thread(
+        target=lambda: stop_result.append(
+            spool.stop_retention_maintenance(timeout=5)
+        ),
+        daemon=True,
+    )
+    stopper.start()
+    time.sleep(0.05)
+    assert stopper.is_alive(), "teardown returned without joining startup retention"
+    release_bootstrap.set()
+    stopper.join(2)
+
+    assert not stopper.is_alive()
+    assert stop_result == [True]
+    assert spool._RETENTION_BOOTSTRAP_THREAD is None
+    assert spool._RETENTION_STARTED is False
+
+
+@pytest.mark.unit
 def test_startup_retention_captures_root_and_age_before_thread_runs(
     monkeypatch, tmp_path,
 ):
@@ -1003,7 +1079,9 @@ def test_startup_retention_captures_root_and_age_before_thread_runs(
             self.target(*self.args)
 
     monkeypatch.setattr(spool, "threading", SimpleNamespace(Thread=_DeferredThread))
-    monkeypatch.setattr(spool, "_schedule_retention", lambda *_args: None)
+    monkeypatch.setattr(
+        spool, "_schedule_retention", lambda *_args, **_kwargs: None,
+    )
 
     assert spool.start_retention_maintenance() is True
     [bootstrap] = deferred_threads

--- a/tests/unit/test_health_probe_responsiveness.py
+++ b/tests/unit/test_health_probe_responsiveness.py
@@ -133,6 +133,7 @@ def test_locked_metadata_probe_returns_promptly_without_stalling_another_request
         _http_get(server.server_port, "/health-probe-concurrent", results)
 
     concurrent_client = threading.Thread(target=request_concurrently, daemon=True)
+    safety_timer_alive = False
 
     try:
         health_client.start()
@@ -148,11 +149,15 @@ def test_locked_metadata_probe_returns_promptly_without_stalling_another_request
         concurrent_client.join(timeout=0.1)
     finally:
         safety_timer.cancel()
+        if safety_timer.ident is not None:
+            safety_timer.join(timeout=2)
+        safety_timer_alive = safety_timer.is_alive()
         if not unlock_fired.is_set():
             writer.rollback()
         writer.close()
         server.stop(timeout=1)
 
+    assert not safety_timer_alive, "safety unlock timer survived test teardown"
     assert not health_client.is_alive(), (
         "/health did not return within the five-second test bound"
     )

--- a/tests/unit/test_offloaded_request_context_i18n.py
+++ b/tests/unit/test_offloaded_request_context_i18n.py
@@ -21,6 +21,8 @@ so they fail on the behaviour a user would notice.
 from __future__ import annotations
 
 import ast
+import shutil
+import subprocess
 import threading
 from pathlib import Path
 
@@ -45,9 +47,9 @@ MSGID = "Error Downloading Cover"
 GERMAN = "Fehler beim Herunterladen des Covers"
 
 
-def _app():
+def _app(translations=TRANSLATIONS):
     app = Flask(__name__)
-    app.config["BABEL_TRANSLATION_DIRECTORIES"] = str(TRANSLATIONS)
+    app.config["BABEL_TRANSLATION_DIRECTORIES"] = str(translations)
     app.config["BABEL_DEFAULT_LOCALE"] = "de"
     Babel(app, locale_selector=lambda: "de")
     return app
@@ -66,31 +68,51 @@ def _run_on_worker_thread(fn):
     return box["value"]
 
 
-@pytest.mark.skipif(
-    not (TRANSLATIONS / "de" / "LC_MESSAGES" / "messages.mo").exists(),
-    reason="compiled de catalog absent; run scripts/compile_translations.sh",
-)
+@pytest.fixture(scope="module")
+def german_translations(tmp_path_factory):
+    """Compile into test-owned storage; never depend on suite execution order."""
+    msgfmt = shutil.which("msgfmt")
+    if msgfmt is None:
+        pytest.skip("msgfmt not available on this host")
+    root = tmp_path_factory.mktemp("offloaded-i18n")
+    messages = root / "de" / "LC_MESSAGES"
+    messages.mkdir(parents=True)
+    subprocess.run(
+        [
+            msgfmt,
+            str(TRANSLATIONS / "de" / "LC_MESSAGES" / "messages.po"),
+            "-o",
+            str(messages / "messages.mo"),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return root
+
+
 class TestOffloadedWorkKeepsItsTranslations:
-    def test_the_string_is_actually_translated_in_context(self):
+    def test_the_string_is_actually_translated_in_context(self, german_translations):
         """Guards the guard: if this msgid ever loses its German translation
         the two tests below would both return English and agree for the wrong
         reason."""
-        with _app().test_request_context("/"):
+        with _app(german_translations).test_request_context("/"):
             assert gettext(MSGID) == GERMAN
 
-    def test_unwrapped_offload_silently_falls_back_to_english(self):
+    def test_unwrapped_offload_silently_falls_back_to_english(
+        self, german_translations,
+    ):
         """The failure mode being defended against. gettext does not raise off
         the request context — it returns the msgid, so the regression is
         invisible unless a test looks at a non-English locale."""
-        with _app().test_request_context("/"):
+        with _app(german_translations).test_request_context("/"):
             got = _run_on_worker_thread(lambda: gettext(MSGID))
         assert got == MSGID, (
             "off-context gettext no longer falls back silently; if flask_babel "
             "started raising instead, the wrapper below can be simplified"
         )
 
-    def test_wrapped_offload_keeps_the_users_language(self):
-        with _app().test_request_context("/"):
+    def test_wrapped_offload_keeps_the_users_language(self, german_translations):
+        with _app(german_translations).test_request_context("/"):
             wrapped = copy_current_request_context(lambda: gettext(MSGID))
             got = _run_on_worker_thread(wrapped)
         assert got == GERMAN, (


### PR DESCRIPTION
Closes #1868. Source-level fixes for the confirmed non-determinism mechanisms: the retention-thread leak gets a deterministic lifecycle (stop/join API, red-then-green), plus a sweep of sibling fixture-spawned threads/timers without teardown joins; `--dist=loadfile` retained as the belt (already in tests.yml, and measured faster, not just safer).

Determinism proof, both environments: implementer measured 3× identical runs; independently reproduced on the dev machine — **three consecutive xdist runs, 7771 passed / 0 failed each** (~80s per run). A green CI now means what we treat it as meaning — this also unblocks judging community PR #1894's red honestly (the #1868 caveat on that PR's unit failures is retired once this merges).