### PR TITLE
fix(spa): render the narrow delete control conditionally; de-race the Customize spec (#2006 follow-up)

### DIFF
--- a/changelog.d/2009-narrow-delete-conditional.md
+++ b/changelog.d/2009-narrow-delete-conditional.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Screen readers no longer encounter a nameless hidden delete control on desktop book pages.** The narrow-screen delete button is now only rendered on narrow screens instead of being present but invisible everywhere.

--- a/frontend/e2e/book-detail-delete-prominence.spec.ts
+++ b/frontend/e2e/book-detail-delete-prominence.spec.ts
@@ -172,9 +172,9 @@ test('book-detail deletion is a quiet region in light and dark themes (#1862)', 
  * #1828 — mobile counterpart to the region assertions above. On narrow
  * viewports whole-book deletion is an icon-level control at the end of the
  * ordinary action row: a red trash icon, the same accessible name, the same
- * confirm dialog doing the guarding. The bordered desktop region stays in the
- * DOM but is not displayed, so nothing red dominates the scroll path to the
- * description.
+ * confirm dialog doing the guarding. The bordered desktop region is not
+ * rendered at all at this width (conditional render, never a hidden control),
+ * so nothing red dominates the scroll path to the description.
  */
 test('mobile demotes deletion to a hit-testable icon control in the action row (#1828)', async ({ page, isMobile }) => {
   test.skip(isMobile !== true, 'mobile-only layout');
@@ -190,13 +190,13 @@ test('mobile demotes deletion to a hit-testable icon control in the action row (
   });
   await page.goto(`/app/book/${book!.id}`, { waitUntil: 'domcontentloaded' });
 
-  // The heavy region yields on mobile…
-  await expect(page.getByTestId('book-destructive-actions')).not.toBeVisible();
+  // The heavy region is not in the narrow DOM at all…
+  await expect(page.getByTestId('book-destructive-actions')).toHaveCount(0);
 
   // …and the icon control replaces it inside the ordinary action row, keeping
   // the #1939 disambiguating name and gaining the tooltip the reporter asked
-  // for. Exactly one visible control carries the name — strict mode enforces
-  // that the hidden region button does not double it.
+  // for. Exactly one control carries the name — with the region unrendered,
+  // strict mode enforces that nothing doubles it.
   const icon = page.getByTestId('book-actions')
     .getByRole('button', { name: 'Delete from the global library' });
   await expect(icon).toBeVisible();

--- a/frontend/e2e/delete-book-discoverability.spec.ts
+++ b/frontend/e2e/delete-book-discoverability.spec.ts
@@ -139,12 +139,12 @@ test('mobile groups deletion as an icon-level control inside the action row (#18
 
   // The mobile trade: the destructive control joins the ordinary action row as
   // an icon (the confirm dialog is the guard), and the separated desktop
-  // region is not displayed. The reporter's ask, verbatim, was that "a red
-  // trash can is more than enough for book delete".
+  // region is not rendered at this width at all. The reporter's ask, verbatim,
+  // was that "a red trash can is more than enough for book delete".
   const ordinaryActions = page.getByTestId('book-actions');
   await expect(ordinaryActions).toBeVisible();
   await expect(
     ordinaryActions.getByRole('button', { name: 'Delete from the global library' }),
   ).toHaveCount(1);
-  await expect(page.getByTestId('book-destructive-actions')).not.toBeVisible();
+  await expect(page.getByTestId('book-destructive-actions')).toHaveCount(0);
 });

--- a/frontend/e2e/sp2-display-options.spec.ts
+++ b/frontend/e2e/sp2-display-options.spec.ts
@@ -65,6 +65,14 @@ test('Customize panel can restore hidden Table view', async ({ page }) => {
   // click times out at 45s. Open the drawer first when it is there. (Same
   // shape as the collapsed search field; the suite's sidebar spec already
   // drives the hamburger this way.)
+  //
+  // Wait for catalog content BEFORE probing for the hamburger: the TopBar
+  // mounts asynchronously after goto resolves, and isVisible() is a one-shot
+  // probe — under CI load it ran before the hamburger existed, skipped the
+  // click, and the Customize click then retried against a closed drawer for
+  // the full 45s (first attempt on #2006's run; the retry, warm, took 1.1s).
+  // mobile.spec.ts's drawer spec uses this same content-first ordering.
+  await expect(page.locator('a[href*="/book/"]').first()).toBeVisible();
   const hamburger = page.getByRole('button', { name: /open navigation/i });
   if (await hamburger.isVisible().catch(() => false)) await hamburger.click();
   await page.getByRole('button', { name: 'Customize navigation' }).click();

--- a/frontend/src/lib/useMediaQuery.ts
+++ b/frontend/src/lib/useMediaQuery.ts
@@ -1,0 +1,22 @@
+/* Generic matchMedia hook. The sidebar's useIsMobile (lib/a11y/useIsMobile.ts)
+ * is pinned to the sidebar's 767px cutover, so a component whose responsive
+ * breakpoint belongs to its own stylesheet uses this with its own query —
+ * keep each call site's query in sync with the stylesheet that owns the same
+ * cutover, exactly as useIsMobile does with Sidebar.module.css. */
+import { useEffect, useState } from 'react';
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(
+    () => typeof window !== 'undefined' && window.matchMedia(query).matches,
+  );
+
+  useEffect(() => {
+    const mql = window.matchMedia(query);
+    const onChange = () => setMatches(mql.matches);
+    onChange();
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  }, [query]);
+
+  return matches;
+}

--- a/frontend/src/pages/BookDetail.module.css
+++ b/frontend/src/pages/BookDetail.module.css
@@ -484,13 +484,26 @@
   margin: 0;
 }
 
-/* Mobile-only icon-level delete (#1828) — display:none on desktop, where the
-   separated dangerZone region above carries whole-book deletion. The media
-   query below turns this on and the region off; both controls share the same
-   handler, aria-label and confirm dialog. */
+/* Narrow-layout icon-level delete (#1828). The component renders this button
+   only at ≤700px (useMediaQuery — the bordered dangerZone region renders at
+   wider widths instead), so this rule styles an element that only exists in
+   the narrow layout; no display toggling lives here on purpose: a hidden
+   interactive element in the DOM is an a11y/sweep hazard, not a solution. */
 .deleteIconButton {
-  display: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 34px;
+  height: 34px;
+  border-radius: var(--r-md);
+  border: 1px solid var(--danger);
+  background: transparent;
+  color: var(--danger);
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease);
 }
+.deleteIconButton:hover:not(:disabled) { background: var(--danger-soft); }
+.deleteIconButton:disabled { opacity: 0.6; cursor: default; }
 
 /* Tags row */
 .tags {
@@ -572,24 +585,10 @@
   .description { order: 0; }
 
   /* #1828: whole-book deletion trades its bordered region for an icon-level
-     button at the end of the action row. The confirm dialog is the guard; the
-     region's box was the loudest element between the reader and the book. */
-  .dangerZone { display: none; }
-  .deleteIconButton {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 34px;
-    height: 34px;
-    border-radius: var(--r-md);
-    border: 1px solid var(--danger);
-    background: transparent;
-    color: var(--danger);
-    cursor: pointer;
-    transition: background var(--dur-fast) var(--ease);
-  }
-  .deleteIconButton:hover:not(:disabled) { background: var(--danger-soft); }
-  .deleteIconButton:disabled { opacity: 0.6; cursor: default; }
+     button at the end of the action row (both are conditionally rendered in
+     the component — the region never exists in the narrow DOM). The confirm
+     dialog is the guard; the region's box was the loudest element between the
+     reader and the book. */
 
   /* #1828 chip compression: the action row was a wall of 38px chips with wide
      gaps, pushing the description off the first two screens. 34px keeps the

--- a/frontend/src/pages/BookDetail.tsx
+++ b/frontend/src/pages/BookDetail.tsx
@@ -27,6 +27,7 @@ import { useCardActionsHidden } from '../lib/useCardActionsHidden';
 import { BookUserNotices } from '../components/UserNotices';
 import { backTarget } from '../lib/backLink';
 import { useAnnouncer } from '../lib/a11y/announcer';
+import { useMediaQuery } from '../lib/useMediaQuery';
 
 /* `fetchpriority` is a plain DOM attribute. react-dom 18.3 has no knowledge of
    it, so the camelCase `fetchPriority` that @types/react declares would trip its
@@ -338,6 +339,13 @@ export function BookDetail() {
   const [deviceSendBanner, setDeviceSendBanner] = useState<{ ok: boolean; text: string } | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [reloadMessage, setReloadMessage] = useState('');
+  /* #1828's destructive-control swap is a CONDITIONAL RENDER, not a hidden
+     element: the icon button and the bordered region never exist in the DOM
+     together, because a display:none control still shows up in DOM sweeps with
+     an empty accessible name (it has none — it is not rendered) and failed
+     hidden-books.spec's every-control-is-named sweep on desktop. Keep this
+     query in sync with the 700px mobile cutover in BookDetail.module.css. */
+  const narrowLayout = useMediaQuery('(max-width: 700px)');
   // Shelf membership for the metadata list (#1254). Both queries are already
   // in flight for the always-rendered AddToShelf popover below and share its
   // cache keys, so reading them here costs no extra request.
@@ -711,14 +719,14 @@ export function BookDetail() {
               </button>
             )}
 
-            {/* Mobile-only destructive control (#1828): on narrow viewports the
-                whole-book delete is demoted from the bordered region below to an
-                icon-level button at the END of this row — a red trash can, the
-                confirm dialog doing the actual guarding. CSS hides it on desktop,
-                where the separated region remains; the two never render visibly
-                at once, and both share requestDeleteBook. Placed last so the
-                primary actions keep their positions. */}
-            {me?.role?.delete_books && me?.role?.edit && (
+            {/* Narrow-viewport destructive control (#1828): the whole-book
+                delete is an icon-level button at the END of this row — a red
+                trash can, the confirm dialog doing the actual guarding. It is
+                rendered only in the narrow layout; at desktop widths the
+                separated region below renders instead (both share
+                requestDeleteBook, so behaviour is identical). Placed last so
+                the primary actions keep their positions. */}
+            {narrowLayout && me?.role?.delete_books && me?.role?.edit && (
               <button
                 type="button"
                 data-testid="book-delete-icon"
@@ -736,11 +744,12 @@ export function BookDetail() {
           <p className={reloadMessage ? styles.actionStatus : undefined} role="status">{reloadMessage}</p>
 
           {/* Whole-book deletion is intentionally separated from the wrapping row
-              of ordinary action chips (#1046) on desktop; on mobile the region is
-              hidden and the icon-level control inside the action row above takes
-              over (#1828). This uses the same delete-and-edit policy as the server;
+              of ordinary action chips (#1046) in the wide layout; in the narrow
+              layout the icon-level control inside the action row above renders
+              INSTEAD of this region (#1828) — neither is ever hidden in the DOM.
+              This uses the same delete-and-edit policy as the server;
               this gate and grouping are the discoverability/UX layer. */}
-          {me?.role?.delete_books && me?.role?.edit && (
+          {!narrowLayout && me?.role?.delete_books && me?.role?.edit && (
             <section className={styles.dangerZone} data-testid="book-destructive-actions"
               aria-label={t('Delete from the global library')}>
               <button


### PR DESCRIPTION
Fix-forward for the two e2e failures #2006 merged over (that merge was my process error — the red was real).

**Defect 1 (real, 3/3):** the mobile-only delete icon shipped `display:none` on desktop but stayed in the DOM, computing an empty accessible name in the hidden-books sweep. Now conditionally rendered (new `useMediaQuery` at the layout's own 700px breakpoint): no hidden interactive element exists at any width; the #2006 specs upgraded to assert `toHaveCount(0)`.

**Defect 2 (refuted as regression, evidence in-PR-thread):** the Customize timeout was a latent spec race — a one-shot `isVisible()` probe before the TopBar mounts (passed on retry in 1.1s; passed 869ms on the previous main run; the flow never touches the #2006 code paths). Spec now waits for catalog content first, same ordering as the sibling drawer spec.

Build green; 563 tests collect clean; the e2e lane on this PR is the proof run.