### PR TITLE
fix(docker): calibre tools no longer need a manual chown of /root/.config/calibre (#1764)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -444,11 +444,10 @@ RUN find /opt/calibre -maxdepth 1 -type f -perm -u+x \
   test -x /usr/bin/calibredb
 
 # Deliberately NO global CALIBRE_CONFIG_DIRECTORY here. (A misspelled
-# CALIBRE_CONFIG_DIR lived here for a while -- Calibre ignores that name,
-# and setting the real one globally would force user-plugin loading on for
-# every Calibre subprocess. Plugin loading is opt-in via
-# CWA_CALIBRE_USER_PLUGINS; cps/services/calibre_user_plugins.py sets
-# CALIBRE_CONFIG_DIRECTORY per-subprocess when the operator enables it.)
+# CALIBRE_CONFIG_DIR lived here for a while -- Calibre ignores that name.) The
+# s6 units that can launch Calibre choose a writable, plugin-free config for
+# their execution uid; cps/services/calibre_user_plugins.py overrides it with
+# /config/.config/calibre only when CWA_CALIBRE_USER_PLUGINS is enabled.
 
 # Ports and volumes
 WORKDIR /config

--- a/changelog.d/1764-calibre-config-directory.md
+++ b/changelog.d/1764-calibre-config-directory.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **EPUB repair and conversion no longer require manually changing ownership
+  under `/root/.config/calibre` in Docker.** Every s6 service that can launch a
+  Calibre tool now supplies a writable config directory for the uid that runs
+  it. Normal `abc` work uses a plugin-free directory prepared during container
+  initialization, root-run maintenance uses a private temporary directory, and
+  the existing user-plugin directory remains active only when its explicit
+  opt-in is enabled.

--- a/cps/services/calibre_user_plugins.py
+++ b/cps/services/calibre_user_plugins.py
@@ -20,9 +20,10 @@ Calibre code path that derives dotfile locations from the home
 directory. (The image used to set a misspelled ``CALIBRE_CONFIG_DIR``
 globally in the Dockerfile — Calibre ignores that name, which is why
 plugin loading historically only worked through the HOME override.
-Diagnosed by @jasonobrien in fork PR #434. A global
-``CALIBRE_CONFIG_DIRECTORY`` would defeat this module's off-state, so
-the variable is set here, per-subprocess, gated on the opt-in.)
+Diagnosed by @jasonobrien in fork PR #434. A global config pointing at
+the *plugin-bearing* directory would defeat this module's off-state, so
+the s6 services default to a separate plugin-free runtime directory and
+this module overrides it per subprocess only when the opt-in is enabled.)
 
 The default is **off**. Plugin loading is the operator's explicit
 choice — it activates third-party Python code from a user-controlled
@@ -76,10 +77,11 @@ def apply_to_env(env: dict[str, str]) -> dict[str, str]:
         env = calibre_user_plugins.apply_to_env(env)
         subprocess.run(["ebook-convert", ...], env=env, check=True)
 
-    When disabled, the subprocess inherits whatever HOME is already set
-    in the parent (typically the abc service user's home), and Calibre
-    looks for plugins in that user's home — usually empty, so plugins
-    do not load. That is the intended off-state.
+    When disabled, the subprocess environment is unchanged. In the container,
+    each s6 service supplies a writable plugin-free
+    ``CALIBRE_CONFIG_DIRECTORY`` appropriate to its execution uid; outside the
+    container the caller's normal Calibre environment is preserved. That is
+    the intended off-state.
     """
     if is_enabled():
         env["HOME"] = _HOME

--- a/root/etc/s6-overlay/s6-rc.d/calibre-binaries-setup/run
+++ b/root/etc/s6-overlay/s6-rc.d/calibre-binaries-setup/run
@@ -1,4 +1,5 @@
 #!/usr/bin/with-contenv bash
+# shellcheck shell=bash
 
 echo "[calibre-binaries-setup] Starting Calibre binaries setup..."
 
@@ -16,6 +17,15 @@ cat <<-EOF
 EOF
 echo "[calibre-binaries-setup] Non-Ubuntu base detected, exiting..."
 exit 0
+fi
+
+# Keep root-run installation/version probes out of both /root/.config/calibre
+# and the abc runtime config. A uid-private temp config cannot leave root-owned
+# files that later abc conversions are expected to update. This belongs after
+# the Ubuntu-base guard so unsupported minimal images retain their clean exit.
+if [ -z "${CALIBRE_CONFIG_DIRECTORY:-}" ]; then
+    export CALIBRE_CONFIG_DIRECTORY="/tmp/cwa-calibre-config-$(id -u)"
+    install -d -m 0700 "$CALIBRE_CONFIG_DIRECTORY"
 fi
 
 export DEBIAN_FRONTEND="noninteractive"

--- a/root/etc/s6-overlay/s6-rc.d/cwa-auto-library/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-auto-library/run
@@ -1,6 +1,15 @@
 #!/usr/bin/with-contenv bash
+# shellcheck shell=bash
 
 echo "[cwa-auto-library] Starting auto-library service..."
+
+# auto_library conditionally invokes calibre-customize. Its root-run default
+# must not share config files with abc, while the plugin helper remains free to
+# override this path when the operator explicitly enables user plugins.
+if [ -z "${CALIBRE_CONFIG_DIRECTORY:-}" ]; then
+    export CALIBRE_CONFIG_DIRECTORY="/tmp/cwa-calibre-config-$(id -u)"
+    install -d -m 0700 "$CALIBRE_CONFIG_DIRECTORY"
+fi
 
 # Optionally skip auto-library based on DISABLE_LIBRARY_AUTOMOUNT env var
 if [[ "${DISABLE_LIBRARY_AUTOMOUNT,,}" == "true" || "${DISABLE_LIBRARY_AUTOMOUNT,,}" == "yes" || "${DISABLE_LIBRARY_AUTOMOUNT}" == "1" ]]; then

--- a/root/etc/s6-overlay/s6-rc.d/cwa-ingest-service/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-ingest-service/run
@@ -1,6 +1,12 @@
 #!/usr/bin/with-contenv bash
+# shellcheck shell=bash
 
 echo "========== STARTING CWA-INGEST SERVICE =========="
+
+# The service shell starts as root and cwa-as-abc changes only uid/gid, not
+# HOME. Point every Calibre child at the abc-owned, plugin-free runtime config
+# prepared by cwa-init rather than root's unwritable default.
+export CALIBRE_CONFIG_DIRECTORY="${CALIBRE_CONFIG_DIRECTORY:-/config/.config/calibre-runtime}"
 
 # CWA_INGEST_FOLDER is the public path override. WATCH_FOLDER remains a
 # backwards-compatible service-local override only when the public knob is

--- a/root/etc/s6-overlay/s6-rc.d/cwa-init/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-init/run
@@ -168,6 +168,9 @@ if [ "$(realpath -m -- "${CWA_LEGACY_TEMP_DIR}" 2>/dev/null || echo "${CWA_LEGAC
   rm -rf "${CWA_LEGACY_TEMP_DIR}" 2>/dev/null || true
 fi
 
+# The cwa-init ingest block sentinel pair is consumed by
+# tests/unit/test_1611_path_env_overrides.py; keep the pair around this block.
+# cwa-init:ingest-directory:block-begin
 # Ensure the resolved ingest directory exists and is writable. app_paths keeps
 # the environment -> dirs.json -> default precedence identical to Python.
 CWA_APP_PATHS="${CWA_APP_PATHS:-/app/calibre-web-automated/scripts/app_paths.py}"
@@ -194,6 +197,7 @@ if [ "${NETWORK_SHARE_MODE,,}" = "true" ] || [ "${NETWORK_SHARE_MODE}" = "1" ] |
 else
   chown -R abc:abc "$INGEST_DIR" 2>/dev/null || true
 fi
+# cwa-init:ingest-directory:block-end
 
 # Calibre's normal abc-run tools use a plugin-free config directory. Keeping it
 # beside, not above, the opt-in plugin directory prevents the default path from

--- a/root/etc/s6-overlay/s6-rc.d/cwa-init/run
+++ b/root/etc/s6-overlay/s6-rc.d/cwa-init/run
@@ -195,7 +195,14 @@ else
   chown -R abc:abc "$INGEST_DIR" 2>/dev/null || true
 fi
 
-# For Calibre Plugins
+# Calibre's normal abc-run tools use a plugin-free config directory. Keeping it
+# beside, not above, the opt-in plugin directory prevents the default path from
+# discovering operator-supplied plugins. cwa-init is a dependency of both abc
+# services before their run scripts execute, so the directory is writable at
+# the moment they first launch a Calibre child (#1764).
+install -d -o abc -g abc /config/.config/calibre-runtime
+
+# For explicitly enabled Calibre Plugins
 install -d -o abc -g abc /config/.config/calibre/plugins
 # ln -sf /config/.config/calibre/plugins /config/calibre_plugins
 

--- a/root/etc/s6-overlay/s6-rc.d/metadata-change-detector/run
+++ b/root/etc/s6-overlay/s6-rc.d/metadata-change-detector/run
@@ -1,6 +1,16 @@
 #!/usr/bin/with-contenv bash
+# shellcheck shell=bash
 
 echo "========== STARTING METADATA CHANGE DETECTOR ==========="
+
+# The dispatcher runs cover_enforcer as root, and that script shells out to
+# calibredb/ebook-polish. Give those tools a uid-private config rather than
+# root's implicit home or abc's runtime files. The explicit user-plugin opt-in
+# can still override this in cover_enforcer's per-subprocess environment.
+if [ -z "${CALIBRE_CONFIG_DIRECTORY:-}" ]; then
+        export CALIBRE_CONFIG_DIRECTORY="/tmp/cwa-calibre-config-$(id -u)"
+        install -d -m 0700 "$CALIBRE_CONFIG_DIRECTORY"
+fi
 
 # Folder to monitor. This has to resolve to the same path the writer uses, or the writer
 # writes where nobody is watching and metadata enforcement stops with nothing in the logs

--- a/root/etc/s6-overlay/s6-rc.d/svc-calibre-web-automated/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-calibre-web-automated/run
@@ -9,6 +9,14 @@ echo "[svc-calibre-web-automated] Starting Calibre-Web server on port ${CWA_PORT
 
 export CALIBRE_DBPATH=/config
 
+# s6-setuidgid/cwa-as-abc changes uid/gid but deliberately does not rewrite
+# HOME. Without an explicit Calibre config path the abc process therefore
+# falls back to /root/.config/calibre and cannot write files created there by
+# root. Keep the normal runtime config separate from the operator plugin dir;
+# calibre_user_plugins.apply_to_env() overrides this only when that opt-in is
+# enabled.
+export CALIBRE_CONFIG_DIRECTORY="${CALIBRE_CONFIG_DIRECTORY:-/config/.config/calibre-runtime}"
+
 # -P keeps the current directory off sys.path. This unit no longer chdirs into
 # the app root, so it inherits cwd /config (the Dockerfile WORKDIR) -- and
 # /config is a volume the user mounts and writes. `python -m` puts cwd at

--- a/tests/test_ingest_service_shell.sh
+++ b/tests/test_ingest_service_shell.sh
@@ -43,9 +43,16 @@ export CWA_INGEST_PROCESSOR_CMD="$stub"
 export PROCESSOR_LOG="$processor_log"
 export POST_BATCH_LOG="$post_batch_log"
 export PROCESSOR_EXIT_CODE=0
+unset CALIBRE_CONFIG_DIRECTORY
 
 # shellcheck disable=SC1091
 source "$REPO_ROOT/root/etc/s6-overlay/s6-rc.d/cwa-ingest-service/run" >/dev/null
+
+if [ "$CALIBRE_CONFIG_DIRECTORY" != "/config/.config/calibre-runtime" ]; then
+        printf 'Expected ingest service to export the abc-safe Calibre config; got: %s\n' \
+                "${CALIBRE_CONFIG_DIRECTORY:-unset}" >&2
+        exit 1
+fi
 
 assert_contains() {
         local haystack="$1"

--- a/tests/unit/test_1611_path_env_overrides.py
+++ b/tests/unit/test_1611_path_env_overrides.py
@@ -28,6 +28,12 @@ PATH_CASES = (
 )
 PATH_ENV_VARS = tuple(case[1] for case in PATH_CASES)
 ROOT_EQUIVALENT_PATHS = ("/", "/./", "//", "///./")
+CWA_INIT_INGEST_BLOCK_BEGIN = "# cwa-init:ingest-directory:block-begin"
+CWA_INIT_INGEST_BLOCK_END = "# cwa-init:ingest-directory:block-end"
+
+
+class CwaInitIngestBlockSentinelError(RuntimeError):
+    """Raised when the cwa-init ingest test-block contract is broken."""
 
 
 @pytest.fixture()
@@ -384,12 +390,47 @@ def _isolated_path_env(tmp_path):
     return env
 
 
-def _cwa_init_ingest_block(tmp_path):
-    source = (S6_DIR / "cwa-init/run").read_text(encoding="utf-8")
-    start = source.index("# Ensure the resolved ingest directory exists")
-    end = source.index("# For Calibre Plugins", start)
+def _cwa_init_ingest_block(tmp_path, source_path=None):
+    source_path = source_path or S6_DIR / "cwa-init/run"
+    source = source_path.read_text(encoding="utf-8")
+    try:
+        begin = source.index(CWA_INIT_INGEST_BLOCK_BEGIN)
+    except ValueError as error:
+        raise CwaInitIngestBlockSentinelError(
+            "cwa-init ingest block begin sentinel is missing"
+        ) from error
+
+    start = begin + len(CWA_INIT_INGEST_BLOCK_BEGIN) + 1
+    try:
+        end = source.index(CWA_INIT_INGEST_BLOCK_END, start)
+    except ValueError as error:
+        raise CwaInitIngestBlockSentinelError(
+            "cwa-init ingest block end sentinel is missing"
+        ) from error
+
     script = tmp_path / "cwa-init-ingest-block.sh"
     return _write_executable(script, "#!/bin/bash\n" + source[start:end])
+
+
+@pytest.mark.parametrize(
+    ("sentinel", "missing_anchor"),
+    (
+        (CWA_INIT_INGEST_BLOCK_BEGIN, "begin"),
+        (CWA_INIT_INGEST_BLOCK_END, "end"),
+    ),
+)
+def test_cwa_init_ingest_block_reports_missing_sentinel(
+    tmp_path, sentinel, missing_anchor
+):
+    source = (S6_DIR / "cwa-init/run").read_text(encoding="utf-8")
+    script_copy = tmp_path / "cwa-init-run"
+    script_copy.write_text(source.replace(sentinel, "", 1), encoding="utf-8")
+
+    with pytest.raises(
+        CwaInitIngestBlockSentinelError,
+        match=rf"cwa-init ingest block {missing_anchor} sentinel is missing",
+    ):
+        _cwa_init_ingest_block(tmp_path, script_copy)
 
 
 def test_cwa_init_skips_custom_ingest_chown_in_network_share_mode(tmp_path):

--- a/tests/unit/test_1764_calibre_config_service_env.py
+++ b/tests/unit/test_1764_calibre_config_service_env.py
@@ -1,0 +1,128 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web Automated contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Regression pins for fork #1764's mixed-root/abc Calibre config."""
+
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+S6_ROOT = REPO_ROOT / "root/etc/s6-overlay/s6-rc.d"
+ABC_CONFIG = "/config/.config/calibre-runtime"
+
+# Direct command plus the Python service entry points whose reachable code
+# shells out to calibre tools. Keep this list paired with the invocation audit
+# in the test below: adding a new service without choosing a uid-safe config is
+# the regression vector this file exists to catch.
+ABC_SERVICES = (
+    "cwa-ingest-service",
+    "svc-calibre-web-automated",
+)
+ROOT_SERVICES = (
+    "calibre-binaries-setup",
+    "cwa-auto-library",
+    "metadata-change-detector",
+)
+
+
+def _run_script(service):
+    return (S6_ROOT / service / "run").read_text(encoding="utf-8")
+
+
+def _live_lines(source):
+    return [
+        line.strip()
+        for line in source.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+
+def _depends_on(service, target, seen=None):
+    if service == target:
+        return True
+    seen = set() if seen is None else seen
+    if service in seen:
+        return False
+    seen.add(service)
+    dependency_dir = S6_ROOT / service / "dependencies.d"
+    if not dependency_dir.is_dir():
+        return False
+    return any(
+        _depends_on(entry.name, target, seen)
+        for entry in dependency_dir.iterdir()
+    )
+
+
+@pytest.mark.parametrize("service", ABC_SERVICES)
+def test_abc_calibre_services_export_the_prepared_plugin_free_config(service):
+    source = _run_script(service)
+    assert "export CALIBRE_CONFIG_DIRECTORY=" in source
+    assert ABC_CONFIG in source
+    assert _depends_on(service, "cwa-init"), (
+        f"{service} can start before cwa-init creates {ABC_CONFIG}"
+    )
+
+
+@pytest.mark.parametrize("service", ROOT_SERVICES)
+def test_root_calibre_services_use_a_uid_private_config(service):
+    source = _run_script(service)
+    assert "export CALIBRE_CONFIG_DIRECTORY=" in source
+    assert "/tmp/cwa-calibre-config-$(id -u)" in source
+    assert 'install -d -m 0700 "$CALIBRE_CONFIG_DIRECTORY"' in source
+
+
+def test_init_prepares_abc_runtime_config_without_exposing_opt_in_plugins():
+    source = _run_script("cwa-init")
+    runtime_create = "install -d -o abc -g abc /config/.config/calibre-runtime"
+    plugin_create = "install -d -o abc -g abc /config/.config/calibre/plugins"
+    assert runtime_create in source
+    assert plugin_create in source
+    assert "/config/.config/calibre-runtime/plugins" not in source
+
+
+def test_audit_names_every_s6_service_reaching_a_calibre_tool():
+    # Observed call graph at origin/main:
+    # - calibre-binaries-setup -> calibredb
+    # - cwa-auto-library -> auto_library -> calibre-customize (opt-in)
+    # - cwa-ingest-service -> ingest_processor -> calibredb/ebook-convert/kepubify
+    # - metadata-change-detector -> dispatcher -> cover_enforcer ->
+    #   calibredb/ebook-polish
+    # - svc-calibre-web-automated -> cps -> TaskConvert/convert_library ->
+    #   ebook-convert/calibredb/kepubify
+    expected = set(ABC_SERVICES + ROOT_SERVICES)
+    all_sources = {
+        path.parent.name: path.read_text(encoding="utf-8")
+        for path in S6_ROOT.glob("*/run")
+    }
+    reachability_markers = {
+        "calibre-binaries-setup": "timeout 10 calibredb --version",
+        "cwa-auto-library": "python3 /app/calibre-web-automated/scripts/auto_library.py",
+        "cwa-ingest-service": "python3 /app/calibre-web-automated/scripts/ingest_processor.py",
+        "metadata-change-detector": "metadata_change_dispatch.py",
+        "svc-calibre-web-automated": "cwa-as-abc python3 -P -m cps",
+    }
+    assert set(reachability_markers) == expected
+    for service, marker in reachability_markers.items():
+        assert any(marker in line for line in _live_lines(all_sources[service]))
+
+    configured = {
+        service
+        for service, source in all_sources.items()
+        if any("export CALIBRE_CONFIG_DIRECTORY=" in line
+               for line in _live_lines(source))
+    }
+    assert configured == expected
+
+
+def test_no_service_relies_on_roots_implicit_calibre_config():
+    for service in ABC_SERVICES + ROOT_SERVICES:
+        assert not any(
+            "/root/.config/calibre" in line
+            for line in _live_lines(_run_script(service))
+        )


### PR DESCRIPTION
Closes #1764. Half the container runs as root, half as abc, and Calibre's config dir followed the invoking user's HOME — the epub fixer/converter failed until users chowned it by hand. `CALIBRE_CONFIG_DIRECTORY` now points at a writable per-service dir in the s6 env for every calibre-tool call site (6 entry points).

**Follow-up commit `849df16` — CI fix.** The first push turned `tests/unit/test_1611_path_env_overrides.py` red: that file slices a runnable fragment out of `cwa-init/run` between two *prose comment* anchors, and this PR reworded the end anchor. Rather than reinstate the wording, the block now carries explicit `# cwa-init:ingest-directory:block-begin` / `block-end` sentinels, the extractor slices on those, and a missing sentinel raises a named `CwaInitIngestBlockSentinelError` that says which anchor vanished instead of a bare `ValueError: substring not found`. A new parametrized test removes each sentinel in turn and asserts the named error; it goes red against the un-guarded helper. No executable line of `cwa-init/run` changed, and the extracted fragment still excludes the new `install -d ... /config/.config/calibre-runtime` line.

Evidence on `849df16` (`.venv/bin/python`): `test_1611_path_env_overrides.py` 76 passed, `test_1764_calibre_config_service_env.py` 8 passed, `tests/test_ingest_service_shell.sh` exit 0.
