### PR TITLE
fix(annotations): preserve wire child-index representation

### DIFF
--- a/changelog.d/1886.md
+++ b/changelog.d/1886.md
@@ -2,4 +2,7 @@
 
 - **Importing a Kobo database no longer reports unchanged cloud-delivered
   highlights as newer server conflicts.** Equivalent `NULL` and `-99` KoboSpan
-  selector markers are matched before deciding whether recovery data differs.
+  selector markers are matched before deciding whether recovery data differs,
+  while real server edits still report a conflict. Newer device edits preserve
+  an existing wire-written `NULL` instead of flipping it to the equivalent
+  `-99` representation.

--- a/cps/annotations.py
+++ b/cps/annotations.py
@@ -1627,28 +1627,23 @@ def _bookmark_matches_annotation(bm, content_id, row) -> bool:
 def _apply_imported_bookmark(row, bm, content_id, *, device_modified_at,
                              origin_device_id):
     """Apply the content half of an already-authorised newer device edit."""
-    imported_values = list(_bookmark_values(bm, content_id))
-    imported_values[5] = _imported_container_child_index(
-        row.start_container_child_index, imported_values[5],
+    row.highlighted_text = bm.text
+    row.note_text = bm.annotation
+    row.highlight_color = bm.color
+    row.content_id = content_id
+    row.start_container_path = bm.start_container_path
+    row.start_container_child_index = _imported_container_child_index(
+        row.start_container_child_index, bm.start_container_child_index,
     )
-    imported_values[8] = _imported_container_child_index(
-        row.end_container_child_index, imported_values[8],
+    row.start_offset = bm.start_offset
+    row.end_container_path = bm.end_container_path
+    row.end_container_child_index = _imported_container_child_index(
+        row.end_container_child_index, bm.end_container_child_index,
     )
-    (
-        row.highlighted_text,
-        row.note_text,
-        row.highlight_color,
-        row.content_id,
-        row.start_container_path,
-        row.start_container_child_index,
-        row.start_offset,
-        row.end_container_path,
-        row.end_container_child_index,
-        row.end_offset,
-        row.context_string,
-        row.chapter_progress,
-        row.annotation_type,
-    ) = imported_values
+    row.end_offset = bm.end_offset
+    row.context_string = bm.context_string
+    row.chapter_progress = bm.chapter_progress
+    row.annotation_type = to_storage_type(bm.annotation_type)
     row.client_modified_at = device_modified_at
     row.server_modified_at = datetime.now(timezone.utc)
     row.last_synced = datetime.now(timezone.utc)

--- a/cps/annotations.py
+++ b/cps/annotations.py
@@ -1546,13 +1546,30 @@ def _matching_container_child_index(value):
     the child-index fields, which stores as ``NULL``.  Both the position
     converter and the web-reader locator consume either spelling as "use the
     selector path", so the recovery comparator must not invent a content
-    conflict from that structural transport difference.
+    conflict from that structural transport difference.  See the measured wire
+    behavior documented in ``cps/services/kobo_position.py:153``.
     """
     from .services.kobo_position import KOBO_SELECTOR_SENTINEL
 
     if value is None or value == KOBO_SELECTOR_SENTINEL:
         return None
     return value
+
+
+def _imported_container_child_index(existing, imported):
+    """Keep the stored spelling when an imported child index is equivalent.
+
+    An authorised device edit may replace real content, but it should not turn
+    a wire-written ``NULL`` into the equivalent device sentinel ``-99`` as a
+    side effect.  A genuinely different child index still comes from the newer
+    device row.
+    """
+    if (
+        _matching_container_child_index(existing)
+        == _matching_container_child_index(imported)
+    ):
+        return existing
+    return imported
 
 
 def _matching_annotation_values(values):
@@ -1610,6 +1627,13 @@ def _bookmark_matches_annotation(bm, content_id, row) -> bool:
 def _apply_imported_bookmark(row, bm, content_id, *, device_modified_at,
                              origin_device_id):
     """Apply the content half of an already-authorised newer device edit."""
+    imported_values = list(_bookmark_values(bm, content_id))
+    imported_values[5] = _imported_container_child_index(
+        row.start_container_child_index, imported_values[5],
+    )
+    imported_values[8] = _imported_container_child_index(
+        row.end_container_child_index, imported_values[8],
+    )
     (
         row.highlighted_text,
         row.note_text,
@@ -1624,7 +1648,7 @@ def _apply_imported_bookmark(row, bm, content_id, *, device_modified_at,
         row.context_string,
         row.chapter_progress,
         row.annotation_type,
-    ) = _bookmark_values(bm, content_id)
+    ) = imported_values
     row.client_modified_at = device_modified_at
     row.server_modified_at = datetime.now(timezone.utc)
     row.last_synced = datetime.now(timezone.utc)

--- a/tests/unit/test_annotations_import_endpoint.py
+++ b/tests/unit/test_annotations_import_endpoint.py
@@ -216,19 +216,16 @@ class TestIngestCounts:
 
 @pytest.mark.unit
 class TestWireAndDatabaseSentinelEquivalence:
-    def test_wire_delivered_annotation_is_already_present(
-        self, memory_db, synthetic_db, monkeypatch,
-    ):
-        """NULL on the wire and -99 in SQLite describe one KoboSpan selector."""
+    BOOK_UUID = "b3d1b38b-74fd-43b7-a796-996e5a6a8b04"
+
+    @staticmethod
+    def _write_wire_row(session, monkeypatch):
         from cps import ub
-        from cps.annotations import ingest_bookmarks
         from cps.services.annotation_sync import (
             dispatch_annotation_sync,
             reset_registry_for_testing,
             set_remote_enqueue,
         )
-
-        session, _, _ = memory_db
 
         def commit():
             session.commit()
@@ -238,8 +235,11 @@ class TestWireAndDatabaseSentinelEquivalence:
         monkeypatch.setattr(ub, "session_commit", commit)
         reset_registry_for_testing()
         set_remote_enqueue(None)
-        book_uuid = "b3d1b38b-74fd-43b7-a796-996e5a6a8b04"
-        book = SimpleNamespace(id=348, uuid=book_uuid, title="Animal Farm")
+        book = SimpleNamespace(
+            id=348,
+            uuid=TestWireAndDatabaseSentinelEquivalence.BOOK_UUID,
+            title="Animal Farm",
+        )
         user = SimpleNamespace(id=7)
         payload = {
             "id": "bm-001",
@@ -265,12 +265,23 @@ class TestWireAndDatabaseSentinelEquivalence:
         ).one()
         assert wire_row.start_container_child_index is None
         assert wire_row.end_container_child_index is None
+        return wire_row, commit
+
+    def test_wire_delivered_annotation_is_already_present(
+        self, memory_db, synthetic_db, monkeypatch,
+    ):
+        """NULL on the wire and -99 in SQLite describe one KoboSpan selector."""
+        from cps import ub
+        from cps.annotations import ingest_bookmarks
+
+        session, _, _ = memory_db
+        _, commit = self._write_wire_row(session, monkeypatch)
 
         result = ingest_bookmarks(
             synthetic_db,
             user_id=7,
             session=session,
-            book_lookup=_make_book_lookup({book_uuid: 348}),
+            book_lookup=_make_book_lookup({self.BOOK_UUID: 348}),
             commit=commit,
         )
 
@@ -279,6 +290,59 @@ class TestWireAndDatabaseSentinelEquivalence:
         assert session.query(ub.Annotation).filter_by(
             user_id=7, book_id=348, annotation_id="bm-001",
         ).count() == 1
+
+    def test_wire_delivered_annotation_with_newer_server_content_is_rejected(
+        self, memory_db, synthetic_db, monkeypatch,
+    ):
+        """Sentinel equivalence must not hide a real server-side edit."""
+        from cps.annotations import ingest_bookmarks
+
+        session, _, _ = memory_db
+        wire_row, commit = self._write_wire_row(session, monkeypatch)
+        wire_row.note_text = "newer server note"
+        session.commit()
+
+        result = ingest_bookmarks(
+            synthetic_db,
+            user_id=7,
+            session=session,
+            book_lookup=_make_book_lookup({self.BOOK_UUID: 348}),
+            commit=commit,
+        )
+
+        assert result["skipped_existing"] == 0, result
+        assert result["skipped_newer_server"] == 1, result
+        assert wire_row.note_text == "newer server note"
+        assert wire_row.start_container_child_index is None
+        assert wire_row.end_container_child_index is None
+
+    def test_newer_device_edit_preserves_wire_child_index_representation(
+        self, memory_db, synthetic_db, monkeypatch,
+    ):
+        """A content update must not turn wire NULLs into equivalent -99s."""
+        from cps.annotations import ingest_bookmarks
+
+        session, _, _ = memory_db
+        wire_row, commit = self._write_wire_row(session, monkeypatch)
+        old_clock = datetime(2025, 1, 1)
+        wire_row.client_modified_at = old_clock
+        wire_row.server_modified_at = old_clock
+        wire_row.last_synced = old_clock
+        wire_row.created_at = old_clock
+        session.commit()
+
+        result = ingest_bookmarks(
+            synthetic_db,
+            user_id=7,
+            session=session,
+            book_lookup=_make_book_lookup({self.BOOK_UUID: 348}),
+            commit=commit,
+        )
+
+        assert result["updated"] == 1, result
+        assert result["skipped_newer_server"] == 0, result
+        assert wire_row.start_container_child_index is None
+        assert wire_row.end_container_child_index is None
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Why

Addresses #1886.

PR #2003 landed the primary matcher normalization on `main` while this task was in flight. That made a wire-written `NULL` row and its device `-99` counterpart count as the same annotation, but the issue also called out a second effect: an authorized newer device edit still rewrote the live row from `NULL` to the equivalent `-99` representation.

## Root cause

`_apply_imported_bookmark` assigned the complete device tuple directly. The matcher knew `NULL` and `-99` were equivalent, but the update path did not use that equivalence and introduced representation-only churn.

## Fix

- Keep the existing child-index spelling when the stored and imported values normalize to the same semantic value.
- Still replace genuinely different positive child indices from an authorized newer device row.
- Cite the measured wire behavior at `cps/services/kobo_position.py:153` in the matcher comment.
- Exercise the real wire dispatcher followed by the KoboReader.sqlite importer in all counter cases.

The counters now mean:

- `skipped_existing`: all semantic annotation fields match; wire `NULL` and device `-99` are the same KoboSpan no-child-anchor value.
- `skipped_newer_server`: the device row lacks overwrite authority and at least one semantic field really differs; sentinel spelling alone cannot produce this count.

## Red / green evidence

On current `origin/main`, the new authorized-update regression was red with `assert -99 is None` (`1 failed, 2 passed`). With this change the focused class is `3 passed`.

The primary counter regression itself was already green on current `origin/main` because #2003 merged before this branch started; the stale dispatch premise that current main lacked that fix could not honestly be reproduced. The same-path negative case newly proves a real server note edit still yields `skipped_newer_server == 1`.

## Sabotage

Removed the `-99` arm at the single normalization choke point and reran the focused class: `2 failed, 1 passed`. The identical wire/device row reverted to `skipped_existing == 0`, and the representation-preservation test reverted to `-99 is None`. Restored the arm and reran: `3 passed`.

## Validation

- Focused annotation/Kobo slice: `98 passed in 1.50s`.
- Full unit suite: `7784 passed, 109 skipped, 6166 warnings in 595.05s (0:09:55)`.
- `git diff --check`: clean.

## Scope

No dependency, schema, route, authentication, or user-visible string change. No live hardware/container run: the regression drives the production wire dispatcher into an in-memory app DB and then imports the production-shaped KoboReader.sqlite fixture, which exercises the affected request-to-import state transition without middleware or deployment changes.