### PR TITLE
fix(kobo): refresh library without disposing the shared engine

### DIFF
--- a/changelog.d/1977-kobo-sync-refresh.md
+++ b/changelog.d/1977-kobo-sync-refresh.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- **Kobo library sync no longer closes the shared library database connection
+  underneath other requests.** Sync still refreshes its view of books written
+  by Calibre desktop or a network-share workflow, but now uses the existing
+  non-disposing refresh path. If that refresh cannot complete, the request
+  returns a defined service-unavailable response and writes a Kobo-specific
+  error to the server log instead of disappearing mid-sync (#1977, #1857).

--- a/cps/db.py
+++ b/cps/db.py
@@ -2371,22 +2371,44 @@ class CalibreDB:
         Replaces the prior async TaskReconnectDatabase path which
         disposed the shared engine on a worker thread and raced with
         in-flight request greenlets (fork issue #192).
+
+        Every instance is attempted. If any active session cannot be
+        refreshed, raise after the sweep so callers never mistake a partial
+        refresh for success.
         """
+        failures = []
         with cls._reconnect_lock:
             for inst in list(cls.instances):
                 try:
-                    if inst.session is not None:
-                        try:
-                            inst.session.expire_all()
-                        except Exception:
-                            pass
-                        try:
-                            inst.session.rollback()
-                        except Exception:
-                            pass
-                except Exception:
-                    # One bad instance must not block the rest.
+                    session = inst._peek_session()
+                    if session is None:
+                        continue
+                except Exception as exc:
+                    # Refresh every other instance before reporting failure to
+                    # the caller. A partial refresh must not be reported as a
+                    # success: request handlers need a defined failure path.
+                    failures.append(exc)
                     continue
+
+                session_failure = None
+                try:
+                    session.expire_all()
+                except Exception as exc:
+                    session_failure = exc
+                try:
+                    session.rollback()
+                except Exception as exc:
+                    if session_failure is None:
+                        session_failure = exc
+                if session_failure is not None:
+                    failures.append(session_failure)
+
+        if failures:
+            raise RuntimeError(
+                "Could not refresh {} Calibre database session(s)".format(
+                    len(failures)
+                )
+            ) from failures[0]
 
 
 def lcase(s):

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -719,7 +719,11 @@ def HandleSyncRequest():
     books_to_delete_ids = set()
     rehydrate_positions_emitted = []
 
-    calibre_db.reconnect_db(config, ub.app_DB_path)
+    try:
+        calibre_db.refresh_for_new_data()
+    except Exception:
+        log.exception("Kobo Sync: failed to refresh the library database")
+        return abort(503)
 
     # Upgrade bridge: existing devices already have flat delivery markers but
     # no per-device hashes. Seed before selecting any replay so the FIRST

--- a/tests/unit/test_1925_kobo_sync_dedownload.py
+++ b/tests/unit/test_1925_kobo_sync_dedownload.py
@@ -160,6 +160,7 @@ def sync_harness(monkeypatch):
     fake_calibre_db = SimpleNamespace(
         session=session,
         reconnect_db=lambda *_args, **_kwargs: None,
+        refresh_for_new_data=lambda: None,
         common_filters=lambda **_kwargs: true(),
         get_book=lambda book_id: session.query(db.Books).filter_by(id=book_id).one_or_none(),
         get_book_by_uuid_for_kobo=lambda book_uuid, **_kwargs: session.query(
@@ -264,6 +265,79 @@ def sync_harness(monkeypatch):
 
     session.close()
     engine.dispose()
+
+
+def test_sync_refresh_preserves_a_concurrent_library_session(
+    sync_harness, monkeypatch,
+):
+    """A library sync must not dispose the engine under another request.
+
+    The old reconnect path disposed the shared StaticPool connection. Keep a
+    second SQLAlchemy session in a live transaction while the real Kobo sync
+    body runs; that session must remain usable after the refresh.
+    """
+    from cps import db
+
+    engine = sync_harness.session.get_bind()
+    concurrent_session = sessionmaker(bind=engine)()
+    dispose_calls = []
+
+    def destructive_reconnect(*_args, **_kwargs):
+        dispose_calls.append(True)
+        engine.dispose()
+
+    def nondisposing_refresh():
+        sync_harness.session.expire_all()
+        sync_harness.session.rollback()
+
+    monkeypatch.setattr(
+        sync_harness.calibre_db, "reconnect_db", destructive_reconnect
+    )
+    monkeypatch.setattr(
+        sync_harness.calibre_db, "refresh_for_new_data", nondisposing_refresh
+    )
+
+    try:
+        assert concurrent_session.query(db.Books).count() == 1
+        response = sync_harness.sync()
+
+        assert response.status_code == 200
+        assert dispose_calls == [], (
+            "Kobo sync invoked the destructive reconnect path and disposed "
+            "the class-level library engine"
+        )
+        assert concurrent_session.query(db.Books).count() == 1, (
+            "Kobo sync invalidated a concurrent library session"
+        )
+    finally:
+        concurrent_session.close()
+
+
+def test_sync_refresh_failure_logs_kobo_error_and_aborts_503(
+    sync_harness, monkeypatch, caplog,
+):
+    """An incomplete pre-sync refresh is loud and has a stable HTTP status."""
+    from werkzeug.exceptions import ServiceUnavailable
+
+    def fail_refresh():
+        raise RuntimeError("library refresh unavailable")
+
+    monkeypatch.setattr(
+        sync_harness.calibre_db, "refresh_for_new_data", fail_refresh
+    )
+
+    with caplog.at_level(logging.ERROR, logger="cps.kobo"):
+        with pytest.raises(ServiceUnavailable) as exc_info:
+            sync_harness.sync()
+
+    assert exc_info.value.code == 503
+    assert any(
+        record.name == "cps.kobo"
+        and "Kobo Sync: failed to refresh the library database"
+        in record.getMessage()
+        and record.exc_info is not None
+        for record in caplog.records
+    ), "refresh failure must produce a Kobo-side exception log before aborting"
 
 
 def test_interrupted_sync_token_loss_does_not_redeliver_unchanged_entitlement(

--- a/tests/unit/test_kobo_cont_sync_firmware_cursor.py
+++ b/tests/unit/test_kobo_cont_sync_firmware_cursor.py
@@ -93,6 +93,7 @@ def test_full_library_sync_drains_when_firmware_pins_cursor_on_continue(
     fake_calibre_db = SimpleNamespace(
         session=session,
         reconnect_db=lambda *_args, **_kwargs: None,
+        refresh_for_new_data=lambda: None,
         common_filters=lambda **_kwargs: true(),
     )
 

--- a/tests/unit/test_metadata_db_write_coordination.py
+++ b/tests/unit/test_metadata_db_write_coordination.py
@@ -171,6 +171,45 @@ class TestReconnectEndpointIsSynchronousAndLightweight:
             "engine-recreating and racy."
         )
 
+    def test_refresh_helper_reports_partial_failure_after_sweeping_instances(
+        self, monkeypatch
+    ):
+        """A failed session is not silently treated as a complete refresh."""
+        from cps.db import CalibreDB
+
+        calls = []
+
+        class GoodSession:
+            def expire_all(self):
+                calls.append("good-expire")
+
+            def rollback(self):
+                calls.append("good-rollback")
+
+        class BadSession:
+            def expire_all(self):
+                calls.append("bad-expire")
+                raise RuntimeError("expire failed")
+
+            def rollback(self):
+                calls.append("bad-rollback")
+
+        good = CalibreDB()
+        good.session = GoodSession()
+        bad = CalibreDB()
+        bad.session = BadSession()
+        monkeypatch.setattr(CalibreDB, "instances", {good, bad})
+
+        with pytest.raises(RuntimeError, match="Could not refresh 1"):
+            CalibreDB.refresh_for_new_data()
+
+        assert set(calls) == {
+            "good-expire",
+            "good-rollback",
+            "bad-expire",
+            "bad-rollback",
+        }
+
 
 # ---------------------------------------------------------------------------
 # Contributor 2 — process-shared advisory flock for metadata.db writers

--- a/tests/unit/test_my_library_backend_1939.py
+++ b/tests/unit/test_my_library_backend_1939.py
@@ -1866,6 +1866,7 @@ def _exercise_seed_on_enable_kobo_sync(monkeypatch, *, wire_contract):
     cdb.session = session
     cdb.config = SimpleNamespace(config_restricted_column=0)
     cdb.reconnect_db = lambda *_args, **_kwargs: None
+    cdb.refresh_for_new_data = lambda: None
     monkeypatch.setattr(db.ub, "session", session)
     monkeypatch.setattr(db, "current_user", user)
     monkeypatch.setattr(ub, "session", session)

--- a/tests/unit/test_my_library_leg6_regressions.py
+++ b/tests/unit/test_my_library_leg6_regressions.py
@@ -89,6 +89,7 @@ def test_sync_all_delivers_old_books_after_membership_add_across_pages(monkeypat
     )
     cdb = SimpleNamespace(
         session=session, reconnect_db=lambda *_a, **_kw: None,
+        refresh_for_new_data=lambda: None,
         common_filters=lambda **_kw: true(),
     )
     monkeypatch.setattr(ub, "session", session)


### PR DESCRIPTION
## User symptom

Kobo library sync can stop with “Sync failed” before any later `cps.kobo` log line, while concurrent library work can fail with a closed-database error. This addresses #1977 and the unresolved sync half of #1857.

## Mechanism and fix

**OBSERVED:** `/v1/library/sync` unconditionally called `reconnect_db()`. That path disposes the class-level SQLAlchemy engine and every live library session before rebuilding them. A concurrent request can therefore lose its connection, and a rebuild failure can abort the sync outside any Kobo-specific error boundary.

The sync route now uses the existing synchronous, non-disposing `refresh_for_new_data()` model. It expires loaded objects and rolls back held read transactions so Calibre desktop and network-share writes remain visible without closing the shared engine. The refresh helper attempts every live instance and reports partial failure after the sweep. The Kobo route logs that exception and returns HTTP 503.

No KEPUB conversion or delivery behavior changed.

## Regression evidence

- **OBSERVED red on `origin/main` (`8114dd8bdd`):** the two new route tests both failed. The concurrency test aborted inside the real sync body with `sqlalchemy.exc.ProgrammingError: Cannot operate on a closed database`; the forced refresh failure produced no 503 because the route never called the refresh helper.
- **OBSERVED green with the fix:** focused route/refresh/current-main tests: `21 passed, 56 warnings in 3.40s`.
- **OBSERVED sabotage:** replacing the fixed route call with the old `reconnect_db(config, ub.app_DB_path)` call made the concurrency regression test fail again with `Cannot operate on a closed database` (exit 1); restoring the refresh call returned it to green.
- **OBSERVED full unit pass before the final test-only upstream rebase:** `========= 7785 passed, 109 skipped, 6222 warnings in 426.79s (0:07:06) =========`.
- **OBSERVED current-base aggregate caveat:** two local aggregate attempts ran under extreme shared-machine load and each had one unrelated timing failure with all 7,788 other tests green. One missed the s6 unresponsive-watcher two-second deadline; the next measured an existing process-lock wait at 0.23s versus its 0.3s minimum. Both cases pass focused; the upstream mutation-harness tests added by the rebase also pass 4/4. No production path involved in either timing failure is changed here.

## Scope and confidence

**OBSERVED:** the old reconnect is gone from the Kobo sync route; the regression holds a concurrent SQLAlchemy session open across the real handler body and proves it remains queryable; forced refresh failure logs a `cps.kobo` exception and aborts with 503.

**ASSUMED:** this reconnect race is the exact request-level failure seen by the #1857 reporters. The source mechanism and matching closed-database behavior are reproduced, but the original device request and deployment conditions were not reproduced locally.

**NOT ESTABLISHED:** the reported KEPUB-preference correlation. The reconnect ran in both preference states, and this PR intentionally does not change KEPUB behavior.

Practical physical-device/container reproduction was not performed because the reporter’s library, concurrency timing, and device request were unavailable locally. The real Flask handler body, database engine disposal, concurrent session, failure log, and HTTP abort status are covered directly by unit regressions.

## Isolated CI

**OBSERVED on pushed SHA `4750369bf1`:** GitHub Fast Tests (Smoke + Unit) passed in 6m39s, Docker integration passed in 11m15s, both architecture image builds passed, and author/path validation passed. This isolated-run result resolves the shared-Mac timing caveat above; SPA E2E was still pending when this evidence was recorded.