### PR TITLE
test(kobo): a seeded membership must be silent on the wire, and a later one must not be

### DIFF
--- a/tests/unit/test_my_library_backend_1939.py
+++ b/tests/unit/test_my_library_backend_1939.py
@@ -834,9 +834,8 @@ def test_http_route_contract_is_registered():
     assert routes["/ajax/mylibrary/<int:book_id>/remove"] >= {"POST"}
 
 
-def test_seed_on_enable_is_chunked_idempotent_and_preserves_next_kobo_sync(
-        monkeypatch):
-    """The enable transition must not turn already-synced books into removals."""
+def _exercise_seed_on_enable_kobo_sync(monkeypatch, *, wire_contract):
+    """Drive the shared seed/re-seed fixture into the real Kobo sync route."""
     from cps import kobo as kobo_module, kobo_sync_status, user_library
 
     engine = create_engine("sqlite://")
@@ -944,18 +943,74 @@ def test_seed_on_enable_is_chunked_idempotent_and_preserves_next_kobo_sync(
             headers={kobo_module.SyncToken.SyncToken.SYNC_TOKEN_HEADER: token},
         ):
             response = kobo_module.HandleSyncRequest.__wrapped__()
-        archived = [
-            item for item in response.get_json()
-            if item.get("ChangedEntitlement", {})
-            .get("BookEntitlement", {}).get("IsRemoved") is True
-        ]
-        assert archived == []
         assert session.query(ub.ArchivedBook).filter_by(user_id=user.id).count() == 1
         assert session.query(ub.UserHiddenBook).filter_by(user_id=user.id).count() == 1
         assert session.query(ub.KoboSyncedBooks).filter_by(user_id=user.id).count() == 5
+
+        if wire_contract:
+            entitlement_envelopes = [
+                item for item in response.get_json()
+                if "NewEntitlement" in item or "ChangedEntitlement" in item
+            ]
+            assert entitlement_envelopes == []
+
+            # Prove the zero-wave guard did not make the membership cursor
+            # inert. This book enters the metadata database only after the
+            # baseline seed, but carries an old modification/creation clock.
+            # Its membership added_at is therefore the only cursor arm that
+            # can deliver it.
+            old = datetime(2026, 1, 1, 12, 0, 0)
+            later_book = _book(6, "Added after seed")
+            later_book.last_modified = old
+            later_book.timestamp = old
+            later_book.uuid = "uuid-6"
+            session.add(later_book)
+            session.add(db.Data(later_book.id, "EPUB", 1, "book-6"))
+            session.commit()
+            assert user_library.admin_add_book(
+                user, later_book.id, app_session=session, cdb=cdb
+            ).id == later_book.id
+
+            next_token = response.headers[
+                kobo_module.SyncToken.SyncToken.SYNC_TOKEN_HEADER
+            ]
+            with app.test_request_context(
+                "/v1/library/sync",
+                headers={
+                    kobo_module.SyncToken.SyncToken.SYNC_TOKEN_HEADER:
+                        next_token
+                },
+            ):
+                later_response = kobo_module.HandleSyncRequest.__wrapped__()
+            delivered = [
+                item.get("NewEntitlement") or item.get("ChangedEntitlement")
+                for item in later_response.get_json()
+                if "NewEntitlement" in item or "ChangedEntitlement" in item
+            ]
+            assert [
+                int(item["BookEntitlement"]["Id"]) for item in delivered
+            ] == [later_book.id]
+        else:
+            archived = [
+                item for item in response.get_json()
+                if item.get("ChangedEntitlement", {})
+                .get("BookEntitlement", {}).get("IsRemoved") is True
+            ]
+            assert archived == []
     finally:
         session.close()
         engine.dispose()
+
+
+def test_seed_on_enable_is_chunked_idempotent_and_preserves_next_kobo_sync(
+        monkeypatch):
+    """The enable transition must not turn already-synced books into removals."""
+    _exercise_seed_on_enable_kobo_sync(monkeypatch, wire_contract=False)
+
+
+def test_seed_and_reseed_are_wire_silent_but_later_addition_syncs(monkeypatch):
+    """Baseline membership is silent; a later membership remains deliverable."""
+    _exercise_seed_on_enable_kobo_sync(monkeypatch, wire_contract=True)
 
 
 def test_rejected_post_seed_switch_keeps_fence_false_and_retry_seeds(


### PR DESCRIPTION
## The constant this protects

`cps/user_library.py` seeds membership rows with `"added_at": datetime.min`. The Kobo delivery key is `max(Books.last_modified, UserLibraryBook.added_at)`, so that constant is the only thing stopping a mode switch from arriving at **every Kobo on the server as N brand-new books**. On a 20k-book archive that is the difference between an invisible administrative change and every device on the household re-downloading the library.

It had exactly **one** guard, and that guard was a direct assertion on the stored column value. Measured by mutation on main: changing it to `datetime.utcnow()` produced `1 failed, 69 passed`. One edit to one test and the protection disappears silently.

## A second guard, deliberately of a different shape

Another assertion on the column would be the same test twice. This one asserts the **consequence at the wire**: after the account is switched to `personal_library`, the real chunked seed runs, and an idempotent re-seed runs, a real `HandleSyncRequest` inside a real Flask request context — driven with the device sync token — returns a response containing neither `NewEntitlement` nor `ChangedEntitlement`.

It never reads `added_at`.

## Why it is not vacuous, which is the part that matters

A naive "zero new entitlements after seeding" assertion passes for **two different reasons**, and only one of them is correct:

1. the seed is silent because `added_at` predates every device cursor — what we want; or
2. membership additions are invisible to the cursor **permanently** — which would also produce zero, and is the obvious wrong fix.

So the test carries a negative control. After the silent sync it creates book 6, gives it modification and creation timestamps deliberately **older** than the device cursor, adds it via `user_library.admin_add_book`, carries forward the token from the first sync, and asserts book 6 **is** delivered. Because book 6's metadata clocks are older than the cursor, its membership `added_at` is the only arm of the delivery key capable of selecting it.

Both directions were then confirmed by mutation, through `tests/mutation/mutate.py` so every restore was hash-verified:

| direction | mutant | result |
|---|---|---|
| the seed must be silent | `datetime.min` → `datetime.utcnow()` in `user_library.py` | **caught** — 1 failed |
| a later membership must still reach the device | drop the `added_at` arm from `library_delivery_key` in `cps/kobo.py` | **caught** — 1 failed |

The second mutant is what proves the control does its job: without it, a change that froze membership out of the cursor forever would sail through a "zero new entitlements" test.

## Also covered by the shared fixture

Idempotence (`prepare_user_library_seed` re-run returns `0` and leaves membership at five rows), chunking (a five-book seed performed in three bounded write chunks, with the expected commit sequence: read release, three chunk commits, then the atomic seed-fence/mode commit), and the pre-existing guard that the mode switch does not turn hidden or archived books into Kobo *removal* commands.

Tests only — one file, 64 insertions. No changelog fragment, per `changelog.d/README.md`.
