### PR TITLE
feat(kobo): per-device reading positions with rehydrate-on-sync (#1942 M3)

### DIFF
--- a/changelog.d/1942-m3-device-reading-position.md
+++ b/changelog.d/1942-m3-device-reading-position.md
@@ -1,0 +1,14 @@
+### Added
+
+- **Reading positions are now retained per Kobo and browser device.** A
+  re-downloaded Kobo book receives its resolved reading state on the next sync
+  even when the normal reading-state cursor is already ahead, while
+  byte-identical entitlement replays remain suppressed without re-arming the
+  repair.
+
+### Fixed
+
+- **A fresh-download cover reset can no longer overwrite a real cross-device
+  position.** Device observations remain independently inspectable, resolved
+  progress keeps the furthest position, and status and reading statistics use
+  the newest valid device timestamp.

--- a/changelog.d/1942-m3-device-reading-position.md
+++ b/changelog.d/1942-m3-device-reading-position.md
@@ -1,14 +1,19 @@
 ### Added
 
 - **Reading positions are now retained per Kobo and browser device.** A
-  re-downloaded Kobo book receives its resolved reading state on the next sync
-  even when the normal reading-state cursor is already ahead, while
-  byte-identical entitlement replays remain suppressed without re-arming the
-  repair.
+  re-downloaded Kobo book receives its resolved reading state on a subsequent,
+  bounded sync page even when the normal reading-state cursor is already
+  ahead. The response which offers replacement bytes only arms the repair;
+  byte-identical entitlement replays remain suppressed without re-arming it.
 
 ### Fixed
 
 - **A fresh-download cover reset can no longer overwrite a real cross-device
   position.** Device observations remain independently inspectable, resolved
-  progress keeps the furthest position, and status and reading statistics use
-  the newest valid device timestamp.
+  progress suppresses only an armed near-cover reset, intentional newer
+  backward jumps still reach the resolved row and external progress carriers,
+  and status and reading statistics use the newest valid device timestamp.
+- **Kobo sync response state is committed atomically.** Shelf tombstones,
+  entitlement fingerprints, synced-book markers, and position repair latches
+  now share the request's one checked commit, so a failed response remains
+  fully retryable.

--- a/cps/api/reader.py
+++ b/cps/api/reader.py
@@ -101,6 +101,7 @@ def save_bookmark(book_id):
                     book_id,
                     percentage,
                     origin_device_id=g.annotation_origin_device_id,
+                    cfi=bookmark_key,
                 )
             except Exception as e:
                 # Position sharing must never cost the user their bookmark.

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -59,6 +59,10 @@ KOBO_STOREAPI_URL = "https://storeapi.kobo.com"
 KOBO_IMAGEHOST_URL = "https://cdn.kobo.com/book-images"
 
 SYNC_ITEM_LIMIT = 100
+# Nickel reports a fresh/replaced download at the cover.  Only this narrow
+# start-of-book shape is eligible for the armed rehydrate no-regress guard;
+# ordinary newer backward jumps remain intentional reading movements.
+KOB0_COVER_RESET_PROGRESS_EPSILON = 1.0
 
 # Stored alongside the payload hash, never sent to Kobo.  Increment this when
 # the server intentionally changes the entitlement renderer's declared shape;
@@ -166,7 +170,8 @@ def _seed_existing_device_entitlement_ledgers(user_id):
     A durable per-device completion marker prevents later missing rows from
     being mistaken for migration work: resend, unsync, archive, purge and
     duplicate-merge paths deliberately clear individual ledger rows so the
-    next sync can deliver them.
+    next sync can deliver them. All writes are staged for HandleSyncRequest's
+    single checked commit; this helper never commits independently.
     """
     device_ids = kobo_sync_status.get_unseeded_kobo_device_ids(user_id)
     if not device_ids:
@@ -183,8 +188,6 @@ def _seed_existing_device_entitlement_ledgers(user_id):
             kobo_sync_status.user_has_completed_entitlement_seed(user_id)
         if existing_user_seed:
             kobo_sync_status.mark_device_entitlement_ledgers_seeded(device_ids)
-            if ub.session_commit() is False:
-                return False
             elapsed_ms = round((monotonic() - started) * 1000, 1)
             log.debug(
                 "Kobo Sync ledger seed: user=%s devices=%d books=0 deleted=0 "
@@ -323,11 +326,6 @@ def _seed_existing_device_entitlement_ledgers(user_id):
                 ENTITLEMENT_PAYLOAD_SCHEMA_VERSION,
             )
         kobo_sync_status.mark_device_entitlement_ledgers_seeded(device_ids)
-        # Legacy tests and a few downstream integrations replace this helper
-        # with a commit callable that returns None. Only the real helper's
-        # explicit False means the transaction was rolled back.
-        if ub.session_commit() is False:
-            return False
     except Exception:
         ub.session.rollback()
         log.exception(
@@ -666,6 +664,11 @@ def HandleSyncRequest():
     sync_token = SyncToken.SyncToken.from_headers(request.headers)
     sync_cursor_in = _sync_cursor_summary(sync_token)
     requesting_device_id = getattr(g, "annotation_origin_device_id", None)
+    # A server-time fence distinguishes repair work that existed when this
+    # request began from work armed by an entitlement/reset in this response.
+    # The latter must survive until the next request, after the device has had
+    # a chance to download and report a cover-shaped reset.
+    rehydrate_request_cutoff = device_positions.rehydrate_request_cutoff()
     replay_suppression_enabled = bool(getattr(
         config, "config_kobo_suppress_replayed_entitlements", True))
     # Layer 2 deliberately cannot suppress a tokenless request. A factory
@@ -1327,11 +1330,12 @@ def HandleSyncRequest():
             new_reading_state_last_modified = max(new_reading_state_last_modified, kobo_reading_state.last_modified)
 
     # Re-download repair is independent of the opaque reading-state cursor.
-    # Rows armed by a non-identical entitlement (or the legacy-marker reset)
-    # are deliberately emitted even if this response already carried the same
-    # state next to an entitlement: the standalone envelope is the repair
-    # contract. Clear only rows we can actually render, and stage that clear in
-    # the single checked request-level commit below.
+    # Only latches which pre-date this request are eligible: work armed by an
+    # entitlement/reset in this response must remain queued until a later sync,
+    # after the device has had a chance to replace the bytes. Entitlements
+    # delivered in this response are excluded even when their latch was older.
+    # The cap bounds renderer migrations/account resets; unserved rows stay
+    # latched and drain in book-id order on later requests.
     if requesting_device_id:
         pending_rehydrates = (
             ub.session.query(
@@ -1347,11 +1351,17 @@ def HandleSyncRequest():
                 ub.DeviceReadingPosition.device_id
                 == int(requesting_device_id),
                 ub.DeviceReadingPosition.rehydrate_needed.is_(True),
+                ub.DeviceReadingPosition.server_modified_at
+                < rehydrate_request_cutoff,
                 ub.KoboReadingState.user_id == current_user.id,
             )
             .order_by(ub.DeviceReadingPosition.book_id)
-            .all()
         )
+        if rehydrate_book_ids:
+            pending_rehydrates = pending_rehydrates.filter(
+                ub.DeviceReadingPosition.book_id.notin_(rehydrate_book_ids),
+            )
+        pending_rehydrates = pending_rehydrates.limit(SYNC_ITEM_LIMIT).all()
         for position, kobo_reading_state in pending_rehydrates:
             book = calibre_db.session.query(db.Books).filter(
                 db.Books.id == position.book_id,
@@ -1532,9 +1542,9 @@ def HandleSyncRequest():
             ub.KoboSyncedBooks.book_id.in_(books_to_delete_ids),
         ).delete(synchronize_session=False)
 
-    # Do not move this mutation above ``sync_shelves``: that legacy helper
-    # still has unchecked commits. The latch is acknowledged only here, with
-    # no intervening commit before the checked request-level boundary.
+    # The latch is acknowledged only here. Every sync helper above is
+    # stage-only, so this mutation and all response ledger/shelf effects become
+    # durable together at the checked request-level boundary below.
     for position in rehydrate_positions_emitted:
         position.rehydrate_needed = False
 
@@ -2258,6 +2268,7 @@ def HandleTagRemoveItem(tag_id):
 # Add new, changed, or deleted shelves to the sync_results.
 # Note: Public shelves that aren't owned by the user aren't supported.
 def sync_shelves(sync_token, sync_results, only_kobo_shelves=False):
+    """Stage shelf response effects for HandleSyncRequest's checked commit."""
     new_tags_last_modified = sync_token.tags_last_modified
     # transmit all archived shelfs independent of last sync (why should this matter?)
     for shelf in ub.session.query(ub.ShelfArchive).filter(ub.ShelfArchive.user_id == current_user.id):
@@ -2271,7 +2282,6 @@ def sync_shelves(sync_token, sync_results, only_kobo_shelves=False):
             }
         })
         ub.session.delete(shelf)
-        ub.session_commit()
 
     extra_filters = []
     if only_kobo_shelves:
@@ -2316,7 +2326,6 @@ def sync_shelves(sync_token, sync_results, only_kobo_shelves=False):
                 "ChangedTag": tag
             })
     sync_token.tags_last_modified = new_tags_last_modified
-    ub.session_commit()
 
 
 # Creates a Kobo "Tag" object from a ub.Shelf object
@@ -2419,16 +2428,25 @@ def HandleStateRequest(book_uuid):
                 )
 
                 stored_progress = current_bookmark.progress_percent
-                resolved_bookmark_accepted = (
-                    incoming_progress is None
-                    and device_positions.timestamp_is_newer(
-                        request_lm, current_bookmark.last_modified,
-                    )
-                ) or (
-                    incoming_progress is not None
-                    and (
-                        stored_progress is None
-                        or incoming_progress >= stored_progress
+                incoming_is_newer = device_positions.timestamp_is_newer(
+                    request_lm, current_bookmark.last_modified,
+                )
+                cover_reset_suppressed = bool(
+                    rehydrate_pending
+                    and incoming_progress is not None
+                    and stored_progress is not None
+                    and incoming_progress < stored_progress
+                    and incoming_progress
+                    <= KOB0_COVER_RESET_PROGRESS_EPSILON
+                )
+                resolved_bookmark_accepted = not cover_reset_suppressed and (
+                    incoming_is_newer
+                    or (
+                        incoming_progress is not None
+                        and (
+                            stored_progress is None
+                            or incoming_progress >= stored_progress
+                        )
                     )
                 )
                 if resolved_bookmark_accepted:
@@ -2443,12 +2461,10 @@ def HandleStateRequest(book_uuid):
                         current_bookmark.location_type = location["Type"]
                         current_bookmark.location_source = location["Source"]
                     _apply_kobo_last_modified(current_bookmark, request_lm)
-                elif (incoming_progress is not None
-                      and stored_progress is not None
-                      and incoming_progress < stored_progress):
+                elif cover_reset_suppressed:
                     log.info(
-                        "Kobo position decrease suppressed for device %s "
-                        "book %s (rehydrate_pending=%s): %.2f%% < %.2f%%",
+                        "Kobo cover reset suppressed for device %s book %s "
+                        "(rehydrate_pending=%s): %.2f%% < %.2f%%",
                         getattr(g, "annotation_origin_device_id", None),
                         book.id,
                         rehydrate_pending,

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -49,6 +49,7 @@ from .kobo_cover_cache import build_cover_image_id, normalize_cover_uuid
 from .helper import get_download_link
 from .services import SyncToken as SyncToken, hardcover
 from .services import cover_preview, parallel
+from .services import device_reading_position as device_positions
 from .fs import FileSystem
 from .web import download_required
 from .kobo_auth import requires_kobo_auth, get_auth_token
@@ -683,6 +684,12 @@ def HandleSyncRequest():
 
     # if no books synced don't respect sync_token
     if not ub.session.query(ub.KoboSyncedBooks).filter(ub.KoboSyncedBooks.user_id == current_user.id).count():
+        # A cleared legacy marker is the account-level reset signal. Re-arm
+        # only this requesting device's existing position rows; another Kobo's
+        # journal must not gain response work because this device lost state.
+        device_positions.mark_existing_positions_for_rehydrate(
+            requesting_device_id,
+        )
         sync_token.books_last_modified = datetime.min
         sync_token.books_last_created = datetime.min
         sync_token.reading_state_last_modified = datetime.min
@@ -707,6 +714,7 @@ def HandleSyncRequest():
     new_archived_last_modified = datetime.min
     sync_results = []
     books_to_delete_ids = set()
+    rehydrate_positions_emitted = []
 
     calibre_db.reconnect_db(config, ub.app_DB_path)
 
@@ -1042,6 +1050,7 @@ def HandleSyncRequest():
     reseeded_shape_change_book_ids = set()
     reseeded_shape_change_deleted_uuids = set()
     delivered_book_identities = []
+    rehydrate_book_ids = set()
     for book in books_list:
         kobo_reading_state = book.KoboReadingState  # None when no record exists yet
         entitlement = {
@@ -1114,6 +1123,11 @@ def HandleSyncRequest():
                 sync_results.append({"NewEntitlement": entitlement})
             else:
                 sync_results.append({"ChangedEntitlement": entitlement})
+            # Only a real delivery arms repair. A byte-identical replay that
+            # #1925 suppresses (including a declared #1953 shape reseed) must
+            # not mass-arm the user's position journal.
+            if requesting_device_id:
+                rehydrate_book_ids.add(book.Books.id)
             if replay_suppression_enabled and requesting_device_id:
                 entitlement_fingerprint_updates[book.Books.id] = entitlement_fingerprint
                 entitlement_change_basis_updates[book.Books.id] = \
@@ -1167,6 +1181,10 @@ def HandleSyncRequest():
     kobo_sync_status.add_synced_books_batch(
         delivered_book_identities,
         commit=False,
+    )
+    device_positions.mark_rehydrate_needed(
+        requesting_device_id,
+        rehydrate_book_ids,
     )
 
     # Magic-shelf sub-cursor: advance to the highest magic-shelf book id
@@ -1305,7 +1323,51 @@ def HandleSyncRequest():
                     "ReadingState": get_kobo_reading_state_response(book, kobo_reading_state)
                 }
             })
+            reading_state_book_ids_emitted.append(kobo_reading_state.book_id)
             new_reading_state_last_modified = max(new_reading_state_last_modified, kobo_reading_state.last_modified)
+
+    # Re-download repair is independent of the opaque reading-state cursor.
+    # Rows armed by a non-identical entitlement (or the legacy-marker reset)
+    # are deliberately emitted even if this response already carried the same
+    # state next to an entitlement: the standalone envelope is the repair
+    # contract. Clear only rows we can actually render, and stage that clear in
+    # the single checked request-level commit below.
+    if requesting_device_id:
+        pending_rehydrates = (
+            ub.session.query(
+                ub.DeviceReadingPosition,
+                ub.KoboReadingState,
+            )
+            .join(
+                ub.KoboReadingState,
+                ub.KoboReadingState.book_id
+                == ub.DeviceReadingPosition.book_id,
+            )
+            .filter(
+                ub.DeviceReadingPosition.device_id
+                == int(requesting_device_id),
+                ub.DeviceReadingPosition.rehydrate_needed.is_(True),
+                ub.KoboReadingState.user_id == current_user.id,
+            )
+            .order_by(ub.DeviceReadingPosition.book_id)
+            .all()
+        )
+        for position, kobo_reading_state in pending_rehydrates:
+            book = calibre_db.session.query(db.Books).filter(
+                db.Books.id == position.book_id,
+            ).one_or_none()
+            if book is None:
+                continue
+            if position.book_id not in reading_state_book_ids_emitted:
+                sync_results.append({
+                    "ChangedReadingState": {
+                        "ReadingState": get_kobo_reading_state_response(
+                            book, kobo_reading_state,
+                        ),
+                    },
+                })
+                reading_state_book_ids_emitted.append(position.book_id)
+            rehydrate_positions_emitted.append(position)
 
     sync_shelves(sync_token, sync_results, only_kobo_shelves)
 
@@ -1469,6 +1531,12 @@ def HandleSyncRequest():
             ub.KoboSyncedBooks.user_id == current_user.id,
             ub.KoboSyncedBooks.book_id.in_(books_to_delete_ids),
         ).delete(synchronize_session=False)
+
+    # Do not move this mutation above ``sync_shelves``: that legacy helper
+    # still has unchecked commits. The latch is acknowledged only here, with
+    # no intervening commit before the checked request-level boundary.
+    for position in rehydrate_positions_emitted:
+        position.rehydrate_needed = False
 
     # Commit the live ledger, synced-book markers, hard-delete ledger, and
     # two-way-removal cleanup atomically before token construction. In
@@ -2313,6 +2381,7 @@ def HandleStateRequest(book_uuid):
         return jsonify([get_kobo_reading_state_response(book, kobo_reading_state)])
     else:
         update_results_response = {"EntitlementId": book_uuid}
+        resolved_bookmark_accepted = False
 
         try:
             request_data = request.json
@@ -2334,33 +2403,82 @@ def HandleStateRequest(book_uuid):
             request_bookmark = request_reading_state["CurrentBookmark"]
             if request_bookmark:
                 current_bookmark = kobo_reading_state.current_bookmark
-                current_bookmark.progress_percent = request_bookmark["ProgressPercent"]
-                current_bookmark.content_source_progress_percent = request_bookmark["ContentSourceProgressPercent"]
                 location = request_bookmark.get("Location")
-                if location:
-                    current_bookmark.location_value = location["Value"]
-                    current_bookmark.location_type = location["Type"]
-                    current_bookmark.location_source = location["Source"]
-                _apply_kobo_last_modified(current_bookmark, request_lm)
+                incoming_progress = request_bookmark.get("ProgressPercent")
+                rehydrate_pending = device_positions.stage_position(
+                    device_id=getattr(g, "annotation_origin_device_id", None),
+                    book_id=book.id,
+                    progress_percent=incoming_progress,
+                    content_source_progress_percent=request_bookmark.get(
+                        "ContentSourceProgressPercent",
+                    ),
+                    location_value=location.get("Value") if location else None,
+                    location_type=location.get("Type") if location else None,
+                    location_source=location.get("Source") if location else None,
+                    client_modified_at=request_lm,
+                )
+
+                stored_progress = current_bookmark.progress_percent
+                resolved_bookmark_accepted = (
+                    incoming_progress is None
+                    and device_positions.timestamp_is_newer(
+                        request_lm, current_bookmark.last_modified,
+                    )
+                ) or (
+                    incoming_progress is not None
+                    and (
+                        stored_progress is None
+                        or incoming_progress >= stored_progress
+                    )
+                )
+                if resolved_bookmark_accepted:
+                    if incoming_progress is not None:
+                        current_bookmark.progress_percent = incoming_progress
+                    if "ContentSourceProgressPercent" in request_bookmark:
+                        current_bookmark.content_source_progress_percent = (
+                            request_bookmark["ContentSourceProgressPercent"]
+                        )
+                    if location:
+                        current_bookmark.location_value = location["Value"]
+                        current_bookmark.location_type = location["Type"]
+                        current_bookmark.location_source = location["Source"]
+                    _apply_kobo_last_modified(current_bookmark, request_lm)
+                elif (incoming_progress is not None
+                      and stored_progress is not None
+                      and incoming_progress < stored_progress):
+                    log.info(
+                        "Kobo position decrease suppressed for device %s "
+                        "book %s (rehydrate_pending=%s): %.2f%% < %.2f%%",
+                        getattr(g, "annotation_origin_device_id", None),
+                        book.id,
+                        rehydrate_pending,
+                        incoming_progress,
+                        stored_progress,
+                    )
                 update_results_response["CurrentBookmarkResult"] = {"Result": "Success"}
 
             request_statistics = request_reading_state["Statistics"]
             if request_statistics:
                 statistics = kobo_reading_state.statistics
-                spent = request_statistics.get("SpentReadingMinutes")
-                if spent is not None:
-                    statistics.spent_reading_minutes = int(spent)
-                remaining = request_statistics.get("RemainingTimeMinutes")
-                if remaining is not None:
-                    statistics.remaining_time_minutes = int(remaining)
-                _apply_kobo_last_modified(statistics, request_lm)
+                if device_positions.timestamp_is_newer(
+                        request_lm, statistics.last_modified):
+                    spent = request_statistics.get("SpentReadingMinutes")
+                    if spent is not None:
+                        statistics.spent_reading_minutes = int(spent)
+                    remaining = request_statistics.get("RemainingTimeMinutes")
+                    if remaining is not None:
+                        statistics.remaining_time_minutes = int(remaining)
+                    _apply_kobo_last_modified(statistics, request_lm)
                 update_results_response["StatisticsResult"] = {"Result": "Success"}
 
             request_status_info = request_reading_state["StatusInfo"]
             if request_status_info:
                 book_read = kobo_reading_state.book_read_link
                 new_book_read_status = get_ub_read_status(request_status_info["Status"])
-                if new_book_read_status != book_read.read_status:
+                if (new_book_read_status != book_read.read_status
+                        and device_positions.timestamp_is_newer(
+                            request_lm, book_read.last_modified,
+                        )):
                     if new_book_read_status == ub.ReadBook.STATUS_IN_PROGRESS:
                         book_read.times_started_reading += 1
                         book_read.last_time_started_reading = datetime.now(timezone.utc)
@@ -2372,10 +2490,16 @@ def HandleStateRequest(book_uuid):
             ub.session.rollback()
             abort(400, description="Malformed request data is missing 'ReadingStates' key")
 
-        if request_bookmark and request_bookmark.get("ProgressPercent") is not None:
-            push_reading_state_to_hardcover(current_user, book, request_bookmark["ProgressPercent"])
-            share_kobo_progress_with_koreader(
-                current_user.id, book.id, request_bookmark["ProgressPercent"])
+        if resolved_bookmark_accepted:
+            if request_bookmark and request_bookmark.get("ProgressPercent") is not None:
+                push_reading_state_to_hardcover(
+                    current_user, book, request_bookmark["ProgressPercent"],
+                )
+                share_kobo_progress_with_koreader(
+                    current_user.id,
+                    book.id,
+                    request_bookmark["ProgressPercent"],
+                )
 
         ub.session.merge(kobo_reading_state)
         # #1318 again, on the reading-state path: ``session_commit()`` returns

--- a/cps/services/device_reading_position.py
+++ b/cps/services/device_reading_position.py
@@ -22,6 +22,17 @@ def _now():
     return datetime.now(timezone.utc)
 
 
+def rehydrate_request_cutoff():
+    """Return the server clock fence for one sync request.
+
+    A latch whose ``server_modified_at`` is at or beyond this fence was armed
+    during the current request.  It cannot be consumed until a later request,
+    after the device has had a chance to apply the entitlement/download that
+    may reset its local position.
+    """
+    return _now()
+
+
 def timestamp_is_newer(candidate, current):
     """Compare SQLite clocks while tolerating naive/aware round trips."""
     if candidate is None:

--- a/cps/services/device_reading_position.py
+++ b/cps/services/device_reading_position.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+"""Per-device reading-position journal and rehydrate latch (#1942 M3).
+
+The user-level ``KoboReadingState`` graph remains the resolved carrier served
+to Kobo, Hardcover, KOSync, and the book-detail UI. This module stores each
+device's own observation without committing; request handlers retain ownership
+of their existing transaction boundaries.
+"""
+
+from datetime import datetime, timezone
+
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
+from .. import ub
+
+
+def _now():
+    return datetime.now(timezone.utc)
+
+
+def timestamp_is_newer(candidate, current):
+    """Compare SQLite clocks while tolerating naive/aware round trips."""
+    if candidate is None:
+        return False
+    if current is None:
+        return True
+    if (candidate.tzinfo is None) != (current.tzinfo is None):
+        candidate = candidate.replace(tzinfo=None)
+        current = current.replace(tzinfo=None)
+    return candidate > current
+
+
+def stage_position(
+    *,
+    device_id,
+    book_id,
+    progress_percent=None,
+    content_source_progress_percent=None,
+    location_source=None,
+    location_type=None,
+    location_value=None,
+    cfi=None,
+    client_modified_at=None,
+    session=None,
+):
+    """Upsert one device observation and return its prior rehydrate latch.
+
+    An ordinary position write never clears ``rehydrate_needed``. That latch
+    belongs to the sync response which actually emits the repair and is
+    cleared only in that request's checked commit.
+    """
+    if not device_id:
+        return False
+    s = session if session is not None else ub.session
+    device_id = int(device_id)
+    book_id = int(book_id)
+    with s.no_autoflush:
+        existing = s.query(ub.DeviceReadingPosition).filter(
+            ub.DeviceReadingPosition.device_id == device_id,
+            ub.DeviceReadingPosition.book_id == book_id,
+        ).one_or_none()
+        rehydrate_pending = bool(
+            existing is not None and existing.rehydrate_needed,
+        )
+
+    now = _now()
+    values = {
+        "device_id": device_id,
+        "book_id": book_id,
+        "location_source": location_source,
+        "location_type": location_type,
+        "location_value": location_value,
+        "progress_percent": progress_percent,
+        "content_source_progress_percent": content_source_progress_percent,
+        "cfi": cfi,
+        "client_modified_at": client_modified_at,
+        "server_modified_at": now,
+        "rehydrate_needed": rehydrate_pending,
+    }
+    statement = sqlite_insert(ub.DeviceReadingPosition).values(**values)
+    updates = {
+        "location_source": statement.excluded.location_source,
+        "location_type": statement.excluded.location_type,
+        "location_value": statement.excluded.location_value,
+        "progress_percent": statement.excluded.progress_percent,
+        "content_source_progress_percent": (
+            statement.excluded.content_source_progress_percent
+        ),
+        "cfi": statement.excluded.cfi,
+        "server_modified_at": statement.excluded.server_modified_at,
+    }
+    # A rejected/missing device clock is not a newer observation and must not
+    # erase the last usable ordering clock from this device's journal.
+    if client_modified_at is not None:
+        updates["client_modified_at"] = statement.excluded.client_modified_at
+    s.execute(statement.on_conflict_do_update(
+        index_elements=["device_id", "book_id"],
+        set_=updates,
+    ))
+    return rehydrate_pending
+
+
+def mark_rehydrate_needed(device_id, book_ids, *, session=None):
+    """Arm selected books for one device, creating blank journal rows."""
+    if not device_id:
+        return 0
+    normalized = sorted({int(book_id) for book_id in book_ids})
+    if not normalized:
+        return 0
+    s = session if session is not None else ub.session
+    now = _now()
+    rows = [
+        {
+            "device_id": int(device_id),
+            "book_id": book_id,
+            "server_modified_at": now,
+            "rehydrate_needed": True,
+        }
+        for book_id in normalized
+    ]
+    statement = sqlite_insert(ub.DeviceReadingPosition).values(rows)
+    s.execute(statement.on_conflict_do_update(
+        index_elements=["device_id", "book_id"],
+        set_={
+            "server_modified_at": statement.excluded.server_modified_at,
+            "rehydrate_needed": True,
+        },
+    ))
+    return len(normalized)
+
+
+def mark_existing_positions_for_rehydrate(device_id, *, session=None):
+    """Arm every existing journal row during the legacy synced-book reset."""
+    if not device_id:
+        return 0
+    s = session if session is not None else ub.session
+    return s.query(ub.DeviceReadingPosition).filter(
+        ub.DeviceReadingPosition.device_id == int(device_id),
+    ).update(
+        {
+            ub.DeviceReadingPosition.rehydrate_needed: True,
+            ub.DeviceReadingPosition.server_modified_at: _now(),
+        },
+        synchronize_session=False,
+    )

--- a/cps/services/reading_position.py
+++ b/cps/services/reading_position.py
@@ -55,9 +55,11 @@ finished-book guard below stays clearable on a custom-read-column install too
 """
 
 import math
+from datetime import datetime, timezone
 from typing import Optional
 
 from .. import logger, ub
+from .device_reading_position import stage_position
 
 log = logger.create()
 
@@ -86,7 +88,7 @@ def coerce_percentage(raw) -> Optional[float]:
 
 
 def record_web_reader_progress(user, book_id: int, percentage: float,
-                               *, origin_device_id=None) -> bool:
+                               *, origin_device_id=None, cfi=None) -> bool:
     """Advance the shared progress carrier from a web-reader position.
 
     Returns ``True`` when the carrier was advanced.  The caller is responsible
@@ -175,6 +177,28 @@ def record_web_reader_progress(user, book_id: int, percentage: float,
             ub.session.refresh(state.current_bookmark)
             stored = state.current_bookmark.progress_percent
 
+    # The device journal records what this browser actually reported even when
+    # its percentage loses the resolved furthest-wins comparison below. Its
+    # exact epub.js CFI is intentionally private to this browser row; Kobo and
+    # KOReader continue to receive only the portable percentage.
+    if origin_device_id:
+        observed_at = datetime.now(timezone.utc)
+        try:
+            with ub.begin_contained_nested(ub.session):
+                stage_position(
+                    device_id=origin_device_id,
+                    book_id=book_id,
+                    progress_percent=percentage,
+                    cfi=cfi,
+                    client_modified_at=observed_at,
+                )
+        except Exception as e:
+            log.warning(
+                "Could not record web-reader device position for user %s "
+                "book %s: %s", user_id, book_id, e,
+            )
+            return False
+
     # Imported lazily: the KOSync protocol module pulls in cps.kobo, and this
     # service is imported from cps.web / cps.api.reader at request time.
     from ..progress_syncing.protocols.kosync import (read_status_for_percentage,
@@ -233,7 +257,7 @@ def record_web_reader_progress(user, book_id: int, percentage: float,
     # write raising inside this best-effort helper, where the routes' broad
     # handler logs it as an optional progress-sharing failure and answers success
     # anyway. Both bookmark routes settle before calling in.
-    # Both carriers go in the one savepoint: the Kobo bookmark that
+    # Both resolved carriers go in the one savepoint: the Kobo bookmark that
     # ``update_book_read_status`` maintains, and the KOSync row KOReader pulls
     # from (#1366). They describe the same position, so a partial write would
     # leave the two devices disagreeing about where the user is — worse than

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -1191,6 +1191,48 @@ class Device(Base):
     )
 
 
+class DeviceReadingPosition(Base):
+    """One device's last reported position for a Calibre book.
+
+    ``book_id`` deliberately has no foreign key because the book lives in
+    metadata.db while this journal lives in app.db. ``KoboReadingState`` stays
+    the resolved, user-level carrier served on the Kobo wire; this table keeps
+    the device observations that feed that resolution and the rehydrate latch.
+    """
+    __tablename__ = 'device_reading_position'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    device_id = Column(
+        Integer, ForeignKey('device.id', ondelete='CASCADE'), nullable=False,
+    )
+    book_id = Column(Integer, nullable=False)
+    location_source = Column(String, nullable=True)
+    location_type = Column(String, nullable=True)
+    location_value = Column(String, nullable=True)
+    progress_percent = Column(Float, nullable=True)
+    content_source_progress_percent = Column(Float, nullable=True)
+    cfi = Column(Text, nullable=True)
+    client_modified_at = Column(DateTime, nullable=True)
+    server_modified_at = Column(
+        DateTime, nullable=False, default=lambda: datetime.now(timezone.utc),
+    )
+    rehydrate_needed = Column(
+        Boolean, nullable=False, default=False, server_default='0',
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            'device_id', 'book_id',
+            name='uq_device_reading_position_device_book',
+        ),
+        Index('ix_device_reading_position_book', 'book_id'),
+        Index(
+            'ix_device_reading_position_rehydrate',
+            'device_id', 'rehydrate_needed',
+        ),
+    )
+
+
 class DeviceIdentity(Base):
     """Versioned, keyed derivation of an upstream device identifier."""
     __tablename__ = 'device_identity'
@@ -3877,6 +3919,29 @@ def migrate_webreader_device_identity_slice(engine, _session):
         ))
 
 
+def migrate_device_reading_position_slice(engine, _session):
+    """Install M3's additive per-device position journal before ORM use."""
+    Base.metadata.create_all(
+        engine,
+        tables=[DeviceReadingPosition.__table__],
+        checkfirst=True,
+    )
+    with engine.begin() as conn:
+        if not conn.execute(text(
+            "SELECT 1 FROM sqlite_master "
+            "WHERE type='table' AND name='device_reading_position'"
+        )).first():
+            return
+        conn.execute(text(
+            "CREATE INDEX IF NOT EXISTS ix_device_reading_position_book "
+            "ON device_reading_position(book_id)"
+        ))
+        conn.execute(text(
+            "CREATE INDEX IF NOT EXISTS ix_device_reading_position_rehydrate "
+            "ON device_reading_position(device_id, rehydrate_needed)"
+        ))
+
+
 def migrate_kobo_annotation_seed_pipeline(engine, _session):
     """Install M2's sticky-authority and capture-kind columns before ORM use."""
     Base.metadata.create_all(
@@ -4693,6 +4758,7 @@ def migrate_Database(_session):
     migrate_multi_device_annotation_safe_slice(engine, _session)
     migrate_device_management_slice(engine, _session)
     migrate_webreader_device_identity_slice(engine, _session)
+    migrate_device_reading_position_slice(engine, _session)
     migrate_kobo_annotation_seed_pipeline(engine, _session)
     migrate_kobo_two_way_annotation_sync(engine, _session)
     migrate_book_cover_preview_table(engine, _session)

--- a/cps/user_book_data.py
+++ b/cps/user_book_data.py
@@ -81,7 +81,7 @@ def _delete_annotation(session, annotation):
 
 # Models tied to a user and book handled by this module, with merge semantics
 # for migrate. BookShelf has no user_id (shelf-scoped), the Kobo entitlement
-# ledger resolves user scope through Device, and KoboBookmark/KoboStatistics/
+# ledgers resolve user scope through Device, and KoboBookmark/KoboStatistics/
 # AnnotationSyncTarget are children reached through their parents; all are
 # still handled below.
 PER_USER_BOOK_MODELS = (
@@ -98,11 +98,15 @@ PER_USER_BOOK_MODELS = (
     "BookCoverPreview",
     "UserLibraryBook",
 )
-# This ledger is user-scoped through Device rather than a user_id column.
+# These ledgers are user-scoped through Device rather than a user_id column.
 # Keep the device-scoped registry extension separate from the flat-model tuple
 # so independently added flat per-user models merge without competing for the
 # tuple's final insertion point.
-PER_USER_BOOK_MODELS += ("KoboDeviceBookEntitlement", "DeviceBookDelivery")
+PER_USER_BOOK_MODELS += (
+    "KoboDeviceBookEntitlement",
+    "DeviceBookDelivery",
+    "DeviceReadingPosition",
+)
 
 
 def migrate_user_book_data(from_book_id, to_book_id, session=None):
@@ -235,6 +239,45 @@ def migrate_user_book_data(from_book_id, to_book_id, session=None):
     session.query(ub.KoboDeviceBookEntitlement).filter(
         ub.KoboDeviceBookEntitlement.book_id == from_book_id,
     ).delete(synchronize_session=False)
+
+    # Per-device reading positions survive duplicate merges. A device may
+    # already have observations for both copies, so keep the greater client
+    # clock and use progress as the deterministic equal-clock tie-break. The
+    # rehydrate latch is request state rather than position content: OR it
+    # across the pair so resolving a duplicate cannot silently consume a
+    # pending device repair.
+    for position in session.query(ub.DeviceReadingPosition).filter(
+            ub.DeviceReadingPosition.book_id == from_book_id).all():
+        clash = session.query(ub.DeviceReadingPosition).filter(
+            ub.DeviceReadingPosition.device_id == position.device_id,
+            ub.DeviceReadingPosition.book_id == to_book_id,
+        ).first()
+        if clash is None:
+            position.book_id = to_book_id
+            continue
+        keep_source = _newer(
+            position.client_modified_at, clash.client_modified_at,
+        )
+        if not keep_source and not _newer(
+                clash.client_modified_at, position.client_modified_at):
+            keep_source = (
+                position.progress_percent
+                if position.progress_percent is not None else float("-inf")
+            ) > (
+                clash.progress_percent
+                if clash.progress_percent is not None else float("-inf")
+            )
+        pending_rehydrate = bool(
+            position.rehydrate_needed or clash.rehydrate_needed,
+        )
+        if keep_source:
+            position.rehydrate_needed = pending_rehydrate
+            session.delete(clash)
+            session.flush()
+            position.book_id = to_book_id
+        else:
+            clash.rehydrate_needed = pending_rehydrate
+            session.delete(position)
 
     # Wanted-book rows are per physical device. Preserve an outstanding claim
     # when its source book is merged into the kept copy; if that device already
@@ -369,6 +412,17 @@ def purge_user_book_data(book_id=None, user_id=None, session=None,
         entitlement_state = entitlement_state.filter(
             ub.KoboDeviceBookEntitlement.device_id.in_(device_ids))
     entitlement_state.delete(synchronize_session=False)
+
+    position_state = session.query(ub.DeviceReadingPosition)
+    if book_id is not None:
+        position_state = position_state.filter(
+            ub.DeviceReadingPosition.book_id == book_id)
+    if user_id is not None:
+        device_ids = session.query(ub.Device.id).filter(
+            ub.Device.user_id == user_id).scalar_subquery()
+        position_state = position_state.filter(
+            ub.DeviceReadingPosition.device_id.in_(device_ids))
+    position_state.delete(synchronize_session=False)
 
     # Pull-delivery rows are scoped through Device, just like the Kobo
     # entitlement ledger. A removed metadata book can never satisfy a queued

--- a/cps/web.py
+++ b/cps/web.py
@@ -326,6 +326,7 @@ def set_bookmark(book_id, book_format):
                 book_id,
                 percentage,
                 origin_device_id=g.annotation_origin_device_id,
+                cfi=bookmark_key,
             )
         except Exception as e:
             # Position sharing must never cost the user their bookmark.

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -41,7 +41,7 @@ surfaces; reverse dependents cannot be discovered by that traversal and must be 
 prefixes. The whole `cps/api/` blueprint tree is therefore protected explicitly: its registration in
 `cps/main.py` points toward the handlers, opposite to the import direction walked by the classifier. The
 two-level cutoff only bounds each root's dependency fan-out—it is not what excludes reverse dependents.
-At this revision the derived set is 155 of 221 local Python modules (the closure correctly picks
+At this revision the derived set is 156 of 222 local Python modules (the closure correctly picks
 up `cps/services/device_delivery.py` through the book-action request path, and this branch's
 `cps/user_preferences.py` through the account API path). Measured at `origin/main`
 `e6298e0d560b`, the previous and expanded policies each fired on 26 of the latest 100 first-parent commits;

--- a/tests/unit/test_1925_kobo_sync_dedownload.py
+++ b/tests/unit/test_1925_kobo_sync_dedownload.py
@@ -1467,6 +1467,94 @@ def test_unsuppressed_reading_state_count_and_cursor_remain_one_shot(
     assert sync_harness.session.query(ub.KoboDeviceBookEntitlement).count() == 0
 
 
+def test_rehydrate_emits_past_advanced_cursor_clears_atomically_and_ignores_exact_replay(
+    sync_harness, monkeypatch,
+):
+    """M3's device latch repairs a download without reopening #1925/#1953."""
+    from cps import kobo, ub
+
+    monkeypatch.setattr(
+        kobo.config,
+        "config_kobo_suppress_replayed_entitlements",
+        True,
+    )
+    first = sync_harness.sync()
+    assert len(_entitlements(first)) == 1
+    position = sync_harness.session.query(ub.DeviceReadingPosition).one()
+    assert position.device_id == sync_harness.device.id
+    assert position.rehydrate_needed is True
+
+    modified = datetime(2026, 8, 28, 12, 30, 0)
+    _add_reading_state(sync_harness, modified, progress=48.0)
+    cursor_ahead = modified + timedelta(days=1)
+    advanced = kobo.SyncToken.SyncToken.from_headers({
+        sync_harness.token_header: first.headers[sync_harness.token_header],
+    })
+    advanced.reading_state_last_modified = cursor_ahead
+
+    rehydrated = sync_harness.sync(advanced.build_sync_token())
+    states = _changed_reading_states(rehydrated)
+    assert len(states) == 1
+    assert states[0]["EntitlementId"] == sync_harness.book.uuid
+    assert states[0]["CurrentBookmark"]["ProgressPercent"] == 48
+    sync_harness.session.expire_all()
+    assert sync_harness.session.query(
+        ub.DeviceReadingPosition.rehydrate_needed,
+    ).scalar() is False
+
+    response_token = kobo.SyncToken.SyncToken.from_headers({
+        sync_harness.token_header:
+            rehydrated.headers[sync_harness.token_header],
+    })
+    assert response_token.reading_state_last_modified == cursor_ahead
+    assert _changed_reading_states(sync_harness.sync(
+        rehydrated.headers[sync_harness.token_header],
+    )) == []
+
+    # Select the book again with a stale but valid CWNG cursor. Layer 2
+    # suppresses the exact entitlement; that suppression must not re-arm every
+    # device position during a #1953-style renderer replay.
+    stale = kobo.SyncToken.SyncToken(
+        reading_state_last_modified=cursor_ahead,
+    ).build_sync_token()
+    replay = sync_harness.sync(stale)
+    assert _entitlements(replay) == []
+    sync_harness.session.expire_all()
+    assert sync_harness.session.query(
+        ub.DeviceReadingPosition.rehydrate_needed,
+    ).scalar() is False
+
+
+def test_rehydrate_latch_survives_checked_sync_commit_failure(
+    sync_harness, monkeypatch,
+):
+    """A response that cannot commit must leave the repair queued."""
+    from werkzeug.exceptions import ServiceUnavailable
+    from cps import kobo, ub
+
+    first = sync_harness.sync()
+    assert len(_entitlements(first)) == 1
+    modified = datetime(2026, 8, 28, 12, 30, 0)
+    _add_reading_state(sync_harness, modified, progress=52.0)
+    advanced = kobo.SyncToken.SyncToken.from_headers({
+        sync_harness.token_header: first.headers[sync_harness.token_header],
+    })
+    advanced.reading_state_last_modified = modified + timedelta(days=1)
+
+    def reject_commit(*_args, **_kwargs):
+        sync_harness.session.rollback()
+        return False
+
+    monkeypatch.setattr(ub, "session_commit", reject_commit)
+    with pytest.raises(ServiceUnavailable):
+        sync_harness.sync(advanced.build_sync_token())
+
+    sync_harness.session.expire_all()
+    assert sync_harness.session.query(
+        ub.DeviceReadingPosition.rehydrate_needed,
+    ).scalar() is True
+
+
 def test_payload_stabilization_replays_byte_identically_with_layer2_off(
     sync_harness,
 ):

--- a/tests/unit/test_1925_kobo_sync_dedownload.py
+++ b/tests/unit/test_1925_kobo_sync_dedownload.py
@@ -162,10 +162,17 @@ def sync_harness(monkeypatch):
         reconnect_db=lambda *_args, **_kwargs: None,
         common_filters=lambda **_kwargs: true(),
         get_book=lambda book_id: session.query(db.Books).filter_by(id=book_id).one_or_none(),
+        get_book_by_uuid_for_kobo=lambda book_uuid, **_kwargs: session.query(
+            db.Books,
+        ).filter_by(uuid=str(book_uuid)).one_or_none(),
     )
 
     monkeypatch.setattr(ub, "session", session)
-    monkeypatch.setattr(ub, "session_commit", lambda *_args, **_kwargs: session.commit())
+    monkeypatch.setattr(
+        ub,
+        "session_commit",
+        lambda *_args, **_kwargs: session.commit() or True,
+    )
     monkeypatch.setattr(kobo, "calibre_db", fake_calibre_db)
     monkeypatch.setattr(kobo, "current_user", user)
     monkeypatch.setattr(kobo_sync_status, "current_user", user)
@@ -184,7 +191,14 @@ def sync_harness(monkeypatch):
     monkeypatch.setattr(kobo, "get_epub_layout", lambda *_args: "reflowable")
     monkeypatch.setattr(kobo, "get_magic_shelf_book_ids_for_kobo", lambda _user_id: (set(), True))
     monkeypatch.setattr(kobo, "get_magic_shelf_membership_added_at", lambda _user_id: None)
+    real_sync_shelves = kobo.sync_shelves
     monkeypatch.setattr(kobo, "sync_shelves", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        kobo, "push_reading_state_to_hardcover", lambda *_args: None,
+    )
+    monkeypatch.setattr(
+        kobo, "share_kobo_progress_with_koreader", lambda *_args: None,
+    )
 
     app = Flask(__name__)
     app.secret_key = "issue-1925-test-key"
@@ -207,10 +221,40 @@ def sync_harness(monkeypatch):
             g.annotation_origin_device_id = internal_device_id
             return kobo.HandleSyncRequest.__wrapped__()
 
+    def put_position(percent, *, clock, internal_device_id=None):
+        internal_device_id = internal_device_id or device.id
+        payload = {"ReadingStates": [{
+            "LastModified": clock,
+            "CurrentBookmark": {
+                "ProgressPercent": percent,
+                "ContentSourceProgressPercent": percent,
+                "Location": {
+                    "Value": "device.{}".format(percent),
+                    "Type": "KoboSpan",
+                    "Source": "kepub",
+                },
+            },
+            "Statistics": {
+                "SpentReadingMinutes": 0,
+                "RemainingTimeMinutes": 100,
+            },
+            "StatusInfo": {"Status": "Reading"},
+        }]}
+        with app.test_request_context(
+                "/v1/library/{}/state".format(book.uuid),
+                method="PUT",
+                json=payload):
+            g.annotation_origin_device_id = internal_device_id
+            return app.make_response(
+                kobo.HandleStateRequest.__wrapped__(book.uuid),
+            )
+
     yield SimpleNamespace(
         app=app,
         book=book,
         device=device,
+        put_position=put_position,
+        real_sync_shelves=real_sync_shelves,
         calibre_db=fake_calibre_db,
         session=session,
         sync=sync,
@@ -619,6 +663,8 @@ def test_legacy_null_basis_version_transition_delivers_then_suppresses(
     )
     caplog.set_level(logging.DEBUG, logger="cps.kobo")
     assert len(_entitlements(sync_harness.sync())) == 1
+    modified = datetime(2026, 8, 28, 12, 30, 0)
+    _add_reading_state(sync_harness, modified, progress=61.0)
     row = sync_harness.session.query(ub.KoboDeviceBookEntitlement).one()
     row.change_basis = None
     row.updated_at = sync_harness.book.last_modified + timedelta(seconds=1)
@@ -640,6 +686,10 @@ def test_legacy_null_basis_version_transition_delivers_then_suppresses(
     delivered = sync_harness.sync(stale_token)
 
     assert len(_entitlements(delivered)) == 1
+    assert _changed_reading_states(delivered) == [], (
+        "even a fail-open legacy renderer delivery must not consume its latch "
+        "in the same response"
+    )
     sync_harness.session.expire_all()
     migrated = sync_harness.session.query(
         ub.KoboDeviceBookEntitlement,
@@ -649,12 +699,167 @@ def test_legacy_null_basis_version_transition_delivers_then_suppresses(
         None,
     )
     assert migrated.payload_schema_version == next_schema
-    assert _entitlements(sync_harness.sync(stale_token)) == []
+    assert sync_harness.session.query(
+        ub.DeviceReadingPosition.rehydrate_needed,
+    ).scalar() is True
+
+    # The now-stable payload suppresses on the next request while the bounded
+    # repair feed independently serves and acknowledges the pending state.
+    repaired = sync_harness.sync(delivered.headers[sync_harness.token_header])
+    assert _entitlements(repaired) == []
+    states = _changed_reading_states(repaired)
+    assert len(states) == 1
+    assert states[0]["CurrentBookmark"]["ProgressPercent"] == 61
+    sync_harness.session.expire_all()
+    assert sync_harness.session.query(
+        ub.DeviceReadingPosition.rehydrate_needed,
+    ).scalar() is False
     summaries = [
         record.getMessage() for record in caplog.records
         if record.getMessage().startswith("Kobo Sync summary:")
     ]
     assert "reseeded_shape_change=0" in summaries[-1]
+
+
+def test_legacy_null_basis_mass_transition_arms_then_drains_bounded_repairs(
+        sync_harness, monkeypatch):
+    """Fail-open renderer pages cannot create an unbounded repair response."""
+    from cps import db, kobo, ub
+
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+    monkeypatch.setattr(kobo, "SYNC_ITEM_LIMIT", 2)
+    modified = sync_harness.book.last_modified
+    for index in range(2):
+        book = db.Books(
+            "Legacy shape {}".format(index),
+            "Legacy shape {}".format(index),
+            "Author",
+            modified,
+            db.Books.DEFAULT_PUBDATE,
+            "1.0",
+            modified,
+            "legacy-shape-{}".format(index),
+            0,
+            [],
+            [],
+        )
+        sync_harness.session.add(book)
+        sync_harness.session.flush()
+        book.uuid = "00000000-0000-0000-0000-{:012d}".format(3000 + index)
+        sync_harness.session.add(db.Data(
+            book.id,
+            "EPUB",
+            2_000 + index,
+            "legacy-shape-{}".format(index),
+        ))
+    sync_harness.session.commit()
+
+    initial_a = sync_harness.sync()
+    initial_b = sync_harness.sync(
+        initial_a.headers[sync_harness.token_header],
+    )
+    assert [len(_entitlements(initial_a)), len(_entitlements(initial_b))] == [
+        2, 1,
+    ]
+    assert sync_harness.session.query(
+        ub.KoboDeviceBookEntitlement,
+    ).count() == 3
+
+    state_clock = modified + timedelta(minutes=30)
+    books = sync_harness.session.query(db.Books).order_by(db.Books.id).all()
+    for index, book in enumerate(books):
+        read = ub.ReadBook(
+            user_id=sync_harness.user.id,
+            book_id=book.id,
+            read_status=ub.ReadBook.STATUS_IN_PROGRESS,
+        )
+        state = ub.KoboReadingState(
+            user_id=sync_harness.user.id,
+            book_id=book.id,
+            priority_timestamp=state_clock,
+        )
+        state.current_bookmark = ub.KoboBookmark(
+            last_modified=state_clock,
+            progress_percent=60.0 + index,
+        )
+        state.statistics = ub.KoboStatistics(last_modified=state_clock)
+        read.kobo_reading_state = state
+        sync_harness.session.add(read)
+    sync_harness.session.query(ub.KoboDeviceBookEntitlement).update({
+        ub.KoboDeviceBookEntitlement.change_basis: None,
+    })
+    sync_harness.session.query(ub.DeviceReadingPosition).update({
+        ub.DeviceReadingPosition.rehydrate_needed: False,
+    })
+    sync_harness.session.commit()
+    sync_harness.session.query(ub.KoboReadingState).update(
+        {ub.KoboReadingState.last_modified: state_clock},
+        synchronize_session=False,
+    )
+    sync_harness.session.commit()
+
+    original_get_metadata = kobo.get_metadata
+
+    def shape_b(book):
+        payload = original_get_metadata(book)
+        payload["Issue1953MassShapeProbe"] = "shape-b"
+        return payload
+
+    monkeypatch.setattr(kobo, "get_metadata", shape_b)
+    monkeypatch.setattr(
+        kobo,
+        "ENTITLEMENT_PAYLOAD_SCHEMA_VERSION",
+        kobo.ENTITLEMENT_PAYLOAD_SCHEMA_VERSION + 1,
+    )
+
+    def entitlement_ids(response):
+        ids = set()
+        for envelope in _entitlements(response):
+            payload = envelope.get("NewEntitlement") \
+                or envelope["ChangedEntitlement"]
+            ids.add(payload["BookEntitlement"]["Id"])
+        return ids
+
+    token = kobo.SyncToken.SyncToken(
+        reading_state_last_modified=state_clock + timedelta(days=1),
+    ).build_sync_token()
+    transition_a = sync_harness.sync(token)
+    delivered_a = entitlement_ids(transition_a)
+    assert len(delivered_a) == 2
+    assert _changed_reading_states(transition_a) == []
+    assert sync_harness.session.query(ub.DeviceReadingPosition).filter(
+        ub.DeviceReadingPosition.rehydrate_needed.is_(True),
+    ).count() == 2
+
+    transition_b = sync_harness.sync(
+        transition_a.headers[sync_harness.token_header],
+    )
+    delivered_b = entitlement_ids(transition_b)
+    repaired_b = {
+        state["EntitlementId"] for state in _changed_reading_states(transition_b)
+    }
+    assert len(delivered_b) == 1
+    assert repaired_b == delivered_a
+    assert delivered_b.isdisjoint(repaired_b)
+    assert len(repaired_b) <= kobo.SYNC_ITEM_LIMIT
+
+    transition_c = sync_harness.sync(
+        transition_b.headers[sync_harness.token_header],
+    )
+    repaired_c = {
+        state["EntitlementId"] for state in _changed_reading_states(transition_c)
+    }
+    assert repaired_c == delivered_b
+    assert _entitlements(transition_c) == []
+    transition_d = sync_harness.sync(
+        transition_c.headers[sync_harness.token_header],
+    )
+    assert _changed_reading_states(transition_d) == []
+    assert sync_harness.session.query(ub.DeviceReadingPosition).filter(
+        ub.DeviceReadingPosition.rehydrate_needed.is_(True),
+    ).count() == 0
 
 
 def test_real_last_modified_bump_under_new_payload_shape_delivers_once(
@@ -1478,14 +1683,18 @@ def test_rehydrate_emits_past_advanced_cursor_clears_atomically_and_ignores_exac
         "config_kobo_suppress_replayed_entitlements",
         True,
     )
+    modified = datetime(2026, 8, 28, 12, 30, 0)
+    _add_reading_state(sync_harness, modified, progress=48.0)
     first = sync_harness.sync()
     assert len(_entitlements(first)) == 1
+    assert _changed_reading_states(first) == [], (
+        "a state attached to the newly delivered entitlement must not consume "
+        "the repair latch in the offering response"
+    )
     position = sync_harness.session.query(ub.DeviceReadingPosition).one()
     assert position.device_id == sync_harness.device.id
     assert position.rehydrate_needed is True
 
-    modified = datetime(2026, 8, 28, 12, 30, 0)
-    _add_reading_state(sync_harness, modified, progress=48.0)
     cursor_ahead = modified + timedelta(days=1)
     advanced = kobo.SyncToken.SyncToken.from_headers({
         sync_harness.token_header: first.headers[sync_harness.token_header],
@@ -1523,6 +1732,260 @@ def test_rehydrate_emits_past_advanced_cursor_clears_atomically_and_ignores_exac
     assert sync_harness.session.query(
         ub.DeviceReadingPosition.rehydrate_needed,
     ).scalar() is False
+
+
+@pytest.mark.parametrize(
+    "ordering",
+    ["download_then_sync", "sync_then_download"],
+)
+def test_real_download_and_sync_orderings_converge(
+        sync_harness, ordering):
+    """Both legal offer/download orderings repair the simulated device."""
+    from cps import kobo, ub
+    from cps.services import device_reading_position as positions
+
+    modified = datetime(2026, 8, 28, 12, 30, 0)
+    _add_reading_state(sync_harness, modified, progress=80.0)
+    cursor_ahead = modified + timedelta(days=1)
+    advanced = kobo.SyncToken.SyncToken(
+        books_last_modified=cursor_ahead,
+        books_last_created=cursor_ahead,
+        reading_state_last_modified=cursor_ahead,
+    ).build_sync_token()
+
+    if ordering == "download_then_sync":
+        # A prior non-identical offer armed the device; its byte replacement
+        # and cover PUT happen before the repairing sync request.
+        sync_harness.session.add(ub.KoboSyncedBooks(
+            user_id=sync_harness.user.id,
+            book_id=sync_harness.book.id,
+            book_uuid=sync_harness.book.uuid,
+        ))
+        positions.mark_rehydrate_needed(
+            sync_harness.device.id, [sync_harness.book.id],
+        )
+        sync_harness.session.commit()
+        repair_token = advanced
+    else:
+        # The sync offers bytes first. Even though it attaches the current
+        # state, this response only arms the latch; it cannot acknowledge it.
+        offered = sync_harness.sync()
+        assert len(_entitlements(offered)) == 1
+        assert _changed_reading_states(offered) == []
+        assert sync_harness.session.query(
+            ub.DeviceReadingPosition.rehydrate_needed,
+        ).scalar() is True
+        repair_token = offered.headers[sync_harness.token_header]
+
+    reset = sync_harness.put_position(
+        0.0, clock="2026-08-29T15:00:00Z",
+    )
+    assert reset.status_code == 200
+    sync_harness.session.expire_all()
+    resolved = sync_harness.session.query(ub.KoboReadingState).one()
+    journal = sync_harness.session.query(ub.DeviceReadingPosition).one()
+    assert resolved.current_bookmark.progress_percent == 80.0
+    assert journal.progress_percent == 0.0
+    assert journal.rehydrate_needed is True
+
+    repaired = sync_harness.sync(repair_token)
+    repairs = _changed_reading_states(repaired)
+    assert len(repairs) == 1
+    assert repairs[0]["CurrentBookmark"]["ProgressPercent"] == 80
+    simulated_device_progress = 80.0
+    sync_harness.session.expire_all()
+    journal = sync_harness.session.query(ub.DeviceReadingPosition).one()
+    assert journal.progress_percent == 0.0
+    assert journal.rehydrate_needed is False
+
+    # Nickel confirms the state it applied; both orderings now have identical
+    # server rows, journal state, and simulated device position.
+    sync_harness.put_position(
+        simulated_device_progress,
+        clock="2026-08-29T16:00:00Z",
+    )
+    sync_harness.session.expire_all()
+    resolved = sync_harness.session.query(ub.KoboReadingState).one()
+    journal = sync_harness.session.query(ub.DeviceReadingPosition).one()
+    assert resolved.current_bookmark.progress_percent == 80.0
+    assert journal.progress_percent == 80.0
+    assert journal.rehydrate_needed is False
+    assert simulated_device_progress == 80.0
+
+    following_token = kobo.SyncToken.SyncToken.from_headers({
+        sync_harness.token_header: repaired.headers[sync_harness.token_header],
+    })
+    following_token.reading_state_last_modified = datetime(2026, 8, 30)
+    following = sync_harness.sync(following_token.build_sync_token())
+    assert _changed_reading_states(following) == []
+
+
+def test_rehydrate_backlog_is_capped_and_drains_without_duplicates_or_starvation(
+        sync_harness, monkeypatch):
+    """Repair work is an independent bounded page after ordinary states."""
+    from cps import db, kobo, ub
+
+    monkeypatch.setattr(kobo, "SYNC_ITEM_LIMIT", 2)
+    old_clock = datetime(2026, 8, 1, 12, 0, 0)
+    cursor_clock = datetime(2026, 8, 2, 12, 0, 0)
+    ordinary_clock = datetime(2026, 8, 3, 12, 0, 0)
+    repair_ids = []
+    repair_uuids = set()
+    ordinary_uuid = None
+
+    for index in range(6):
+        book = db.Books(
+            "Repair {}".format(index),
+            "Repair {}".format(index),
+            "Author",
+            old_clock,
+            db.Books.DEFAULT_PUBDATE,
+            "1.0",
+            old_clock,
+            "repair-{}".format(index),
+            0,
+            [],
+            [],
+        )
+        sync_harness.session.add(book)
+        sync_harness.session.flush()
+        book.uuid = "00000000-0000-0000-0000-{:012d}".format(2000 + index)
+        sync_harness.session.add(db.Data(
+            book.id, "EPUB", 1_000 + index, "repair-{}".format(index),
+        ))
+        read = ub.ReadBook(
+            user_id=sync_harness.user.id,
+            book_id=book.id,
+            read_status=ub.ReadBook.STATUS_IN_PROGRESS,
+        )
+        state = ub.KoboReadingState(
+            user_id=sync_harness.user.id,
+            book_id=book.id,
+            priority_timestamp=old_clock,
+        )
+        state.current_bookmark = ub.KoboBookmark(
+            last_modified=(ordinary_clock if index == 5 else old_clock),
+            progress_percent=50.0 + index,
+        )
+        state.statistics = ub.KoboStatistics(last_modified=old_clock)
+        read.kobo_reading_state = state
+        sync_harness.session.add(read)
+        if index < 5:
+            repair_ids.append(book.id)
+            repair_uuids.add(str(book.uuid))
+            sync_harness.session.add(ub.DeviceReadingPosition(
+                device_id=sync_harness.device.id,
+                book_id=book.id,
+                server_modified_at=old_clock,
+                rehydrate_needed=True,
+            ))
+        else:
+            ordinary_uuid = str(book.uuid)
+
+    sync_harness.session.add(ub.KoboSyncedBooks(
+        user_id=sync_harness.user.id,
+        book_id=sync_harness.book.id,
+        book_uuid=sync_harness.book.uuid,
+    ))
+    sync_harness.session.commit()
+    sync_harness.session.query(ub.KoboReadingState).filter(
+        ub.KoboReadingState.book_id.in_(repair_ids),
+    ).update(
+        {ub.KoboReadingState.last_modified: old_clock},
+        synchronize_session=False,
+    )
+    ordinary_id = sync_harness.session.query(db.Books.id).filter_by(
+        uuid=ordinary_uuid,
+    ).scalar()
+    sync_harness.session.query(ub.KoboReadingState).filter_by(
+        book_id=ordinary_id,
+    ).update({ub.KoboReadingState.last_modified: ordinary_clock})
+    sync_harness.session.commit()
+
+    token = kobo.SyncToken.SyncToken(
+        books_last_modified=datetime(2027, 1, 1),
+        books_last_created=datetime(2027, 1, 1),
+        reading_state_last_modified=cursor_clock,
+    ).build_sync_token()
+    seen_repairs = []
+    repair_page_sizes = []
+    ordinary_seen = False
+    for _round in range(4):
+        response = sync_harness.sync(token)
+        states = _changed_reading_states(response)
+        uuids = [state["EntitlementId"] for state in states]
+        if ordinary_uuid in uuids:
+            ordinary_seen = True
+        page_repairs = [uuid for uuid in uuids if uuid in repair_uuids]
+        repair_page_sizes.append(len(page_repairs))
+        seen_repairs.extend(page_repairs)
+        token = response.headers[sync_harness.token_header]
+
+    assert ordinary_seen, "ordinary cursor work must not be starved by repairs"
+    assert repair_page_sizes == [2, 2, 1, 0]
+    assert len(seen_repairs) == len(set(seen_repairs)) == 5
+    assert set(seen_repairs) == repair_uuids
+    assert sync_harness.session.query(ub.DeviceReadingPosition).filter_by(
+        rehydrate_needed=True,
+    ).count() == 0
+
+
+def test_sync_has_one_checked_commit_after_all_response_state_is_staged(
+        sync_harness, monkeypatch):
+    """Shelf work and M2/M3 ledgers share the final checked commit."""
+    from cps import kobo, ub
+
+    calls = []
+
+    def counted_commit(*_args, **_kwargs):
+        calls.append("checked")
+        sync_harness.session.commit()
+        return True
+
+    monkeypatch.setattr(kobo, "sync_shelves", sync_harness.real_sync_shelves)
+    monkeypatch.setattr(ub, "session_commit", counted_commit)
+    response = sync_harness.sync()
+
+    assert len(_entitlements(response)) == 1
+    assert calls == ["checked"]
+    assert sync_harness.session.query(ub.KoboSyncedBooks).count() == 1
+    assert sync_harness.session.query(ub.DeviceReadingPosition).count() == 1
+
+
+def test_failed_only_sync_commit_leaves_all_response_state_retryable(
+        sync_harness, monkeypatch):
+    """A 503 cannot durably suppress an entitlement the device never got."""
+    from werkzeug.exceptions import ServiceUnavailable
+    from cps import kobo, ub
+
+    calls = []
+
+    def reject_commit(*_args, **_kwargs):
+        calls.append("rejected")
+        sync_harness.session.rollback()
+        return False
+
+    monkeypatch.setattr(kobo, "sync_shelves", sync_harness.real_sync_shelves)
+    monkeypatch.setattr(ub, "session_commit", reject_commit)
+    with pytest.raises(ServiceUnavailable):
+        sync_harness.sync()
+
+    assert calls == ["rejected"]
+    assert sync_harness.session.query(ub.KoboSyncedBooks).count() == 0
+    assert sync_harness.session.query(ub.KoboDeviceBookEntitlement).count() == 0
+    assert sync_harness.session.query(ub.DeviceReadingPosition).count() == 0
+
+    monkeypatch.setattr(
+        ub,
+        "session_commit",
+        lambda *_args, **_kwargs: sync_harness.session.commit() or True,
+    )
+    retried = sync_harness.sync()
+    assert len(_entitlements(retried)) == 1
+    assert sync_harness.session.query(ub.KoboSyncedBooks).count() == 1
+    assert sync_harness.session.query(
+        ub.DeviceReadingPosition.rehydrate_needed,
+    ).scalar() is True
 
 
 def test_rehydrate_latch_survives_checked_sync_commit_failure(

--- a/tests/unit/test_1942_device_reading_position.py
+++ b/tests/unit/test_1942_device_reading_position.py
@@ -242,7 +242,7 @@ def state_harness(monkeypatch):
     engine.dispose()
 
 
-def test_resolved_policy_is_furthest_progress_and_newest_status_statistics(
+def test_newer_backward_jump_updates_resolved_row_and_both_fanouts(
         state_harness):
     harness = state_harness
 
@@ -254,12 +254,12 @@ def test_resolved_policy_is_furthest_progress_and_newest_status_statistics(
     )
     assert lower.get_json()["RequestResult"] == "Success"
     harness.session.expire_all()
-    assert harness.state.current_bookmark.progress_percent == 80.0
+    assert harness.state.current_bookmark.progress_percent == 20.0
     assert harness.read.read_status == ub.ReadBook.STATUS_FINISHED
     assert harness.state.statistics.spent_reading_minutes == 40
     journal = harness.session.query(ub.DeviceReadingPosition).one()
     assert journal.progress_percent == 20.0
-    assert harness.fanout == [], "a rejected decrease must not escape via fanout"
+    assert harness.fanout == [("hardcover", 20.0), ("kosync", 20.0)]
 
     higher = harness.put(
         90.0,
@@ -272,7 +272,12 @@ def test_resolved_policy_is_furthest_progress_and_newest_status_statistics(
     assert harness.state.current_bookmark.progress_percent == 90.0
     assert harness.read.read_status == ub.ReadBook.STATUS_FINISHED
     assert harness.state.statistics.spent_reading_minutes == 40
-    assert harness.fanout == [("hardcover", 90.0), ("kosync", 90.0)]
+    assert harness.fanout == [
+        ("hardcover", 20.0),
+        ("kosync", 20.0),
+        ("hardcover", 90.0),
+        ("kosync", 90.0),
+    ]
 
 
 def test_rehydrate_latch_survives_cover_reset_until_sync_clears_it(
@@ -289,6 +294,7 @@ def test_rehydrate_latch_survives_cover_reset_until_sync_clears_it(
     assert position.progress_percent == 0.0, "the device journal is truthful"
     assert position.rehydrate_needed is True
     assert harness.state.current_bookmark.progress_percent == 80.0
+    assert harness.fanout == [], "an armed cover reset must not escape"
 
     # HandleSyncRequest clears this field only after it has appended the state;
     # this direct clear models that single request-level commit boundary.
@@ -299,32 +305,48 @@ def test_rehydrate_latch_survives_cover_reset_until_sync_clears_it(
     ).scalar() is False
 
 
-def test_sync_then_download_and_download_then_sync_converge(state_harness):
+def test_armed_non_cover_backward_jump_is_not_misclassified_as_reset(
+        state_harness):
     from cps.services import device_reading_position as positions
 
     harness = state_harness
-
-    # Download/reset before the repairing sync.
     positions.mark_rehydrate_needed(harness.device.id, [BOOK_ID])
     harness.session.commit()
-    harness.put(0.0, clock="2026-08-29T15:00:00Z", spent=0)
-    before_sync = harness.state.current_bookmark.progress_percent
+    harness.put(30.0, clock="2026-08-29T15:00:00Z", spent=25)
+    harness.session.expire_all()
 
-    # Restore the starting point and model the inverse ordering: the sync has
-    # emitted and cleared its latch before Nickel reports the cover reset.
-    harness.session.query(ub.DeviceReadingPosition).delete()
-    harness.state.current_bookmark.progress_percent = 80.0
-    harness.session.commit()
+    position = harness.session.query(ub.DeviceReadingPosition).one()
+    assert position.progress_percent == 30.0
+    assert position.rehydrate_needed is True
+    assert harness.state.current_bookmark.progress_percent == 30.0
+    assert harness.fanout == [("hardcover", 30.0), ("kosync", 30.0)]
+
+
+@pytest.mark.parametrize(
+    ("cover_progress", "suppressed"),
+    [(0.0, True), (1.0, True), (1.01, False)],
+)
+def test_cover_reset_guard_is_latch_and_epsilon_scoped(
+        state_harness, cover_progress, suppressed):
+    from cps.services import device_reading_position as positions
+
+    harness = state_harness
     positions.mark_rehydrate_needed(harness.device.id, [BOOK_ID])
-    harness.session.flush()
-    harness.session.query(ub.DeviceReadingPosition).update({
-        ub.DeviceReadingPosition.rehydrate_needed: False,
-    })
     harness.session.commit()
-    harness.put(0.0, clock="2026-08-29T16:00:00Z", spent=0)
-    after_sync = harness.state.current_bookmark.progress_percent
 
-    assert before_sync == after_sync == 80.0
+    harness.put(
+        cover_progress,
+        clock="2026-08-29T15:00:00Z",
+        spent=0,
+    )
+    harness.session.expire_all()
+
+    expected = 80.0 if suppressed else cover_progress
+    assert harness.state.current_bookmark.progress_percent == expected
+    assert harness.session.query(
+        ub.DeviceReadingPosition.progress_percent,
+    ).scalar() == cover_progress
+    assert bool(harness.fanout) is not suppressed
 
 
 def test_duplicate_merge_keeps_newer_client_clock_then_progress_tie_break(

--- a/tests/unit/test_1942_device_reading_position.py
+++ b/tests/unit/test_1942_device_reading_position.py
@@ -1,0 +1,442 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""#1942 M3: per-device positions, resolution, and rehydrate safety."""
+
+from datetime import datetime, timezone
+import sys
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask, g
+from sqlalchemy import create_engine, inspect
+from sqlalchemy.orm import sessionmaker
+
+from cps import ub
+
+
+pytestmark = pytest.mark.unit
+USER_ID = 17
+BOOK_ID = 42
+
+
+def _clock(hour):
+    return datetime(2026, 8, 29, hour, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def position_session(monkeypatch):
+    engine = create_engine("sqlite:///:memory:")
+    ub.Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    monkeypatch.setattr(ub, "session", session)
+    devices = [
+        ub.Device(
+            user_id=USER_ID,
+            kind=kind,
+            display_name=name,
+            active=True,
+            created_by="auto",
+        )
+        for kind, name in (("kobo", "Clara"), ("webreader", "Browser"))
+    ]
+    session.add_all(devices)
+    session.commit()
+    yield session, devices
+    session.close()
+    engine.dispose()
+
+
+def test_per_device_upsert_keeps_one_row_per_device_and_preserves_latch(
+        position_session):
+    from cps.services import device_reading_position as positions
+
+    session, (kobo, browser) = position_session
+    positions.stage_position(
+        device_id=kobo.id,
+        book_id=BOOK_ID,
+        progress_percent=25.0,
+        location_value="kobo.1",
+        client_modified_at=_clock(10),
+    )
+    positions.mark_rehydrate_needed(kobo.id, [BOOK_ID])
+    positions.stage_position(
+        device_id=kobo.id,
+        book_id=BOOK_ID,
+        progress_percent=35.0,
+        location_value="kobo.2",
+        client_modified_at=_clock(11),
+    )
+    positions.stage_position(
+        device_id=browser.id,
+        book_id=BOOK_ID,
+        progress_percent=55.0,
+        cfi="epubcfi(/6/4!/4/2:9)",
+        client_modified_at=_clock(12),
+    )
+    session.commit()
+
+    rows = session.query(ub.DeviceReadingPosition).order_by(
+        ub.DeviceReadingPosition.device_id,
+    ).all()
+    assert len(rows) == 2
+    by_device = {row.device_id: row for row in rows}
+    assert by_device[kobo.id].progress_percent == 35.0
+    assert by_device[kobo.id].location_value == "kobo.2"
+    assert by_device[kobo.id].rehydrate_needed is True
+    assert by_device[browser.id].progress_percent == 55.0
+    assert by_device[browser.id].cfi == "epubcfi(/6/4!/4/2:9)"
+
+
+def test_web_reader_records_its_exact_cfi_even_when_resolved_progress_is_lower(
+        position_session, monkeypatch):
+    from cps.services import reading_position
+    import cps.progress_syncing.protocols.kosync  # noqa: F401
+    kosync = sys.modules["cps.progress_syncing.protocols.kosync"]
+
+    session, (_kobo, browser) = position_session
+    read = ub.ReadBook(
+        user_id=USER_ID,
+        book_id=BOOK_ID,
+        read_status=ub.ReadBook.STATUS_IN_PROGRESS,
+    )
+    state = ub.KoboReadingState(user_id=USER_ID, book_id=BOOK_ID)
+    state.current_bookmark = ub.KoboBookmark(progress_percent=80.0)
+    read.kobo_reading_state = state
+    session.add(read)
+    session.commit()
+    monkeypatch.setattr(kosync, "update_book_read_status", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        kosync, "record_percentage_only_progress", lambda *_a, **_k: None,
+    )
+
+    advanced = reading_position.record_web_reader_progress(
+        SimpleNamespace(id=USER_ID),
+        BOOK_ID,
+        20.0,
+        origin_device_id=browser.id,
+        cfi="epubcfi(/6/8!/4/6:2)",
+    )
+    session.commit()
+
+    assert advanced is False
+    assert state.current_bookmark.progress_percent == 80.0
+    journal = session.query(ub.DeviceReadingPosition).one()
+    assert journal.device_id == browser.id
+    assert journal.progress_percent == 20.0
+    assert journal.cfi == "epubcfi(/6/8!/4/6:2)"
+
+
+@pytest.fixture
+def state_harness(monkeypatch):
+    from cps import kobo
+
+    engine = create_engine("sqlite:///:memory:")
+    ub.Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    device = ub.Device(
+        user_id=USER_ID,
+        kind="kobo",
+        display_name="Clara",
+        active=True,
+        created_by="auto",
+    )
+    read = ub.ReadBook(
+        user_id=USER_ID,
+        book_id=BOOK_ID,
+        read_status=ub.ReadBook.STATUS_IN_PROGRESS,
+        last_modified=_clock(10),
+        times_started_reading=1,
+    )
+    state = ub.KoboReadingState(
+        user_id=USER_ID,
+        book_id=BOOK_ID,
+        last_modified=_clock(10),
+        priority_timestamp=_clock(10),
+    )
+    state.current_bookmark = ub.KoboBookmark(
+        progress_percent=80.0,
+        content_source_progress_percent=80.0,
+        location_value="resolved.80",
+        location_type="KoboSpan",
+        location_source="kepub",
+        last_modified=_clock(10),
+    )
+    state.statistics = ub.KoboStatistics(
+        spent_reading_minutes=10,
+        remaining_time_minutes=20,
+        last_modified=_clock(10),
+    )
+    read.kobo_reading_state = state
+    session.add_all([device, read])
+    session.commit()
+
+    book = SimpleNamespace(
+        id=BOOK_ID,
+        uuid="00000000-0000-0000-0000-000000001942",
+        data=[SimpleNamespace(format="KEPUB")],
+        identifiers=[],
+    )
+    user = SimpleNamespace(id=USER_ID, name="m3-reader")
+    fanout = []
+
+    monkeypatch.setattr(ub, "session", session)
+
+    def commit(*_args, **_kwargs):
+        session.commit()
+        return True
+
+    monkeypatch.setattr(ub, "session_commit", commit)
+    monkeypatch.setattr(kobo, "current_user", user)
+    monkeypatch.setattr(
+        kobo,
+        "calibre_db",
+        SimpleNamespace(get_book_by_uuid_for_kobo=lambda *_a, **_k: book),
+    )
+    monkeypatch.setattr(kobo, "get_or_create_reading_state", lambda _book_id: state)
+    monkeypatch.setattr(
+        kobo,
+        "push_reading_state_to_hardcover",
+        lambda *_args: fanout.append(("hardcover", _args[-1])),
+    )
+    monkeypatch.setattr(
+        kobo,
+        "share_kobo_progress_with_koreader",
+        lambda *_args: fanout.append(("kosync", _args[-1])),
+    )
+
+    app = Flask(__name__)
+
+    def put(percent, *, clock, status="Reading", spent=10):
+        payload = {"ReadingStates": [{
+            "LastModified": clock,
+            "CurrentBookmark": {
+                "ProgressPercent": percent,
+                "ContentSourceProgressPercent": percent,
+                "Location": {
+                    "Value": "device.{}".format(percent),
+                    "Type": "KoboSpan",
+                    "Source": "kepub",
+                },
+            },
+            "Statistics": {
+                "SpentReadingMinutes": spent,
+                "RemainingTimeMinutes": max(0, 100 - spent),
+            },
+            "StatusInfo": {"Status": status},
+        }]}
+        with app.test_request_context(method="PUT", json=payload):
+            g.annotation_origin_device_id = device.id
+            return kobo.HandleStateRequest.__wrapped__(book.uuid)
+
+    yield SimpleNamespace(
+        app=app,
+        book=book,
+        device=device,
+        fanout=fanout,
+        put=put,
+        read=read,
+        session=session,
+        state=state,
+    )
+    session.close()
+    engine.dispose()
+
+
+def test_resolved_policy_is_furthest_progress_and_newest_status_statistics(
+        state_harness):
+    harness = state_harness
+
+    lower = harness.put(
+        20.0,
+        clock="2026-08-29T14:00:00Z",
+        status="Finished",
+        spent=40,
+    )
+    assert lower.get_json()["RequestResult"] == "Success"
+    harness.session.expire_all()
+    assert harness.state.current_bookmark.progress_percent == 80.0
+    assert harness.read.read_status == ub.ReadBook.STATUS_FINISHED
+    assert harness.state.statistics.spent_reading_minutes == 40
+    journal = harness.session.query(ub.DeviceReadingPosition).one()
+    assert journal.progress_percent == 20.0
+    assert harness.fanout == [], "a rejected decrease must not escape via fanout"
+
+    higher = harness.put(
+        90.0,
+        clock="2026-08-29T09:00:00Z",
+        status="ReadyToRead",
+        spent=5,
+    )
+    assert higher.get_json()["RequestResult"] == "Success"
+    harness.session.expire_all()
+    assert harness.state.current_bookmark.progress_percent == 90.0
+    assert harness.read.read_status == ub.ReadBook.STATUS_FINISHED
+    assert harness.state.statistics.spent_reading_minutes == 40
+    assert harness.fanout == [("hardcover", 90.0), ("kosync", 90.0)]
+
+
+def test_rehydrate_latch_survives_cover_reset_until_sync_clears_it(
+        state_harness):
+    from cps.services import device_reading_position as positions
+
+    harness = state_harness
+    positions.mark_rehydrate_needed(harness.device.id, [BOOK_ID])
+    harness.session.commit()
+
+    harness.put(0.0, clock="2026-08-29T15:00:00Z", spent=0)
+    harness.session.expire_all()
+    position = harness.session.query(ub.DeviceReadingPosition).one()
+    assert position.progress_percent == 0.0, "the device journal is truthful"
+    assert position.rehydrate_needed is True
+    assert harness.state.current_bookmark.progress_percent == 80.0
+
+    # HandleSyncRequest clears this field only after it has appended the state;
+    # this direct clear models that single request-level commit boundary.
+    position.rehydrate_needed = False
+    harness.session.commit()
+    assert harness.session.query(
+        ub.DeviceReadingPosition.rehydrate_needed,
+    ).scalar() is False
+
+
+def test_sync_then_download_and_download_then_sync_converge(state_harness):
+    from cps.services import device_reading_position as positions
+
+    harness = state_harness
+
+    # Download/reset before the repairing sync.
+    positions.mark_rehydrate_needed(harness.device.id, [BOOK_ID])
+    harness.session.commit()
+    harness.put(0.0, clock="2026-08-29T15:00:00Z", spent=0)
+    before_sync = harness.state.current_bookmark.progress_percent
+
+    # Restore the starting point and model the inverse ordering: the sync has
+    # emitted and cleared its latch before Nickel reports the cover reset.
+    harness.session.query(ub.DeviceReadingPosition).delete()
+    harness.state.current_bookmark.progress_percent = 80.0
+    harness.session.commit()
+    positions.mark_rehydrate_needed(harness.device.id, [BOOK_ID])
+    harness.session.flush()
+    harness.session.query(ub.DeviceReadingPosition).update({
+        ub.DeviceReadingPosition.rehydrate_needed: False,
+    })
+    harness.session.commit()
+    harness.put(0.0, clock="2026-08-29T16:00:00Z", spent=0)
+    after_sync = harness.state.current_bookmark.progress_percent
+
+    assert before_sync == after_sync == 80.0
+
+
+def test_duplicate_merge_keeps_newer_client_clock_then_progress_tie_break(
+        position_session):
+    from cps.user_book_data import PER_USER_BOOK_MODELS, migrate_user_book_data
+
+    session, (device_a, device_b) = position_session
+    assert "DeviceReadingPosition" in PER_USER_BOOK_MODELS
+    session.add_all([
+        ub.DeviceReadingPosition(
+            device_id=device_a.id,
+            book_id=1,
+            progress_percent=60.0,
+            client_modified_at=_clock(12),
+            server_modified_at=_clock(12),
+        ),
+        ub.DeviceReadingPosition(
+            device_id=device_a.id,
+            book_id=2,
+            progress_percent=90.0,
+            client_modified_at=_clock(11),
+            server_modified_at=_clock(11),
+            rehydrate_needed=True,
+        ),
+        ub.DeviceReadingPosition(
+            device_id=device_b.id,
+            book_id=1,
+            progress_percent=70.0,
+            client_modified_at=_clock(12),
+            server_modified_at=_clock(12),
+        ),
+        ub.DeviceReadingPosition(
+            device_id=device_b.id,
+            book_id=2,
+            progress_percent=65.0,
+            client_modified_at=_clock(12),
+            server_modified_at=_clock(12),
+        ),
+    ])
+    session.commit()
+
+    migrate_user_book_data(1, 2, session=session)
+    session.commit()
+
+    rows = session.query(ub.DeviceReadingPosition).order_by(
+        ub.DeviceReadingPosition.device_id,
+    ).all()
+    assert [(row.device_id, row.book_id, row.progress_percent) for row in rows] == [
+        (device_a.id, 2, 60.0),
+        (device_b.id, 2, 70.0),
+    ]
+    assert rows[0].rehydrate_needed is True, "merge must not consume repair work"
+
+
+def test_book_delete_purges_device_positions_for_every_user(position_session):
+    from cps.user_book_data import purge_user_book_data
+
+    session, (device_a, device_b) = position_session
+    session.add_all([
+        ub.DeviceReadingPosition(
+            device_id=device_a.id,
+            book_id=BOOK_ID,
+            server_modified_at=_clock(10),
+        ),
+        ub.DeviceReadingPosition(
+            device_id=device_b.id,
+            book_id=BOOK_ID,
+            server_modified_at=_clock(10),
+        ),
+        ub.DeviceReadingPosition(
+            device_id=device_a.id,
+            book_id=BOOK_ID + 1,
+            server_modified_at=_clock(10),
+        ),
+    ])
+    session.commit()
+
+    purge_user_book_data(
+        book_id=BOOK_ID,
+        session=session,
+        remove_backup_files=False,
+    )
+    session.commit()
+
+    remaining = session.query(ub.DeviceReadingPosition).one()
+    assert remaining.book_id == BOOK_ID + 1
+
+
+def test_additive_migration_is_idempotent_and_indexed():
+    engine = create_engine("sqlite:///:memory:")
+    ub.migrate_device_reading_position_slice(engine, None)
+    ub.migrate_device_reading_position_slice(engine, None)
+
+    schema = inspect(engine)
+    assert "device_reading_position" in schema.get_table_names()
+    columns = {column["name"] for column in schema.get_columns(
+        "device_reading_position",
+    )}
+    assert {
+        "device_id",
+        "book_id",
+        "progress_percent",
+        "cfi",
+        "client_modified_at",
+        "server_modified_at",
+        "rehydrate_needed",
+    } <= columns
+    indexes = {index["name"] for index in schema.get_indexes(
+        "device_reading_position",
+    )}
+    assert {
+        "ix_device_reading_position_book",
+        "ix_device_reading_position_rehydrate",
+    } <= indexes
+    engine.dispose()


### PR DESCRIPTION
Milestone M3 of #1942. Every reading position is journaled per (device, book) — Kobo state PUTs and web-reader saves both write their device's row (M1 identities) — while `kobo_reading_state` stays the resolved cross-device row, so Hardcover/KOSync/book-page semantics are unchanged.

**Rehydrate:** a device that re-downloads a book gets its position re-sent as `ChangedReadingState` regardless of the sync-token cursor — the direct fix for the #1925-class position loss. The latch arms on entitlement delivery (never on suppressed byte-identical replays, so a #1953-style redelivery can't storm it) and emits only on a sync AFTER the download offer, so both orderings converge.

**Never-lose-the-newer-side:** the resolved row rejects only a cover-reset-shaped regress (≤1% progress) inside the armed rehydrate window — deliberate backward jumps propagate with exact pre-M3 fanout semantics; the one bounded ambiguity (an intentional jump to ≤1% during the window) fails safe and is documented.

**Verification:** two adversarial review rounds (P1 backward-jump loss, P2 same-response latch consumption, P3 commit-singularity — all CLOSED, final verdict MERGE); full unit suite **7906 passed / 0 failed**; commit-instrumentation regression pins exactly one checked request-level commit with forced-failure retryability; order-independence and rehydrate lifecycle regressions included.