### PR TITLE
fix(i18n): Dutch rendered two density options as the same word (F-4079f1)

### DIFF
--- a/changelog.d/4079f1-dutch-density-labels.md
+++ b/changelog.d/4079f1-dutch-density-labels.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- **Dutch readers can tell the Compact and Dense library layouts apart.** The
+  Library View density picker offers Comfortable, Compact and Dense, but Dutch
+  translated both Compact and Dense as "Compact" — so two of the three choices
+  were the same word, and picking between them was guesswork. Dense now reads
+  "Zeer compact".

--- a/cps/translations/nl/LC_MESSAGES/messages.po
+++ b/cps/translations/nl/LC_MESSAGES/messages.po
@@ -5082,7 +5082,7 @@ msgstr "{name} verwijderd."
 
 #: cps/spa_strings.py
 msgid "Dense"
-msgstr "Compact"
+msgstr "Zeer compact"
 
 #: cps/spa_strings.py cps/templates/book_edit.html
 #: cps/templates/cwa_settings.html cps/templates/search_form.html

--- a/tests/unit/test_4079f1_distinct_option_labels.py
+++ b/tests/unit/test_4079f1_distinct_option_labels.py
@@ -1,0 +1,87 @@
+"""Mutually exclusive option labels must stay distinguishable in every locale.
+
+F-4079f1: Dutch translated both "Compact" and "Dense" to "Compact", so the
+Library View density picker offered two options a Dutch reader could not tell
+apart. Nothing caught it, because every string WAS translated — the i18n gate
+counts coverage, and coverage is blind to two msgids colliding on one msgstr.
+
+The defect is a property of a SET, not of any single string, so the guard has to
+be written over the set. Any group of choices presented together belongs here.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+LOCALES = ("fr", "nl")
+
+# Groups of msgids the interface shows together as mutually exclusive choices.
+# A reader must be able to tell every member apart from every other member.
+EXCLUSIVE_CHOICE_GROUPS = {
+    "catalog density (frontend/src/pages/Catalog.tsx DENSITY_OPTIONS)": (
+        "Comfortable",
+        "Compact",
+        "Dense",
+    ),
+}
+
+
+def _catalog(locale):
+    """msgid -> msgstr for one locale, ignoring empty and fuzzy entries."""
+    po = REPO / "cps" / "translations" / locale / "LC_MESSAGES" / "messages.po"
+    text = po.read_text(encoding="utf-8")
+    out = {}
+    for block in text.split("\n\n"):
+        if "#, fuzzy" in block:
+            continue
+        mid = re.search(r'^msgid "((?:[^"\\]|\\.)*)"', block, re.M)
+        mstr = re.search(r'^msgstr "((?:[^"\\]|\\.)*)"', block, re.M)
+        if mid and mstr and mid.group(1) and mstr.group(1):
+            out[mid.group(1)] = mstr.group(1)
+    return out
+
+
+@pytest.mark.parametrize("locale", LOCALES)
+@pytest.mark.parametrize("group", sorted(EXCLUSIVE_CHOICE_GROUPS))
+def test_exclusive_choices_are_distinguishable(locale, group):
+    msgids = EXCLUSIVE_CHOICE_GROUPS[group]
+    catalog = _catalog(locale)
+
+    seen = {}
+    collisions = []
+    for msgid in msgids:
+        rendered = catalog.get(msgid, msgid)  # untranslated falls back to English
+        if rendered in seen:
+            collisions.append((seen[rendered], msgid, rendered))
+        seen[rendered] = msgid
+
+    assert not collisions, (
+        "{} option(s) in the '{}' group render identically in {}, so a reader "
+        "cannot tell them apart (F-4079f1). Give each its own translation in "
+        "cps/translations/{}/LC_MESSAGES/messages.po.\n".format(
+            len(collisions), group, locale, locale
+        )
+        + "\n".join(
+            "  {!r} and {!r} both render as {!r}".format(a, b, r)
+            for a, b, r in collisions
+        )
+    )
+
+
+def test_the_group_lists_msgids_that_actually_exist():
+    """A typo'd msgid would silently fall back to English and never collide."""
+    source = (REPO / "frontend" / "src" / "pages" / "Catalog.tsx").read_text(
+        encoding="utf-8"
+    )
+    block = source.split("const DENSITY_OPTIONS", 1)[1].split("]", 1)[0]
+    declared = set(re.findall(r"label: '([^']+)'", block))
+    listed = set(EXCLUSIVE_CHOICE_GROUPS[
+        "catalog density (frontend/src/pages/Catalog.tsx DENSITY_OPTIONS)"
+    ])
+    assert declared == listed, (
+        "DENSITY_OPTIONS in Catalog.tsx declares {} but the guard checks {}. "
+        "The guard is only as good as its list — update it.".format(
+            sorted(declared), sorted(listed)
+        )
+    )


### PR DESCRIPTION
Closes F-4079f1.

Dutch translated both **Compact** and **Dense** to `"Compact"`. The Library View
density picker offers Comfortable / Compact / Dense, so two of its three mutually
exclusive choices were literally the same word — a Dutch reader could not tell them
apart, or predict which one they had selected. French renders them distinctly, which
is why this surfaced in `nl` alone.

`Dense` now reads **"Zeer compact"** — unambiguously tighter than "Compact". A bare
"Dicht" was rejected because it collides with the everyday sense "closed".

## Why nothing caught it

Every one of these strings *was* translated, so the i18n gate was green. **That gate
measures coverage, and coverage cannot see two msgids colliding on one msgstr.**

The defect is a property of the option **set**, not of any string in it — so the new
guard is written over the set: for each group of choices the interface presents
together, every member must render distinguishably in every locale. That shape
generalizes to any future picker, which is why it is a table rather than a one-off
assertion about density.

## Verification

**Discriminated, not asserted.** Against the translations exactly as they stood, the
guard fails on `nl` and **passes on `fr`** — it is anchored to the defect, not failing
everywhere:

```
'Compact' and 'Dense' both render as 'Compact'
1 failed, 2 passed
```

After the fix: `3 passed`. `tests/unit/test_615_residual_i18n.py` stays at `37 passed`.

**Checked through the compiled catalog, not the source file** — `msgfmt` then a real
`gettext.GNUTranslations` lookup, which is the mechanism the application actually reads:

```
Comfortable    -> 'Comfortabel'
Compact        -> 'Compact'
Dense          -> 'Zeer compact'
all distinct: True
```

A second test pins the guard's own list against `DENSITY_OPTIONS` in `Catalog.tsx`,
because a typo'd msgid would fall back to English and so could never collide — the
guard would stay green while measuring nothing.
