### PR TITLE
fix(spa): first scroll-jank pass — page-local stagger, content-visibility, memoized cards (#1813)

### DIFF
--- a/changelog.d/1813-scroll-jank-first-pass.md
+++ b/changelog.d/1813-scroll-jank-first-pass.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Scrolling large libraries is noticeably smoother.** Newly loaded catalog pages appear immediately instead of staying invisible for most of a second, off-screen covers no longer cost rendering work, and selecting books in a big grid no longer re-renders every card.

--- a/frontend/src/components/BookCard.tsx
+++ b/frontend/src/components/BookCard.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { BookOpen, BookCheck, BookPlus, Check, EyeOff, X, Pencil } from 'lucide-react';
 import { Link } from 'wouter';
 import type { Book } from '../lib/api';
@@ -56,7 +57,7 @@ function formatSeriesIndex(idx: number | null | undefined): string | null {
   return Number.isInteger(idx) ? String(idx) : String(idx);
 }
 
-export function BookCard({
+function BookCardInner({
   book, style, onRemove, removeLabel = 'Remove',
   selectable = false, selected = false, onToggleSelect,
   showSeriesIndex = false,
@@ -268,3 +269,7 @@ export function BookCard({
     </div>
   );
 }
+
+/** Grid items re-render only when their own props change: a selection tap or
+ *  settings refetch in a 500-card catalog must not reconcile every card. */
+export const BookCard = memo(BookCardInner);

--- a/frontend/src/pages/AdvancedSearch.tsx
+++ b/frontend/src/pages/AdvancedSearch.tsx
@@ -254,7 +254,7 @@ export function AdvancedSearch({ defaultFilter }: { defaultFilter?: AdvancedSear
                 {results.map((book, i) => (
                   <BookCard key={book.id} book={book} quickEdit={canEdit} canRead={!!me?.role?.viewer}
                     hideActions={cardActionsHidden}
-                    style={{ animationDelay: `${Math.min(i, 24) * 35}ms` }} />
+                    style={{ animationDelay: i < 24 ? `${i * 35}ms` : '0ms' }} />
                 ))}
               </div>
               {hasMore && (

--- a/frontend/src/pages/Catalog.module.css
+++ b/frontend/src/pages/Catalog.module.css
@@ -129,6 +129,10 @@
 
 .grid > * {
   animation: fadeRise var(--dur-slow) var(--ease-out) both;
+  /* Off-screen cards skip render work entirely; the intrinsic size keeps the
+     scrollbar stable for the unvirtualized, accumulating grid (#1813). */
+  content-visibility: auto;
+  contain-intrinsic-size: auto 280px;
 }
 
 /* The first-load spinner is a grid child (it is what gives the column

--- a/frontend/src/pages/Catalog.tsx
+++ b/frontend/src/pages/Catalog.tsx
@@ -1039,7 +1039,7 @@ export function Catalog({ entityKind, entityId, view, defaultFilter }: CatalogPr
                 key={book.id}
                 book={book}
                 showSeriesIndex={isSeries}
-                style={{ animationDelay: `${Math.min(i, 24) * 35}ms` }}
+                style={{ animationDelay: i < 24 ? `${i * 35}ms` : '0ms' }}
                 quickEdit={canEdit && !selecting}
                 canRead={!!me?.role?.viewer}
                 hideActions={cardActionsHidden}

--- a/frontend/src/pages/MagicShelfView.tsx
+++ b/frontend/src/pages/MagicShelfView.tsx
@@ -182,7 +182,7 @@ export function MagicShelfView({ id }: { id: string }) {
           <div className={styles.grid}>
             {books.map((b, i) => (
               <BookCard key={b.id} book={b} hideActions={cardActionsHidden} canRead={!!me?.role?.viewer}
-                style={{ animationDelay: `${Math.min(i, 24) * 35}ms` }} />
+                style={{ animationDelay: i < 24 ? `${i * 35}ms` : '0ms' }} />
             ))}
           </div>
           {hasMore && (

--- a/frontend/src/pages/Shelf.tsx
+++ b/frontend/src/pages/Shelf.tsx
@@ -329,7 +329,7 @@ export function Shelf({ id }: { id: string }) {
               <BookCard
                 key={book.id}
                 book={book}
-                style={{ animationDelay: `${Math.min(i, 24) * 35}ms` }}
+                style={{ animationDelay: i < 24 ? `${i * 35}ms` : '0ms' }}
                 onRemove={canEdit ? onRemoveBook : undefined}
                 removeLabel={t('Remove from shelf')}
                 canRead={!!me?.role?.viewer}


### PR DESCRIPTION
First implementation pass on #1813, items 1–3 of the audit posted there (complete-sweep, ranked by mechanism):

1. **Appended pages no longer paint blank for 840ms** — the entry-stagger was keyed off the global index with `fill-mode: both`, so every infinite-scroll page sat at `opacity: 0` for the full capped delay. Stagger now applies only to the first screenful.
2. **Off-screen cards skip render work** — `content-visibility: auto` + stable intrinsic size on grid children, the pure-CSS mitigation for the unvirtualized accumulating grid (real windowing tracked separately).
3. **BookCard memoized** — a selection tap in a 500-card grid reconciles one card instead of all of them (the repo had zero `memo` uses).

Items 4+ (sidebar width animation → transform, VirtualizedList scroll-state coalescing, BrowseList deferred filter, Reader progress scaleX) follow as a second pass. Build green; 579 e2e specs collect; the do-not-regress ledger in the audit covers the #1745/#1965 compositing fixes, all verified intact.