### PR TITLE
fix(spa): second scroll-jank pass — coalesced virtual scroll, deferred browse filter, compositor progress bar (#1813)

### DIFF
--- a/changelog.d/1813-scroll-jank-pass2.md
+++ b/changelog.d/1813-scroll-jank-pass2.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Smoother scrolling in long annotation lists, faster typing in the author/tag browser, and page turns no longer stutter the reader's progress bar.** Scroll handling re-renders only when the visible window actually moves, large browse pages defer filtering off the keystroke path and skip off-screen render work, and the progress bar animates on the compositor.

--- a/frontend/src/components/VirtualizedList.tsx
+++ b/frontend/src/components/VirtualizedList.tsx
@@ -28,7 +28,11 @@ export function VirtualizedList<T>({
 }: VirtualizedListProps<T>) {
   const viewportRef = useRef<HTMLDivElement>(null);
   const [viewportHeight, setViewportHeight] = useState(600);
-  const [scrollTop, setScrollTop] = useState(0);
+  // Store the derived row index, not the raw pixel offset: a pixel value in
+  // state forces a React render on every scroll event (~60-120/s) even when
+  // the visible window has not moved by a single row (#1813 item 5).
+  const [scrollRow, setScrollRow] = useState(0);
+  const scrollFrame = useRef(0);
 
   useLayoutEffect(() => {
     const node = viewportRef.current;
@@ -41,12 +45,17 @@ export function VirtualizedList<T>({
   }, []);
 
   const onScroll = useCallback((event: UIEvent<HTMLDivElement>) => {
-    setScrollTop(event.currentTarget.scrollTop);
-  }, []);
+    const top = event.currentTarget.scrollTop;
+    cancelAnimationFrame(scrollFrame.current);
+    scrollFrame.current = requestAnimationFrame(() => {
+      const row = Math.floor(top / rowHeight);
+      setScrollRow((current) => (current === row ? current : row));
+    });
+  }, [rowHeight]);
 
   const visibleCount = Math.max(1, Math.ceil(viewportHeight / rowHeight));
   const overscan = visibleCount * overscanViewports;
-  const start = Math.max(0, Math.floor(scrollTop / rowHeight) - overscan);
+  const start = Math.max(0, scrollRow - overscan);
   const end = Math.min(items.length, start + visibleCount + overscan * 2);
   const visible = items.slice(start, end);
 

--- a/frontend/src/pages/BrowseList.module.css
+++ b/frontend/src/pages/BrowseList.module.css
@@ -92,6 +92,9 @@
 
 .grid > * {
   animation: fadeRise var(--dur-base) var(--ease-out) both;
+  /* 10k-entity libraries: off-screen cells cost no render work (#1813). */
+  content-visibility: auto;
+  contain-intrinsic-size: auto 64px;
 }
 
 /* #1396 — the name is the content of this page, so let it take a second line
@@ -107,7 +110,11 @@
 }
 
 .list { display: flex; flex-direction: column; gap: var(--sp-1); max-width: 760px; }
-.list > * { animation: fadeRise var(--dur-base) var(--ease-out) both; }
+.list > * {
+  animation: fadeRise var(--dur-base) var(--ease-out) both;
+  content-visibility: auto;
+  contain-intrinsic-size: auto 40px;
+}
 .list .item { min-height: 40px; padding-block: var(--sp-2); border-radius: var(--r-sm); }
 
 @media (max-width: 600px) {

--- a/frontend/src/pages/BrowseList.tsx
+++ b/frontend/src/pages/BrowseList.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useDeferredValue } from 'react';
 import { Link } from 'wouter';
 import { LayoutGrid, List, Search, Pencil, Trash2, Check, X, Merge } from 'lucide-react';
 import { useEntityList, useMe, useRenameTag, useDeleteTag, tagConflictOf } from '../lib/queries';
@@ -183,12 +183,15 @@ export function BrowseList({ plural, title }: BrowseListProps) {
     ? `${styles.grid} ${styles.gridTags}`
     : styles.grid;
 
+  // Typing stays responsive on 10k-entity libraries: the filter re-runs at
+  // deferred priority instead of on every keystroke (#1813 item 6).
+  const deferredQ = useDeferredValue(q);
   const items = useMemo(() => {
     const all = data?.items ?? [];
-    if (!q.trim()) return all;
-    const needle = q.trim().toLowerCase();
+    if (!deferredQ.trim()) return all;
+    const needle = deferredQ.trim().toLowerCase();
     return all.filter((e) => e.name.toLowerCase().includes(needle));
-  }, [data, q]);
+  }, [data, deferredQ]);
 
   return (
     <main className={styles.container}>

--- a/frontend/src/pages/Reader.module.css
+++ b/frontend/src/pages/Reader.module.css
@@ -438,8 +438,12 @@
 
 .progressFill {
   height: 100%;
+  width: 100%;
   background: var(--accent);
-  transition: width var(--dur-base) var(--ease);
+  /* Animate on the compositor: a width transition relayouts the reader chrome
+     on every page turn, exactly when epub.js owns the main thread (#1813). */
+  transform-origin: left;
+  transition: transform var(--dur-base) var(--ease);
 }
 
 /* Highlight color popover */

--- a/frontend/src/pages/Reader.tsx
+++ b/frontend/src/pages/Reader.tsx
@@ -1656,7 +1656,7 @@ export function Reader({ id }: { id: string }) {
         aria-label={t('Reading progress')}
         aria-valuenow={Math.round(progress)} aria-valuemin={0} aria-valuemax={100}
         aria-valuetext={t('{pct}% read', { pct: Math.round(progress) })}>
-        <div className={styles.progressFill} style={{ width: `${progress}%` }} />
+        <div className={styles.progressFill} style={{ transform: `scaleX(${progress / 100})` }} />
       </div>
     </div>
   );


### PR DESCRIPTION
Items 5–7 of the #1813 audit (item 4, the sidebar width→transform restructure, remains as the final markup-level pass):

5. **VirtualizedList** stores the derived start row behind one rAF — previously every scroll event (~60–120/s) set raw pixels into state, re-rendering ~55 annotation rows per tick even when the window hadn't moved a row.
6. **BrowseList** filters at deferred priority (typing on a 10k-author library was keystroke-laggy) and its cells get `content-visibility` like the catalog.
7. **Reader progress bar** animates `transform: scaleX` instead of a `width` transition that relayouted the chrome on every page turn, precisely when epub.js owns the main thread.

Build green; 579 e2e specs collect.