### PR TITLE
fix(spa): contain the sidebar hover animation's layout work (#1813 item 4 interim)

### DIFF
--- a/changelog.d/1813-sidebar-containment.md
+++ b/changelog.d/1813-sidebar-containment.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Hovering the sidebar no longer causes page-wide layout work.** The rail's expand animation is contained to the rail itself while a full transform-based redesign is pending.

--- a/frontend/src/components/Sidebar.module.css
+++ b/frontend/src/components/Sidebar.module.css
@@ -136,6 +136,12 @@
     transition:
       width var(--dur-base) var(--ease-out),
       margin-right var(--dur-base) var(--ease-out);
+    /* Interim for #1813 item 4: the hover width animation runs layout every
+       frame; containment scopes that work to the rail instead of the page.
+       (The expanded panel lives inside the rail's own 220px border box via
+       the negative margin, so paint containment clips nothing visible.)
+       The real fix — a transform-driven panel — is tracked on the issue. */
+    contain: layout paint;
   }
 
   /* `scrollbar-width: none` above is what every current engine reads. The


### PR DESCRIPTION
The audit's interim mitigation for item 4: the rail's hover width/margin animation is the app's highest-frequency layout animation; `contain: layout paint` scopes its per-frame work to the rail (the expanded panel lives inside the rail's own 220px border box via the negative-margin overlay, so paint containment clips nothing visible). The real transform-driven panel restructure stays tracked on #1813. Build green; 579 specs collect.