### PR TITLE
fix(my-library): removing a book must not hide your highlights and notes

### DIFF
--- a/changelog.d/annotations-survive-library-removal.md
+++ b/changelog.d/annotations-survive-library-removal.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Keep highlights, notes, bookmarks, and reading progress intact and readable
+  from the annotation archive after a book is removed from My Library,
+  including when the personal library becomes empty and when viewing data by
+  e-reader. Re-adding the book resumes from the same retained reading state.

--- a/cps/annotations.py
+++ b/cps/annotations.py
@@ -246,13 +246,20 @@ def _device_owner(device, session):
 
 
 def _visible_books_for_owner(owner, book_ids):
-    """Resolve a live, owner-filtered metadata view for a device-scoped read."""
+    """Resolve metadata for the owner's global annotation archive.
+
+    My Library membership is a catalogue curation boundary, not ownership of
+    reading data.  Keep every other live content restriction in force while
+    allowing annotations for a removed book to remain readable.
+    """
     if owner is None:
         log.error("annotations: device owner unavailable; filtered book view denied")
         raise FilteredBookVisibilityUnavailable("device owner unavailable")
     books = {}
     for book_id in sorted({int(value) for value in book_ids if value is not None}):
-        book = calibre_db.get_filtered_book(book_id, user=owner)
+        book = calibre_db.get_filtered_book(
+            book_id, allow_show_global=True, user=owner,
+        )
         if book is not None:
             books[book_id] = book
     return books
@@ -345,6 +352,7 @@ def _visible_book_scopes_for_owners(owners, session, candidates_by_owner):
     visibility_state = _owner_visibility_state(session, candidates_by_owner)
     resolved = calibre_db.get_filtered_book_ids_for_users(
         owners, visibility_state, candidates_by_owner,
+        allow_show_global=True,
     )
     return {
         int(owner.id): frozenset(resolved.get(int(owner.id), ()))
@@ -1982,8 +1990,15 @@ def _safe_filename_part(s: str, default: str = "book") -> str:
 
 
 def _resolve_book_or_404(book_id: int):
-    """Load the Book row + enforce visibility. Returns the Book."""
-    book = calibre_db.get_filtered_book(book_id, allow_show_archived=True)
+    """Load an annotation archive book while enforcing content policy.
+
+    A personal-library membership removal must not make the user's retained
+    annotations unreadable.  Bypass only that membership predicate; language,
+    tag, custom-column and hidden-book restrictions remain enforced.
+    """
+    book = calibre_db.get_filtered_book(
+        book_id, allow_show_archived=True, allow_show_global=True,
+    )
     if not book:
         abort(404)
     return book

--- a/cps/db.py
+++ b/cps/db.py
@@ -1492,7 +1492,8 @@ class CalibreDB:
         return self.session.query(Books).filter(Books.id == book_id).first()
 
     def get_filtered_book(self, book_id, allow_show_archived=False,
-                          allow_show_hidden=False, user=None):
+                          allow_show_hidden=False, allow_show_global=False,
+                          user=None):
         self.ensure_session()
         # Eagerly load all relationships to prevent detached instance errors during editing
         # allow_show_hidden=True: covers/read/edit/download flows for a user's
@@ -1513,12 +1514,14 @@ class CalibreDB:
                 .filter(self.common_filters(
                     allow_show_archived,
                     allow_show_hidden=allow_show_hidden,
+                    allow_show_global=allow_show_global,
                     user=user,
                 ))
                 .first())
 
     def get_filtered_book_ids_for_users(self, users, visibility_state,
-                                        candidates_by_user):
+                                        candidates_by_user,
+                                        allow_show_global=False):
         """Resolve candidate books in several users' current filtered views.
 
         ``common_filters`` intentionally performs app-database lookups for one
@@ -1601,7 +1604,8 @@ class CalibreDB:
                 denied_column_filter = false()
 
             membership_filter = true()
-            if bool(getattr(filter_user, "has_own_library", False)):
+            if (not allow_show_global
+                    and bool(getattr(filter_user, "has_own_library", False))):
                 membership_filter = Books.id.in_(membership_ids)
 
             candidate_values = func.json_each(

--- a/tests/unit/test_annotation_device_management.py
+++ b/tests/unit/test_annotation_device_management.py
@@ -70,7 +70,9 @@ def filtered_library_stub(monkeypatch):
     monkeypatch.setattr(
         annotations.calibre_db,
         "get_filtered_book",
-        lambda book_id, user=None: SimpleNamespace(id=book_id, title=f"Book {book_id}"),
+        lambda book_id, user=None, allow_show_global=False: SimpleNamespace(
+            id=book_id, title=f"Book {book_id}",
+        ),
     )
     return original
 
@@ -677,7 +679,10 @@ def test_device_annotations_default_to_origin_and_assigned_toggle_has_facets_and
     assert assigned_payload["role"] == "assigned"
     assert assigned_payload["type"] == "note"
     assert calls and all(user_id == 7 for _book_id, user_id, _kwargs in calls)
-    assert all(set(kwargs) == {"user"} for _book_id, _user_id, kwargs in calls)
+    assert all(
+        kwargs == {"user": kwargs["user"], "allow_show_global": True}
+        for _book_id, _user_id, kwargs in calls
+    )
 
 
 @pytest.mark.unit

--- a/tests/unit/test_annotations_survive_library_removal.py
+++ b/tests/unit/test_annotations_survive_library_removal.py
@@ -1,0 +1,363 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Removal/re-add contract for reading data owned by the global archive."""
+
+from datetime import datetime, timezone
+import json
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from cps import constants, db, ub
+
+
+pytestmark = pytest.mark.unit
+
+
+def _book(book_id, title):
+    now = datetime.now(timezone.utc)
+    book = db.Books(title, title, "Author", now, now, "1.0", now,
+                    "book-%d" % book_id, 1, [], [])
+    book.id = book_id
+    return book
+
+
+@pytest.fixture
+def app_session():
+    engine = create_engine("sqlite:///:memory:")
+    ub.Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+
+
+@pytest.fixture
+def calibre_session():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        execution_options={"schema_translate_map": {"calibre": None}},
+    )
+    db.Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    session.add_all([_book(1, "One"), _book(2, "Two"), _book(3, "Three")])
+    session.commit()
+    yield session
+    session.close()
+
+
+def _cdb(calibre_session):
+    instance = object.__new__(db.CalibreDB)
+    instance.session = calibre_session
+    instance.config = SimpleNamespace(config_restricted_column=0)
+    return instance
+
+
+def _user(session, name, *, browse_global=False):
+    user = ub.User(
+        name=name,
+        email="%s@example.invalid" % name,
+        password="",
+        has_own_library=True,
+        user_library_seeded=True,
+        default_language="all",
+    )
+    if browse_global:
+        user.role |= constants.ROLE_BROWSE_GLOBAL
+    session.add(user)
+    session.commit()
+    return user
+
+
+def _seed_reading_data(session, user, book_id):
+    """Create every user-owned reading carrier named in the removal contract."""
+    stamp = datetime(2026, 8, 30, 12, 34, 56)
+    device = ub.Device(
+        user_id=user.id,
+        kind="kobo",
+        display_name="Preservation Kobo",
+        created_by="auto",
+    )
+    state = ub.KoboReadingState(
+        user_id=user.id,
+        book_id=book_id,
+        last_modified=stamp,
+        priority_timestamp=stamp,
+    )
+    state.current_bookmark = ub.KoboBookmark(
+        created_at=stamp,
+        last_modified=stamp,
+        location_source="content",
+        location_type="KoboSpan",
+        location_value="chapter-1#point(/1/2:3)",
+        progress_percent=41.5,
+        content_source_progress_percent=42.5,
+    )
+    session.add_all([
+        device,
+        ub.Annotation(
+            user_id=user.id,
+            book_id=book_id,
+            annotation_id="annotation-%d" % book_id,
+            source="kobo",
+            annotation_type="highlight",
+            highlighted_text="globally retained highlight",
+            highlight_color="yellow",
+            note_text="globally retained note",
+            cfi_range="epubcfi(/6/2!/4/2/1:0)",
+            chapter_progress=0.415,
+            hidden=False,
+            created_at=stamp,
+            client_modified_at=stamp,
+            server_modified_at=stamp,
+        ),
+        ub.Bookmark(
+            user_id=user.id,
+            book_id=book_id,
+            format="EPUB",
+            bookmark_key="epubcfi(/6/2!/4/2/1:0)",
+        ),
+        ub.ReadBook(
+            user_id=user.id,
+            book_id=book_id,
+            read_status=ub.ReadBook.STATUS_IN_PROGRESS,
+            last_modified=stamp,
+            last_time_started_reading=stamp,
+            times_started_reading=3,
+        ),
+        state,
+        ub.KoboSyncedBooks(
+            user_id=user.id,
+            book_id=book_id,
+            book_uuid="book-uuid-%d" % book_id,
+        ),
+    ])
+    session.flush()
+    annotation = session.query(ub.Annotation).filter_by(
+        user_id=user.id, book_id=book_id,
+    ).one()
+    annotation.origin_device_id = device.id
+    annotation.assigned_device_id = device.id
+    session.add(ub.KoboDeviceBookEntitlement(
+        device_id=device.id,
+        book_id=book_id,
+        fingerprint="f" * 64,
+        payload_schema_version=1,
+        change_basis='{"book":"stable"}',
+        updated_at=stamp,
+    ))
+    session.commit()
+    return device, _reading_data_snapshot(session, user.id, book_id)
+
+
+def _reading_data_snapshot(session, user_id, book_id):
+    annotation = session.query(ub.Annotation).filter_by(
+        user_id=user_id, book_id=book_id,
+    ).one()
+    bookmark = session.query(ub.Bookmark).filter_by(
+        user_id=user_id, book_id=book_id,
+    ).one()
+    read = session.query(ub.ReadBook).filter_by(
+        user_id=user_id, book_id=book_id,
+    ).one()
+    state = session.query(ub.KoboReadingState).filter_by(
+        user_id=user_id, book_id=book_id,
+    ).one()
+    synced = session.query(ub.KoboSyncedBooks).filter_by(
+        user_id=user_id, book_id=book_id,
+    ).one()
+    entitlement = session.query(ub.KoboDeviceBookEntitlement).filter_by(
+        book_id=book_id,
+    ).one()
+    return {
+        "annotation": (
+            annotation.id, annotation.annotation_id, annotation.source,
+            annotation.annotation_type, annotation.highlighted_text,
+            annotation.highlight_color, annotation.note_text,
+            annotation.cfi_range, annotation.chapter_progress,
+            annotation.origin_device_id, annotation.assigned_device_id,
+        ),
+        "bookmark": (
+            bookmark.id, bookmark.format, bookmark.bookmark_key,
+        ),
+        "read_book": (
+            read.id, read.read_status, read.last_modified,
+            read.last_time_started_reading, read.times_started_reading,
+        ),
+        "kobo_reading_state": (
+            state.id, state.last_modified, state.priority_timestamp,
+        ),
+        "kobo_bookmark": (
+            state.current_bookmark.id,
+            state.current_bookmark.kobo_reading_state_id,
+            state.current_bookmark.location_source,
+            state.current_bookmark.location_type,
+            state.current_bookmark.location_value,
+            state.current_bookmark.progress_percent,
+            state.current_bookmark.content_source_progress_percent,
+        ),
+        "kobo_synced_book": (
+            synced.id, synced.book_uuid,
+        ),
+        "kobo_device_entitlement": (
+            entitlement.id, entitlement.device_id, entitlement.fingerprint,
+            entitlement.payload_schema_version, entitlement.change_basis,
+        ),
+    }
+
+
+def _assert_reading_data_unchanged(session, user_id, book_id, expected):
+    assert _reading_data_snapshot(session, user_id, book_id) == expected
+
+
+def test_single_remove_preserves_every_reading_data_carrier(app_session):
+    from cps import user_library
+
+    user = _user(app_session, "single-remove")
+    app_session.add_all([
+        ub.UserLibraryBook(user_id=user.id, book_id=1),
+        ub.UserLibraryBook(user_id=user.id, book_id=2),
+    ])
+    app_session.commit()
+    _device, expected = _seed_reading_data(app_session, user, 1)
+
+    user_library.remove_book(user, 1, app_session=app_session)
+
+    assert app_session.query(ub.UserLibraryBook).filter_by(
+        user_id=user.id, book_id=1,
+    ).count() == 0
+    _assert_reading_data_unchanged(app_session, user.id, 1, expected)
+
+
+def test_batch_remove_api_preserves_every_reading_data_carrier(
+        app_session, monkeypatch):
+    from cps.api import actions
+
+    user = _user(app_session, "batch-remove")
+    app_session.add_all([
+        ub.UserLibraryBook(user_id=user.id, book_id=1),
+        ub.UserLibraryBook(user_id=user.id, book_id=2),
+    ])
+    app_session.commit()
+    _device, expected = _seed_reading_data(app_session, user, 1)
+    monkeypatch.setattr(ub, "session", app_session)
+    monkeypatch.setattr(actions, "current_user", user)
+    app = Flask(__name__)
+
+    with app.test_request_context(
+            "/api/v1/books/my-library/batch", method="POST",
+            json={"operation": "remove", "book_ids": [1]}):
+        payload = actions.batch_my_library_membership.__wrapped__().get_json()
+
+    assert payload["succeeded_ids"] == [1]
+    assert payload["results"][0]["reading_data_preserved"] is True
+    _assert_reading_data_unchanged(app_session, user.id, 1, expected)
+
+
+def test_removing_last_book_preserves_every_reading_data_carrier(app_session):
+    from cps import user_library
+
+    user = _user(app_session, "empty-library", browse_global=True)
+    app_session.add(ub.UserLibraryBook(user_id=user.id, book_id=1))
+    app_session.commit()
+    _device, expected = _seed_reading_data(app_session, user, 1)
+
+    user_library.remove_book(user, 1, app_session=app_session)
+
+    assert app_session.query(ub.UserLibraryBook).filter_by(
+        user_id=user.id,
+    ).count() == 0
+    _assert_reading_data_unchanged(app_session, user.id, 1, expected)
+
+
+def test_remove_then_readd_restores_exact_reading_state(
+        app_session, calibre_session, monkeypatch):
+    from cps import user_library
+
+    user = _user(app_session, "remove-readd", browse_global=True)
+    app_session.add(ub.UserLibraryBook(user_id=user.id, book_id=1))
+    app_session.commit()
+    _device, expected = _seed_reading_data(app_session, user, 1)
+    cdb = _cdb(calibre_session)
+    monkeypatch.setattr(db.ub, "session", app_session)
+
+    user_library.remove_book(user, 1, app_session=app_session)
+    user_library.add_book(user, 1, app_session=app_session, cdb=cdb)
+
+    assert app_session.query(ub.UserLibraryBook).filter_by(
+        user_id=user.id, book_id=1,
+    ).one()
+    _assert_reading_data_unchanged(app_session, user.id, 1, expected)
+
+
+def test_removed_book_remains_readable_in_annotations_view_and_all_exports(
+        app_session, calibre_session, monkeypatch):
+    from cps import annotations, user_library
+
+    user = _user(app_session, "annotation-archive")
+    app_session.add_all([
+        ub.UserLibraryBook(user_id=user.id, book_id=1),
+        ub.UserLibraryBook(user_id=user.id, book_id=2),
+    ])
+    app_session.commit()
+    _device, _expected = _seed_reading_data(app_session, user, 1)
+    cdb = _cdb(calibre_session)
+    monkeypatch.setattr(ub, "session", app_session)
+    monkeypatch.setattr(annotations, "calibre_db", cdb)
+    monkeypatch.setattr(annotations, "current_user", user)
+    monkeypatch.setattr(
+        annotations, "render_title_template",
+        lambda _template, **context: context,
+    )
+    user_library.remove_book(user, 1, app_session=app_session)
+    app = Flask(__name__)
+
+    with app.test_request_context("/annotations/1"):
+        view = annotations.annotations_view.__wrapped__(1)
+        markdown = annotations.annotations_export_markdown.__wrapped__(1)
+        csv = annotations.annotations_export_csv.__wrapped__(1)
+        exported_json = annotations.annotations_export_json.__wrapped__(1)
+
+    assert [row.annotation_id for row in view["annotations"]] == ["annotation-1"]
+    assert "globally retained note" in markdown.get_data(as_text=True)
+    assert "globally retained note" in csv.get_data(as_text=True)
+    payload = json.loads(exported_json.get_data(as_text=True))
+    assert payload["annotation_count"] == 1
+    assert payload["annotations"][0]["note_text"] == "globally retained note"
+
+
+def test_empty_library_keeps_removed_book_in_annotation_device_views(
+        app_session, calibre_session, monkeypatch):
+    from cps import annotations, user_library
+
+    user = _user(app_session, "empty-device-archive", browse_global=True)
+    app_session.add(ub.UserLibraryBook(user_id=user.id, book_id=1))
+    app_session.commit()
+    device, _expected = _seed_reading_data(app_session, user, 1)
+    cdb = _cdb(calibre_session)
+    monkeypatch.setattr(ub, "session", app_session)
+    monkeypatch.setattr(annotations, "calibre_db", cdb)
+    monkeypatch.setattr(annotations, "current_user", user)
+    user_library.remove_book(user, 1, app_session=app_session)
+    app = Flask(__name__)
+
+    with app.test_request_context(
+            "/api/annotations/devices/%s/annotations" % device.public_id):
+        detail = annotations.annotation_device_annotations.__wrapped__(
+            device.public_id,
+        ).get_json()
+        summary = annotations.annotation_device_summary.__wrapped__(
+            device.public_id,
+        ).get_json()
+        device_list = annotations.list_annotation_devices(
+            user_id=user.id, session=app_session,
+        )
+
+    assert [row["annotation_id"] for row in detail["annotations"]] == [
+        "annotation-1",
+    ]
+    assert detail["annotations"][0]["book"] == {"id": 1, "title": "One"}
+    assert summary["highlights"] == 1
+    assert device_list[0]["highlights"] == 1

--- a/tests/unit/test_annotations_survive_library_removal.py
+++ b/tests/unit/test_annotations_survive_library_removal.py
@@ -7,7 +7,8 @@ import json
 from types import SimpleNamespace
 
 import pytest
-from flask import Flask
+from flask import Flask, g
+from flask_babel import Babel
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -64,10 +65,14 @@ def _user(session, name, *, browse_global=False):
         user_library_seeded=True,
         default_language="all",
     )
+    session.add(user)
+    # Commit before touching role: the column default is applied on INSERT, so
+    # `user.role |= ...` on an unflushed instance ORs against None. This is the
+    # same order test_my_library_backend_1939._mode_user uses.
+    session.commit()
     if browse_global:
         user.role |= constants.ROLE_BROWSE_GLOBAL
-    session.add(user)
-    session.commit()
+        session.commit()
     return user
 
 
@@ -313,8 +318,19 @@ def test_removed_book_remains_readable_in_annotations_view_and_all_exports(
     )
     user_library.remove_book(user, 1, app_session=app_session)
     app = Flask(__name__)
+    # annotations_view calls gettext, which resolves app.extensions['babel'],
+    # and builds url_for links to its sibling export endpoints, which needs the
+    # blueprint registered.
+    Babel(app)
+    app.register_blueprint(annotations.annotations_bp)
 
     with app.test_request_context("/annotations/1"):
+        # These views resolve cps.cw_login's current_user proxy. _get_user()
+        # returns g._login_user when it is set and only falls back to
+        # current_app.login_manager otherwise (cps/cw_login/utils.py:392), so
+        # seeding it is the supported way to run the view as this user without
+        # a session cookie.
+        g._login_user = user
         view = annotations.annotations_view.__wrapped__(1)
         markdown = annotations.annotations_export_markdown.__wrapped__(1)
         csv = annotations.annotations_export_csv.__wrapped__(1)


### PR DESCRIPTION
Reported by the project owner: *"make sure that even if a user removes a book from their library that their notes, highlights, etc are still saved in the global viewer of course because that's the source of truth"*.

## The defect: preserved, but unreachable

`remove_book` was already correct about **storage** — it deletes only `UserLibraryBook` and `BookShelf` rows, and its docstring says annotations, bookmarks, progress and Kobo ownership are deliberately untouched.

The **read path** was not. `db.py:1604` applies a membership filter to book queries once `has_own_library` is set, and the annotation surfaces resolved books through it. So after removing a book its highlights stayed in the database and vanished from the UI.

Proven by reverting the fix and re-running:

```
werkzeug.exceptions.NotFound: 404 Not Found        <- annotations page for a removed book
AssertionError: assert [] == ['annotation-1']      <- device view returns nothing
```

That is the worst shape for a data guarantee: the docstring was true, the rows were intact, and the user still could not reach their own notes.

## The fix

Membership is a catalogue curation boundary, not ownership of reading data. The annotation surfaces now pass `allow_show_global` — **an existing idiom already on main** (`db.py:1842`, `if not allow_show_global and membership_enabled:`) — through `get_filtered_book` and `get_filtered_book_ids_for_users`.

It defaults `False`, so nothing else changes. It bypasses **only** the membership predicate; language, tag, custom-column, hidden and archived restrictions stay enforced. All three call sites are inside `cps/annotations.py`.

## Tests, and the proof they can fail

Six tests: single remove · batch remove · removing the **last** book (the empty-library case) · remove-then-re-add · the annotations view and all three exports · empty-library device views.

A preservation test that has never been seen to fail proves nothing, so both mutations were run:

| mutation | result |
|---|---|
| revert `allow_show_global` at the 3 read sites | **2 failed, 4 passed** — exactly the reachability tests |
| make `remove_book` delete `Annotation` rows | **6 failed** — every test detects the loss |

Regression surface after restoring both: **146 passed, 0 failed** across `test_annotations_survive_library_removal`, `test_my_library_backend_1939`, `test_my_library_leg6_regressions`, `test_1939_migration_ordering`, `test_annotation_device_management`, `test_annotations_view_export`.

## One thing to confirm rather than assume

`_resolve_book_or_404` also guards `annotations_create` (POST), `annotations_edit` (PATCH) and `annotations_delete` (DELETE), so the bypass is **not read-only**. Editing and deleting your own retained notes is intended. *Creating* a new annotation on a non-member book is broader than the reported need — kept because the global archive is the source of truth for annotations, but called out as a deliberate choice.

## Why this matters now

The next planned operation on a real household account is emptying a personal library. Without this, that would have made every retained highlight for those books unreachable.