### PR TITLE
fix(install): a fresh app.db gets the settings table before boot writes to it (#2047)

### DIFF
--- a/changelog.d/2047-fresh-appdb-settings.md
+++ b/changelog.d/2047-fresh-appdb-settings.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fresh bare-metal installs now create the complete `app.db` settings schema before configuring the Calibre library.

--- a/scripts/auto_library.py
+++ b/scripts/auto_library.py
@@ -38,8 +38,19 @@ def _is_definitely_not_a_database(error) -> bool:
 
 def create_appdb(appdb_path):
     app_paths.ensure_app_root_on_sys_path()
-    from cps import ub
+    from cps import config_sql, ub
+
     ub.init_db(appdb_path)
+    # app.db is split across two declarative bases. ub.init_db() creates the
+    # user-facing tables; the canonical configuration bootstrap creates and
+    # migrates settings/flask_settings and inserts the singleton settings row.
+    # Auto-library writes that row before the Flask application starts (#2047).
+    encrypt_key, error = config_sql.get_encryption_key(
+        os.path.dirname(appdb_path)
+    )
+    config_sql.load_configuration(ub.session, encrypt_key)
+    if error:
+        print(f"[cwa-auto-library] WARN: {error}", flush=True)
 
 
 def create_metadb(metadb_path):
@@ -383,13 +394,30 @@ class AutoLibrary:
             try:
                 print("[cwa-auto-library]: Updating Settings Database with library location...")
                 con = sqlite3.connect(self.app_db, timeout=30)
-                cur = con.cursor()
-                cur.execute(f'UPDATE settings SET config_calibre_dir="{self.lib_path}";')
-                con.commit()
+                try:
+                    result = con.execute(
+                        "UPDATE settings SET config_calibre_dir = ?",
+                        (self.lib_path,),
+                    )
+                    if result.rowcount != 1:
+                        raise RuntimeError(
+                            "expected exactly one settings row; "
+                            f"updated {result.rowcount}"
+                        )
+                    con.commit()
+                finally:
+                    con.close()
                 return
-            except Exception as e:
-                print("[cwa-auto-library]: ERROR: Could not update Calibre Web Database")
-                print(e)
+            except (sqlite3.Error, OSError, RuntimeError) as error:
+                print(
+                    "[cwa-auto-library]: FATAL: Could not persist the library "
+                    "location to the Calibre Web Database"
+                )
+                print(f"[cwa-auto-library]: {type(error).__name__}: {error}")
+                print(
+                    "[cwa-auto-library]: Startup cannot continue because "
+                    "app.db would be left unconfigured."
+                )
                 sys.exit(1)
         else:
             print(f"[cwa-auto-library]: ERROR: app.db in {self.app_db} not found")

--- a/tests/unit/test_2047_fresh_appdb_settings_table.py
+++ b/tests/unit/test_2047_fresh_appdb_settings_table.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Fresh app.db creation includes the configuration schema (#2047)."""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from auto_library import create_appdb
+
+
+def test_create_appdb_seeds_usable_settings_row(tmp_path):
+    """The real first-boot path must be writable before auto-library uses it."""
+    app_db = tmp_path / "app.db"
+    library_dir = tmp_path / "calibre-library"
+
+    create_appdb(str(app_db))
+
+    with sqlite3.connect(app_db) as connection:
+        result = connection.execute(
+            "UPDATE settings SET config_calibre_dir = ?",
+            (str(library_dir),),
+        )
+        assert result.rowcount == 1
+        stored_path = connection.execute(
+            "SELECT config_calibre_dir FROM settings"
+        ).fetchone()
+
+    assert stored_path == (str(library_dir),)
+
+
+def test_update_calibre_web_db_exits_when_settings_row_is_missing(
+    tmp_path, capsys
+):
+    """A structurally unusable app.db must stop boot, not look configured."""
+    from auto_library import AutoLibrary
+
+    app_db = tmp_path / "app.db"
+    create_appdb(str(app_db))
+    with sqlite3.connect(app_db) as connection:
+        connection.execute("DELETE FROM settings")
+
+    auto_library = AutoLibrary.__new__(AutoLibrary)
+    auto_library.app_db = str(app_db)
+    auto_library.lib_path = str(tmp_path / "calibre-library")
+
+    with pytest.raises(SystemExit) as exit_info:
+        auto_library.update_calibre_web_db()
+
+    assert exit_info.value.code == 1
+    output = capsys.readouterr().out
+    assert "FATAL" in output
+    assert "expected exactly one settings row; updated 0" in output
+    assert "app.db would be left unconfigured" in output


### PR DESCRIPTION
Fixes #2047.

## The bug

On a **fresh** bare-metal install, `scripts/auto_library.py` creates `app.db` via
`cps.ub.init_db()`. That builds only the tables on `cps/ub.py`'s declarative base — which is why
the reporter's log shows magic shelves being created for user 1. The `settings` table is declared
on a *different* base in `cps/config_sql.py` and is only created when the configuration layer
initialises, which nothing had done at that point.

So the next step, `UPDATE settings SET config_calibre_dir=...`, died on `no such table: settings`.
The old handler printed the error and returned, so boot continued and the install came up with no
library configured. Upgrades and container installs never hit it: their `app.db` already carries
the table.

## The fix

- `create_appdb()` now runs the same configuration bootstrap the app itself
  (`cps/__init__.py`) and `scripts/ingest_processor.py` already use —
  `config_sql.get_encryption_key()` + `config_sql.load_configuration()` — so a newly created
  `app.db` has both bases' schema and the singleton settings row, with the persisted key rather
  than an ephemeral one.
- `update_calibre_web_db()` parameterises the UPDATE (it was f-string-interpolating a filesystem
  path into SQL), asserts it touched exactly one row, closes its connection, and **exits non-zero**
  on failure instead of continuing into a silently unconfigured install.

## Evidence

Regression test: `tests/unit/test_2047_fresh_appdb_settings_table.py`.

- **Red without the fix** (production change stashed, test unchanged): 2 failed — OBSERVED.
- **Green with it**: 2 passed, run twice — OBSERVED.
- Focused subsystem gate (`test_auto_library_default_path`, `test_1462_scripts_app_paths`,
  `test_1482_appdb_creation_failure_reports_cleanly`, this file): **64 passed** — OBSERVED.
  Delegate's wider 140-test auto-library/paths gate also passed.

End-to-end, the reporter's actual scenario (empty config dir + empty library dir, no `app.db`):

- **Pre-fix**: `[cwa-auto-library]: ERROR: Could not update Calibre Web Database` /
  `no such table: settings` — the reporter's exact output, reproduced — OBSERVED.
- **Post-fix**: `Library location successfully set to: …` and
  `SELECT config_calibre_dir FROM settings` returns the library path — OBSERVED.

No new dependencies, no license changes, no new external URLs.

**Security review:** this touches crypto/secrets (`get_encryption_key`) and puts a filesystem path
into SQL, so it is in the risk classes. The `/security-review` harness aborted on a cwd mismatch
(`origin/HEAD...` unresolvable from the project root), so the review was done by the reviewer of
record over the full diff: the change *removes* an f-string SQL interpolation in favour of a bound
parameter; the key bootstrap is the codebase's existing `get_encryption_key` (persists `.key` at
`0600`, generated once, read by the app afterwards); the only new output is that function's
`PermissionError` string, which carries no key material.
