### PR TITLE
fix(spa): reject unlaid-out catalog grid measurements (grid collapses to one column)

### DIFF
--- a/changelog.d/catalog-grid-zero-width-measure.md
+++ b/changelog.d/catalog-grid-zero-width-measure.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **The library grid no longer collapses to one card per row after a hard refresh.** A first-layout race could measure the catalog grid while it had no width; the single resolved track that comes back was accepted as a real one-column layout and stuck. Measurements are now rejected until the grid's own width can actually fit its minimum card, and the grid self-heals within a frame if an early read slipped through.

--- a/frontend/src/lib/catalogGridMeasurement.ts
+++ b/frontend/src/lib/catalogGridMeasurement.ts
@@ -1,0 +1,33 @@
+export interface CatalogGridMeasurement {
+  gridTemplateColumns: string;
+  gridWidth: number;
+  minColumnWidth: number;
+}
+
+const RESOLVED_LENGTH = /^(?:0|[1-9]\d*)(?:\.\d+)?px$/;
+
+/**
+ * Return the resolved catalog track count only when the grid has a usable
+ * content box. A hidden/settling grid can report one genuine 140px track while
+ * its own width is zero or near zero; accepting that track is what can strand
+ * virtualization at one card per row.
+ */
+export function measureCatalogColumnCount({
+  gridTemplateColumns,
+  gridWidth,
+  minColumnWidth,
+}: CatalogGridMeasurement): number | null {
+  if (!Number.isFinite(gridWidth)
+    || !Number.isFinite(minColumnWidth)
+    || gridWidth <= 0
+    || minColumnWidth < 0
+    || gridWidth < minColumnWidth) return null;
+
+  const tracks = gridTemplateColumns.trim();
+  if (!tracks || tracks === 'none') return null;
+
+  const resolvedTracks = tracks.split(/\s+/);
+  return resolvedTracks.every((track) => RESOLVED_LENGTH.test(track))
+    ? resolvedTracks.length
+    : null;
+}

--- a/frontend/src/pages/Catalog.module.css
+++ b/frontend/src/pages/Catalog.module.css
@@ -109,14 +109,15 @@
 
 .grid {
   --catalog-grid-gap: var(--sp-5);
+  --catalog-grid-min: 150px;
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(var(--catalog-grid-min), 1fr));
   column-gap: var(--catalog-grid-gap);
   row-gap: 0;
 }
-.grid.density_comfortable { grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); }
-.grid.density_compact { --catalog-grid-gap: var(--sp-4); grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); }
-.grid.density_dense { --catalog-grid-gap: var(--sp-3); grid-template-columns: repeat(auto-fill, minmax(110px, 1fr)); }
+.grid.density_comfortable { --catalog-grid-min: 180px; }
+.grid.density_compact { --catalog-grid-gap: var(--sp-4); --catalog-grid-min: 140px; }
+.grid.density_dense { --catalog-grid-gap: var(--sp-3); --catalog-grid-min: 110px; }
 .virtualRow {
   display: grid;
   grid-column: 1 / -1;
@@ -296,6 +297,7 @@
 }
 @media (max-width: 600px) {
   .container { padding-inline: var(--sp-3); }
+  .grid { --catalog-grid-min: 0px; }
   .grid.density_comfortable { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .grid.density_compact { grid-template-columns: repeat(3, minmax(0, 1fr)); }
   .grid.density_dense { --catalog-grid-gap: var(--sp-2); grid-template-columns: repeat(4, minmax(0, 1fr)); }

--- a/frontend/src/pages/Catalog.module.css
+++ b/frontend/src/pages/Catalog.module.css
@@ -297,7 +297,9 @@
 }
 @media (max-width: 600px) {
   .container { padding-inline: var(--sp-3); }
-  .grid { --catalog-grid-min: 0px; }
+  /* Doubled class beats the density selectors above (0,2,0), so the 0px
+     minimum actually lands on the fixed-track mobile layouts. */
+  .grid.grid { --catalog-grid-min: 0px; }
   .grid.density_comfortable { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .grid.density_compact { grid-template-columns: repeat(3, minmax(0, 1fr)); }
   .grid.density_dense { --catalog-grid-gap: var(--sp-2); grid-template-columns: repeat(4, minmax(0, 1fr)); }

--- a/frontend/src/pages/Catalog.tsx
+++ b/frontend/src/pages/Catalog.tsx
@@ -21,6 +21,7 @@ import { usePersistentChoice } from '../lib/usePersistentChoice';
 import { useCardActionsHidden } from '../lib/useCardActionsHidden';
 import { useT } from '../lib/i18n';
 import { useAnnouncer } from '../lib/a11y/announcer';
+import { measureCatalogColumnCount } from '../lib/catalogGridMeasurement';
 import styles from './Catalog.module.css';
 import { canUploadBooks } from '../lib/permissions';
 
@@ -352,37 +353,68 @@ export function Catalog({ entityKind, entityId, view, defaultFilter }: CatalogPr
   const [seriesPresentation, setSeriesPresentation] = usePersistentChoice(
     'cwng:series-presentation-v1', ['grid', 'list'] as const, 'grid');
   const settingsRef = useRef<HTMLDivElement>(null);
+  const measureGridRef = useRef<() => void>(() => {});
 
   useEffect(() => {
     if (!gridNode) return;
-    if (typeof ResizeObserver === 'undefined') return;
+    let frame = 0;
+    let cancelled = false;
 
-    const observer = new ResizeObserver(() => {
-      // Both layout reads happen in ResizeObserver's post-layout delivery. The
-      // old effect-body read ran immediately after React DOM writes and forced
-      // style/layout; keeping one grid node mounted also removes the loading ->
-      // loaded ref churn that used to repeat that forced read (#1813 item 8).
-      const tracks = getComputedStyle(gridNode).gridTemplateColumns.trim();
-      // An empty or 'none' track list means the grid has not been laid out yet
-      // (a hidden ancestor, a panel mid-transition), which is the absence of a
-      // measurement rather than a measurement of one column. Releasing the gate
-      // on it would query at rowsPerLoad x 1 and then correct once the real
-      // layout arrived — reinstating the double fetch this gate exists to stop.
-      // Leave gridMeasured false and let the next observer callback, or the
-      // fail-open timer, resolve it.
-      if (tracks && tracks !== 'none') {
-        setColumnCount(Math.max(1, tracks.split(/\s+/).length));
+    const measure = () => {
+      const style = getComputedStyle(gridNode);
+      const bounds = gridNode.getBoundingClientRect();
+      const nextColumnCount = measureCatalogColumnCount({
+        gridTemplateColumns: style.gridTemplateColumns,
+        gridWidth: bounds.width,
+        minColumnWidth: Number.parseFloat(style.getPropertyValue('--catalog-grid-min')),
+      });
+      // Zero width or an absent track list is no measurement. Keep the query
+      // gate closed (until its fail-open timer) and retain the last known count;
+      // a later observer/rAF/font sample can still correct it without user input.
+      if (nextColumnCount !== null) {
+        setColumnCount(nextColumnCount);
         setGridMeasured(true);
       }
-      setGridTop(gridNode.getBoundingClientRect().top + window.scrollY);
+      setGridTop(bounds.top + window.scrollY);
+    };
+    measureGridRef.current = measure;
+    const scheduleMeasure = () => {
+      if (frame) return;
+      frame = requestAnimationFrame(() => {
+        frame = 0;
+        measure();
+      });
+    };
+
+    // ResizeObserver remains the owner of live border-box measurement. Its first
+    // delivery can race Safari's resolved grid-track serialization, so every
+    // delivery gets one coalesced next-frame self-heal rather than trusting that
+    // delivery to be the only sample until the window changes again.
+    const observer = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(() => {
+      measure();
+      scheduleMeasure();
     });
-    observer.observe(gridNode);
+    observer?.observe(gridNode);
     // Content above the grid (notably Discover and the settings disclosure) can
     // change its document offset without changing the grid's own border box.
     // Observing the stable page container keeps that cached offset current;
     // scroll handling itself remains layout-read-free.
-    if (catalogNode) observer.observe(catalogNode);
-    return () => observer.disconnect();
+    if (catalogNode) observer?.observe(catalogNode);
+
+    // The first post-paint sample also keeps the fail-open path useful when
+    // ResizeObserver is unavailable. Web-font completion can change usable card
+    // geometry without guaranteeing another grid border-box notification.
+    scheduleMeasure();
+    void document.fonts?.ready.then(() => {
+      if (!cancelled) scheduleMeasure();
+    });
+
+    return () => {
+      cancelled = true;
+      observer?.disconnect();
+      cancelAnimationFrame(frame);
+      if (measureGridRef.current === measure) measureGridRef.current = () => {};
+    };
   }, [catalogNode, gridNode, density]);
 
   // Fail-open. The measurement needs the grid element to exist, and a first
@@ -390,11 +422,16 @@ export function Catalog({ entityKind, entityId, view, defaultFilter }: CatalogPr
   // measurement -> query stays disabled -> no data. Rendering the loading state
   // inside the grid container (below) is what breaks that cycle, but the gate
   // must not be the only thing standing between a user and their library, so
-  // any path that fails to measure within a frame falls back to the guess and
-  // queries anyway. Worst case is the old redundant fetch; never an empty page.
+  // any path that fails to measure within a short grace window falls back to the
+  // guess and queries anyway. Recheck immediately before opening the gate so a
+  // first-layout race heals even if no second observer delivery arrives. Worst
+  // case is the old redundant fetch; never an empty page.
   useEffect(() => {
     if (gridMeasured) return;
-    const timer = setTimeout(() => setGridMeasured(true), 150);
+    const timer = setTimeout(() => {
+      measureGridRef.current();
+      setGridMeasured(true);
+    }, 150);
     return () => clearTimeout(timer);
   }, [gridMeasured]);
 

--- a/frontend/unit/catalogGridMeasurement.test.ts
+++ b/frontend/unit/catalogGridMeasurement.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { measureCatalogColumnCount } from '../src/lib/catalogGridMeasurement.ts';
+
+test('zero-width and below-minimum one-track reads are unmeasured', () => {
+  const measurements = [0, 60].map((gridWidth) => measureCatalogColumnCount({
+    gridTemplateColumns: '140px',
+    gridWidth,
+    minColumnWidth: 140,
+  }));
+
+  assert.deepEqual(measurements, [null, null]);
+});
+
+test('a laid-out follow-up self-heals an initially unmeasured grid', () => {
+  const nextFrame = measureCatalogColumnCount({
+    gridTemplateColumns: '164px 164px 164px 164px 164px',
+    gridWidth: 900,
+    minColumnWidth: 140,
+  });
+
+  assert.equal(nextFrame, 5);
+});
+
+test('resolved healthy templates preserve five and eight track layouts', () => {
+  assert.equal(measureCatalogColumnCount({
+    gridTemplateColumns: '184px 184px 184px 184px 184px',
+    gridWidth: 1000,
+    minColumnWidth: 180,
+  }), 5);
+  assert.equal(measureCatalogColumnCount({
+    gridTemplateColumns: '162px 162px 162px 162px 162px 162px 162px 162px',
+    gridWidth: 1440,
+    minColumnWidth: 140,
+  }), 8);
+});
+
+test('a real one-column grid at the minimum width remains valid', () => {
+  assert.equal(measureCatalogColumnCount({
+    gridTemplateColumns: '140px',
+    gridWidth: 140,
+    minColumnWidth: 140,
+  }), 1);
+});
+
+test('fixed mobile tracks use their zero CSS minimum after the breakpoint override', () => {
+  assert.equal(measureCatalogColumnCount({
+    gridTemplateColumns: '30px 30px',
+    gridWidth: 60,
+    minColumnWidth: 0,
+  }), 2);
+});

--- a/frontend/unit/structuralPerformance.test.ts
+++ b/frontend/unit/structuralPerformance.test.ts
@@ -45,6 +45,9 @@ test('catalog owns one stable measured grid node and delegates its cards to the 
   const gridTestIds = catalog.match(/data-testid="catalog-grid"/g) ?? [];
 
   assert.equal(gridTestIds.length, 1);
-  assert.match(catalog, /new ResizeObserver\(\(\) => \{[\s\S]*?getComputedStyle\(gridNode\)\.gridTemplateColumns/);
+  assert.match(catalog, /new ResizeObserver\(\(\) => \{[\s\S]*?measure\(\);[\s\S]*?scheduleMeasure\(\);/);
+  assert.match(catalog, /measureCatalogColumnCount\(\{[\s\S]*?gridTemplateColumns:[\s\S]*?gridWidth:/);
+  assert.match(catalog, /requestAnimationFrame\([\s\S]*?document\.fonts\?\.ready/);
+  assert.match(catalog, /setTimeout\(\(\) => \{[\s\S]*?measureGridRef\.current\(\);[\s\S]*?setGridMeasured\(true\)/);
   assert.match(catalog, /<VirtualizedGridRows[\s\S]*?columnCount=\{columnCount\}/);
 });


### PR DESCRIPTION
LIVE P1, operator-reported on the canary with a screenshot: after a hard refresh the library grid renders one fully-drawn card per full-width row.

**Mechanism (peer-measured, both engines)**: the catalog's columnCount comes from parsing `getComputedStyle(grid).gridTemplateColumns`. A grid measured at zero/near-zero width resolves to a SINGLE genuine track (e.g. `140px`) — indistinguishable from a real one-column layout — and the existing ''/'none' guard can't catch it. Once accepted, it sticks: no further ResizeObserver delivery arrives at a constant window size. Every automated probe (Chromium + WebKit, 1000–2000px, all densities/roles, through the tunnel) wins the race; a real interactive browser can lose it.

**Fix**: measurements are rejected while the grid's own content-box width is zero or below the CSS minmax minimum (now a shared custom property so CSS and JS can't drift; the mobile fixed-track breakpoint pins it to 0). Self-heal via the next observer delivery, one coalesced rAF re-measure, `document.fonts.ready`, and a final check before the 150ms fail-open.

**Red proof on the true input**: the defective parser accepted `'140px'` at gridWidth 0 and 60 as columnCount 1 (test run exits 1, values [1,1] vs expected [null,null]); fixed code returns unmeasured. A wrong earlier hypothesis (unresolved `repeat(...)` string) was measured to 3 tokens and explicitly discarded as evidence. Healthy paths pinned: 5@1000, 8@1440, legitimate 1@140, mobile 2-track.

tsc (base + e2e config) green; unit 20/20.