### PR TITLE
fix(spa): reject arithmetically impossible catalog column measurements

### DIFF
--- a/changelog.d/catalog-columncount-arithmetic.md
+++ b/changelog.d/catalog-columncount-arithmetic.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- **The catalog no longer gets stuck showing one oversized book per row in
+  Safari.** A transient browser layout could report one full-width grid column
+  even when the available space fit a complete row, causing the catalog to load
+  only two books and preserve that incorrect layout. Column measurements now
+  have to agree with the grid width, card minimum, and gap before they can
+  control pagination.

--- a/frontend/src/lib/catalogGridMeasurement.ts
+++ b/frontend/src/lib/catalogGridMeasurement.ts
@@ -1,7 +1,8 @@
 export interface CatalogGridMeasurement {
   gridTemplateColumns: string;
   gridWidth: number;
-  minColumnWidth: number;
+  minColumnWidth?: number;
+  columnGap: number;
 }
 
 const RESOLVED_LENGTH = /^(?:0|[1-9]\d*)(?:\.\d+)?px$/;
@@ -16,18 +17,35 @@ export function measureCatalogColumnCount({
   gridTemplateColumns,
   gridWidth,
   minColumnWidth,
+  columnGap,
 }: CatalogGridMeasurement): number | null {
   if (!Number.isFinite(gridWidth)
-    || !Number.isFinite(minColumnWidth)
-    || gridWidth <= 0
-    || minColumnWidth < 0
-    || gridWidth < minColumnWidth) return null;
+    || gridWidth <= 0) return null;
 
   const tracks = gridTemplateColumns.trim();
   if (!tracks || tracks === 'none') return null;
 
   const resolvedTracks = tracks.split(/\s+/);
-  return resolvedTracks.every((track) => RESOLVED_LENGTH.test(track))
-    ? resolvedTracks.length
-    : null;
+  if (!resolvedTracks.every((track) => RESOLVED_LENGTH.test(track))) return null;
+
+  // Mobile replaces auto-fill with fixed repeat(n) tracks and pins the shared
+  // minimum to zero. An absent CSS minimum likewise leaves no auto-fill
+  // geometry to validate, so preserve the resolved-track behavior in both
+  // cases. Other invalid minima cannot describe either layout safely.
+  if (minColumnWidth === undefined || Number.isNaN(minColumnWidth) || minColumnWidth === 0) {
+    return resolvedTracks.length;
+  }
+  if (!Number.isFinite(minColumnWidth)
+    || minColumnWidth < 0
+    || !Number.isFinite(columnGap)
+    || columnGap < 0
+    || gridWidth < minColumnWidth) return null;
+
+  // auto-fill can fit floor((W + gap) / (min + gap)) tracks. Keep the exact
+  // integer floor: subtracting a width tolerance would lower it immediately
+  // above every track threshold and admit the undercount this gate screens out.
+  const requiredTrackCount = Math.max(1, Math.floor(
+    (gridWidth + columnGap) / (minColumnWidth + columnGap),
+  ));
+  return resolvedTracks.length < requiredTrackCount ? null : resolvedTracks.length;
 }

--- a/frontend/src/pages/Catalog.tsx
+++ b/frontend/src/pages/Catalog.tsx
@@ -367,6 +367,7 @@ export function Catalog({ entityKind, entityId, view, defaultFilter }: CatalogPr
         gridTemplateColumns: style.gridTemplateColumns,
         gridWidth: bounds.width,
         minColumnWidth: Number.parseFloat(style.getPropertyValue('--catalog-grid-min')),
+        columnGap: Number.parseFloat(style.columnGap),
       });
       // Zero width or an absent track list is no measurement. Keep the query
       // gate closed (until its fail-open timer) and retain the last known count;

--- a/frontend/unit/catalogGridMeasurement.test.ts
+++ b/frontend/unit/catalogGridMeasurement.test.ts
@@ -2,11 +2,21 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { measureCatalogColumnCount } from '../src/lib/catalogGridMeasurement.ts';
 
+test('rejects Safari transient one-track serialization at the live catalog width', () => {
+  assert.equal(measureCatalogColumnCount({
+    gridTemplateColumns: '142px',
+    gridWidth: 1248,
+    minColumnWidth: 140,
+    columnGap: 16,
+  }), null);
+});
+
 test('zero-width and below-minimum one-track reads are unmeasured', () => {
   const measurements = [0, 60].map((gridWidth) => measureCatalogColumnCount({
     gridTemplateColumns: '140px',
     gridWidth,
     minColumnWidth: 140,
+    columnGap: 16,
   }));
 
   assert.deepEqual(measurements, [null, null]);
@@ -14,9 +24,10 @@ test('zero-width and below-minimum one-track reads are unmeasured', () => {
 
 test('a laid-out follow-up self-heals an initially unmeasured grid', () => {
   const nextFrame = measureCatalogColumnCount({
-    gridTemplateColumns: '164px 164px 164px 164px 164px',
+    gridTemplateColumns: '167.2px 167.2px 167.2px 167.2px 167.2px',
     gridWidth: 900,
     minColumnWidth: 140,
+    columnGap: 16,
   });
 
   assert.equal(nextFrame, 5);
@@ -24,29 +35,70 @@ test('a laid-out follow-up self-heals an initially unmeasured grid', () => {
 
 test('resolved healthy templates preserve five and eight track layouts', () => {
   assert.equal(measureCatalogColumnCount({
-    gridTemplateColumns: '184px 184px 184px 184px 184px',
+    gridTemplateColumns: '180.8px 180.8px 180.8px 180.8px 180.8px',
     gridWidth: 1000,
     minColumnWidth: 180,
+    columnGap: 24,
   }), 5);
   assert.equal(measureCatalogColumnCount({
-    gridTemplateColumns: '162px 162px 162px 162px 162px 162px 162px 162px',
-    gridWidth: 1440,
+    gridTemplateColumns: '142px 142px 142px 142px 142px 142px 142px 142px',
+    gridWidth: 1248,
     minColumnWidth: 140,
+    columnGap: 16,
   }), 8);
 });
 
-test('a real one-column grid at the minimum width remains valid', () => {
+test('a real one-column grid at 150px remains valid', () => {
   assert.equal(measureCatalogColumnCount({
-    gridTemplateColumns: '140px',
-    gridWidth: 140,
+    gridTemplateColumns: '150px',
+    gridWidth: 150,
     minColumnWidth: 140,
+    columnGap: 16,
   }), 1);
 });
 
 test('fixed mobile tracks use their zero CSS minimum after the breakpoint override', () => {
   assert.equal(measureCatalogColumnCount({
-    gridTemplateColumns: '30px 30px',
-    gridWidth: 60,
+    gridTemplateColumns: '67px 67px',
+    gridWidth: 150,
     minColumnWidth: 0,
+    columnGap: 16,
   }), 2);
+});
+
+test('fixed tracks remain measurable when the CSS minimum is absent', () => {
+  assert.equal(measureCatalogColumnCount({
+    gridTemplateColumns: '67px 67px',
+    gridWidth: 150,
+    columnGap: 16,
+  }), 2);
+});
+
+test('genuine WebKit layouts stay measurable on both sides of a track threshold', () => {
+  assert.equal(measureCatalogColumnCount({
+    gridTemplateColumns: '162.25px 162.25px 162.25px 162.25px 162.25px 162.25px 162.25px',
+    gridWidth: 1231.75,
+    minColumnWidth: 140,
+    columnGap: 16,
+  }), 7);
+  assert.equal(measureCatalogColumnCount({
+    gridTemplateColumns: '154.1875px 154.1875px 154.1875px 154.1875px 154.1875px 154.1875px 154.1875px 154.1875px',
+    gridWidth: 1233.5,
+    minColumnWidth: 140,
+    columnGap: 16,
+  }), 8);
+});
+
+test('rejects a one-track undercount at and above the eight-track threshold', () => {
+  const transientCounts = [
+    { gridWidth: 1232, trackWidth: '162.285714px' },
+    { gridWidth: 1233.5, trackWidth: '162.5px' },
+  ].map(({ gridWidth, trackWidth }) => measureCatalogColumnCount({
+    gridTemplateColumns: Array(7).fill(trackWidth).join(' '),
+    gridWidth,
+    minColumnWidth: 140,
+    columnGap: 16,
+  }));
+
+  assert.deepEqual(transientCounts, [null, null]);
 });

--- a/frontend/unit/structuralPerformance.test.ts
+++ b/frontend/unit/structuralPerformance.test.ts
@@ -47,6 +47,7 @@ test('catalog owns one stable measured grid node and delegates its cards to the 
   assert.equal(gridTestIds.length, 1);
   assert.match(catalog, /new ResizeObserver\(\(\) => \{[\s\S]*?measure\(\);[\s\S]*?scheduleMeasure\(\);/);
   assert.match(catalog, /measureCatalogColumnCount\(\{[\s\S]*?gridTemplateColumns:[\s\S]*?gridWidth:/);
+  assert.match(catalog, /columnGap: Number\.parseFloat\(style\.columnGap\)/);
   assert.match(catalog, /requestAnimationFrame\([\s\S]*?document\.fonts\?\.ready/);
   assert.match(catalog, /setTimeout\(\(\) => \{[\s\S]*?measureGridRef\.current\(\);[\s\S]*?setGridMeasured\(true\)/);
   assert.match(catalog, /<VirtualizedGridRows[\s\S]*?columnCount=\{columnCount\}/);


### PR DESCRIPTION
Closes the LIVE Safari 26.6 catalog collapse the operator reproduced tonight after #2066: at first load Safari transiently resolved `repeat(auto-fill, minmax(140px,1fr))` to ONE full-width track at gridWidth 1248 — a reading the #2066 width-gate accepted as legitimate, latching columnCount 1 (perPage collapsed to 2). The operator's own console paste captured the poisoned state, and opening DevTools (a resize) proved the #2066 self-heal machinery corrects it — the acceptance gate was the hole.

**Fix**: auto-fill's final track count is fully determined by geometry — `floor((width + gap) / (min + gap))`. Any resolved count below that is a transient lie and is now rejected (unmeasured), so the existing observer/rAF/fonts/fail-open re-measure chain keeps hunting until a consistent reading lands. Gap is read from computed style (density/root-font proof); the mobile fixed-track breakpoint (min pinned 0) bypasses the arithmetic.

**Adversarial loop**: first cut carried a 2px tolerance — review REPRODUCED a 2px blind band at every column threshold (transient 7-of-8 accepted at 1233.5px) and proved the tolerance test pinned an impossible layout (8 tracks where real WebKit resolves 9). Amended to the exact floor with tolerance NONE, justified empirically: a quarter-pixel WebKit sweep of genuine layouts across all densities at 16px+20px roots shows zero false rejections. Closure pass re-ran both reproductions (dead) and the sweep (still zero). Red-proofs on the live 1248px singleton and on threshold bands both sides of T(8).