### PR TITLE
fix(edit): a bulk edit that partly failed no longer reports that every book succeeded

### DIFF
--- a/changelog.d/issue-2073.md
+++ b/changelog.d/issue-2073.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- **Bulk edits now warn when only some selected books were updated instead of
+  reporting that everything succeeded.** The warning identifies failed books.
+  A book which failed after its files were renamed may now be inconsistent with
+  its library database entry.

--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -279,6 +279,7 @@ def edit_selected_books():
                     'files_may_be_inconsistent': False,
                 })
                 continue
+            resolved_book_id = book.id
 
             # Collect all changes
             changes = {key: d.get(key) for key in ['title', 'title_sort', 'author_sort', 'authors', 'categories', 'series', 'languages', 'publishers', 'comments'] if d.get(key)}
@@ -347,12 +348,12 @@ def edit_selected_books():
 
             # Update directory structure once if title or authors changed
             if title_changed or authors_changed:
-                rename_error = helper.update_dir_structure(book.id, config.get_book_path(), input_authors[0])
+                rename_error = helper.update_dir_structure(resolved_book_id, config.get_book_path(), input_authors[0])
                 if rename_error:
                     calibre_db.session.rollback()
-                    log.error("Bulk edit failed to rename book %s: %s", book.id, rename_error)
+                    log.error("Bulk edit failed to rename book %s: %s", resolved_book_id, rename_error)
                     failed_books.append({
-                        'book_id': book.id,
+                        'book_id': resolved_book_id,
                         'stage': 'rename',
                         'files_may_be_inconsistent': True,
                     })
@@ -365,13 +366,13 @@ def edit_selected_books():
                 calibre_db.session.rollback()
                 log.error_or_exception("Database error: {}".format(e))
                 failed_books.append({
-                    'book_id': book.id,
+                    'book_id': resolved_book_id,
                     'stage': 'commit',
                     'files_may_be_inconsistent': title_changed or authors_changed,
                 })
                 continue
 
-            successful_books.append(book.id)
+            successful_books.append(resolved_book_id)
             if metadata_changed and log_payload:
                 try:
                     log_payload.setdefault('title', book.title)
@@ -387,12 +388,12 @@ def edit_selected_books():
                     os.makedirs(constants.CWA_METADATA_CHANGE_LOGS_DIR, exist_ok=True)
                     log_path = os.path.join(
                         constants.CWA_METADATA_CHANGE_LOGS_DIR,
-                        f'{now.strftime("%Y%m%d%H%M%S")}-{book.id}.json')
+                        f'{now.strftime("%Y%m%d%H%M%S")}-{resolved_book_id}.json')
                     with open(log_path, 'w', encoding='utf-8') as f:
                         json.dump(log_payload, f, indent=4, ensure_ascii=False)
-                    log.debug(f"Created metadata change log for book {book.id} with changes: {list(log_payload.keys())}")
+                    log.debug(f"Created metadata change log for book {resolved_book_id} with changes: {list(log_payload.keys())}")
                 except Exception as e:
-                    log.error_or_exception(f"Failed to write metadata change log for book {book.id}: {e}")
+                    log.error_or_exception(f"Failed to write metadata change log for book {resolved_book_id}: {e}")
 
         if failed_books:
             failed_ids = ", ".join(

--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -395,15 +395,23 @@ def edit_selected_books():
                     log.error_or_exception(f"Failed to write metadata change log for book {book.id}: {e}")
 
         if failed_books:
-            failed_ids = ", ".join(str(failure['book_id']) for failure in failed_books)
+            failed_ids = ", ".join(
+                str(failure['book_id'])
+                for failure in failed_books
+                if isinstance(failure['book_id'], int)
+                and not isinstance(failure['book_id'], bool)
+            )
+            failed_ids_message = _(
+                " (book IDs: %(failed_ids)s)", failed_ids=failed_ids,
+            ) if failed_ids else ""
             message = _(
                 "Bulk edit completed with errors: %(success_count)s succeeded and "
-                "%(failure_count)s failed (book IDs: %(failed_ids)s). One or more "
+                "%(failure_count)s failed%(failed_ids_message)s. One or more "
                 "failed books may have had files renamed before the database update "
                 "failed; their files and database entries may now be inconsistent.",
                 success_count=len(successful_books),
                 failure_count=len(failed_books),
-                failed_ids=failed_ids,
+                failed_ids_message=failed_ids_message,
             )
             return json.dumps({
                 'success': False,

--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -263,6 +263,8 @@ def edit_selected_books():
     checkA = d.get('checkA')
 
     if len(selections) != 0:
+        successful_books = []
+        failed_books = []
         for book_id in selections:
             vals = {
                 "pk": book_id,
@@ -271,6 +273,11 @@ def edit_selected_books():
             }
             book = calibre_db.get_book(book_id)
             if not book:
+                failed_books.append({
+                    'book_id': book_id,
+                    'stage': 'lookup',
+                    'files_may_be_inconsistent': False,
+                })
                 continue
 
             # Collect all changes
@@ -342,9 +349,14 @@ def edit_selected_books():
             if title_changed or authors_changed:
                 rename_error = helper.update_dir_structure(book.id, config.get_book_path(), input_authors[0])
                 if rename_error:
-                    # Handle error appropriately, maybe flash a message
                     calibre_db.session.rollback()
-                    continue # or return an error response
+                    log.error("Bulk edit failed to rename book %s: %s", book.id, rename_error)
+                    failed_books.append({
+                        'book_id': book.id,
+                        'stage': 'rename',
+                        'files_may_be_inconsistent': True,
+                    })
+                    continue
 
             helper.mark_book_modified(book, set_dirty=metadata_changed)
             try:
@@ -352,9 +364,14 @@ def edit_selected_books():
             except (OperationalError, IntegrityError, StaleDataError) as e:
                 calibre_db.session.rollback()
                 log.error_or_exception("Database error: {}".format(e))
-                # Handle error appropriately
+                failed_books.append({
+                    'book_id': book.id,
+                    'stage': 'commit',
+                    'files_may_be_inconsistent': title_changed or authors_changed,
+                })
                 continue
 
+            successful_books.append(book.id)
             if metadata_changed and log_payload:
                 try:
                     log_payload.setdefault('title', book.title)
@@ -377,6 +394,24 @@ def edit_selected_books():
                 except Exception as e:
                     log.error_or_exception(f"Failed to write metadata change log for book {book.id}: {e}")
 
+        if failed_books:
+            failed_ids = ", ".join(str(failure['book_id']) for failure in failed_books)
+            message = _(
+                "Bulk edit completed with errors: %(success_count)s succeeded and "
+                "%(failure_count)s failed (book IDs: %(failed_ids)s). One or more "
+                "failed books may have had files renamed before the database update "
+                "failed; their files and database entries may now be inconsistent.",
+                success_count=len(successful_books),
+                failure_count=len(failed_books),
+                failed_ids=failed_ids,
+            )
+            return json.dumps({
+                'success': False,
+                'partial': bool(successful_books),
+                'successful_books': successful_books,
+                'failed_books': failed_books,
+                'message': message,
+            })
         return json.dumps({'success': True})
     return ""
 

--- a/cps/static/js/table.js
+++ b/cps/static/js/table.js
@@ -390,7 +390,12 @@ $(function() {
                 $("#publishers_input").val("");
                 $("#comments_input").val("");
 
-                handleListServerResponse;
+                if (booTitles && booTitles.success === false) {
+                    handleListServerResponse([{
+                        type: "danger",
+                        message: booTitles.message
+                    }]);
+                }
             }
         });
     });

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -320,6 +320,13 @@ CWA_METADATA_LOCK_DIR=${CONFIG_DIR}
 # E2E_USER=admin
 # E2E_PASS=admin123
 
+# Titles of the two books the legacy bulk-edit partial-failure spec selects, on an
+# instance where the first book's directory has been made unwritable so the rename
+# genuinely fails. Both unset means that spec skips; it is an evidence harness, not
+# part of the ordinary suite.
+# E2E_BULK_EDIT_FAILURE_TITLE=
+# E2E_BULK_EDIT_SUCCESS_TITLE=
+
 # Route the user-notices E2E page through the current Vite source server.
 # Default: unset/off. Set to a non-empty value only for that focused local test rig.
 # E2E_CURRENT_SOURCE=

--- a/frontend/e2e/bulk-edit-partial-failure.spec.ts
+++ b/frontend/e2e/bulk-edit-partial-failure.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const FAILURE_TITLE = process.env.E2E_BULK_EDIT_FAILURE_TITLE;
+const SUCCESS_TITLE = process.env.E2E_BULK_EDIT_SUCCESS_TITLE;
+
+async function selectBookThroughCheckbox(page: Page, title: string) {
+  const matchingRows = page.locator('#books-table tbody tr:not(.no-records-found)').filter({
+    has: page.getByRole('link', { name: title, exact: true }),
+  });
+  await expect(matchingRows, `the legacy table should find exactly one book named "${title}"`).toHaveCount(1);
+
+  const checkbox = matchingRows.locator('td.bs-checkbox input[type="checkbox"]');
+  await expect(checkbox).toBeVisible();
+  await checkbox.check();
+}
+
+test('legacy bulk edit renders the server partial-failure message (#2073)', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop', 'the legacy callback is viewport-independent');
+  test.skip(
+    !FAILURE_TITLE || !SUCCESS_TITLE,
+    'requires E2E_BULK_EDIT_FAILURE_TITLE and E2E_BULK_EDIT_SUCCESS_TITLE on a fault-injected instance',
+  );
+
+  await page.goto('/table');
+  await expect(page.getByRole('heading', { name: 'Books List' })).toBeVisible();
+
+  await selectBookThroughCheckbox(page, FAILURE_TITLE!);
+  await selectBookThroughCheckbox(page, SUCCESS_TITLE!);
+
+  const editSelected = page.locator('#edit_selected_books');
+  await expect(editSelected).not.toHaveClass(/\bdisabled\b/);
+  await editSelected.click();
+
+  const modal = page.locator('#edit_selected_modal');
+  await expect(modal).toBeVisible();
+  await modal.locator('#title_input').fill('E2E partial-failure title');
+
+  const responsePromise = page.waitForResponse((response) =>
+    response.request().method() === 'POST'
+      && new URL(response.url()).pathname.endsWith('/ajax/editselectedbooks'));
+  await modal.locator('#edit_selected_confirm').click();
+  const response = await responsePromise;
+  expect(response.ok(), 'the route reports per-book failure in JSON, not as an HTTP error').toBe(true);
+
+  const payload = await response.json() as {
+    success: boolean;
+    partial: boolean;
+    successful_books: number[];
+    failed_books: Array<{
+      book_id: number;
+      stage: string;
+      files_may_be_inconsistent: boolean;
+    }>;
+    message: string;
+  };
+  expect(payload.success).toBe(false);
+  expect(payload.partial).toBe(true);
+  expect(payload.successful_books).toHaveLength(1);
+  expect(payload.failed_books).toEqual([
+    expect.objectContaining({
+      stage: 'rename',
+      files_may_be_inconsistent: true,
+    }),
+  ]);
+  expect(payload.message).toMatch(
+    /^Bulk edit completed with errors: 1 succeeded and 1 failed \(book IDs: \d+\)\./,
+  );
+
+  const dangerBanner = page.locator('#flash_danger');
+  await expect(dangerBanner).toBeVisible();
+  await expect(dangerBanner).toHaveText(payload.message);
+});

--- a/tests/unit/test_2073_bulk_edit_reports_failures.py
+++ b/tests/unit/test_2073_bulk_edit_reports_failures.py
@@ -24,7 +24,7 @@ def _book(book_id):
     )
 
 
-def _run_bulk_edit(monkeypatch, tmp_path, failure_stage):
+def _run_bulk_edit(monkeypatch, tmp_path, failure_stage, selections=None):
     from cps import editbooks
 
     books = {book_id: _book(book_id) for book_id in (1, 2, 3)}
@@ -67,7 +67,7 @@ def _run_bulk_edit(monkeypatch, tmp_path, failure_stage):
         "/ajax/editselectedbooks",
         method="POST",
         json={
-            "selections": [1, 2, 3],
+            "selections": selections if selections is not None else [1, 2, 3],
             "title": "Updated title",
             "checkA": "false",
         },
@@ -109,6 +109,29 @@ def test_bulk_edit_keeps_the_legacy_all_success_shape(monkeypatch, tmp_path):
     assert rename_attempts == [1, 2, 3]
     assert session.commit.call_count == 3
     session.rollback.assert_not_called()
+
+
+def test_non_numeric_failed_id_is_not_reflected_in_user_message(
+    monkeypatch, tmp_path,
+):
+    hostile_id = '<img src=x onerror="alert(1)">'
+    payload, rename_attempts, session = _run_bulk_edit(
+        monkeypatch,
+        tmp_path,
+        failure_stage=None,
+        selections=[hostile_id, 1],
+    )
+
+    assert payload["success"] is False
+    assert hostile_id not in payload["message"]
+    assert payload["failed_books"] == [{
+        "book_id": hostile_id,
+        "stage": "lookup",
+        "files_may_be_inconsistent": False,
+    }]
+    assert payload["successful_books"] == [1]
+    assert rename_attempts == [1]
+    session.commit.assert_called_once_with()
 
 
 def test_books_table_surfaces_the_partial_failure_message():

--- a/tests/unit/test_2073_bulk_edit_reports_failures.py
+++ b/tests/unit/test_2073_bulk_edit_reports_failures.py
@@ -24,11 +24,44 @@ def _book(book_id):
     )
 
 
-def _run_bulk_edit(monkeypatch, tmp_path, failure_stage, selections=None):
+class _ExpiringIdBook:
+    def __init__(self, book_id):
+        self._book_id = book_id
+        self._id_expired = False
+        self.title = f"Book {book_id}"
+        self.authors = [SimpleNamespace(name="Author")]
+
+    @property
+    def id(self):
+        if self._id_expired:
+            raise AssertionError("book.id accessed after transaction boundary")
+        return self._book_id
+
+    def expire_id(self):
+        self._id_expired = True
+
+
+def _run_bulk_edit(
+    monkeypatch,
+    tmp_path,
+    failure_stage,
+    selections=None,
+    expire_book_ids_on_boundary=False,
+    decode_response=True,
+):
     from cps import editbooks
 
-    books = {book_id: _book(book_id) for book_id in (1, 2, 3)}
+    book_factory = _ExpiringIdBook if expire_book_ids_on_boundary else _book
+    books = {book_id: book_factory(book_id) for book_id in (1, 2, 3)}
     rename_attempts = []
+    active_book = None
+    active_book_id = None
+
+    def get_book(book_id):
+        nonlocal active_book, active_book_id
+        active_book = books.get(book_id)
+        active_book_id = book_id
+        return active_book
 
     def update_dir_structure(book_id, *_args):
         rename_attempts.append(book_id)
@@ -36,16 +69,24 @@ def _run_bulk_edit(monkeypatch, tmp_path, failure_stage, selections=None):
             return "forced rename failure"
         return False
 
-    commit = MagicMock()
-    if failure_stage == "commit":
-        commit.side_effect = [
-            None,
-            OperationalError("forced commit failure", {}, Exception("forced")),
-            None,
-        ]
-    session = SimpleNamespace(commit=commit, rollback=MagicMock())
+    def commit_book():
+        if failure_stage == "commit" and active_book_id == 2:
+            raise OperationalError(
+                "forced commit failure", {}, Exception("forced"),
+            )
+        if expire_book_ids_on_boundary:
+            active_book.expire_id()
 
-    monkeypatch.setattr(editbooks.calibre_db, "get_book", books.get)
+    def rollback_book():
+        if expire_book_ids_on_boundary:
+            active_book.expire_id()
+
+    session = SimpleNamespace(
+        commit=MagicMock(side_effect=commit_book),
+        rollback=MagicMock(side_effect=rollback_book),
+    )
+
+    monkeypatch.setattr(editbooks.calibre_db, "get_book", get_book)
     monkeypatch.setattr(editbooks.calibre_db, "session", session)
     monkeypatch.setattr(
         editbooks.helper, "update_dir_structure", update_dir_structure,
@@ -74,7 +115,8 @@ def _run_bulk_edit(monkeypatch, tmp_path, failure_stage, selections=None):
     ):
         result = inspect.unwrap(editbooks.edit_selected_books)()
 
-    return json.loads(result), rename_attempts, session
+    payload = json.loads(result) if decode_response else result
+    return payload, rename_attempts, session
 
 
 @pytest.mark.parametrize("failure_stage", ["rename", "commit"])
@@ -102,13 +144,39 @@ def test_bulk_edit_reports_each_failure_and_continues(
 
 def test_bulk_edit_keeps_the_legacy_all_success_shape(monkeypatch, tmp_path):
     payload, rename_attempts, session = _run_bulk_edit(
-        monkeypatch, tmp_path, failure_stage=None,
+        monkeypatch, tmp_path, failure_stage=None, decode_response=False,
     )
 
-    assert payload == {"success": True}
+    assert payload == '{"success": true}'
     assert rename_attempts == [1, 2, 3]
     assert session.commit.call_count == 3
     session.rollback.assert_not_called()
+
+
+@pytest.mark.parametrize("failure_stage", [None, "rename", "commit"])
+def test_bulk_edit_captures_book_id_before_transaction_boundary(
+    monkeypatch, tmp_path, failure_stage,
+):
+    selections = [1] if failure_stage is None else [2]
+    payload, rename_attempts, _session = _run_bulk_edit(
+        monkeypatch,
+        tmp_path,
+        failure_stage,
+        selections=selections,
+        expire_book_ids_on_boundary=True,
+    )
+
+    if failure_stage is None:
+        assert payload == {"success": True}
+        assert rename_attempts == [1]
+    else:
+        assert payload["success"] is False
+        assert payload["successful_books"] == []
+        assert payload["failed_books"] == [{
+            "book_id": 2,
+            "stage": failure_stage,
+            "files_may_be_inconsistent": True,
+        }]
 
 
 def test_non_numeric_failed_id_is_not_reflected_in_user_message(

--- a/tests/unit/test_2073_bulk_edit_reports_failures.py
+++ b/tests/unit/test_2073_bulk_edit_reports_failures.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Regression coverage for truthful bulk-edit outcomes (#2073)."""
+
+import inspect
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from flask import Flask
+import pytest
+from sqlalchemy.exc import OperationalError
+
+
+pytestmark = pytest.mark.unit
+
+
+def _book(book_id):
+    return SimpleNamespace(
+        id=book_id,
+        title=f"Book {book_id}",
+        authors=[SimpleNamespace(name="Author")],
+    )
+
+
+def _run_bulk_edit(monkeypatch, tmp_path, failure_stage):
+    from cps import editbooks
+
+    books = {book_id: _book(book_id) for book_id in (1, 2, 3)}
+    rename_attempts = []
+
+    def update_dir_structure(book_id, *_args):
+        rename_attempts.append(book_id)
+        if failure_stage == "rename" and book_id == 2:
+            return "forced rename failure"
+        return False
+
+    commit = MagicMock()
+    if failure_stage == "commit":
+        commit.side_effect = [
+            None,
+            OperationalError("forced commit failure", {}, Exception("forced")),
+            None,
+        ]
+    session = SimpleNamespace(commit=commit, rollback=MagicMock())
+
+    monkeypatch.setattr(editbooks.calibre_db, "get_book", books.get)
+    monkeypatch.setattr(editbooks.calibre_db, "session", session)
+    monkeypatch.setattr(
+        editbooks.helper, "update_dir_structure", update_dir_structure,
+    )
+    monkeypatch.setattr(editbooks.helper, "mark_book_modified", MagicMock())
+    monkeypatch.setattr(editbooks.config, "get_book_path", lambda: str(tmp_path))
+    monkeypatch.setattr(
+        editbooks.constants, "CWA_METADATA_CHANGE_LOGS_DIR", str(tmp_path / "logs"),
+    )
+    monkeypatch.setattr(editbooks, "handle_title_on_edit", lambda *_args: True)
+    monkeypatch.setattr(
+        editbooks,
+        "_",
+        lambda message, **values: message % values if values else message,
+    )
+
+    app = Flask(__name__)
+    with app.test_request_context(
+        "/ajax/editselectedbooks",
+        method="POST",
+        json={
+            "selections": [1, 2, 3],
+            "title": "Updated title",
+            "checkA": "false",
+        },
+    ):
+        result = inspect.unwrap(editbooks.edit_selected_books)()
+
+    return json.loads(result), rename_attempts, session
+
+
+@pytest.mark.parametrize("failure_stage", ["rename", "commit"])
+def test_bulk_edit_reports_each_failure_and_continues(
+    monkeypatch, tmp_path, failure_stage,
+):
+    payload, rename_attempts, session = _run_bulk_edit(
+        monkeypatch, tmp_path, failure_stage,
+    )
+
+    assert payload["success"] is False
+    assert payload["successful_books"] == [1, 3]
+    assert payload["failed_books"] == [
+        {
+            "book_id": 2,
+            "stage": failure_stage,
+            "files_may_be_inconsistent": True,
+        },
+    ]
+    assert "may now be inconsistent" in payload["message"]
+    assert rename_attempts == [1, 2, 3]
+    assert session.commit.call_count == (2 if failure_stage == "rename" else 3)
+    session.rollback.assert_called_once_with()
+
+
+def test_bulk_edit_keeps_the_legacy_all_success_shape(monkeypatch, tmp_path):
+    payload, rename_attempts, session = _run_bulk_edit(
+        monkeypatch, tmp_path, failure_stage=None,
+    )
+
+    assert payload == {"success": True}
+    assert rename_attempts == [1, 2, 3]
+    assert session.commit.call_count == 3
+    session.rollback.assert_not_called()
+
+
+def test_books_table_surfaces_the_partial_failure_message():
+    table_js = (
+        Path(__file__).resolve().parents[2] / "cps" / "static" / "js" / "table.js"
+    ).read_text(encoding="utf-8")
+    callback = table_js.split(
+        'url: window.location.pathname + "/../ajax/editselectedbooks"', 1,
+    )[1].split("});", 1)[0]
+
+    assert "booTitles.success === false" in callback
+    assert "booTitles.message" in callback
+    assert "handleListServerResponse" in callback


### PR DESCRIPTION
Reported by @noahphex in #2073, which this partly addresses. It does **not** close it.

A bulk edit over several selected books could tell you every book succeeded when some of them had
failed — and one of the failure branches leaves a book actively broken.

`edit_selected_books()` loops over the selection. When the title or authors changed it calls
`helper.update_dir_structure(...)`, which moves the book's directory and renames every format **on
disk** and assigns the new `books.path` / `data.name` in memory (`cps/helper.py:1213-1297`,
`1038-1103`), and only afterwards commits. Both per-book failure branches — a truthy
`rename_error`, and `OperationalError` / `IntegrityError` / `StaleDataError` from the commit — did
`session.rollback()` and `continue`, and the function then returned `{'success': True}`
unconditionally. Nothing moves the directory back, so in the commit-failure case the file is at its
new name while the database row still points at the old one, and the user is told it worked. That
is the shape @noahphex found on a live library: 3 books orphaned inside one editing window, no
error anywhere.

**What changed**

- Per-book outcomes are collected. When anything failed, the response is
  `success: false` with `partial`, `successful_books`, and `failed_books` (each carrying the id,
  the `stage` that failed — `lookup` / `rename` / `commit` — and `files_may_be_inconsistent`).
  Books after a failure are still processed, as before.
- The message says plainly that a book which failed after its files were renamed may now be
  inconsistent with its database entry. Silently swallowing that is the bug.
- The all-succeeded response is byte-for-byte the previous `{"success": true}`, so the existing
  caller is unaffected on the happy path.
- `cps/static/js/table.js` now actually shows the failure. The previous line there was
  `handleListServerResponse;` — an expression statement that evaluated the function and discarded
  it, so it had never displayed anything.
- Only integer ids reach the human-readable message. `handleListServerResponse` injects its
  message as raw HTML via string concatenation, and a `lookup`-stage id is whatever the caller put
  in `selections`, so an arbitrary string could otherwise have reached the DOM. The
  machine-readable `failed_books` entry still carries the original value.

**Deliberately out of scope**, because they are larger and separate: the filesystem/commit ordering
itself, any compensating rename on rollback, and repair of books that are already orphaned. #2073
stays open for those — the repair pass is the one that actually gets the reporter's books back.

**Evidence**

`tests/unit/test_2073_bulk_edit_reports_failures.py` drives the real route function with a forced
failure in each branch.

- RED on `200e3b42c4` (this PR's base, test file copied in, code otherwise untouched): **4 failed, 1 passed**
- GREEN on this head: **5 passed**

**Browser evidence for the legacy banner (the condition this PR previously left open)**

`frontend/e2e/bulk-edit-partial-failure.spec.ts` drives the real legacy `/table` page: it selects
two books, submits a title change through `#edit_selected_modal`, asserts the JSON contract on the
`ajax/editselectedbooks` response, and asserts `#flash_danger` renders that exact server message.

The failure is injected server-side, not mocked: one author directory in an isolated copy of the
library is bind-mounted read-only, so `helper.update_dir_structure` genuinely fails for that book
and succeeds for the other. The container logged it:

```
ERROR {cps.editbooks:353} Bulk edit failed to rename book 221: Rename title from:
'/calibre-library/Franz Kafka/Metamorphosis (221)' to
'/calibre-library/Franz Kafka/E2E partial-failure title (221)' failed with error:
[Errno 30] Read-only file system
```

Run against a container on 8095 built from `calibre-web-nextgen:local` with this branch's
`cps/editbooks.py` and `cps/static/js/table.js` mounted over the image copies:

- **GREEN** (branch `table.js`): `2 passed (11.2s)` — banner visible, text equal to the payload message.
- **RED** (identical container, only `table.js` swapped to base `200e3b42c4`; the served file's
  sha256 was checked to confirm the swap and that `editbooks.py` stayed on the branch):
  `1 failed` at `expect(locator('#flash_danger')).toBeVisible()` — *element(s) not found* — plus the
  setup project passing. The books were restored to their original titles/paths first, so the two
  runs differ only in the JavaScript callback under test.

The spec is gated on `E2E_BULK_EDIT_FAILURE_TITLE` / `E2E_BULK_EDIT_SUCCESS_TITLE` and skips without
them, so it does not run in the ordinary suite or CI, which have no fault-injected library. It is a
reproducible evidence harness for this flow, not standing protection.

**Review pass (cross-family, on `363e5e7b79`) and what it changed**

No blockers; two should-fix findings.

1. **Fixed in `c43de237ed`.** The accounting added by this PR read `book.id` *after*
   `session.rollback()` and *after* `session.commit()`. That session is `expire_on_commit=True` and
   rollback expires instances unconditionally, so each read issued a refresh `SELECT` — and in the
   concurrent-delete case this code exists to report, that refresh raises `ObjectDeletedError`,
   escaping the handler and turning the partial-failure payload into a 500. The happy path also
   gained a refresh query per successful book. The id is now captured once after the lookup and
   used throughout. New parametrised regression:
   `test_bulk_edit_captures_book_id_before_transaction_boundary` — **3 failed, 5 passed** without
   the fix, **8 passed** with it.
2. **Accepted and disclosed, not fixed.** The Playwright spec above is environment-gated, so the
   ordinary suite still has no executing coverage of the banner — the `table.js` assertion that
   runs in CI pins source text. Stated plainly in the section above rather than glossed; recorded
   in the findings ledger. Closing it needs a fault-injection fixture in the E2E rig, which is its
   own piece of work.
