### PR TITLE
fix(book detail): the tag disclosure has to earn its place

### DIFF
--- a/changelog.d/issue-2080.md
+++ b/changelog.d/issue-2080.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- **Book pages now keep short tag lists fully visible instead of replacing one
+  or two tags with a wider Show all button.** Long lists still collapse on
+  phones after 8 tags and on wider screens after 20. Reported by @magdalar.

--- a/frontend/e2e/issue-2080-tag-disclosure.spec.ts
+++ b/frontend/e2e/issue-2080-tag-disclosure.spec.ts
@@ -1,0 +1,60 @@
+import { expect, Page, test } from '@playwright/test';
+
+const TAG_LINKS = '#book-tags a[href*="/tags/"]';
+
+async function firstBookId(page: Page): Promise<number | null> {
+  await page.goto('/app');
+  return page.evaluate(async () => {
+    const response = await fetch('/api/v1/books?per_page=1', {
+      headers: { Accept: 'application/json' },
+    }).catch(() => null);
+    if (!response?.ok) return null;
+    return (await response.json())?.items?.[0]?.id ?? null;
+  });
+}
+
+async function showBookWithTags(page: Page, bookId: number, count: number) {
+  await page.route(`**/api/v1/books/${bookId}`, async (route) => {
+    const response = await route.fetch();
+    const book = await response.json();
+    book.tags = Array.from({ length: count }, (_, index) => ({
+      id: 992_080_000 + index,
+      name: `Issue 2080 tag ${String(index + 1).padStart(2, '0')}`,
+    }));
+    await route.fulfill({ response, json: book });
+  });
+
+  await page.goto(`/app/book/${bookId}`, { waitUntil: 'domcontentloaded' });
+  await expect(page.locator('main h1')).toBeVisible({ timeout: 10_000 });
+}
+
+test('desktop shows all nine tags without a disclosure (#2080)', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop', 'desktop project only');
+  const bookId = await firstBookId(page);
+  test.skip(bookId == null, 'seed has no books');
+
+  await showBookWithTags(page, bookId!, 9);
+
+  await expect(page.locator(TAG_LINKS)).toHaveCount(9);
+  await expect(page.getByRole('button', { name: /Show all \d+ tags/ })).toHaveCount(0);
+});
+
+test('mobile still collapses and expands a genuinely long tag list (#2080)', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'mobile', 'mobile project only');
+  const bookId = await firstBookId(page);
+  test.skip(bookId == null, 'seed has no books');
+
+  await showBookWithTags(page, bookId!, 25);
+
+  const disclosure = page.getByRole('button', { name: 'Show all 25 tags' });
+  await expect(page.locator(TAG_LINKS)).toHaveCount(8);
+  await expect(disclosure).toHaveAttribute('aria-expanded', 'false');
+  await expect(disclosure).toHaveAttribute('aria-controls', 'book-tags');
+
+  await disclosure.click();
+
+  await expect(page.locator(TAG_LINKS)).toHaveCount(25);
+  const showFewer = page.getByRole('button', { name: 'Show fewer tags' });
+  await expect(showFewer).toHaveAttribute('aria-expanded', 'true');
+  await expect(showFewer).toHaveAttribute('aria-controls', 'book-tags');
+});

--- a/frontend/e2e/sp2-display-options.spec.ts
+++ b/frontend/e2e/sp2-display-options.spec.ts
@@ -43,7 +43,11 @@ test('book detail exposes imported name, tag disclosure, and semantic progress',
     detail.original_filename = 'reader-selected-name.epub';
     detail.in_progress = true;
     detail.kosync_progress = 42.4;
-    detail.tags = Array.from({ length: 10 }, (_, i) => ({ id: i + 1000, name: `SP2 tag ${i + 1}` }));
+    // 25 tags, not 10: the disclosure now only collapses when it hides at
+    // least three tags, and its cap is 20 above the 700px cutover (#2080).
+    // This spec is about the control's accessible name and expand behaviour,
+    // so it needs a list that genuinely collapses in BOTH projects.
+    detail.tags = Array.from({ length: 25 }, (_, i) => ({ id: i + 1000, name: `SP2 tag ${i + 1}` }));
     await route.fulfill({ response, json: detail });
   });
   await page.goto(`/app/book/${book.id}`);
@@ -51,11 +55,11 @@ test('book detail exposes imported name, tag disclosure, and semantic progress',
   const progress = page.getByRole('progressbar', { name: 'Reading progress' });
   await expect(progress).toHaveAttribute('aria-valuenow', '42');
   const disclosure = page.locator('button[aria-controls="book-tags"]');
-  await expect(disclosure).toHaveAccessibleName('Show all 10 tags');
-  await expect(page.getByText('SP2 tag 10')).toHaveCount(0);
+  await expect(disclosure).toHaveAccessibleName('Show all 25 tags');
+  await expect(page.getByText('SP2 tag 25')).toHaveCount(0);
   await disclosure.click();
   await expect(disclosure).toHaveAttribute('aria-expanded', 'true');
-  await expect(page.getByText('SP2 tag 10')).toBeVisible();
+  await expect(page.getByText('SP2 tag 25')).toBeVisible();
 });
 
 test('Customize panel can restore hidden Table view', async ({ page }) => {

--- a/frontend/src/pages/BookDetail.tsx
+++ b/frontend/src/pages/BookDetail.tsx
@@ -40,6 +40,7 @@ import { useMediaQuery } from '../lib/useMediaQuery';
    Drop the indirection on the React 19 upgrade, which knows the attribute. */
 type LowercaseFetchPriority = { fetchpriority: 'high' | 'low' | 'auto' };
 const COVER_PRIORITY: LowercaseFetchPriority = { fetchpriority: 'high' };
+const BOOK_DETAIL_NARROW_QUERY = '(max-width: 700px)';
 
 function formatBytes(bytes: number): string {
   const mb = bytes / (1024 * 1024);
@@ -199,8 +200,10 @@ function TagEditor({ bookId, tags, canEdit }:
   const [adding, setAdding] = useState(false);
   const [input, setInput] = useState('');
   const [expanded, setExpanded] = useState(false);
-  const visibleTags = expanded ? tags : tags.slice(0, 8);
-  const hasMore = tags.length > 8;
+  const narrowLayout = useMediaQuery(BOOK_DETAIL_NARROW_QUERY);
+  const collapsedTagLimit = narrowLayout ? 8 : 20;
+  const hasMore = tags.length - collapsedTagLimit >= 3;
+  const visibleTags = expanded || !hasMore ? tags : tags.slice(0, collapsedTagLimit);
 
   const names = tags.map((tg) => tg.name);
   const apply = (next: string[]) => update.mutate({ tags: next.join(', ') });
@@ -345,7 +348,7 @@ export function BookDetail() {
      an empty accessible name (it has none — it is not rendered) and failed
      hidden-books.spec's every-control-is-named sweep on desktop. Keep this
      query in sync with the 700px mobile cutover in BookDetail.module.css. */
-  const narrowLayout = useMediaQuery('(max-width: 700px)');
+  const narrowLayout = useMediaQuery(BOOK_DETAIL_NARROW_QUERY);
   // Shelf membership for the metadata list (#1254). Both queries are already
   // in flight for the always-rendered AddToShelf popover below and share its
   // cache keys, so reading them here costs no extra request.


### PR DESCRIPTION
Fixes #2080.

@magdalar reported that on `/app/book/:id` at ≥1280px, a nine-tag book collapses
behind **Show all 9 tags** — hiding exactly one tag and replacing it with a button
wider than the tag it hid. Their screenshots show the collapsed row taking *more*
vertical space than the expanded one.

## Root cause

`TagEditor` in `frontend/src/pages/BookDetail.tsx` used a flat count:

```ts
const visibleTags = expanded ? tags : tags.slice(0, 8);
const hasMore = tags.length > 8;
```

The disclosure was introduced for **phone** layout ("collapse long tag lists behind
a Show all control after the first eight"). Applying that phone threshold at desktop
width is the whole defect — it is viewport-blind, and it fires when the remainder is
smaller than the control that replaces it.

## The rule now

Two conditions, both required before anything is hidden:

1. **The cap is viewport-derived** — 8 under the existing `(max-width: 700px)` cutover
   the page already uses for `narrowLayout`, 20 above it. The query string is now a
   shared constant, so the breakpoint stays single-sourced.
2. **The collapse must hide at least three tags**, because the button occupies a chip
   slot of its own. Hiding one or two costs more layout than it saves.

| tags | viewport | before | after |
|---|---|---|---|
| 9 | 1280px | collapsed to 8 + button | all 9, no button |
| 9 | 375px | collapsed to 8 + button | all 9, no button |
| 25 | 375px | collapsed to 8 + button | unchanged |
| 40 | 1280px | collapsed to 8 + button | collapsed to 20 + button |

Both the read-only and the editor branch derive the values once instead of repeating
the slice.

## Evidence

New spec `frontend/e2e/issue-2080-tag-disclosure.spec.ts` pins the reported case at
the reporter's viewport and the phone protection it must not break.

- **RED, OBSERVED** — same spec against a pre-fix build (`cwn-local`, `main`):
  `1 failed` — `locator resolved to 8 elements … unexpected value "8"` where 9 were
  expected, i.e. the disclosure firing on a nine-tag book at 1280×800.
- **GREEN, OBSERVED** — against a container built from this branch: `3 passed`
  (desktop 9-tags-no-disclosure, mobile 25-tags-still-collapses-and-expands).
- `tsc -b` and `tsc -p tsconfig.e2e.json --noEmit` both clean.

Both runs drove the real SPA in a real container, not a mock.

## Not covered

The reporter also asked about tags that are excessive by *length* (a tag carrying a
whole description). That is a different mechanism — truncation, already handled
separately by #1396 — and is deliberately not touched here.
