### PR TITLE
test(catalog): a layout-invariant watchdog that catches the column-collapse bug class before merge

### DIFF
--- a/changelog.d/catalog-layout-watchdog.md
+++ b/changelog.d/catalog-layout-watchdog.md
@@ -1,0 +1,22 @@
+### Fixed
+
+- **Catalog first-load column regressions are now caught before release.** A
+  continuous browser watchdog checks that the rendered grid and the column count
+  accepted by virtualization converge on the available-width formula, including
+  opt-in Chromium and WebKit runs with deliberately staggered stylesheet and
+  JavaScript responses. Grid mutations and resizes timestamp actual healthy/bad
+  transitions. Synchronous DOM, CSSOM, declaration, class/dataset, and Typed OM
+  hooks evaluate the same healthy/bad invariant predicate immediately before
+  and after the browser write; only a truth flip licenses measured time, so
+  irrelevant properties and truth-preserving geometry changes cannot turn a
+  coincident layout state into a false failure. Bad-to-differently-bad writes
+  update diagnostics without splitting the episode. Nested hooks share the
+  outer measurement and do no work until the grid exists.
+  Asynchronous stylesheet/font/observer notifications remain diagnostic unless
+  an exact synchronous state-changing surface brackets them. Measured bad
+  durations accumulate across brief flaps without turning healthy stalls into
+  failures. Safety-only
+  observations remain visible diagnostics but deliberately contribute no
+  duration: the small named gap is preferable to inferred or coincident timing
+  that can produce both false reds and false greens. Any violation still active
+  at settle fails unconditionally.

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -323,3 +323,9 @@ CWA_METADATA_LOCK_DIR=${CONFIG_DIR}
 # Route the user-notices E2E page through the current Vite source server.
 # Default: unset/off. Set to a non-empty value only for that focused local test rig.
 # E2E_CURRENT_SOURCE=
+
+# Enable the opt-in hostile-load Playwright projects, which delay stylesheet and
+# script responses to reproduce the load ordering that made the catalog grid
+# collapse (#2072). Default: unset/off, so normal CI pays nothing for them.
+# Set to 1 only when running that matrix.
+# E2E_HOSTILE_LOAD=

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -23,6 +23,58 @@ Env knobs: `E2E_BASE_URL` (default `http://localhost:8086`), `E2E_USER`/`E2E_PAS
 `admin`/`admin123`), `E2E_SUBPATH_URL` (set to the `cwn-nginx-571` rig `http://localhost:8087` to run the
 reverse-proxy project).
 
+The catalog layout watchdog runs once in the normal Chromium lane. Its hostile-load matrix is opt-in so
+the broad suite stays fast: set `E2E_HOSTILE_LOAD=1` and select one or more
+`hostile-{css-slow,script-slow}-{chromium,webkit}` projects. The profiles delay fulfilled stylesheet and
+JavaScript responses in opposite orders through `page.route`, so the same settling-window reproduction
+works in both engines. CWNG currently uses system fonts and requests no webfont, so this lane makes no
+font-delay claim. The watchdog measures grid state transitions directly. Around every synchronous
+test-realm DOM, CSSOM, declaration, class/dataset, and CSS Typed OM write, it evaluates each invariant
+immediately before and after the outermost browser call. A write may establish measured evidence only when
+that invariant's healthy/bad truth flips across the call. The transition gate and the recorder share the
+same predicate: resolved tracks must equal the width formula's expected count, and an accepted column value
+must be absent or equal that count. Ownership, selector matching, property names, and raw input movement
+never license duration. An irrelevant `color` write stays diagnostic; a width/minimum class swap that keeps
+seven tracks correct also stays diagnostic; and a write that really flips seven correct tracks to one is
+measured without a guessable property allowlist or input-vector comparison. Bad-to-differently-bad writes
+update diagnostics without splitting or resetting the episode.
+
+CSSOM `insertRule`, `deleteRule`, `replaceSync`, declaration `setProperty`/`removeProperty`/`cssText`,
+direct declaration assignments, selector and stylesheet-state setters, `document.adoptedStyleSheets`,
+element attributes/classes/datasets, and CSS Typed OM `set`/`delete`/`clear` all use this truth-flip gate.
+No computed-style reads occur until a catalog grid is attached, and nested hooks for one browser write
+reuse the outermost measurement instead of forcing duplicate reads. A grid-scoped MutationObserver remains
+a diagnostic fallback for cross-realm or browser-internal mutations; ResizeObserver supplies the geometry
+change boundary. Matching stylesheet lifecycle and relevant-family FontFaceSet notifications are also
+diagnostic because their asynchronous callbacks have no synchronous pre-change endpoint. Selector checks
+that throw, opaque/cross-origin sheets, and container-query activation that the browser cannot answer remain
+diagnostic rather than guessed causal. Each exactly measured bad-to-healthy transition contributes its
+actual duration to a per-invariant total for the whole convergence window, so brief heals do not discard
+bad time and genuinely healthy stalls are never charged.
+
+The rAF safety sample is diagnostic only. If it is the only surface that observes an episode, the snapshot
+records `durationEvidence: "unmeasured-safety-net"` and zero duration; it never infers what happened between
+two samples and therefore cannot create either a scheduler-starvation false red or a sample-spacing false
+green. A violation still active at settle fails unconditionally. A CSS animation, media/container-query
+reevaluation, cross-realm stylesheet mutation, or other browser-internal recalculation that triggers no
+grid insertion/resize or synchronously state-changing DOM/CSSOM/Typed-OM write can therefore heal before
+settle as diagnostic-only evidence. Asynchronous stylesheet replacement and font application are included
+in that residual when no synchronous state-changing write brackets them. This named gap is intentional: CI
+reports what it observed but does not turn coincident or unknowable time into a pass/fail duration.
+
+The `CSSStyleDeclaration`, `style`, `dataset`, and `classList` interception is installed at DOM/CSSOM
+prototype boundaries in the Playwright test realm. Named CSS declaration properties have no configurable
+per-property descriptors in Chromium or WebKit, so declarations use stable proxies. This placement obtains
+the synchronous before/after state pair before asynchronous discovery or observer delivery can coalesce
+changes; it has no production consumer or production bundle effect.
+The private rig already passes all arguments after the worktree through to Playwright:
+
+```bash
+E2E_HOSTILE_LOAD=1 /absolute/path/to/local-dev/private-e2e-rig.sh test /absolute/path/to/worktree \
+  --project=hostile-css-slow-chromium --project=hostile-css-slow-webkit \
+  --project=hostile-script-slow-chromium --project=hostile-script-slow-webkit
+```
+
 In CI, a same-repository PR whose concurrency/engine dependency closure changed runs this suite as a
 hard gate against `sha-<PR head>` — the dev-image workflow builds that exact commit and the test workflow
 waits for, then pins, its manifest digest. Frontend-only PRs retain the cheaper SPA-overlay route. To run
@@ -52,6 +104,8 @@ protecting `cps/api/` added zero historical gate runs in that sample.
 | Project | Axis | Guards |
 |---|---|---|
 | `setup` | — | logs in once via the real UI, saves session |
+| `catalog-layout-chromium` | 768/1280/1440 + scheduler-gap probe | continuous CSS + accepted-column invariant watchdog without starvation false reds |
+| `hostile-*-{chromium,webkit}` | opt-in staggered CSS/JS arrival | first-load layout convergence under hostile resource order |
 | `desktop` | 1280×800 | full flow + a11y baseline |
 | `mobile` | 375×667 (chromium emulation) | drawer reachability + scroll-lock (#576), no h-overflow (#288) |
 | `ipad-touch` | 1024×1366 (touch/no hover) | persistent card actions + drawer inert/trap/Escape contract |

--- a/frontend/e2e/catalog-layout-watchdog-classifier.spec.ts
+++ b/frontend/e2e/catalog-layout-watchdog-classifier.spec.ts
@@ -1,0 +1,1141 @@
+import { test, expect, type Page } from '@playwright/test';
+import {
+  CATALOG_LAYOUT_HEAL_MS,
+  installCatalogLayoutWatchdog,
+  readCatalogLayoutWatchdog,
+  type CatalogLayoutWatchdogSnapshot,
+} from './catalog-layout-watchdog';
+
+async function waitForHealthySevenTrackGrid(page: Page): Promise<void> {
+  await expect.poll(async () => page.locator('[data-testid="catalog-grid"]').evaluate((grid) => ({
+    resolvedTracks: getComputedStyle(grid).gridTemplateColumns.trim().split(/\s+/).filter(Boolean).length,
+    acceptedColumns: grid.getAttribute('data-catalog-column-count'),
+  })), {
+    message: 'catalog fixture did not reach its intended final 7-track / accepted-7 state',
+    timeout: 5_000,
+  }).toEqual({ resolvedTracks: 7, acceptedColumns: '7' });
+}
+
+test('a scheduler gap after an immediate layout heal is not observed bad time', async ({ page }) => {
+  await installCatalogLayoutWatchdog(page);
+  const stallMs = CATALOG_LAYOUT_HEAL_MS + 100;
+  const html = `<!doctype html><style>
+    #grid {
+      width: 1168px;
+      --catalog-grid-min: 140px;
+      column-gap: 16px;
+      display: grid;
+      grid-template-columns: 1168px;
+    }
+  </style>
+  <div id="grid" data-testid="catalog-grid" data-catalog-column-count="1"><div>x</div></div>
+  <script>
+    requestAnimationFrame(() => {
+      const grid = document.querySelector('#grid');
+      grid.style.gridTemplateColumns = 'repeat(7, minmax(0, 1fr))';
+      grid.dataset.catalogColumnCount = '7';
+      window.__catalogHealthyAt = performance.now();
+      const until = performance.now() + ${stallMs};
+      while (performance.now() < until) {}
+    });
+  </script>`;
+
+  await page.goto(`data:text/html,${encodeURIComponent(html)}`);
+  await waitForHealthySevenTrackGrid(page);
+
+  const snapshot = await readCatalogLayoutWatchdog(page);
+  expect(snapshot.latest?.resolvedTracks).toBe(7);
+  expect(snapshot.latest?.acceptedColumns).toBe(7);
+  expect(snapshot.violations).toHaveLength(2);
+  expect(snapshot.violations.map(({ invariant }) => invariant).sort()).toEqual([
+    'accepted-column-count',
+    'resolved-track-count',
+  ]);
+  for (const violation of snapshot.violations) {
+    expect(violation.healedAtMs).not.toBeNull();
+    expect(violation.lastSeenMs).toBeGreaterThanOrEqual(violation.firstSeenMs);
+    expect(violation.lastSeenMs, 'lastSeenMs never advances beyond the observed heal')
+      .toBeLessThanOrEqual(violation.healedAtMs ?? 0);
+    expect(violation.durationEvidence).toBe('measured-transition');
+    expect(violation.observedBadMs, 'the measured heal precedes the unsampled scheduler gap')
+      .toBeLessThan(250);
+    expect(violation.cumulativeObservedBadMs).toBe(violation.observedBadMs);
+  }
+  expect(snapshot.unhealed, JSON.stringify(snapshot, null, 2)).toEqual([]);
+});
+
+test('repeated bad frames across slow samples exhaust the healing budget', async ({ page }) => {
+  await installCatalogLayoutWatchdog(page);
+  const html = `<!doctype html><style>
+    #grid {
+      width: 1168px;
+      --catalog-grid-min: 140px;
+      column-gap: 16px;
+      display: grid;
+      grid-template-columns: 1168px;
+    }
+  </style>
+  <div id="grid" data-testid="catalog-grid" data-catalog-column-count="1"></div>
+  <script>
+    window.__catalogSustainedBadAt = performance.now();
+    setTimeout(() => {
+      const row = document.createElement('div');
+      row.dataset.virtualGridRow = 'true';
+      row.textContent = 'row';
+      document.querySelector('#grid').append(row);
+    }, 600);
+
+    let badFramesRemaining = 8;
+    const slowBadFrames = () => requestAnimationFrame(() => {
+      const until = performance.now() + 300;
+      while (performance.now() < until) {}
+      badFramesRemaining -= 1;
+      if (badFramesRemaining > 0) {
+        slowBadFrames();
+      } else {
+        const grid = document.querySelector('#grid');
+        grid.style.gridTemplateColumns = 'repeat(7, minmax(0, 1fr))';
+        grid.dataset.catalogColumnCount = '7';
+        window.__catalogSustainedHealthyAt = performance.now();
+      }
+    });
+    slowBadFrames();
+  </script>`;
+
+  await page.goto(`data:text/html,${encodeURIComponent(html)}`);
+  await page.locator('[data-virtual-grid-row]').waitFor({ state: 'visible' });
+  await page.waitForFunction(() => (window as Window & {
+    __catalogSustainedHealthyAt?: number;
+  }).__catalogSustainedHealthyAt !== undefined);
+  await waitForHealthySevenTrackGrid(page);
+
+  const snapshot = await readCatalogLayoutWatchdog(page);
+  const actualBadMs = await page.evaluate(() => {
+    const probeWindow = window as Window & {
+      __catalogSustainedBadAt?: number;
+      __catalogSustainedHealthyAt?: number;
+    };
+    return (probeWindow.__catalogSustainedHealthyAt ?? 0)
+      - (probeWindow.__catalogSustainedBadAt ?? 0);
+  });
+  expect(actualBadMs).toBeGreaterThan(CATALOG_LAYOUT_HEAL_MS);
+  expect(snapshot.latest?.resolvedTracks).toBe(7);
+  expect(snapshot.latest?.acceptedColumns).toBe(7);
+  expect(snapshot.violations).toHaveLength(2);
+  for (const violation of snapshot.violations) {
+    expect(violation.durationEvidence).toBe('measured-transition');
+    expect(violation.observedBadMs).toBeGreaterThan(CATALOG_LAYOUT_HEAL_MS);
+    expect(Math.abs(violation.observedBadMs - actualBadMs)).toBeLessThan(150);
+    expect(violation.cumulativeObservedBadMs).toBeGreaterThan(CATALOG_LAYOUT_HEAL_MS);
+    expect(violation.healedAtMs).not.toBeNull();
+    expect(violation.lastSeenMs).toBeGreaterThanOrEqual(violation.firstSeenMs);
+    expect(violation.lastSeenMs).toBeLessThanOrEqual(violation.healedAtMs ?? 0);
+  }
+  expect(snapshot.unhealed.map(({ invariant }) => invariant).sort()).toEqual([
+    'accepted-column-count',
+    'resolved-track-count',
+  ]);
+});
+
+test('one healthy frame does not reset cumulative bad evidence', async ({ page }) => {
+  await installCatalogLayoutWatchdog(page);
+  const html = `<!doctype html><style>
+    #grid {
+      width: 1168px;
+      --catalog-grid-min: 140px;
+      column-gap: 16px;
+      display: grid;
+      grid-template-columns: 1168px;
+    }
+  </style>
+  <div id="grid" data-testid="catalog-grid" data-catalog-column-count="1"></div>
+  <script>
+    setTimeout(() => {
+      const row = document.createElement('div');
+      row.dataset.virtualGridRow = 'true';
+      row.textContent = 'row';
+      document.querySelector('#grid').append(row);
+    }, 600);
+
+    const grid = document.querySelector('#grid');
+    let episode = 1;
+    let badFrames = 0;
+    let awaitingHealthySample = false;
+    window.__catalogFlapTransitions = [];
+    window.__catalogFlapBadSpans = [];
+    let badAt = performance.now();
+
+    const drive = () => requestAnimationFrame(() => {
+      if (awaitingHealthySample) {
+        episode += 1;
+        grid.style.gridTemplateColumns = '1168px';
+        grid.dataset.catalogColumnCount = '1';
+        window.__catalogFlapTransitions.push({ type: 'bad-' + episode, at: performance.now() });
+        badAt = performance.now();
+        awaitingHealthySample = false;
+        badFrames = 0;
+        drive();
+        return;
+      }
+
+      // Make the accumulated bad time deterministic without changing the
+      // reviewer's 70-sample / one-healthy-sample shape.
+      const until = performance.now() + 18;
+      while (performance.now() < until) {}
+      badFrames += 1;
+      if (badFrames >= 70) {
+        grid.style.gridTemplateColumns = 'repeat(7, minmax(0, 1fr))';
+        grid.dataset.catalogColumnCount = '7';
+        window.__catalogFlapTransitions.push({ type: 'healthy-' + episode, at: performance.now() });
+        window.__catalogFlapBadSpans.push(performance.now() - badAt);
+        if (episode >= 2) return;
+        awaitingHealthySample = true;
+      }
+      drive();
+    });
+    drive();
+  </script>`;
+
+  await page.goto(`data:text/html,${encodeURIComponent(html)}`);
+  await page.locator('[data-virtual-grid-row]').waitFor({ state: 'visible' });
+  await page.waitForFunction(() => ((window as Window & {
+    __catalogFlapBadSpans?: number[];
+  }).__catalogFlapBadSpans?.length ?? 0) === 2);
+  await waitForHealthySevenTrackGrid(page);
+
+  const snapshot = await readCatalogLayoutWatchdog(page);
+  const timing = await page.evaluate(() => {
+    const probeWindow = window as Window & {
+      __catalogFlapTransitions?: Array<{ type: string; at: number }>;
+      __catalogFlapBadSpans?: number[];
+    };
+    const transitions = probeWindow.__catalogFlapTransitions ?? [];
+    const firstHealthy = transitions
+      .find(({ type }) => type === 'healthy-1');
+    const secondBad = transitions
+      .find(({ type }) => type === 'bad-2');
+    const badSpans = probeWindow.__catalogFlapBadSpans ?? [];
+    return {
+      healthySampleGapMs: (secondBad?.at ?? 0) - (firstHealthy?.at ?? 0),
+      badSpans,
+      totalBadMs: badSpans.reduce((total, duration) => total + duration, 0),
+    };
+  });
+
+  expect(timing.healthySampleGapMs).toBeGreaterThanOrEqual(0);
+  expect(timing.healthySampleGapMs).toBeLessThan(250);
+  expect(timing.totalBadMs).toBeGreaterThan(CATALOG_LAYOUT_HEAL_MS);
+  expect(snapshot.latest?.resolvedTracks).toBe(7);
+  expect(snapshot.latest?.acceptedColumns).toBe(7);
+  expect(snapshot.violations).toHaveLength(4);
+  for (const invariant of ['resolved-track-count', 'accepted-column-count'] as const) {
+    const episodes = snapshot.violations.filter((violation) => violation.invariant === invariant);
+    expect(episodes).toHaveLength(2);
+    expect(episodes.every((violation) => violation.durationEvidence === 'measured-transition')).toBe(true);
+    expect(episodes.every((violation) => violation.observedBadMs < CATALOG_LAYOUT_HEAL_MS)).toBe(true);
+    expect(Math.abs(
+      episodes.reduce((total, violation) => total + violation.observedBadMs, 0)
+      - timing.totalBadMs,
+    )).toBeLessThan(150);
+    expect(episodes[1]?.cumulativeObservedBadMs).toBeGreaterThan(CATALOG_LAYOUT_HEAL_MS);
+  }
+  expect(snapshot.unhealed.map(({ invariant }) => invariant).sort()).toEqual([
+    'accepted-column-count',
+    'resolved-track-count',
+  ]);
+});
+
+test('two isolated bad endpoints do not license their unsampled healthy gap', async ({ page }) => {
+  await installCatalogLayoutWatchdog(page);
+  const stallMs = CATALOG_LAYOUT_HEAL_MS + 100;
+  const html = `<!doctype html><style>
+    #grid {
+      width: 1168px;
+      --catalog-grid-min: 140px;
+      column-gap: 16px;
+      display: grid;
+      grid-template-columns: 1168px;
+    }
+  </style>
+  <div id="grid" data-testid="catalog-grid" data-catalog-column-count="1"><div>x</div></div>
+  <script>
+    window.__catalogBadSpans = [];
+    const initialBadAt = performance.now();
+    requestAnimationFrame(() => {
+      const grid = document.querySelector('#grid');
+      grid.style.gridTemplateColumns = 'repeat(7, minmax(0, 1fr))';
+      grid.dataset.catalogColumnCount = '7';
+      window.__catalogFirstHealthyAt = performance.now();
+      window.__catalogBadSpans.push(window.__catalogFirstHealthyAt - initialBadAt);
+
+      const until = performance.now() + ${stallMs};
+      while (performance.now() < until) {}
+      grid.style.gridTemplateColumns = '1168px';
+      grid.dataset.catalogColumnCount = '1';
+      window.__catalogSecondBadAt = performance.now();
+
+      requestAnimationFrame(() => {
+        grid.style.gridTemplateColumns = 'repeat(7, minmax(0, 1fr))';
+        grid.dataset.catalogColumnCount = '7';
+        window.__catalogBadSpans.push(performance.now() - window.__catalogSecondBadAt);
+      });
+    });
+  </script>`;
+
+  await page.goto(`data:text/html,${encodeURIComponent(html)}`);
+  await page.waitForFunction(() => ((window as Window & {
+    __catalogBadSpans?: number[];
+  }).__catalogBadSpans?.length ?? 0) === 2);
+  await waitForHealthySevenTrackGrid(page);
+
+  const snapshot = await readCatalogLayoutWatchdog(page);
+  const timing = await page.evaluate(() => {
+    const probeWindow = window as Window & {
+      __catalogFirstHealthyAt?: number;
+      __catalogSecondBadAt?: number;
+      __catalogBadSpans?: number[];
+    };
+    const badSpans = probeWindow.__catalogBadSpans ?? [];
+    return {
+      actualHealthyGapMs: (probeWindow.__catalogSecondBadAt ?? 0)
+        - (probeWindow.__catalogFirstHealthyAt ?? 0),
+      totalBadMs: badSpans.reduce((total, duration) => total + duration, 0),
+    };
+  });
+  expect(timing.actualHealthyGapMs).toBeGreaterThanOrEqual(stallMs);
+  expect(snapshot.latest?.resolvedTracks).toBe(7);
+  expect(snapshot.latest?.acceptedColumns).toBe(7);
+  expect(snapshot.violations).toHaveLength(4);
+  for (const invariant of ['resolved-track-count', 'accepted-column-count'] as const) {
+    const episodes = snapshot.violations.filter((violation) => violation.invariant === invariant);
+    expect(episodes).toHaveLength(2);
+    expect(episodes.every((violation) => violation.durationEvidence === 'measured-transition')).toBe(true);
+    expect(Math.abs(
+      episodes.reduce((total, violation) => total + violation.observedBadMs, 0)
+      - timing.totalBadMs,
+    )).toBeLessThan(100);
+    expect(episodes[1]?.cumulativeObservedBadMs).toBeLessThan(250);
+    for (const violation of episodes) {
+      expect(violation.healedAtMs).not.toBeNull();
+      expect(violation.lastSeenMs).toBeGreaterThanOrEqual(violation.firstSeenMs);
+      expect(violation.lastSeenMs).toBeLessThanOrEqual(violation.healedAtMs ?? 0);
+    }
+  }
+  expect(snapshot.unhealed, JSON.stringify(snapshot, null, 2)).toEqual([]);
+});
+
+test('measured two-observation episodes accumulate across brief heals', async ({ page }) => {
+  await installCatalogLayoutWatchdog(page);
+  const html = `<!doctype html><style>
+    #grid {
+      width: 1168px;
+      --catalog-grid-min: 140px;
+      column-gap: 16px;
+      display: grid;
+      grid-template-columns: 1168px;
+    }
+  </style>
+  <div id="grid" data-testid="catalog-grid" data-catalog-column-count="1"><div>x</div></div>
+  <script>
+    const grid = document.querySelector('#grid');
+    window.__catalogBadSpans = [];
+    window.__catalogHealthySpans = [];
+    let episode = 0;
+
+    const beginEpisode = () => {
+      episode += 1;
+      grid.style.gridTemplateColumns = '1168px';
+      grid.dataset.catalogColumnCount = '1';
+      const badAt = performance.now();
+      requestAnimationFrame(() => {
+        const until = performance.now() + 600;
+        while (performance.now() < until) {}
+        requestAnimationFrame(() => {
+          grid.style.gridTemplateColumns = 'repeat(7, minmax(0, 1fr))';
+          grid.dataset.catalogColumnCount = '7';
+          const healthyAt = performance.now();
+          window.__catalogBadSpans.push(healthyAt - badAt);
+          requestAnimationFrame(() => {
+            if (episode >= 4) {
+              window.__catalogDone = true;
+              return;
+            }
+            const nextBadAt = performance.now();
+            window.__catalogHealthySpans.push(nextBadAt - healthyAt);
+            beginEpisode();
+          });
+        });
+      });
+    };
+    beginEpisode();
+  </script>`;
+
+  await page.goto(`data:text/html,${encodeURIComponent(html)}`);
+  await page.waitForFunction(() => (window as Window & { __catalogDone?: boolean }).__catalogDone);
+  await waitForHealthySevenTrackGrid(page);
+
+  const snapshot = await readCatalogLayoutWatchdog(page);
+  const timing = await page.evaluate(() => {
+    const probeWindow = window as Window & {
+      __catalogBadSpans?: number[];
+      __catalogHealthySpans?: number[];
+    };
+    const badSpans = probeWindow.__catalogBadSpans ?? [];
+    const healthySpans = probeWindow.__catalogHealthySpans ?? [];
+    return {
+      badSpans,
+      healthySpans,
+      totalBadMs: badSpans.reduce((total, duration) => total + duration, 0),
+    };
+  });
+
+  expect(timing.badSpans).toHaveLength(4);
+  expect(timing.healthySpans).toHaveLength(3);
+  expect(timing.totalBadMs).toBeGreaterThan(CATALOG_LAYOUT_HEAL_MS);
+  expect(timing.healthySpans.every((duration) => duration < 250)).toBe(true);
+  expect(snapshot.latest?.resolvedTracks).toBe(7);
+  expect(snapshot.latest?.acceptedColumns).toBe(7);
+  expect(snapshot.violations).toHaveLength(8);
+  for (const invariant of ['resolved-track-count', 'accepted-column-count'] as const) {
+    const episodes = snapshot.violations.filter((violation) => violation.invariant === invariant);
+    expect(episodes).toHaveLength(4);
+    expect(episodes.every((violation) => violation.durationEvidence === 'measured-transition')).toBe(true);
+    const measuredBadMs = episodes.reduce(
+      (total, violation) => total + violation.observedBadMs,
+      0,
+    );
+    expect(Math.abs(measuredBadMs - timing.totalBadMs)).toBeLessThan(150);
+    expect(episodes[episodes.length - 1]?.cumulativeObservedBadMs)
+      .toBeGreaterThan(CATALOG_LAYOUT_HEAL_MS);
+  }
+  expect(snapshot.unhealed.map(({ invariant }) => invariant).sort()).toEqual([
+    'accepted-column-count',
+    'resolved-track-count',
+  ]);
+});
+
+test('measured healthy stalls separate three brief bad episodes', async ({ page }) => {
+  await installCatalogLayoutWatchdog(page);
+  const html = `<!doctype html><style>
+    #grid {
+      width: 1168px;
+      --catalog-grid-min: 140px;
+      column-gap: 16px;
+      display: grid;
+      grid-template-columns: 1168px;
+    }
+  </style>
+  <div id="grid" data-testid="catalog-grid" data-catalog-column-count="1"><div>x</div></div>
+  <script>
+    const grid = document.querySelector('#grid');
+    window.__catalogBadSpans = [];
+    window.__catalogHealthySpans = [];
+    let endpoint = 1;
+    let badAt = performance.now();
+
+    const runHealthyGap = () => {
+      grid.style.gridTemplateColumns = 'repeat(7, minmax(0, 1fr))';
+      grid.dataset.catalogColumnCount = '7';
+      const healthyAt = performance.now();
+      window.__catalogBadSpans.push(healthyAt - badAt);
+      const until = performance.now() + 1100;
+      while (performance.now() < until) {}
+      grid.style.gridTemplateColumns = '1168px';
+      grid.dataset.catalogColumnCount = '1';
+      badAt = performance.now();
+      window.__catalogHealthySpans.push(badAt - healthyAt);
+      endpoint += 1;
+      requestAnimationFrame(() => {
+        if (endpoint >= 3) {
+          grid.style.gridTemplateColumns = 'repeat(7, minmax(0, 1fr))';
+          grid.dataset.catalogColumnCount = '7';
+          window.__catalogBadSpans.push(performance.now() - badAt);
+          window.__catalogDone = true;
+        } else {
+          runHealthyGap();
+        }
+      });
+    };
+    requestAnimationFrame(runHealthyGap);
+  </script>`;
+
+  await page.goto(`data:text/html,${encodeURIComponent(html)}`);
+  await page.waitForFunction(() => (window as Window & { __catalogDone?: boolean }).__catalogDone);
+  await waitForHealthySevenTrackGrid(page);
+
+  const snapshot = await readCatalogLayoutWatchdog(page);
+  const timing = await page.evaluate(() => {
+    const probeWindow = window as Window & {
+      __catalogBadSpans?: number[];
+      __catalogHealthySpans?: number[];
+    };
+    const badSpans = probeWindow.__catalogBadSpans ?? [];
+    const healthySpans = probeWindow.__catalogHealthySpans ?? [];
+    return {
+      badSpans,
+      healthySpans,
+      totalBadMs: badSpans.reduce((total, duration) => total + duration, 0),
+      totalHealthyMs: healthySpans.reduce((total, duration) => total + duration, 0),
+    };
+  });
+
+  expect(timing.badSpans).toHaveLength(3);
+  expect(timing.healthySpans).toHaveLength(2);
+  expect(timing.totalHealthyMs).toBeGreaterThanOrEqual(2200);
+  expect(timing.totalBadMs).toBeLessThan(250);
+  expect(snapshot.latest?.resolvedTracks).toBe(7);
+  expect(snapshot.latest?.acceptedColumns).toBe(7);
+  expect(snapshot.violations).toHaveLength(6);
+  for (const invariant of ['resolved-track-count', 'accepted-column-count'] as const) {
+    const episodes = snapshot.violations.filter((violation) => violation.invariant === invariant);
+    expect(episodes).toHaveLength(3);
+    expect(episodes.every((violation) => violation.durationEvidence === 'measured-transition')).toBe(true);
+    const measuredBadMs = episodes.reduce(
+      (total, violation) => total + violation.observedBadMs,
+      0,
+    );
+    expect(Math.abs(measuredBadMs - timing.totalBadMs)).toBeLessThan(100);
+    expect(episodes[episodes.length - 1]?.cumulativeObservedBadMs).toBeLessThan(250);
+  }
+  expect(snapshot.unhealed, JSON.stringify(snapshot, null, 2)).toEqual([]);
+});
+
+test('CSSOM track changes are measured even without grid mutation or resize', async ({ page }) => {
+  await installCatalogLayoutWatchdog(page);
+  const badDurationMs = CATALOG_LAYOUT_HEAL_MS + 200;
+  const html = `<!doctype html><style>
+    #grid {
+      width: 1168px;
+      height: 100px;
+      --catalog-grid-min: 140px;
+      column-gap: 16px;
+      display: grid;
+      grid-template-columns: repeat(7, minmax(0, 1fr));
+    }
+  </style>
+  <style id="override"></style>
+  <div id="grid" data-testid="catalog-grid" data-catalog-column-count="7"><div>x</div></div>
+  <script>
+    const sheet = document.querySelector('#override').sheet;
+    window.__catalogCssomBadAt = performance.now();
+    sheet.insertRule('#grid { grid-template-columns: 1168px !important }', 0);
+    setTimeout(() => {
+      sheet.deleteRule(0);
+      window.__catalogCssomHealthyAt = performance.now();
+    }, ${badDurationMs});
+  </script>`;
+
+  await page.goto(`data:text/html,${encodeURIComponent(html)}`);
+  await page.waitForFunction(() => (window as Window & {
+    __catalogCssomHealthyAt?: number;
+  }).__catalogCssomHealthyAt !== undefined);
+  await waitForHealthySevenTrackGrid(page);
+
+  const snapshot = await readCatalogLayoutWatchdog(page);
+  const actualBadMs = await page.evaluate(() => {
+    const probeWindow = window as Window & {
+      __catalogCssomBadAt?: number;
+      __catalogCssomHealthyAt?: number;
+    };
+    return (probeWindow.__catalogCssomHealthyAt ?? 0)
+      - (probeWindow.__catalogCssomBadAt ?? 0);
+  });
+  expect(actualBadMs).toBeGreaterThan(CATALOG_LAYOUT_HEAL_MS);
+  expect(snapshot.latest?.resolvedTracks).toBe(7);
+  expect(snapshot.latest?.acceptedColumns).toBe(7);
+  expect(snapshot.violations).toHaveLength(1);
+  const violation = snapshot.violations[0];
+  expect(violation?.invariant).toBe('resolved-track-count');
+  expect(violation?.durationEvidence).toBe('measured-transition');
+  expect(violation?.observedBadMs).toBeGreaterThan(CATALOG_LAYOUT_HEAL_MS);
+  expect(Math.abs((violation?.observedBadMs ?? 0) - actualBadMs)).toBeLessThan(100);
+  expect(snapshot.unhealed.map(({ invariant }) => invariant)).toEqual([
+    'resolved-track-count',
+  ]);
+});
+
+test('rule.style brief failures do not charge blocked healthy spans', async ({ page }) => {
+  await installCatalogLayoutWatchdog(page);
+  const html = `<!doctype html><style>
+    #grid {
+      width: 1168px;
+      height: 100px;
+      --catalog-grid-min: 140px;
+      column-gap: 16px;
+      display: grid;
+      grid-template-columns: repeat(7, minmax(0, 1fr));
+    }
+  </style>
+  <style id="override">
+    #grid { grid-template-columns: repeat(7, minmax(0, 1fr)) !important; }
+  </style>
+  <div id="grid" data-testid="catalog-grid" data-catalog-column-count="7"><div>x</div></div>
+  <script>
+    const rule = document.querySelector('#override').sheet.cssRules[0];
+    const good = () => rule.style.setProperty(
+      'grid-template-columns',
+      'repeat(7, minmax(0, 1fr))',
+      'important',
+    );
+    const bad = () => rule.style.setProperty(
+      'grid-template-columns',
+      '1168px',
+      'important',
+    );
+    const block = (duration) => {
+      const until = performance.now() + duration;
+      while (performance.now() < until) {}
+    };
+
+    window.__catalogRuleBadSpans = [];
+    window.__catalogRuleHealthySpans = [];
+    for (let cycle = 0; cycle < 4; cycle += 1) {
+      const badAt = performance.now();
+      bad();
+      block(5);
+      good();
+      const healthyAt = performance.now();
+      window.__catalogRuleBadSpans.push(healthyAt - badAt);
+      block(600);
+      window.__catalogRuleHealthySpans.push(performance.now() - healthyAt);
+    }
+    window.__catalogRuleDone = true;
+  </script>`;
+
+  await page.goto(`data:text/html,${encodeURIComponent(html)}`);
+  await page.waitForFunction(() => (window as Window & { __catalogRuleDone?: boolean })
+    .__catalogRuleDone === true);
+
+  const snapshot = await readCatalogLayoutWatchdog(page);
+  const timing = await page.evaluate(() => {
+    const probeWindow = window as Window & {
+      __catalogRuleBadSpans?: number[];
+      __catalogRuleHealthySpans?: number[];
+    };
+    const badSpans = probeWindow.__catalogRuleBadSpans ?? [];
+    const healthySpans = probeWindow.__catalogRuleHealthySpans ?? [];
+    return {
+      badSpans,
+      healthySpans,
+      totalBadMs: badSpans.reduce((total, duration) => total + duration, 0),
+      totalHealthyMs: healthySpans.reduce((total, duration) => total + duration, 0),
+    };
+  });
+  expect(timing.badSpans).toHaveLength(4);
+  expect(timing.healthySpans).toHaveLength(4);
+  expect(timing.totalBadMs).toBeLessThan(100);
+  expect(timing.totalHealthyMs).toBeGreaterThanOrEqual(2_400);
+  expect(snapshot.latest?.resolvedTracks).toBe(7);
+  expect(snapshot.latest?.acceptedColumns).toBe(7);
+  expect(snapshot.violations).toHaveLength(4);
+  expect(snapshot.violations.every((violation) =>
+    violation.invariant === 'resolved-track-count'
+      && violation.durationEvidence === 'measured-transition')).toBe(true);
+  const measuredBadMs = snapshot.violations.reduce(
+    (total, violation) => total + violation.observedBadMs,
+    0,
+  );
+  expect(Math.abs(measuredBadMs - timing.totalBadMs)).toBeLessThan(100);
+  expect(snapshot.unhealed, JSON.stringify(snapshot, null, 2)).toEqual([]);
+});
+
+test('rule.style sustained failure remains measured across blocked frames', async ({ page }) => {
+  await installCatalogLayoutWatchdog(page);
+  const html = `<!doctype html><style>
+    #grid {
+      width: 1168px;
+      height: 100px;
+      --catalog-grid-min: 140px;
+      column-gap: 16px;
+      display: grid;
+      grid-template-columns: repeat(7, minmax(0, 1fr));
+    }
+  </style>
+  <style id="override">
+    #grid { grid-template-columns: repeat(7, minmax(0, 1fr)) !important; }
+  </style>
+  <div id="grid" data-testid="catalog-grid" data-catalog-column-count="7"><div>x</div></div>
+  <script>
+    const rule = document.querySelector('#override').sheet.cssRules[0];
+    const block = (duration) => {
+      const until = performance.now() + duration;
+      while (performance.now() < until) {}
+    };
+    window.__catalogRuleSustainedBadAt = performance.now();
+    rule.style.setProperty('grid-template-columns', '1168px', 'important');
+    window.__catalogRuleStallSpans = [];
+    for (let stall = 0; stall < 3; stall += 1) {
+      const stallAt = performance.now();
+      block(800);
+      window.__catalogRuleStallSpans.push(performance.now() - stallAt);
+      rule.style.setProperty('grid-template-columns', '1168px', 'important');
+    }
+    rule.style.setProperty(
+      'grid-template-columns',
+      'repeat(7, minmax(0, 1fr))',
+      'important',
+    );
+    window.__catalogRuleSustainedHealthyAt = performance.now();
+  </script>`;
+
+  await page.goto(`data:text/html,${encodeURIComponent(html)}`);
+  const snapshot = await readCatalogLayoutWatchdog(page);
+  const timing = await page.evaluate(() => {
+    const probeWindow = window as Window & {
+      __catalogRuleSustainedBadAt?: number;
+      __catalogRuleSustainedHealthyAt?: number;
+      __catalogRuleStallSpans?: number[];
+    };
+    return {
+      actualBadMs: (probeWindow.__catalogRuleSustainedHealthyAt ?? 0)
+        - (probeWindow.__catalogRuleSustainedBadAt ?? 0),
+      stallSpans: probeWindow.__catalogRuleStallSpans ?? [],
+    };
+  });
+  expect(timing.stallSpans).toHaveLength(3);
+  expect(timing.stallSpans.every((duration) => duration >= 800)).toBe(true);
+  expect(timing.actualBadMs).toBeGreaterThan(CATALOG_LAYOUT_HEAL_MS);
+  expect(snapshot.latest?.resolvedTracks).toBe(7);
+  expect(snapshot.latest?.acceptedColumns).toBe(7);
+  expect(snapshot.violations).toHaveLength(1);
+  const violation = snapshot.violations[0];
+  expect(violation?.invariant).toBe('resolved-track-count');
+  expect(violation?.durationEvidence).toBe('measured-transition');
+  expect(violation?.observedBadMs).toBeGreaterThan(CATALOG_LAYOUT_HEAL_MS);
+  expect(Math.abs((violation?.observedBadMs ?? 0) - timing.actualBadMs)).toBeLessThan(100);
+  expect(snapshot.unhealed.map(({ invariant }) => invariant)).toEqual([
+    'resolved-track-count',
+  ]);
+});
+
+test('grid Typed OM writes stay measured while unrelated declarations stay diagnostic', async ({ page }) => {
+  await installCatalogLayoutWatchdog(page);
+  const html = `<!doctype html><style>
+    #grid {
+      width: 1168px;
+      height: 100px;
+      --catalog-grid-min: 140px;
+      column-gap: 16px;
+      display: grid;
+      grid-template-columns: repeat(7, minmax(0, 1fr));
+    }
+  </style>
+  <div id="grid" data-testid="catalog-grid" data-catalog-column-count="7"><div>x</div></div>
+  <script>
+    const grid = document.querySelector('#grid');
+    const bad = () => grid.attributeStyleMap.set('grid-template-columns', '1168px');
+    const good = () => grid.attributeStyleMap.set(
+      'grid-template-columns',
+      'repeat(7, minmax(0, 1fr))',
+    );
+    const block = (duration) => {
+      const until = performance.now() + duration;
+      while (performance.now() < until) {}
+    };
+    window.__catalogTypedOmSupported = Boolean(grid.attributeStyleMap);
+    window.__catalogTypedOmBadSpans = [];
+    window.__catalogTypedOmHealthySpans = [];
+    for (let cycle = 0; cycle < 4; cycle += 1) {
+      const badAt = performance.now();
+      bad();
+      document.body.style.setProperty('--unrelated-catalog-probe', String(cycle));
+      good();
+      const healthyAt = performance.now();
+      window.__catalogTypedOmBadSpans.push(healthyAt - badAt);
+      block(600);
+      window.__catalogTypedOmHealthySpans.push(performance.now() - healthyAt);
+    }
+    good();
+    document.body.style.setProperty('--unrelated-catalog-probe', 'done');
+    window.__catalogTypedOmDone = true;
+  </script>`;
+
+  await page.goto(`data:text/html,${encodeURIComponent(html)}`);
+  await page.waitForFunction(() => (window as Window & { __catalogTypedOmDone?: boolean })
+    .__catalogTypedOmDone === true);
+  await waitForHealthySevenTrackGrid(page);
+
+  const snapshot = await readCatalogLayoutWatchdog(page);
+  const timing = await page.evaluate(() => {
+    const probeWindow = window as Window & {
+      __catalogTypedOmSupported?: boolean;
+      __catalogTypedOmBadSpans?: number[];
+      __catalogTypedOmHealthySpans?: number[];
+    };
+    const badSpans = probeWindow.__catalogTypedOmBadSpans ?? [];
+    const healthySpans = probeWindow.__catalogTypedOmHealthySpans ?? [];
+    return {
+      supported: probeWindow.__catalogTypedOmSupported,
+      badSpans,
+      healthySpans,
+      totalBadMs: badSpans.reduce((total, duration) => total + duration, 0),
+      totalHealthyMs: healthySpans.reduce((total, duration) => total + duration, 0),
+    };
+  });
+  expect(timing.supported).toBe(true);
+  expect(timing.badSpans).toHaveLength(4);
+  expect(timing.healthySpans).toHaveLength(4);
+  expect(timing.totalBadMs).toBeLessThan(100);
+  expect(timing.totalHealthyMs).toBeGreaterThanOrEqual(2_400);
+  expect(snapshot.violations).toHaveLength(4);
+  expect(snapshot.violations.every((violation) =>
+    violation.invariant === 'resolved-track-count'
+      && violation.durationEvidence === 'measured-transition')).toBe(true);
+  const measuredBadMs = snapshot.violations.reduce(
+    (total, violation) => total + violation.observedBadMs,
+    0,
+  );
+  expect(Math.abs(measuredBadMs - timing.totalBadMs)).toBeLessThan(100);
+  expect(snapshot.unhealed, JSON.stringify(snapshot, null, 2)).toEqual([]);
+});
+
+test('unrelated declaration cannot upgrade an animation-only bad state', async ({ page }) => {
+  await installCatalogLayoutWatchdog(page);
+  const html = `<!doctype html><style>
+    @keyframes catalog-unhooked-bad-tracks {
+      from { grid-template-columns: 1168px; }
+      to { grid-template-columns: 1168px; }
+    }
+    #grid {
+      width: 1168px;
+      height: 100px;
+      --catalog-grid-min: 140px;
+      column-gap: 16px;
+      display: grid;
+      grid-template-columns: repeat(7, minmax(0, 1fr));
+      animation: catalog-unhooked-bad-tracks 800ms 200ms linear 1;
+    }
+  </style>
+  <div id="grid" data-testid="catalog-grid" data-catalog-column-count="7"><div>x</div></div>
+  <script>
+    const grid = document.querySelector('#grid');
+    grid.addEventListener('animationstart', () => {
+      window.__catalogAnimationBadAt = performance.now();
+      window.__catalogAnimationTracksAtBodyWrite = getComputedStyle(grid)
+        .gridTemplateColumns.trim().split(/\\s+/).length;
+      document.body.style.setProperty('--unrelated-catalog-probe', 'while-grid-bad');
+      window.__catalogAnimationDuringBad = window.__catalogLayoutWatchdog.snapshot();
+    });
+    grid.addEventListener('animationend', (event) => {
+      window.__catalogAnimationHealthyAt = performance.now();
+      window.__catalogAnimationElapsedMs = event.elapsedTime * 1000;
+    });
+  </script>`;
+
+  await page.goto(`data:text/html,${encodeURIComponent(html)}`);
+  await page.waitForFunction(() => (window as Window & {
+    __catalogAnimationHealthyAt?: number;
+  }).__catalogAnimationHealthyAt !== undefined);
+  await waitForHealthySevenTrackGrid(page);
+
+  const snapshot = await readCatalogLayoutWatchdog(page);
+  const probe = await page.evaluate(() => {
+    const probeWindow = window as Window & {
+      __catalogAnimationBadAt?: number;
+      __catalogAnimationHealthyAt?: number;
+      __catalogAnimationElapsedMs?: number;
+      __catalogAnimationTracksAtBodyWrite?: number;
+      __catalogAnimationDuringBad?: CatalogLayoutWatchdogSnapshot;
+    };
+    return {
+      actualBadMs: (probeWindow.__catalogAnimationHealthyAt ?? 0)
+        - (probeWindow.__catalogAnimationBadAt ?? 0),
+      animationElapsedMs: probeWindow.__catalogAnimationElapsedMs,
+      tracksAtBodyWrite: probeWindow.__catalogAnimationTracksAtBodyWrite,
+      duringBad: probeWindow.__catalogAnimationDuringBad,
+    };
+  });
+  expect(probe.animationElapsedMs).toBeCloseTo(800, 0);
+  expect(probe.tracksAtBodyWrite).toBe(1);
+  expect(probe.duringBad?.violations).toHaveLength(1);
+  expect(probe.duringBad?.violations[0]?.durationEvidence).toBe('unmeasured-safety-net');
+  expect(probe.duringBad?.violations[0]?.healedAtMs).toBeNull();
+  expect(snapshot.violations).toHaveLength(1);
+  expect(snapshot.violations[0]?.durationEvidence).toBe('unmeasured-safety-net');
+  expect(snapshot.violations[0]?.observedBadMs).toBe(0);
+  expect(snapshot.violations[0]?.healedAtMs).not.toBeNull();
+  expect(snapshot.unhealed, JSON.stringify(snapshot, null, 2)).toEqual([]);
+});
+
+test('irrelevant grid declaration stays diagnostic while a real grid write is measured', async ({ page }) => {
+  await installCatalogLayoutWatchdog(page);
+  const html = `<!doctype html><style>
+    @keyframes catalog-paused-track-probe {
+      from { grid-template-columns: repeat(7, minmax(0, 1fr)); }
+      to { grid-template-columns: 1168px; }
+    }
+    #grid {
+      width: 1168px;
+      height: 100px;
+      --catalog-grid-min: 140px;
+      column-gap: 16px;
+      display: grid;
+      grid-template-columns: repeat(7, minmax(0, 1fr));
+      animation: catalog-paused-track-probe 1000ms linear paused both;
+    }
+  </style>
+  <div id="grid" data-testid="catalog-grid" data-catalog-column-count="7"><div>x</div></div>
+  <script>
+    const grid = document.querySelector('#grid');
+    const animation = grid.getAnimations()[0];
+    const tracks = () => getComputedStyle(grid).gridTemplateColumns
+      .trim().split(/\\s+/).filter(Boolean).length;
+    const block = (duration) => {
+      const until = performance.now() + duration;
+      while (performance.now() < until) {}
+    };
+    window.__catalogIrrelevantGridBadSpans = [];
+    window.__catalogIrrelevantGridHealthySpans = [];
+    for (let cycle = 0; cycle < 4; cycle += 1) {
+      animation.currentTime = 550;
+      const badAt = performance.now();
+      const badTracks = tracks();
+      grid.style.setProperty('color', cycle % 2 ? 'red' : 'blue');
+      animation.currentTime = 0;
+      const healthyAt = performance.now();
+      const healthyTracks = tracks();
+      window.__catalogIrrelevantGridBadSpans.push({
+        duration: healthyAt - badAt,
+        badTracks,
+        healthyTracks,
+      });
+      block(600);
+      window.__catalogIrrelevantGridHealthySpans.push(performance.now() - healthyAt);
+    }
+    animation.currentTime = 0;
+    grid.style.setProperty('color', 'green');
+    window.__catalogIrrelevantGridDone = true;
+  </script>`;
+
+  await page.goto(`data:text/html,${encodeURIComponent(html)}`);
+  await page.waitForFunction(() => (window as Window & {
+    __catalogIrrelevantGridDone?: boolean;
+  }).__catalogIrrelevantGridDone === true);
+  await waitForHealthySevenTrackGrid(page);
+
+  const diagnosticSnapshot = await readCatalogLayoutWatchdog(page);
+  const diagnosticTiming = await page.evaluate(() => {
+    const probeWindow = window as Window & {
+      __catalogIrrelevantGridBadSpans?: Array<{
+        duration: number;
+        badTracks: number;
+        healthyTracks: number;
+      }>;
+      __catalogIrrelevantGridHealthySpans?: number[];
+    };
+    const badSpans = probeWindow.__catalogIrrelevantGridBadSpans ?? [];
+    const healthySpans = probeWindow.__catalogIrrelevantGridHealthySpans ?? [];
+    return {
+      badSpans,
+      healthySpans,
+      totalBadMs: badSpans.reduce((total, span) => total + span.duration, 0),
+      totalHealthyMs: healthySpans.reduce((total, duration) => total + duration, 0),
+    };
+  });
+  expect(diagnosticTiming.badSpans).toHaveLength(4);
+  expect(diagnosticTiming.badSpans.every(({ badTracks, healthyTracks }) =>
+    badTracks === 1 && healthyTracks === 7)).toBe(true);
+  expect(diagnosticTiming.totalBadMs).toBeLessThan(100);
+  expect(diagnosticTiming.totalHealthyMs).toBeGreaterThanOrEqual(2_400);
+  expect(diagnosticSnapshot.violations).toHaveLength(1);
+  expect(diagnosticSnapshot.violations[0]?.durationEvidence).toBe('unmeasured-safety-net');
+  expect(diagnosticSnapshot.violations[0]?.observedBadMs).toBe(0);
+  expect(diagnosticSnapshot.unhealed, JSON.stringify(diagnosticSnapshot, null, 2)).toEqual([]);
+
+  const relevantTiming = await page.evaluate(() => {
+    const grid = document.querySelector<HTMLElement>('#grid');
+    if (!grid) throw new Error('catalog grid missing from relevant-write probe');
+    grid.getAnimations().forEach((animation) => animation.cancel());
+    const tracks = () => getComputedStyle(grid).gridTemplateColumns
+      .trim().split(/\s+/).filter(Boolean).length;
+    const badAt = performance.now();
+    grid.style.setProperty('grid-template-columns', '1168px', 'important');
+    const badTracks = tracks();
+    const until = performance.now() + 650;
+    while (performance.now() < until) {}
+    grid.style.setProperty(
+      'grid-template-columns',
+      'repeat(7, minmax(0, 1fr))',
+      'important',
+    );
+    return {
+      actualBadMs: performance.now() - badAt,
+      badTracks,
+      healthyTracks: tracks(),
+    };
+  });
+  const finalSnapshot = await readCatalogLayoutWatchdog(page);
+  expect(relevantTiming.badTracks).toBe(1);
+  expect(relevantTiming.healthyTracks).toBe(7);
+  expect(relevantTiming.actualBadMs).toBeGreaterThanOrEqual(650);
+  expect(finalSnapshot.violations).toHaveLength(2);
+  const relevantViolation = finalSnapshot.violations[1];
+  expect(relevantViolation?.invariant).toBe('resolved-track-count');
+  expect(relevantViolation?.durationEvidence).toBe('measured-transition');
+  expect(Math.abs((relevantViolation?.observedBadMs ?? 0) - relevantTiming.actualBadMs))
+    .toBeLessThan(100);
+  expect(finalSnapshot.unhealed, JSON.stringify(finalSnapshot, null, 2)).toEqual([]);
+});
+
+test('truth-preserving input changes stay diagnostic and bad values remain one episode', async ({ page }) => {
+  await installCatalogLayoutWatchdog(page);
+  const html = `<!doctype html><style>
+    @keyframes catalog-truth-preserving-probe {
+      from { grid-template-columns: repeat(7, minmax(0, 1fr)); }
+      to { grid-template-columns: 1240px; }
+    }
+    #grid {
+      height: 100px;
+      column-gap: 16px;
+      display: grid;
+      grid-template-columns: repeat(7, minmax(0, 1fr));
+      animation: catalog-truth-preserving-probe 1000ms linear paused both;
+    }
+    #grid.a { width: 1168px; --catalog-grid-min: 140px; }
+    #grid.b { width: 1240px; --catalog-grid-min: 150px; }
+  </style>
+  <div id="grid" class="a" data-testid="catalog-grid" data-catalog-column-count="7">
+    <div>x</div>
+  </div>
+  <script>
+    const grid = document.querySelector('#grid');
+    const animation = grid.getAnimations()[0];
+    const read = () => {
+      const style = getComputedStyle(grid);
+      const width = grid.getBoundingClientRect().width;
+      const min = Number.parseFloat(style.getPropertyValue('--catalog-grid-min'));
+      const gap = Number.parseFloat(style.columnGap);
+      const resolvedTracks = style.gridTemplateColumns.trim().split(/\\s+/).filter(Boolean).length;
+      return {
+        className: grid.className,
+        width,
+        min,
+        gap,
+        expected: Math.floor((width + gap) / (min + gap)),
+        resolvedTracks,
+      };
+    };
+    const block = (duration) => {
+      const until = performance.now() + duration;
+      while (performance.now() < until) {}
+    };
+    window.__catalogTruthPreservingCycles = [];
+    window.__catalogTruthPreservingHealthySpans = [];
+    for (let cycle = 0; cycle < 4; cycle += 1) {
+      animation.currentTime = 1000;
+      const badAt = performance.now();
+      const before = read();
+      grid.className = grid.className === 'a' ? 'b' : 'a';
+      const after = read();
+      animation.currentTime = 0;
+      const healthyAt = performance.now();
+      window.__catalogTruthPreservingCycles.push({
+        duration: healthyAt - badAt,
+        before,
+        after,
+        healthy: read(),
+      });
+      block(600);
+      window.__catalogTruthPreservingHealthySpans.push(performance.now() - healthyAt);
+    }
+    animation.currentTime = 0;
+    grid.className = grid.className === 'a' ? 'b' : 'a';
+    window.__catalogTruthPreservingFinal = read();
+    window.__catalogTruthPreservingDone = true;
+  </script>`;
+
+  await page.goto(`data:text/html,${encodeURIComponent(html)}`);
+  await page.waitForFunction(() => (window as Window & {
+    __catalogTruthPreservingDone?: boolean;
+  }).__catalogTruthPreservingDone === true);
+  await waitForHealthySevenTrackGrid(page);
+
+  const diagnosticSnapshot = await readCatalogLayoutWatchdog(page);
+  const diagnosticTiming = await page.evaluate(() => {
+    const probeWindow = window as Window & {
+      __catalogTruthPreservingCycles?: Array<{
+        duration: number;
+        before: { expected: number; resolvedTracks: number };
+        after: { expected: number; resolvedTracks: number };
+        healthy: { expected: number; resolvedTracks: number };
+      }>;
+      __catalogTruthPreservingHealthySpans?: number[];
+      __catalogTruthPreservingFinal?: { expected: number; resolvedTracks: number };
+    };
+    const cycles = probeWindow.__catalogTruthPreservingCycles ?? [];
+    const healthySpans = probeWindow.__catalogTruthPreservingHealthySpans ?? [];
+    return {
+      cycles,
+      healthySpans,
+      final: probeWindow.__catalogTruthPreservingFinal,
+      totalBadMs: cycles.reduce((total, cycle) => total + cycle.duration, 0),
+      totalHealthyMs: healthySpans.reduce((total, duration) => total + duration, 0),
+    };
+  });
+  expect(diagnosticTiming.cycles).toHaveLength(4);
+  expect(diagnosticTiming.cycles.every(({ before, after, healthy }) =>
+    before.expected === 7
+      && before.resolvedTracks === 1
+      && after.expected === 7
+      && after.resolvedTracks === 1
+      && healthy.expected === 7
+      && healthy.resolvedTracks === 7)).toBe(true);
+  expect(diagnosticTiming.totalBadMs).toBeLessThan(100);
+  expect(diagnosticTiming.totalHealthyMs).toBeGreaterThanOrEqual(2_400);
+  expect(diagnosticTiming.final).toMatchObject({ expected: 7, resolvedTracks: 7 });
+  expect(diagnosticSnapshot.violations).toHaveLength(1);
+  expect(diagnosticSnapshot.violations[0]?.durationEvidence).toBe('unmeasured-safety-net');
+  expect(diagnosticSnapshot.violations[0]?.observedBadMs).toBe(0);
+  expect(diagnosticSnapshot.unhealed, JSON.stringify(diagnosticSnapshot, null, 2)).toEqual([]);
+
+  const wrongValueTiming = await page.evaluate(() => {
+    const grid = document.querySelector<HTMLElement>('#grid');
+    if (!grid) throw new Error('catalog grid missing from wrong-value probe');
+    grid.getAnimations().forEach((animation) => animation.cancel());
+    const tracks = () => getComputedStyle(grid).gridTemplateColumns
+      .trim().split(/\s+/).filter(Boolean).length;
+    const badAt = performance.now();
+    grid.style.setProperty('grid-template-columns', '1240px', 'important');
+    const firstBadTracks = tracks();
+    let until = performance.now() + 400;
+    while (performance.now() < until) {}
+    grid.style.setProperty(
+      'grid-template-columns',
+      'repeat(2, minmax(0, 1fr))',
+      'important',
+    );
+    const differentBadAt = performance.now();
+    const differentBadTracks = tracks();
+    until = performance.now() + 400;
+    while (performance.now() < until) {}
+    grid.style.setProperty(
+      'grid-template-columns',
+      'repeat(7, minmax(0, 1fr))',
+      'important',
+    );
+    return {
+      actualBadMs: performance.now() - badAt,
+      firstBadTracks,
+      differentBadTracks,
+      differentBadAt,
+      healthyTracks: tracks(),
+    };
+  });
+  const finalSnapshot = await readCatalogLayoutWatchdog(page);
+  expect(wrongValueTiming.firstBadTracks).toBe(1);
+  expect(wrongValueTiming.differentBadTracks).toBe(2);
+  expect(wrongValueTiming.healthyTracks).toBe(7);
+  expect(wrongValueTiming.actualBadMs).toBeGreaterThanOrEqual(800);
+  expect(finalSnapshot.violations).toHaveLength(2);
+  const measuredEpisodes = finalSnapshot.violations.filter((violation) =>
+    violation.durationEvidence === 'measured-transition');
+  expect(measuredEpisodes).toHaveLength(1);
+  const wrongValueEpisode = measuredEpisodes[0];
+  expect(wrongValueEpisode?.invariant).toBe('resolved-track-count');
+  expect(wrongValueEpisode?.actual).toBe(2);
+  expect(wrongValueEpisode?.lastSeenMs).toBeGreaterThan(wrongValueEpisode?.firstSeenMs ?? 0);
+  expect(wrongValueEpisode?.lastSeenMs).toBeLessThan(wrongValueEpisode?.healedAtMs ?? 0);
+  expect(Math.abs((wrongValueEpisode?.observedBadMs ?? 0) - wrongValueTiming.actualBadMs))
+    .toBeLessThan(100);
+  expect(finalSnapshot.unhealed, JSON.stringify(finalSnapshot, null, 2)).toEqual([]);
+});

--- a/frontend/e2e/catalog-layout-watchdog.spec.ts
+++ b/frontend/e2e/catalog-layout-watchdog.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from '@playwright/test';
+import {
+  CATALOG_LAYOUT_HEAL_MS,
+  hostileLoadProfile,
+  installCatalogLayoutWatchdog,
+  installHostileLoad,
+  readCatalogLayoutWatchdog,
+  type HostileLoadEvent,
+} from './catalog-layout-watchdog';
+
+const VIEWPORTS = [768, 1_280, 1_440];
+
+test.beforeEach(async ({ page }, testInfo) => {
+  const profile = hostileLoadProfile(testInfo);
+  const events: HostileLoadEvent[] = [];
+  if (profile) await installHostileLoad(page, profile, events);
+  await installCatalogLayoutWatchdog(page);
+  (testInfo as typeof testInfo & { hostileLoadEvents?: HostileLoadEvent[] }).hostileLoadEvents = events;
+});
+
+for (const width of VIEWPORTS) {
+  test(`catalog grid converges to its arithmetic track count at ${width}px`, async ({ page }, testInfo) => {
+    await page.setViewportSize({ width, height: 800 });
+    await page.goto('/app');
+
+    const grid = page.getByTestId('catalog-grid');
+    await expect(grid).toBeVisible();
+    await expect(grid.locator('[data-virtual-grid-row]').first()).toBeVisible();
+    await page.evaluate(() => document.fonts?.ready);
+
+    // Let the convergence contract fully elapse. A still-active episode must be
+    // red at settle time; an episode that healed inside the budget stays in the
+    // evidence log but is tolerated.
+    await page.waitForTimeout(CATALOG_LAYOUT_HEAL_MS + 100);
+    const snapshot = await readCatalogLayoutWatchdog(page);
+    const hostileEvents = (testInfo as typeof testInfo & {
+      hostileLoadEvents?: HostileLoadEvent[];
+    }).hostileLoadEvents ?? [];
+
+    await testInfo.attach('catalog-layout-watchdog.json', {
+      body: JSON.stringify(snapshot, null, 2),
+      contentType: 'application/json',
+    });
+    if (hostileEvents.length > 0) {
+      await testInfo.attach('hostile-load.json', {
+        body: JSON.stringify(hostileEvents, null, 2),
+        contentType: 'application/json',
+      });
+    }
+
+    expect(snapshot.sampledFrames, 'watchdog should sample continuously during load').toBeGreaterThan(0);
+    expect(snapshot.latest, 'catalog auto-fill grid should reach a laid-out sample').not.toBeNull();
+    expect(snapshot.unhealed, JSON.stringify(snapshot, null, 2)).toEqual([]);
+    expect(snapshot.latest?.resolvedTracks).toBe(snapshot.latest?.expected);
+    expect(snapshot.latest?.acceptedColumns).toBe(snapshot.latest?.expected);
+
+    const profile = hostileLoadProfile(testInfo);
+    if (profile) {
+      expect(hostileEvents.some(({ resourceType }) => resourceType === 'stylesheet'),
+        `${profile} must delay at least one stylesheet response`).toBeTruthy();
+      expect(hostileEvents.some(({ resourceType }) => resourceType === 'script'),
+        `${profile} must delay at least one script response`).toBeTruthy();
+      const stylesheetDelay = hostileEvents.find(
+        ({ resourceType }) => resourceType === 'stylesheet',
+      )?.delayMs ?? 0;
+      const scriptDelay = hostileEvents.find(
+        ({ resourceType }) => resourceType === 'script',
+      )?.delayMs ?? 0;
+      if (profile === 'css-slow') {
+        expect(stylesheetDelay, 'css-slow must delay CSS longer than JavaScript')
+          .toBeGreaterThan(scriptDelay);
+      } else {
+        expect(scriptDelay, 'script-slow must delay JavaScript longer than CSS')
+          .toBeGreaterThan(stylesheetDelay);
+      }
+    }
+  });
+}

--- a/frontend/e2e/catalog-layout-watchdog.ts
+++ b/frontend/e2e/catalog-layout-watchdog.ts
@@ -1,0 +1,863 @@
+import type { Page, TestInfo } from '@playwright/test';
+
+export const CATALOG_LAYOUT_HEAL_MS = 2_000;
+
+export type CatalogLayoutInvariant = 'resolved-track-count' | 'accepted-column-count';
+export type CatalogLayoutDurationEvidence =
+  | 'measured-transition'
+  | 'unmeasured-safety-net';
+
+export interface CatalogLayoutViolation {
+  invariant: CatalogLayoutInvariant;
+  firstSeenMs: number;
+  lastSeenMs: number;
+  healedAtMs: number | null;
+  badSampleCount: number;
+  /** Bad time supported by measured transitions; safety-only episodes report zero. */
+  observedBadMs: number;
+  /** Sum of supported bad durations during this page-load convergence window. */
+  cumulativeObservedBadMs: number;
+  durationEvidence: CatalogLayoutDurationEvidence;
+  width: number;
+  gap: number;
+  min: number;
+  expected: number;
+  actual: number;
+  resolvedTemplate: string;
+}
+
+export interface CatalogLayoutSample {
+  atMs: number;
+  width: number;
+  gap: number;
+  min: number;
+  expected: number;
+  resolvedTracks: number;
+  acceptedColumns: number | null;
+  resolvedTemplate: string;
+}
+
+export interface CatalogLayoutWatchdogSnapshot {
+  startedAtEpochMs: number;
+  sampledFrames: number;
+  latest: CatalogLayoutSample | null;
+  violations: CatalogLayoutViolation[];
+  unhealed: CatalogLayoutViolation[];
+}
+
+interface CatalogLayoutWatchdogApi {
+  snapshot: () => CatalogLayoutWatchdogSnapshot;
+}
+
+type WatchdogWindow = Window & {
+  __catalogLayoutWatchdog?: CatalogLayoutWatchdogApi;
+};
+
+/**
+ * Install before navigation so direct grid mutations can be timestamped in the
+ * test realm before application code runs. Observers and synchronous DOM/CSSOM
+ * hooks own exact transition evidence. requestAnimationFrame is a diagnostic
+ * safety net only and never infers duration between sampled endpoints.
+ */
+export async function installCatalogLayoutWatchdog(page: Page): Promise<void> {
+  await page.addInitScript(({ healMs }) => {
+    const watchdogWindow = window as WatchdogWindow;
+    const startedAtEpochMs = Date.now();
+    const startedAt = performance.now();
+    const violations: CatalogLayoutViolation[] = [];
+    const active = new Map<CatalogLayoutInvariant, {
+      violation: CatalogLayoutViolation;
+      transitionStarted: boolean;
+      cumulativeBeforeMs: number;
+    }>();
+    const cumulativeObservedBadMs = new Map<CatalogLayoutInvariant, number>();
+    const RESOLVED_LENGTH = /^(?:0|[1-9]\d*)(?:\.\d+)?px$/;
+    let sampledFrames = 0;
+    let latest: CatalogLayoutSample | null = null;
+    let grid: HTMLElement | null = null;
+    let gridMutationObserver: MutationObserver | null = null;
+    let gridResizeObserver: ResizeObserver | null = null;
+    type TransitionEvidence = boolean | ReadonlySet<CatalogLayoutInvariant>;
+
+    const now = () => performance.now() - startedAt;
+    const recordHealthy = (
+      invariant: CatalogLayoutInvariant,
+      atMs: number,
+      transitionObserved: boolean,
+    ) => {
+      const current = active.get(invariant);
+      if (!current) return;
+
+      const measured = current.transitionStarted && transitionObserved;
+      const duration = measured ? Math.max(0, atMs - current.violation.firstSeenMs) : 0;
+      const cumulative = current.cumulativeBeforeMs + duration;
+      cumulativeObservedBadMs.set(invariant, cumulative);
+      current.violation.healedAtMs = atMs;
+      current.violation.observedBadMs = duration;
+      current.violation.cumulativeObservedBadMs = cumulative;
+      current.violation.durationEvidence = measured
+        ? 'measured-transition'
+        : 'unmeasured-safety-net';
+      active.delete(invariant);
+    };
+    const recordViolation = (
+      invariant: CatalogLayoutInvariant,
+      sample: CatalogLayoutSample,
+      actual: number,
+      transitionObserved: boolean,
+    ) => {
+      const current = active.get(invariant);
+      if (current) {
+        current.violation.badSampleCount += 1;
+        current.violation.lastSeenMs = sample.atMs;
+        current.violation.width = sample.width;
+        current.violation.gap = sample.gap;
+        current.violation.min = sample.min;
+        current.violation.expected = sample.expected;
+        current.violation.actual = actual;
+        current.violation.resolvedTemplate = sample.resolvedTemplate;
+        return;
+      }
+      const cumulative = cumulativeObservedBadMs.get(invariant) ?? 0;
+      const violation: CatalogLayoutViolation = {
+        invariant,
+        firstSeenMs: sample.atMs,
+        lastSeenMs: sample.atMs,
+        healedAtMs: null,
+        badSampleCount: 1,
+        observedBadMs: 0,
+        cumulativeObservedBadMs: cumulative,
+        durationEvidence: transitionObserved
+          ? 'measured-transition'
+          : 'unmeasured-safety-net',
+        width: sample.width,
+        gap: sample.gap,
+        min: sample.min,
+        expected: sample.expected,
+        actual,
+        resolvedTemplate: sample.resolvedTemplate,
+      };
+      violations.push(violation);
+      active.set(invariant, {
+        violation,
+        transitionStarted: transitionObserved,
+        cumulativeBeforeMs: cumulative,
+      });
+    };
+
+    const readLayoutSample = (): CatalogLayoutSample | null => {
+      if (!grid) return null;
+      const style = getComputedStyle(grid);
+      const width = grid.getBoundingClientRect().width;
+      const min = Number.parseFloat(style.getPropertyValue('--catalog-grid-min'));
+      const gap = Number.parseFloat(style.columnGap);
+      const resolvedTemplate = style.gridTemplateColumns.trim();
+      const resolved = resolvedTemplate.split(/\s+/).filter(Boolean);
+
+      // A zero CSS minimum identifies the fixed-track mobile branch. Invalid
+      // geometry or unresolved repeat()/none output is not a laid-out auto-fill
+      // grid, so the invariant does not apply yet.
+      if (!(width > 0)
+        || !(min > 0)
+        || !Number.isFinite(gap)
+        || gap < 0
+        || resolved.length === 0
+        || !resolved.every((track) => RESOLVED_LENGTH.test(track))) return null;
+
+      const atMs = now();
+      const expected = Math.max(1, Math.floor((width + gap) / (min + gap)));
+      const acceptedRaw = grid.dataset.catalogColumnCount;
+      const acceptedColumns = acceptedRaw === undefined ? null : Number.parseInt(acceptedRaw, 10);
+      return {
+        atMs,
+        width,
+        gap,
+        min,
+        expected,
+        resolvedTracks: resolved.length,
+        acceptedColumns: Number.isInteger(acceptedColumns) ? acceptedColumns : null,
+        resolvedTemplate,
+      };
+    };
+    const transitionObservedFor = (
+      evidence: TransitionEvidence,
+      invariant: CatalogLayoutInvariant,
+    ) => typeof evidence === 'boolean' ? evidence : evidence.has(invariant);
+    const invariantIsHealthy = (
+      currentSample: CatalogLayoutSample,
+      invariant: CatalogLayoutInvariant,
+    ) => invariant === 'resolved-track-count'
+      ? currentSample.resolvedTracks === currentSample.expected
+      : currentSample.acceptedColumns === null
+        || currentSample.acceptedColumns === currentSample.expected;
+    const recordSample = (
+      currentSample: CatalogLayoutSample | null,
+      evidence: TransitionEvidence,
+    ) => {
+      sampledFrames += 1;
+      if (!currentSample) return;
+      latest = currentSample;
+
+      if (invariantIsHealthy(currentSample, 'resolved-track-count')) {
+        recordHealthy(
+          'resolved-track-count',
+          currentSample.atMs,
+          transitionObservedFor(evidence, 'resolved-track-count'),
+        );
+      } else {
+        recordViolation(
+          'resolved-track-count',
+          currentSample,
+          currentSample.resolvedTracks,
+          transitionObservedFor(evidence, 'resolved-track-count'),
+        );
+      }
+
+      if (invariantIsHealthy(currentSample, 'accepted-column-count')) {
+        recordHealthy(
+          'accepted-column-count',
+          currentSample.atMs,
+          transitionObservedFor(evidence, 'accepted-column-count'),
+        );
+      } else {
+        recordViolation(
+          'accepted-column-count',
+          currentSample,
+          currentSample.acceptedColumns!,
+          transitionObservedFor(evidence, 'accepted-column-count'),
+        );
+      }
+    };
+    const sample = (evidence: TransitionEvidence) => {
+      recordSample(readLayoutSample(), evidence);
+    };
+
+    const attachGrid = (candidate?: HTMLElement, transitionObserved = false) => {
+      const nextGrid = candidate
+        ?? document.querySelector<HTMLElement>('[data-testid="catalog-grid"]');
+      if (nextGrid === grid) return;
+
+      gridMutationObserver?.disconnect();
+      gridResizeObserver?.disconnect();
+      grid = nextGrid;
+      if (!grid) return;
+
+      // MutationObserver reports that markup changed, not which invariant input
+      // changed across the mutation. Synchronous test-realm hooks own exact
+      // evidence; observer delivery is a diagnostic fallback for other realms.
+      gridMutationObserver = new MutationObserver(() => sample(false));
+      gridMutationObserver.observe(grid, {
+        attributes: true,
+        attributeFilter: ['style', 'class', 'data-catalog-column-count'],
+        childList: true,
+      });
+      gridResizeObserver = new ResizeObserver(() => sample(true));
+      gridResizeObserver.observe(grid);
+      sample(transitionObserved);
+    };
+
+    const isCatalogGrid = (element: Element): element is HTMLElement => element instanceof HTMLElement
+      && element.getAttribute('data-testid') === 'catalog-grid';
+    const isStylesheetElement = (node: Node): node is HTMLStyleElement | HTMLLinkElement =>
+      node instanceof HTMLStyleElement || node instanceof HTMLLinkElement;
+    const stylesheetElementsWithin = (node: Node): Array<HTMLStyleElement | HTMLLinkElement> => {
+      if (isStylesheetElement(node)) return [node];
+      return node instanceof Element
+        ? [...node.querySelectorAll<HTMLStyleElement | HTMLLinkElement>('style, link')]
+        : [];
+    };
+    const stylesheetElementCausality = new WeakMap<HTMLStyleElement | HTMLLinkElement, boolean>();
+
+    const fontFamilyCanAffectGrid = (family: string) => {
+      if (!grid || !family.trim()) return false;
+      const normalize = (value: string) => value.trim().replace(/^['"]|['"]$/g, '').toLowerCase();
+      const target = normalize(family);
+      return getComputedStyle(grid).fontFamily.split(',').some((candidate) =>
+        normalize(candidate) === target);
+    };
+    const stylesheetIsActive = (sheet: CSSStyleSheet): boolean => {
+      if (sheet.disabled) return false;
+      const owner = sheet.ownerNode;
+      if (owner instanceof Element && !owner.isConnected) return false;
+      if (owner instanceof HTMLLinkElement && !owner.relList.contains('stylesheet')) return false;
+      if ((owner instanceof HTMLStyleElement || owner instanceof HTMLLinkElement)
+        && owner.media && !matchMedia(owner.media).matches) return false;
+      if (!owner) {
+        const ownerRule = sheet.ownerRule;
+        if (typeof CSSImportRule !== 'undefined' && ownerRule instanceof CSSImportRule) {
+          if (ownerRule.media.mediaText && !matchMedia(ownerRule.media.mediaText).matches) return false;
+          return ownerRule.parentStyleSheet ? stylesheetIsActive(ownerRule.parentStyleSheet) : false;
+        }
+        return document.adoptedStyleSheets.includes(sheet);
+      }
+      return true;
+    };
+    const ruleContextCanApply = (rule: CSSRule) => {
+      if (rule.parentStyleSheet && !stylesheetIsActive(rule.parentStyleSheet)) return false;
+      let parent = rule.parentRule;
+      while (parent) {
+        if (typeof CSSMediaRule !== 'undefined' && parent instanceof CSSMediaRule
+          && !matchMedia(parent.conditionText).matches) return false;
+        if (typeof CSSSupportsRule !== 'undefined' && parent instanceof CSSSupportsRule
+          && !CSS.supports(parent.conditionText)) return false;
+        // There is no browser API that answers whether a CSSContainerRule is
+        // currently active for this element. Treat it as diagnostic rather than
+        // inventing exact causality from a merely matching nested selector.
+        if (typeof CSSContainerRule !== 'undefined' && parent instanceof CSSContainerRule) {
+          return false;
+        }
+        parent = parent.parentRule;
+      }
+      return true;
+    };
+    const ruleCanAffectGrid = (rule: CSSRule): boolean => {
+      if (!grid || !ruleContextCanApply(rule)) return false;
+      if (typeof CSSStyleRule !== 'undefined' && rule instanceof CSSStyleRule) {
+        try {
+          return grid.matches(rule.selectorText);
+        } catch {
+          // A thrown selector test is unknown, not proof. Marking it causal
+          // could recreate the exact false red fixed here if an unrelated rule
+          // merely followed an earlier unhooked grid change.
+          return false;
+        }
+      }
+      if (typeof CSSFontFaceRule !== 'undefined' && rule instanceof CSSFontFaceRule) {
+        return fontFamilyCanAffectGrid(rule.style.getPropertyValue('font-family'));
+      }
+      if (typeof CSSKeyframeRule !== 'undefined' && rule instanceof CSSKeyframeRule) {
+        const keyframes = rule.parentRule;
+        if (typeof CSSKeyframesRule === 'undefined' || !(keyframes instanceof CSSKeyframesRule)) {
+          return false;
+        }
+        return getComputedStyle(grid).animationName.split(',')
+          .some((name) => name.trim() === keyframes.name);
+      }
+      if (typeof CSSImportRule !== 'undefined' && rule instanceof CSSImportRule) {
+        if (rule.media.mediaText && !matchMedia(rule.media.mediaText).matches) return false;
+        return stylesheetCanAffectGrid(rule.styleSheet);
+      }
+      const nested = (rule as CSSRule & { cssRules?: CSSRuleList }).cssRules;
+      return nested ? [...nested].some(ruleCanAffectGrid) : false;
+    };
+    const stylesheetCanAffectGrid = (sheet: CSSStyleSheet | null): boolean => {
+      if (!sheet || !stylesheetIsActive(sheet)) return false;
+      try {
+        return [...sheet.cssRules].some(ruleCanAffectGrid);
+      } catch {
+        // Cross-origin or otherwise opaque sheets stay diagnostic-only.
+        return false;
+      }
+    };
+    const stylesheetElementCanAffectGrid = (element: HTMLStyleElement | HTMLLinkElement) => {
+      const causal = stylesheetCanAffectGrid(element.sheet as CSSStyleSheet | null);
+      stylesheetElementCausality.set(element, causal);
+      return causal;
+    };
+    const notifyDiagnosticObservation = (couldAffectGrid: boolean) => {
+      if (!couldAffectGrid) return;
+      attachGrid(undefined, false);
+      // Asynchronous lifecycle/font notifications cannot provide a synchronous
+      // before endpoint. Ownership may explain why we looked, but it cannot
+      // license duration; only measureSynchronousWrite can do that for hooks.
+      sample(false);
+    };
+    const invariantTruthChanged = (
+      before: CatalogLayoutSample | null,
+      after: CatalogLayoutSample | null,
+      invariant: CatalogLayoutInvariant,
+    ) => {
+      if (!before || !after) return false;
+      return invariantIsHealthy(before, invariant) !== invariantIsHealthy(after, invariant);
+    };
+    let synchronousWriteDepth = 0;
+    const measureSynchronousWrite = <Result>(write: () => Result): Result => {
+      // Until a grid exists there is no invariant state to read. Nested hooks
+      // describe the same browser write, so the outermost hook owns the one
+      // before/after pair instead of multiplying forced-style reads.
+      if (!grid) attachGrid();
+      if (!grid || synchronousWriteDepth > 0) return write();
+
+      const before = readLayoutSample();
+      synchronousWriteDepth += 1;
+      let result: Result;
+      try {
+        result = write();
+      } finally {
+        synchronousWriteDepth -= 1;
+      }
+      const after = readLayoutSample();
+      const changed = new Set<CatalogLayoutInvariant>();
+      for (const invariant of [
+        'resolved-track-count',
+        'accepted-column-count',
+      ] as const) {
+        if (invariantTruthChanged(before, after, invariant)) changed.add(invariant);
+      }
+      // Ownership and selector matching are only useful prefilters. A measured
+      // transition exists only when this exact call flips the same healthy/bad
+      // predicate recordSample uses; truth-preserving writes stay diagnostic.
+      recordSample(after, changed);
+      return result;
+    };
+
+    // Existing rule declarations do not notify MutationObserver and do not call
+    // CSSStyleSheet's whole-sheet methods. Hook their shared write surface so
+    // `rule.style.setProperty(...)`, inline declarations, and cssText changes
+    // receive exact post-write timestamps.
+    const originalStyleSetProperty = CSSStyleDeclaration.prototype.setProperty;
+    CSSStyleDeclaration.prototype.setProperty = function setProperty(
+      property,
+      value,
+      priority,
+    ) {
+      measureSynchronousWrite(() => {
+        originalStyleSetProperty.call(this, property, value, priority);
+      });
+    };
+    const originalStyleRemoveProperty = CSSStyleDeclaration.prototype.removeProperty;
+    CSSStyleDeclaration.prototype.removeProperty = function removeProperty(property) {
+      return measureSynchronousWrite(() => originalStyleRemoveProperty.call(this, property));
+    };
+    const cssTextDescriptor = Object.getOwnPropertyDescriptor(
+      CSSStyleDeclaration.prototype,
+      'cssText',
+    );
+    if (cssTextDescriptor?.set && cssTextDescriptor.configurable) {
+      Object.defineProperty(CSSStyleDeclaration.prototype, 'cssText', {
+        ...cssTextDescriptor,
+        set(value) {
+          measureSynchronousWrite(() => {
+            cssTextDescriptor.set?.call(this, value);
+          });
+        },
+      });
+    }
+
+    // CSS declarations use Web IDL named-property setters for camelCase and
+    // dashed assignments; Chromium and WebKit expose no configurable property
+    // descriptors for those names. A stable proxy on rule.style is therefore
+    // the reachable interception point for direct property assignment.
+    const ruleStyleProxies = new WeakMap<CSSStyleDeclaration, CSSStyleDeclaration>();
+    const proxyRuleStyle = (target: CSSStyleDeclaration) => {
+      const existing = ruleStyleProxies.get(target);
+      if (existing) return existing;
+      const proxy = new Proxy(target, {
+        get(style, property) {
+          const value = Reflect.get(style, property, style);
+          return typeof value === 'function' ? value.bind(style) : value;
+        },
+        set(style, property, value) {
+          return measureSynchronousWrite(() => Reflect.set(style, property, value, style));
+        },
+      }) as CSSStyleDeclaration;
+      ruleStyleProxies.set(target, proxy);
+      return proxy;
+    };
+    const hookRuleStyleGetter = (prototype: object) => {
+      const descriptor = Object.getOwnPropertyDescriptor(prototype, 'style');
+      if (!descriptor?.get || !descriptor.configurable) return;
+      Object.defineProperty(prototype, 'style', {
+        ...descriptor,
+        get() {
+          return proxyRuleStyle(descriptor.get?.call(this) as CSSStyleDeclaration);
+        },
+      });
+    };
+    if (typeof CSSStyleRule !== 'undefined') hookRuleStyleGetter(CSSStyleRule.prototype);
+    if (typeof CSSFontFaceRule !== 'undefined') hookRuleStyleGetter(CSSFontFaceRule.prototype);
+    if (typeof CSSKeyframeRule !== 'undefined') hookRuleStyleGetter(CSSKeyframeRule.prototype);
+
+    // Rule insertion/removal/replacement on either constructed or DOM-backed
+    // stylesheets. These wrappers live only in Playwright's isolated test page.
+    const originalInsertRule = CSSStyleSheet.prototype.insertRule;
+    CSSStyleSheet.prototype.insertRule = function insertRule(rule, index) {
+      return measureSynchronousWrite(() => originalInsertRule.call(this, rule, index));
+    };
+    const originalDeleteRule = CSSStyleSheet.prototype.deleteRule;
+    CSSStyleSheet.prototype.deleteRule = function deleteRule(index) {
+      measureSynchronousWrite(() => originalDeleteRule.call(this, index));
+    };
+    const originalReplaceSync = CSSStyleSheet.prototype.replaceSync;
+    if (originalReplaceSync) {
+      CSSStyleSheet.prototype.replaceSync = function replaceSync(text) {
+        measureSynchronousWrite(() => originalReplaceSync.call(this, text));
+      };
+    }
+    const originalReplace = CSSStyleSheet.prototype.replace;
+    if (originalReplace) {
+      CSSStyleSheet.prototype.replace = function replace(text) {
+        const replacement = measureSynchronousWrite(() => originalReplace.call(this, text));
+        return replacement.then((sheet) => {
+          // If replacement becomes visible only when the promise resolves,
+          // there is no synchronous pre-change endpoint at resolution. Keep
+          // that completion diagnostic rather than inferring a duration.
+          notifyDiagnosticObservation(stylesheetCanAffectGrid(sheet));
+          return sheet;
+        });
+      };
+    }
+
+    const hookMeasuredSetter = (
+      prototype: object,
+      property: string,
+    ) => {
+      const descriptor = Object.getOwnPropertyDescriptor(prototype, property);
+      if (!descriptor?.set || !descriptor.configurable) return;
+      Object.defineProperty(prototype, property, {
+        ...descriptor,
+        set(this: object, value: unknown) {
+          measureSynchronousWrite(() => {
+            descriptor.set?.call(this, value);
+          });
+        },
+      });
+    };
+    hookMeasuredSetter(CSSStyleSheet.prototype, 'disabled');
+    hookMeasuredSetter(HTMLStyleElement.prototype, 'media');
+    hookMeasuredSetter(HTMLLinkElement.prototype, 'disabled');
+    hookMeasuredSetter(HTMLLinkElement.prototype, 'media');
+    hookMeasuredSetter(HTMLLinkElement.prototype, 'href');
+    hookMeasuredSetter(HTMLLinkElement.prototype, 'rel');
+
+    const adoptedDescriptor = Object.getOwnPropertyDescriptor(Document.prototype, 'adoptedStyleSheets');
+    if (adoptedDescriptor?.set && adoptedDescriptor.configurable) {
+      Object.defineProperty(Document.prototype, 'adoptedStyleSheets', {
+        ...adoptedDescriptor,
+        set(value) {
+          measureSynchronousWrite(() => {
+            adoptedDescriptor.set?.call(this, value);
+          });
+        },
+      });
+    }
+    if (typeof CSSStyleRule !== 'undefined') {
+      hookMeasuredSetter(CSSStyleRule.prototype, 'selectorText');
+    }
+    if (typeof CSSKeyframeRule !== 'undefined') {
+      hookMeasuredSetter(CSSKeyframeRule.prototype, 'keyText');
+    }
+
+    // Attribute changes made by React and ordinary DOM code.
+    const isStylesheetAttribute = (name: string) =>
+      name === 'media' || name === 'disabled' || name === 'href' || name === 'rel';
+    const originalSetAttribute = Element.prototype.setAttribute;
+    Element.prototype.setAttribute = function setAttribute(name, value) {
+      measureSynchronousWrite(() => originalSetAttribute.call(this, name, value));
+      if (name === 'data-testid' && isCatalogGrid(this)) attachGrid(this, false);
+      if (isStylesheetElement(this) && isStylesheetAttribute(name)) {
+        stylesheetElementCanAffectGrid(this);
+      }
+    };
+    const originalRemoveAttribute = Element.prototype.removeAttribute;
+    Element.prototype.removeAttribute = function removeAttribute(name) {
+      measureSynchronousWrite(() => originalRemoveAttribute.call(this, name));
+      if (isStylesheetElement(this) && isStylesheetAttribute(name)) {
+        stylesheetElementCanAffectGrid(this);
+      }
+    };
+    const originalToggleAttribute = Element.prototype.toggleAttribute;
+    Element.prototype.toggleAttribute = function toggleAttribute(name, force) {
+      const changed = measureSynchronousWrite(
+        () => originalToggleAttribute.call(this, name, force),
+      );
+      if (isStylesheetElement(this) && isStylesheetAttribute(name)) {
+        stylesheetElementCanAffectGrid(this);
+      }
+      return changed;
+    };
+
+    // Direct `grid.style.foo = ...` and `grid.style.setProperty(...)` calls do
+    // not invoke the JavaScript setAttribute wrapper, so expose a stable proxy
+    // for this one diagnostic node only.
+    const styleDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'style');
+    const styleProxies = new WeakMap<HTMLElement, CSSStyleDeclaration>();
+    if (styleDescriptor?.get && styleDescriptor.configurable) {
+      Object.defineProperty(HTMLElement.prototype, 'style', {
+        ...styleDescriptor,
+        get() {
+          const element = this as HTMLElement;
+          const target = styleDescriptor.get?.call(element) as CSSStyleDeclaration;
+          const existing = styleProxies.get(element);
+          if (existing) return existing;
+          const proxy = new Proxy(target, {
+            get(style, property) {
+              const value = Reflect.get(style, property, style);
+              if (typeof value !== 'function') return value;
+              return (...args: unknown[]) => Reflect.apply(value, style, args);
+            },
+            set(style, property, value) {
+              return measureSynchronousWrite(() => Reflect.set(style, property, value, style));
+            },
+          }) as CSSStyleDeclaration;
+          styleProxies.set(element, proxy);
+          return proxy;
+        },
+      });
+    }
+
+    // CSS Typed OM writes bypass setAttribute and CSSStyleDeclaration. They use
+    // the same before/after invariant comparison, so ownership alone can never
+    // promote an unrelated map write to measured evidence.
+    if (typeof StylePropertyMap !== 'undefined') {
+      const originalStyleMapSet = StylePropertyMap.prototype.set;
+      StylePropertyMap.prototype.set = function set(property, ...values) {
+        measureSynchronousWrite(() => originalStyleMapSet.call(this, property, ...values));
+      };
+      const originalStyleMapDelete = StylePropertyMap.prototype.delete;
+      StylePropertyMap.prototype.delete = function deleteProperty(property) {
+        measureSynchronousWrite(() => originalStyleMapDelete.call(this, property));
+      };
+      const originalStyleMapClear = StylePropertyMap.prototype.clear;
+      StylePropertyMap.prototype.clear = function clear() {
+        measureSynchronousWrite(() => originalStyleMapClear.call(this));
+      };
+    }
+
+    // DOMStringMap named setters are browser internals rather than calls to the
+    // JavaScript setAttribute method; proxy the grid's dataset for exact timing.
+    const datasetDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'dataset');
+    const datasetProxies = new WeakMap<HTMLElement, DOMStringMap>();
+    if (datasetDescriptor?.get && datasetDescriptor.configurable) {
+      Object.defineProperty(HTMLElement.prototype, 'dataset', {
+        ...datasetDescriptor,
+        get() {
+          const element = this as HTMLElement;
+          const target = datasetDescriptor.get?.call(element) as DOMStringMap;
+          const existing = datasetProxies.get(element);
+          if (existing) return existing;
+          const proxy = new Proxy(target, {
+            set(dataset, property, value) {
+              return measureSynchronousWrite(
+                () => Reflect.set(dataset, property, value, dataset),
+              );
+            },
+            deleteProperty(dataset, property) {
+              return measureSynchronousWrite(() => Reflect.deleteProperty(dataset, property));
+            },
+          }) as DOMStringMap;
+          datasetProxies.set(element, proxy);
+          return proxy;
+        },
+      });
+    }
+
+    // Class changes can affect computed tracks without touching inline style.
+    const classNameDescriptor = Object.getOwnPropertyDescriptor(Element.prototype, 'className');
+    if (classNameDescriptor?.get && classNameDescriptor.set && classNameDescriptor.configurable) {
+      Object.defineProperty(Element.prototype, 'className', {
+        ...classNameDescriptor,
+        set(value) {
+          measureSynchronousWrite(() => {
+            classNameDescriptor.set?.call(this, value);
+          });
+        },
+      });
+    }
+    const classListDescriptor = Object.getOwnPropertyDescriptor(Element.prototype, 'classList');
+    const classListProxies = new WeakMap<Element, DOMTokenList>();
+    if (classListDescriptor?.get && classListDescriptor.configurable) {
+      Object.defineProperty(Element.prototype, 'classList', {
+        ...classListDescriptor,
+        get() {
+          const element = this as Element;
+          const target = classListDescriptor.get?.call(element) as DOMTokenList;
+          const existing = classListProxies.get(element);
+          if (existing) return existing;
+          const proxy = new Proxy(target, {
+            get(tokens, property) {
+              const value = Reflect.get(tokens, property, tokens);
+              if (typeof value !== 'function') return value;
+              return (...args: unknown[]) => {
+                if (property === 'add'
+                  || property === 'remove'
+                  || property === 'toggle'
+                  || property === 'replace') {
+                  return measureSynchronousWrite(() => Reflect.apply(value, tokens, args));
+                }
+                return Reflect.apply(value, tokens, args);
+              };
+            },
+          }) as DOMTokenList;
+          classListProxies.set(element, proxy);
+          return proxy;
+        },
+      });
+    }
+
+    const documentObserver = new MutationObserver((records) => {
+      let addedGrid: HTMLElement | undefined;
+      for (const record of records) {
+        if (record.type === 'attributes'
+          && record.target instanceof Element
+          && isCatalogGrid(record.target)) {
+          addedGrid = record.target;
+          break;
+        }
+        for (const node of record.addedNodes) {
+          if (isCatalogGrid(node as Element)) {
+            addedGrid = node as HTMLElement;
+            break;
+          }
+          if (node instanceof Element) {
+            const nestedGrid = node.querySelector<HTMLElement>('[data-testid="catalog-grid"]');
+            if (nestedGrid) {
+              addedGrid = nestedGrid;
+              break;
+            }
+          }
+        }
+        if (addedGrid) break;
+      }
+      // A newly inserted grid is the beginning of its observable layout
+      // lifetime, so an applicable bad state at that boundary has an exact
+      // start. If a synchronous hook already attached it, attachGrid is a no-op
+      // and cannot retroactively promote a diagnostic episode.
+      attachGrid(addedGrid, Boolean(addedGrid));
+      if (addedGrid) {
+        for (const element of document.querySelectorAll<HTMLStyleElement | HTMLLinkElement>(
+          'style, link',
+        )) stylesheetElementCanAffectGrid(element);
+      }
+      let stylesheetTouched = false;
+      let stylesheetCausal = false;
+      for (const record of records) {
+        if (record.type === 'attributes') {
+          if (isStylesheetElement(record.target) && record.attributeName !== 'data-testid') {
+            stylesheetTouched = true;
+            stylesheetCausal ||= stylesheetElementCanAffectGrid(record.target);
+          }
+          continue;
+        }
+        for (const node of record.addedNodes) {
+          for (const element of stylesheetElementsWithin(node)) {
+            stylesheetTouched = true;
+            stylesheetCausal ||= stylesheetElementCanAffectGrid(element);
+          }
+        }
+        for (const node of record.removedNodes) {
+          for (const element of stylesheetElementsWithin(node)) {
+            stylesheetTouched = true;
+            stylesheetCausal ||= stylesheetElementCausality.get(element) ?? false;
+          }
+        }
+      }
+      if (stylesheetTouched) notifyDiagnosticObservation(stylesheetCausal);
+    });
+    documentObserver.observe(document, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['data-testid', 'media', 'disabled', 'href', 'rel'],
+    });
+    document.addEventListener('load', (event) => {
+      const target = event.target;
+      if (target instanceof Node && isStylesheetElement(target)) {
+        notifyDiagnosticObservation(stylesheetElementCanAffectGrid(target));
+      }
+    }, true);
+    attachGrid();
+
+    // FontFaceSet events run after the corresponding font-load state change.
+    // They give font-metric recalculation an exact notification surface without
+    // assigning duration to the time between unrelated animation frames.
+    const fontEventCanAffectGrid = (event: Event) => {
+      const faces = (event as FontFaceSetLoadEvent).fontfaces;
+      return faces?.some((face) => fontFamilyCanAffectGrid(face.family)) ?? false;
+    };
+    let relevantFontLoadPending = false;
+    document.fonts.addEventListener('loading', (event) => {
+      const causal = fontEventCanAffectGrid(event);
+      relevantFontLoadPending ||= causal;
+      notifyDiagnosticObservation(causal);
+    });
+    const finishFontLoad = (event: Event) => {
+      const causal = relevantFontLoadPending || fontEventCanAffectGrid(event);
+      relevantFontLoadPending = false;
+      notifyDiagnosticObservation(causal);
+    };
+    document.fonts.addEventListener('loadingdone', finishFontLoad);
+    document.fonts.addEventListener('loadingerror', finishFontLoad);
+    void document.fonts.ready.then(() => {
+      const causal = relevantFontLoadPending;
+      relevantFontLoadPending = false;
+      notifyDiagnosticObservation(causal);
+    });
+
+    const snapshot = (): CatalogLayoutWatchdogSnapshot => {
+      // A settle read is a safety observation. It can close an active record,
+      // but cannot manufacture a duration for a transition that observers did
+      // not timestamp.
+      attachGrid();
+      sample(false);
+      const copied = violations.map((violation) => ({ ...violation }));
+      return {
+        startedAtEpochMs,
+        sampledFrames,
+        latest: latest ? { ...latest } : null,
+        violations: copied,
+        unhealed: copied.filter((violation) => violation.healedAtMs === null
+          || violation.cumulativeObservedBadMs > healMs),
+      };
+    };
+
+    watchdogWindow.__catalogLayoutWatchdog = { snapshot };
+    const tick = () => {
+      attachGrid();
+      sample(false);
+      requestAnimationFrame(tick);
+    };
+    requestAnimationFrame(tick);
+  }, { healMs: CATALOG_LAYOUT_HEAL_MS });
+}
+
+export async function readCatalogLayoutWatchdog(
+  page: Page,
+): Promise<CatalogLayoutWatchdogSnapshot> {
+  return page.evaluate(() => {
+    const api = (window as WatchdogWindow).__catalogLayoutWatchdog;
+    if (!api) throw new Error('catalog layout watchdog was not installed before navigation');
+    return api.snapshot();
+  });
+}
+export type HostileLoadProfile = 'css-slow' | 'script-slow';
+
+const HOSTILE_DELAYS_MS: Record<HostileLoadProfile, Record<string, number>> = {
+  'css-slow': { stylesheet: 1_100, script: 250 },
+  'script-slow': { stylesheet: 250, script: 650 },
+};
+
+export interface HostileLoadEvent {
+  resourceType: string;
+  delayMs: number;
+  url: string;
+}
+
+export function hostileLoadProfile(testInfo: TestInfo): HostileLoadProfile | null {
+  const profile = testInfo.project.metadata.hostileLoadProfile;
+  return profile === 'css-slow' || profile === 'script-slow' ? profile : null;
+}
+
+/** Delay fulfilled static responses, which works through Playwright's routing
+ * layer in Chromium and WebKit (unlike CDP network throttling). */
+export async function installHostileLoad(
+  page: Page,
+  profile: HostileLoadProfile,
+  events: HostileLoadEvent[],
+): Promise<void> {
+  const delays = HOSTILE_DELAYS_MS[profile];
+  await page.route('**/*', async (route) => {
+    const request = route.request();
+    const resourceType = request.resourceType();
+    const delayMs = delays[resourceType];
+    if (request.method() !== 'GET' || delayMs === undefined) {
+      await route.continue();
+      return;
+    }
+
+    const response = await route.fetch();
+    events.push({ resourceType, delayMs, url: request.url() });
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    await route.fulfill({ response });
+  });
+}

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -21,6 +21,11 @@ const STORAGE = 'e2e/.auth/state.json';
 const isCI = !!process.env.CI;
 const WEBKIT_READER_SPEC = /native-reader-keyboard-scroll\.spec\.ts/;
 const IPAD_TOUCH_SPECS = /(?:book-card-actions|mobile|sidebar|sidebar-drawer-a11y|sidebar-pin)\.spec\.ts/;
+const CATALOG_LAYOUT_SPEC = /catalog-layout-watchdog\.spec\.ts/;
+const CATALOG_WATCHDOG_CLASSIFIER_SPEC = /catalog-layout-watchdog-classifier\.spec\.ts/;
+const CATALOG_LAYOUT_SPECS = [CATALOG_LAYOUT_SPEC, CATALOG_WATCHDOG_CLASSIFIER_SPEC];
+const hostileLoadEnabled = process.env.E2E_HOSTILE_LOAD === '1';
+const HOSTILE_LOAD_PROFILES = ['css-slow', 'script-slow'] as const;
 
 export default defineConfig({
   testDir: './e2e',
@@ -44,12 +49,42 @@ export default defineConfig({
     // 1. Log in once; every authed project reuses the saved session.
     { name: 'setup', testMatch: /global\.setup\.ts/ },
 
+    // Focused always-on invariant coverage. The broad projects ignore this
+    // spec below so its explicit viewport sweep runs exactly once normally.
+    {
+      name: 'catalog-layout-chromium',
+      testMatch: CATALOG_LAYOUT_SPECS,
+      use: { ...devices['Desktop Chrome'], viewport: { width: 1280, height: 800 }, storageState: STORAGE },
+      dependencies: ['setup'],
+    },
+
+    // Opt-in hostile-load matrix. Response routing—not CDP throttling—keeps the
+    // same deterministic arrival profiles meaningful in Chromium and WebKit.
+    ...(hostileLoadEnabled
+      ? HOSTILE_LOAD_PROFILES.flatMap((hostileLoadProfile) => ([
+          {
+            name: `hostile-${hostileLoadProfile}-chromium`,
+            testMatch: CATALOG_LAYOUT_SPEC,
+            metadata: { hostileLoadProfile },
+            use: { ...devices['Desktop Chrome'], viewport: { width: 1280, height: 800 }, storageState: STORAGE },
+            dependencies: ['setup'],
+          },
+          {
+            name: `hostile-${hostileLoadProfile}-webkit`,
+            testMatch: CATALOG_LAYOUT_SPEC,
+            metadata: { hostileLoadProfile },
+            use: { ...devices['Desktop Safari'], viewport: { width: 1280, height: 800 }, storageState: STORAGE },
+            dependencies: ['setup'],
+          },
+        ]))
+      : []),
+
     // 2. Desktop — the full user flow + a11y (mobile-only specs excluded).
     {
       name: 'desktop',
       use: { ...devices['Desktop Chrome'], viewport: { width: 1280, height: 800 }, storageState: STORAGE },
       dependencies: ['setup'],
-      testIgnore: [/subpath\.spec\.ts/, /mobile\.spec\.ts/, WEBKIT_READER_SPEC],
+      testIgnore: [/subpath\.spec\.ts/, /mobile\.spec\.ts/, WEBKIT_READER_SPEC, ...CATALOG_LAYOUT_SPECS],
     },
 
     // 3. Mobile 375×667 (chromium mobile emulation — no webkit dep) — where every
@@ -69,7 +104,7 @@ export default defineConfig({
       // desktop makes each project clobber the other's writes — a race, not a
       // defect. Desktop owns it until the harness can hand each project its own
       // account; it passes standalone at 375px.
-      testIgnore: [/subpath\.spec\.ts/, /default-library-view\.spec\.ts/, WEBKIT_READER_SPEC],
+      testIgnore: [/subpath\.spec\.ts/, /default-library-view\.spec\.ts/, WEBKIT_READER_SPEC, ...CATALOG_LAYOUT_SPECS],
     },
 
     // 4. iPad-class touch viewport — card actions remain persistent and the

--- a/frontend/src/pages/Catalog.tsx
+++ b/frontend/src/pages/Catalog.tsx
@@ -1031,6 +1031,7 @@ export function Catalog({ entityKind, entityId, view, defaultFilter }: CatalogPr
         <div
           ref={setGridNode}
           data-testid="catalog-grid"
+          data-catalog-column-count={columnCount}
           data-virtualized-grid={usesGrid ? 'true' : undefined}
           className={`${styles.grid} ${styles[`density_${density}`]}`}
         >


### PR DESCRIPTION
## Why

#2072 fixed a live Safari 26.6 grid collapse: `auto-fill` transiently resolved **one** full-width track at a 1248px grid width, the measurement accepted it, `columnCount` latched to 1, and the catalog paginated 2 books per page until a resize healed it. Nothing in CI could have caught that — the bug lives in a transient, load-dependent state that a settled-DOM assertion never sees.

This adds a permanent lane that does.

## What it does

A watchdog installed before application scripts asserts, continuously, that the grid's resolved track count equals the arithmetic truth `floor((width + gap) / (min + gap))` — **and** that the column count React actually accepted matches it. That second check is the important one: the escaped bug had CSS recover while application state stayed latched, so a CSS-only assertion would have passed it.

Plus a hostile-load matrix (opt-in, `E2E_HOSTILE_LOAD=1`) that delays stylesheets and scripts to reproduce the load ordering the bug needs, across Chromium and WebKit at three viewports.

## How duration is established

Every heuristic we tried for "how long was it broken" was wrong in both directions — sampling cannot tell you what happened between samples. The final model measures instead of infers:

- Real DOM transitions are timestamped at their cause: grid mutation/resize, CSSOM rule writes, stylesheet lifecycle, Typed OM, FontFaceSet.
- A hooked write establishes a transition **only if the invariant's truth actually flipped across it** — one predicate, shared with the sample recorder so it cannot drift.
- Anything unobservable contributes **zero** and is reported as a diagnostic, never a pass/fail signal. An honest documented gap beats a threshold that produces both false reds and false greens.
- A violation still active at settle fails unconditionally, independent of duration.

## Verification

- **12 always-on classifier pins**, each asserting independently timestamped DOM spans rather than the watchdog's own bookkeeping.
- **Negative control:** with the pre-#2072 seam restored (`setColumnCount(1)`), the lane goes **red in both Chromium and WebKit** — it catches the original bug class.
- **Flake:** every fixed-delay wait removed in favour of bounded condition-waits. 5 consecutive six-worker identity-asserted runs, 17 tests each, all green, median 9.6s.
- Full hostile matrix green; both `tsc` lanes and `npm run test:unit` clean.
- **Production diff is one line** — a `data-catalog-column-count` attribute exposing existing state so E2E can distinguish "CSS recovered" from "app state recovered". No behaviour change.
- Hostile matrix is opt-in, so **no default-CI cost**.

Nine adversarial review rounds; every reported defect was reproduced against the real exported watchdog before being fixed, and the model got smaller and faster each round.