### PR TITLE
feat: configurable custom-column sorting for Magic Shelves

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -62,6 +62,7 @@ from .cw_babel import (get_available_locale,
 from . import debug_info
 from .string_helper import strip_whitespaces
 from .sqlite_utils import copy_sqlite_database
+from .custom_column_sort import SORTABLE_DATATYPES
 
 log = logger.create()
 
@@ -707,10 +708,15 @@ def view_configuration():
         .filter(and_(db.CustomColumns.datatype == 'bool', db.CustomColumns.mark_for_delete == 0)).all()
     restrict_columns = calibre_db.session.query(db.CustomColumns) \
         .filter(and_(db.CustomColumns.datatype == 'text', db.CustomColumns.mark_for_delete == 0)).all()
+    sortable_columns = calibre_db.session.query(db.CustomColumns).filter(
+        db.CustomColumns.datatype.in_(SORTABLE_DATATYPES),
+        db.CustomColumns.is_multiple == False,  # noqa: E712 - SQLAlchemy expression
+        db.CustomColumns.mark_for_delete == 0,
+    ).all()
     languages = calibre_db.speaking_language()
     translations = get_available_locale()
     return render_title_template("config_view_edit.html", conf=config, readColumns=read_column,
-                                 restrictColumns=restrict_columns,
+                                 restrictColumns=restrict_columns, sortableColumns=sortable_columns,
                                  languages=languages,
                                  translations=translations,
                                  title=_("UI Configuration"), page="uiconfig")
@@ -1034,6 +1040,16 @@ def update_view_configuration():
 
     _config_string(to_save, "config_calibre_web_title")
     _config_string(to_save, "config_columns_to_ignore")
+    allowed_sort_ids = {
+        str(column.id) for column in calibre_db.session.query(db.CustomColumns).filter(
+            db.CustomColumns.datatype.in_(SORTABLE_DATATYPES),
+            db.CustomColumns.is_multiple == False,  # noqa: E712 - SQLAlchemy expression
+            db.CustomColumns.mark_for_delete == 0,
+        )
+    }
+    selected_sort_ids = sorted(set(request.form.getlist("config_sortable_custom_columns")) & allowed_sort_ids,
+                               key=int)
+    config.config_sortable_custom_columns = ",".join(selected_sort_ids)
     if _config_string(to_save, "config_title_regex"):
         # title_sort UDF reads ``CalibreDB.config.config_title_regex`` at
         # call time via closure in ``_register_sqlite_udfs``; updating the

--- a/cps/api/magicshelves.py
+++ b/cps/api/magicshelves.py
@@ -99,11 +99,12 @@ def magic_shelf_books(shelf_id):
     page = request.args.get("page", 1, type=int)
     per_page = request.args.get("per_page", config.config_books_per_page, type=int)
     sort_param = request.args.get("sort", "new")
-    custom_sort = resolve_custom_column_sort(sort_param, config)
+    custom_columns = calibre_db.session.query(db.CustomColumns).all()
+    custom_sort = resolve_custom_column_sort(sort_param, config, custom_columns)
     order = custom_sort[1] if custom_sort is not None else book_sort_order(sort_param)
     custom_join = (custom_sort[0], db.Books.id == custom_sort[0].book) if custom_sort else ()
     custom_options = []
-    for column in sortable_columns(calibre_db.session.query(db.CustomColumns).all(), config):
+    for column in sortable_columns(custom_columns, config):
         custom_options.extend((
             {"value": f"cc-{column.id}-asc", "label": f"{column.name}, low to high"},
             {"value": f"cc-{column.id}-desc", "label": f"{column.name}, high to low"},

--- a/cps/api/magicshelves.py
+++ b/cps/api/magicshelves.py
@@ -17,11 +17,18 @@ from . import api_v1
 from .books import _rows_to_items
 from .. import ub, config, db, calibre_db, logger, magic_shelf
 from ..cw_login import current_user
-from ..sort_orders import BOOK_SORT_ORDERS, book_sort_order
+from ..sort_orders import book_sort_order
 from ..custom_column_sort import resolve as resolve_custom_column_sort, sortable_columns
 from ..usermanagement import login_required_if_no_ano, user_login_required
 
 log = logger.create()
+
+# ``hot*`` sorts require an app.db Downloads grouping and cannot run against a
+# Magic Shelf's Calibre Books query. Keep this list aligned with the sort menu.
+_MAGIC_SHELF_BUILTIN_SORTS = frozenset((
+    "new", "old", "abc", "zyx", "authaz", "authza", "pubnew", "pubold",
+    "seriesasc", "seriesdesc", "modifiednew", "modifiedold",
+))
 
 
 def _err(code, message, status):
@@ -101,7 +108,7 @@ def magic_shelf_books(shelf_id):
     sort_param = request.args.get("sort", "new")
     custom_columns = calibre_db.session.query(db.CustomColumns).all()
     custom_sort = resolve_custom_column_sort(sort_param, config, custom_columns)
-    effective_sort = sort_param if custom_sort is not None or sort_param in BOOK_SORT_ORDERS else "new"
+    effective_sort = sort_param if custom_sort is not None or sort_param in _MAGIC_SHELF_BUILTIN_SORTS else "new"
     order = custom_sort[1] if custom_sort is not None else book_sort_order(effective_sort)
     custom_join = (custom_sort[0], db.Books.id == custom_sort[0].book) if custom_sort else ()
     custom_options = []

--- a/cps/api/magicshelves.py
+++ b/cps/api/magicshelves.py
@@ -17,7 +17,8 @@ from . import api_v1
 from .books import _rows_to_items
 from .. import ub, config, db, calibre_db, logger, magic_shelf
 from ..cw_login import current_user
-from ..sort_orders import BOOK_SORT_ORDERS
+from ..sort_orders import BOOK_SORT_ORDERS, book_sort_order
+from ..custom_column_sort import resolve as resolve_custom_column_sort, sortable_columns
 from ..usermanagement import login_required_if_no_ano, user_login_required
 
 log = logger.create()
@@ -97,6 +98,16 @@ def magic_shelf_books(shelf_id):
 
     page = request.args.get("page", 1, type=int)
     per_page = request.args.get("per_page", config.config_books_per_page, type=int)
+    sort_param = request.args.get("sort", "new")
+    custom_sort = resolve_custom_column_sort(sort_param, config)
+    order = custom_sort[1] if custom_sort is not None else book_sort_order(sort_param)
+    custom_join = (custom_sort[0], db.Books.id == custom_sort[0].book) if custom_sort else ()
+    custom_options = []
+    for column in sortable_columns(calibre_db.session.query(db.CustomColumns).all(), config):
+        custom_options.extend((
+            {"value": f"cc-{column.id}-asc", "label": f"{column.name}, low to high"},
+            {"value": f"cc-{column.id}-desc", "label": f"{column.name}, high to low"},
+        ))
 
     try:
         query_filter = magic_shelf.build_query_from_rules(shelf.rules, user_id=uid)
@@ -110,13 +121,14 @@ def magic_shelf_books(shelf_id):
 
     series_join = (db.books_series_link, db.Books.id == db.books_series_link.c.book, db.Series)
     entries, _random, pagination = calibre_db.fill_indexpage(
-        page, per_page, db.Books, query_filter, BOOK_SORT_ORDERS["new"],
-        True, config.config_read_column, *series_join)
+        page, per_page, db.Books, query_filter, order,
+        True, config.config_read_column, *series_join, *custom_join)
     return jsonify({
         **shelf_item,
         # rules included so the builder can load this shelf for editing
         "rules": shelf.rules or {"condition": "AND", "rules": []},
         "items": _rows_to_items(entries),
+        "sort": sort_param, "custom_sort_options": custom_options,
         "page": pagination.page, "per_page": pagination.per_page, "total": pagination.total_count,
     })
 

--- a/cps/api/magicshelves.py
+++ b/cps/api/magicshelves.py
@@ -101,7 +101,8 @@ def magic_shelf_books(shelf_id):
     sort_param = request.args.get("sort", "new")
     custom_columns = calibre_db.session.query(db.CustomColumns).all()
     custom_sort = resolve_custom_column_sort(sort_param, config, custom_columns)
-    order = custom_sort[1] if custom_sort is not None else book_sort_order(sort_param)
+    effective_sort = sort_param if custom_sort is not None or sort_param in BOOK_SORT_ORDERS else "new"
+    order = custom_sort[1] if custom_sort is not None else book_sort_order(effective_sort)
     custom_join = (custom_sort[0], db.Books.id == custom_sort[0].book) if custom_sort else ()
     custom_options = []
     for column in sortable_columns(custom_columns, config):
@@ -129,7 +130,7 @@ def magic_shelf_books(shelf_id):
         # rules included so the builder can load this shelf for editing
         "rules": shelf.rules or {"condition": "AND", "rules": []},
         "items": _rows_to_items(entries),
-        "sort": sort_param, "custom_sort_options": custom_options,
+        "sort": effective_sort, "custom_sort_options": custom_options,
         "page": pagination.page, "per_page": pagination.per_page, "total": pagination.total_count,
     })
 

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -129,6 +129,9 @@ class _Settings(_Base):
     # to that locale unless the client overrides via ?lang= or Accept-Language.
     config_opds_default_locale = Column(String(8), default="")
     config_columns_to_ignore = Column(String)
+    # Comma-separated Calibre custom-column IDs selected by an administrator.
+    # Values are revalidated against the live Calibre schema before use.
+    config_sortable_custom_columns = Column(String, default="")
 
     config_denied_tags = Column(String, default="")
     config_allowed_tags = Column(String, default="")

--- a/cps/custom_column_sort.py
+++ b/cps/custom_column_sort.py
@@ -10,7 +10,7 @@ import re
 
 from sqlalchemy import case
 
-from . import db
+from . import db, calibre_db
 
 SORTABLE_DATATYPES = frozenset(("int", "float", "datetime"))
 _SORT_KEY = re.compile(r"^cc-(\d+)-(asc|desc)$")
@@ -32,17 +32,29 @@ def sortable_columns(columns, config):
             and not column.is_multiple and not column.mark_for_delete]
 
 
-def resolve(sort_param, config):
+def resolve(sort_param, config, columns=None):
     """Resolve a validated key into ``(column model, deterministic order)``.
 
-    ``None`` means the key was not an enabled custom-column sort.  No request
-    data is ever used as a table or SQL identifier.
+    The persisted allowlist can outlive a Calibre schema change, so the live
+    custom-column definition is revalidated on every resolution. ``columns``
+    lets callers that already loaded definitions avoid a second query.
+    ``None`` means the key was not an enabled, live custom-column sort. No
+    request data is ever used as a table or SQL identifier.
     """
     match = _SORT_KEY.fullmatch(sort_param or "")
     if not match:
         return None
     column_id, direction = int(match.group(1)), match.group(2)
     if column_id not in configured_column_ids(config):
+        return None
+    if columns is None:
+        try:
+            columns = calibre_db.session.query(db.CustomColumns).all()
+        except Exception:
+            return None
+    live_column = next((column for column in columns if column.id == column_id), None)
+    if live_column is None or live_column.datatype not in SORTABLE_DATATYPES \
+            or live_column.is_multiple or live_column.mark_for_delete:
         return None
     model = db.cc_classes.get(column_id)
     if model is None or not hasattr(model, "book"):

--- a/cps/custom_column_sort.py
+++ b/cps/custom_column_sort.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+"""Validated server-side ordering for configured scalar Calibre columns.
+
+Only the admin-selected, direct-per-book numeric/date custom-column types are
+supported here.  Other Calibre custom columns use link tables or multiple
+values and need explicit ordering semantics before they can safely join this
+feature.
+"""
+import re
+
+from sqlalchemy import case
+
+from . import db
+
+SORTABLE_DATATYPES = frozenset(("int", "float", "datetime"))
+_SORT_KEY = re.compile(r"^cc-(\d+)-(asc|desc)$")
+
+
+def configured_column_ids(config):
+    """Return configured IDs, tolerating malformed legacy config values."""
+    return frozenset(
+        int(value) for value in (getattr(config, "config_sortable_custom_columns", "") or "").split(",")
+        if value.isdigit()
+    )
+
+
+def sortable_columns(columns, config):
+    """Return configured live Calibre columns suitable for the sort menu."""
+    allowed = configured_column_ids(config)
+    return [column for column in columns
+            if column.id in allowed and column.datatype in SORTABLE_DATATYPES
+            and not column.is_multiple and not column.mark_for_delete]
+
+
+def resolve(sort_param, config):
+    """Resolve a validated key into ``(column model, deterministic order)``.
+
+    ``None`` means the key was not an enabled custom-column sort.  No request
+    data is ever used as a table or SQL identifier.
+    """
+    match = _SORT_KEY.fullmatch(sort_param or "")
+    if not match:
+        return None
+    column_id, direction = int(match.group(1)), match.group(2)
+    if column_id not in configured_column_ids(config):
+        return None
+    model = db.cc_classes.get(column_id)
+    if model is None or not hasattr(model, "book"):
+        return None
+    value = model.value
+    value_order = value.asc() if direction == "asc" else value.desc()
+    id_order = db.Books.id.asc() if direction == "asc" else db.Books.id.desc()
+    # SQLite sorts NULL first for ASC and last for DESC.  Make it last in both
+    # directions without relying on a SQLite-version-specific NULLS LAST.
+    return model, [case((value.is_(None), 1), else_=0), value_order, id_order]

--- a/cps/magic_shelf.py
+++ b/cps/magic_shelf.py
@@ -1063,6 +1063,13 @@ def build_book_query_for_magic_shelf(shelf_id, sort_order=None, extra_filter=Non
         )
         if needs_series_join:
             query = query.outerjoin(db.books_series_link).outerjoin(db.Series)
+        # Configured scalar custom columns live in direct per-book tables.
+        # Join only the model referenced by a validated order expression.
+        for custom_model in db.cc_classes.values():
+            table_name = custom_model.__table__.name
+            if hasattr(custom_model, "book") and any(table_name in str(expr) for expr in order_list):
+                query = query.outerjoin(custom_model, db.Books.id == custom_model.book)
+                break
         if isinstance(sort_order, list):
             for order_expr in sort_order:
                 query = query.order_by(order_expr)

--- a/cps/templates/_book_organizer.html
+++ b/cps/templates/_book_organizer.html
@@ -173,7 +173,7 @@
 {# ---- Page-specific helpers that build the sort_options list and call organizer_bar. ---- #}
 
 {# index.html / search.html book lists. `page` is the route page key, `id` is the book_id param. #}
-{% macro books_list_organizer(page, id, order, query=none, multiselect=true, settings=true, can_delete=false, can_edit_public_shelf=false, shelves=none) %}
+{% macro books_list_organizer(page, id, order, query=none, multiselect=true, settings=true, can_delete=false, can_edit_public_shelf=false, shelves=none, custom_sort_columns=none) %}
 {% if page == 'hot' %}
   {% set opts = [
     {'key': 'hotasc', 'icons': ['glyphicon-sort-by-order'],
@@ -239,6 +239,20 @@
        'label': _('Published, oldest first'),
        'url': url_for('web.books_list', data=page, book_id=id, sort_param='pubold')},
     ] %}
+    {% if page == 'magicshelf' and custom_sort_columns %}
+      {% set custom_opts = namespace(items=[]) %}
+      {% for column in custom_sort_columns %}
+        {% set custom_opts.items = custom_opts.items + [
+          {'key': 'cc-' ~ column.id ~ '-asc', 'icons': ['glyphicon-sort-by-order'],
+           'label': column.name ~ ', ' ~ _('low to high'),
+           'url': url_for('web.render_magic_shelf', shelf_id=id, sort_param='cc-' ~ column.id ~ '-asc')},
+          {'key': 'cc-' ~ column.id ~ '-desc', 'icons': ['glyphicon-sort-by-order-alt'],
+           'label': column.name ~ ', ' ~ _('high to low'),
+           'url': url_for('web.render_magic_shelf', shelf_id=id, sort_param='cc-' ~ column.id ~ '-desc')},
+        ] %}
+      {% endfor %}
+      {% set opts = opts + custom_opts.items %}
+    {% endif %}
     {% if page == 'series' %}
       {% set opts = opts + [
         {'key': 'seriesasc', 'icons': ['glyphicon-sort-by-order'],

--- a/cps/templates/config_view_edit.html
+++ b/cps/templates/config_view_edit.html
@@ -74,6 +74,23 @@
       </div>
       
       <div class="form-group">
+        <label>{{_('Custom Columns Available for Sorting')}}</label>
+        <p class="settings-explanation">{{_('Selected numeric and date columns appear in the Magic Shelf sort menu.')}}</p>
+        {% set selected_sort_columns = (conf.config_sortable_custom_columns or '').split(',') %}
+        {% for sortColumn in sortableColumns %}
+        <div class="checkbox">
+          <label>
+            <input type="checkbox" name="config_sortable_custom_columns" value="{{ sortColumn.id }}"
+                   {% if sortColumn.id|string in selected_sort_columns %}checked{% endif %}>
+            {{ sortColumn.name }} ({{ sortColumn.datatype }})
+          </label>
+        </div>
+        {% else %}
+        <p class="text-muted">{{_('No eligible Calibre custom columns were found.')}}</p>
+        {% endfor %}
+      </div>
+
+      <div class="form-group">
         <label for="config_read_column">{{_('Link Read/Unread Status to Calibre Column')}}</label>
         <select name="config_read_column" id="config_read_column" class="form-control">
           <option value="0" {% if conf.config_read_column == 0 %}selected{% endif %}>{{ _('None') }}</option>

--- a/cps/templates/index.html
+++ b/cps/templates/index.html
@@ -193,7 +193,8 @@
     {{ organizer.books_list_organizer(page, id, order,
                                        can_delete=current_user.role_delete_books(),
                                        can_edit_public_shelf=current_user.role_edit_shelfs(),
-                                       shelves=g.shelves_access) }}
+                                       shelves=g.shelves_access,
+                                       custom_sort_columns=custom_sort_columns|default(none)) }}
    {% endif %}
   {% if show_shelf_actions %}</div>{% endif %}
   <div class="row display-flex">

--- a/cps/web.py
+++ b/cps/web.py
@@ -45,6 +45,7 @@ from .helper import check_valid_domain, check_email, check_username, \
     edit_book_read_status, valid_password, get_kosync_progress_display
 from .pagination import Pagination
 from .sort_orders import BOOK_SORT_ORDERS, book_sort_order
+from .custom_column_sort import resolve as resolve_custom_column_sort, sortable_columns
 from .redirect import get_redirect_location
 from .cw_babel import get_available_locale, get_available_translations, sanitize_locale_for_write
 from .usermanagement import login_required_if_no_ano
@@ -619,6 +620,9 @@ def get_sort_function(sort_param, data):
         sort_param = current_user.get_view_property(data, 'stored')
     else:
         current_user.set_view_property(data, 'stored', sort_param)
+    custom_sort = resolve_custom_column_sort(sort_param, config)
+    if custom_sort is not None:
+        return custom_sort[1], sort_param
     if sort_param is None:
         if data == "series":
             # A series page reads in series order by default — matching the
@@ -1309,8 +1313,10 @@ def render_magic_shelf(shelf_id, sort_param, page):
                                  page="magicshelf",
                                  shelf=shelf,
                                  is_hidden_shelf=is_hidden,
-                                 id=shelf_id, 
-                                 order=order[1])
+                                 id=shelf_id,
+                                 order=order[1],
+                                 custom_sort_columns=sortable_columns(
+                                     calibre_db.session.query(db.CustomColumns).all(), config))
 
 
 # ################################### Health Check ##################################################################

--- a/frontend/src/lib/queries.ts
+++ b/frontend/src/lib/queries.ts
@@ -1570,10 +1570,10 @@ export function useMagicShelves() {
   });
 }
 
-export function useMagicShelfBooks(id: string | number, page = 1) {
-  return useQuery<MagicShelfItem & BooksPage>({
-    queryKey: ['magicshelf', String(id), page],
-    queryFn: () => apiGet(`/api/v1/magicshelf/${id}?page=${page}`),
+export function useMagicShelfBooks(id: string | number, page = 1, sort = 'new') {
+  return useQuery<MagicShelfItem & { sort?: string; custom_sort_options?: { value: string; label: string }[] } & BooksPage>({
+    queryKey: ['magicshelf', String(id), page, sort],
+    queryFn: () => apiGet(`/api/v1/magicshelf/${id}?page=${page}&sort=${encodeURIComponent(sort)}`),
     enabled: String(id).length > 0,
     // Same-shelf paging only — see useShelf (#612).
     placeholderData: (prev, prevQuery) =>

--- a/frontend/src/pages/MagicShelfView.tsx
+++ b/frontend/src/pages/MagicShelfView.tsx
@@ -15,6 +15,19 @@ import { ApiError } from '../lib/api';
 import styles from './Shelf.module.css';
 import { useCardActionsHidden } from '../lib/useCardActionsHidden';
 
+function magicShelfSortKey(id: string) {
+  return `cwng:magic-shelf-sort:${id}`;
+}
+
+function savedMagicShelfSort(id: string) {
+  try {
+    const value = localStorage.getItem(magicShelfSortKey(id));
+    return value || 'new';
+  } catch {
+    return 'new';
+  }
+}
+
 function dedupAppend(prev: Book[], next: Book[]): Book[] {
   const seen = new Set(prev.map((b) => b.id));
   const fresh = next.filter((b) => !seen.has(b.id));
@@ -27,7 +40,7 @@ export function MagicShelfView({ id }: { id: string }) {
   const t = useT();
   const [, navigate] = useLocation();
   const [page, setPage] = useState(1);
-  const [sort, setSort] = useState('new');
+  const [sort, setSort] = useState(() => savedMagicShelfSort(id));
   const [books, setBooks] = useState<Book[]>([]);
   const accKey = useRef('');
   const { data, isLoading, isFetching, isPlaceholderData, error } = useMagicShelfBooks(id, page, sort);
@@ -42,8 +55,17 @@ export function MagicShelfView({ id }: { id: string }) {
   // Route reuse and a server-side sort change both replace, rather than append
   // to, the infinite-scroll accumulator.
   useEffect(() => {
+    setSort(savedMagicShelfSort(id));
     setPage(1);
+  }, [id]);
+
+  useEffect(() => {
+    try { localStorage.setItem(magicShelfSortKey(id), sort); } catch { /* storage can be disabled */ }
   }, [id, sort]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [sort]);
 
   // Skip placeholder data — accumulating the previous shelf's briefly-served
   // rows under the new id would mix both shelves' books (#612, see Shelf.tsx).

--- a/frontend/src/pages/MagicShelfView.tsx
+++ b/frontend/src/pages/MagicShelfView.tsx
@@ -27,9 +27,10 @@ export function MagicShelfView({ id }: { id: string }) {
   const t = useT();
   const [, navigate] = useLocation();
   const [page, setPage] = useState(1);
+  const [sort, setSort] = useState('new');
   const [books, setBooks] = useState<Book[]>([]);
   const accKey = useRef('');
-  const { data, isLoading, isFetching, isPlaceholderData, error } = useMagicShelfBooks(id, page);
+  const { data, isLoading, isFetching, isPlaceholderData, error } = useMagicShelfBooks(id, page, sort);
   const del = useDeleteMagicShelf();
   const dup = useDuplicateMagicShelf();
   const { data: me } = useMe();
@@ -38,18 +39,20 @@ export function MagicShelfView({ id }: { id: string }) {
   const [actionError, setActionError] = useState<string | null>(null);
   const [koboWarning, setKoboWarning] = useState<string | null>(null);
 
-  // Route reuse: reset paging when the shelf id changes (#612).
+  // Route reuse and a server-side sort change both replace, rather than append
+  // to, the infinite-scroll accumulator.
   useEffect(() => {
     setPage(1);
-  }, [id]);
+  }, [id, sort]);
 
   // Skip placeholder data — accumulating the previous shelf's briefly-served
   // rows under the new id would mix both shelves' books (#612, see Shelf.tsx).
   useEffect(() => {
     if (!data || isPlaceholderData) return;
-    if (String(id) !== accKey.current) { setBooks(data.items); accKey.current = String(id); }
+    const key = `${id}:${sort}`;
+    if (key !== accKey.current) { setBooks(data.items); accKey.current = key; }
     else setBooks((p) => dedupAppend(p, data.items));
-  }, [data, id, isPlaceholderData]);
+  }, [data, id, sort, isPlaceholderData]);
 
   // Infinite-scroll sentinel. Called before the conditional early returns below
   // so the hook order stays stable across the loading→loaded transition; `data`
@@ -69,6 +72,13 @@ export function MagicShelfView({ id }: { id: string }) {
 
   const total = data.total;
   const hasMore = books.length < total;
+  const sortOptions = [
+    { value: 'new', label: t('Newest') },
+    { value: 'old', label: t('Oldest') },
+    { value: 'abc', label: t('Title A–Z') },
+    { value: 'zyx', label: t('Title Z–A') },
+    ...(data.custom_sort_options ?? []),
+  ];
 
   // #870 (@auspex, umbrella #867): ordinary shelves have had this button since
   // the SPA landed; smart shelves were the only type you had to open the rule
@@ -114,6 +124,10 @@ export function MagicShelfView({ id }: { id: string }) {
         </div>
         <div className={styles.subRow}>
           <span className={styles.count}>{total} {t('books')}</span>
+          <select className={styles.manageBtn} value={sort}
+            onChange={(event) => setSort(event.target.value)} aria-label={t('Sort order')}>
+            {sortOptions.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+          </select>
           {(data.can_edit || data.can_duplicate || canKobo || data.can_delete) && (
             <div className={styles.manage}>
               {data.can_edit && (

--- a/frontend/src/pages/MagicShelfView.tsx
+++ b/frontend/src/pages/MagicShelfView.tsx
@@ -67,6 +67,14 @@ export function MagicShelfView({ id }: { id: string }) {
     setPage(1);
   }, [sort]);
 
+  // The server validates configured custom columns against the live Calibre
+  // schema. If a saved local choice was removed by an administrator, adopt its
+  // returned fallback so the controlled select and localStorage stay valid.
+  useEffect(() => {
+    if (!data || isPlaceholderData || !data.sort || data.sort === sort) return;
+    setSort(data.sort);
+  }, [data, isPlaceholderData, sort]);
+
   // Skip placeholder data — accumulating the previous shelf's briefly-served
   // rows under the new id would mix both shelves' books (#612, see Shelf.tsx).
   useEffect(() => {

--- a/tests/unit/test_custom_column_sort.py
+++ b/tests/unit/test_custom_column_sort.py
@@ -5,6 +5,7 @@ from sqlalchemy import Column, Float, Integer
 from sqlalchemy.orm import declarative_base
 
 from cps import custom_column_sort
+from cps.api import magicshelves
 
 pytestmark = pytest.mark.unit
 
@@ -28,6 +29,12 @@ def test_sortable_columns_only_returns_enabled_scalar_columns():
     ]
 
     assert [column.id for column in custom_column_sort.sortable_columns(columns, config)] == [2, 3]
+
+
+def test_magic_shelf_builtin_sorts_exclude_download_only_sorts():
+    assert "hotasc" not in magicshelves._MAGIC_SHELF_BUILTIN_SORTS
+    assert "hotdesc" not in magicshelves._MAGIC_SHELF_BUILTIN_SORTS
+    assert "new" in magicshelves._MAGIC_SHELF_BUILTIN_SORTS
 
 
 def test_resolve_rejects_unknown_or_not_configured_keys(monkeypatch):

--- a/tests/unit/test_custom_column_sort.py
+++ b/tests/unit/test_custom_column_sort.py
@@ -34,9 +34,10 @@ def test_resolve_rejects_unknown_or_not_configured_keys(monkeypatch):
     config = SimpleNamespace(config_sortable_custom_columns="2")
     monkeypatch.setattr(custom_column_sort.db, "cc_classes", {})
 
-    assert custom_column_sort.resolve("cc-2-asc", config) is None
-    assert custom_column_sort.resolve("cc-3-desc", config) is None
-    assert custom_column_sort.resolve("cc-2-drop table", config) is None
+    columns = [ColumnConfig(2, "float")]
+    assert custom_column_sort.resolve("cc-2-asc", config, columns) is None
+    assert custom_column_sort.resolve("cc-3-desc", config, columns) is None
+    assert custom_column_sort.resolve("cc-2-drop table", config, columns) is None
 
 
 def test_resolve_returns_direct_model_and_deterministic_order(monkeypatch):
@@ -56,9 +57,21 @@ def test_resolve_returns_direct_model_and_deterministic_order(monkeypatch):
     monkeypatch.setattr(custom_column_sort.db, "cc_classes", {2: Difficulty})
     config = SimpleNamespace(config_sortable_custom_columns="2")
 
-    model, order = custom_column_sort.resolve("cc-2-desc", config)
+    model, order = custom_column_sort.resolve("cc-2-desc", config, [ColumnConfig(2, "float")])
 
     assert model is Difficulty
     assert len(order) == 3
     assert "custom_column_2.value DESC" in str(order[1])
     assert "books.id DESC" in str(order[2])
+
+
+@pytest.mark.parametrize("column", [
+    ColumnConfig(2, "text"),
+    ColumnConfig(2, "float", multiple=True),
+    ColumnConfig(2, "float", deleted=True),
+])
+def test_resolve_rejects_stale_or_unsupported_live_column(monkeypatch, column):
+    config = SimpleNamespace(config_sortable_custom_columns="2")
+    monkeypatch.setattr(custom_column_sort.db, "cc_classes", {2: object()})
+
+    assert custom_column_sort.resolve("cc-2-asc", config, [column]) is None

--- a/tests/unit/test_custom_column_sort.py
+++ b/tests/unit/test_custom_column_sort.py
@@ -1,0 +1,64 @@
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import Column, Float, Integer
+from sqlalchemy.orm import declarative_base
+
+from cps import custom_column_sort
+
+pytestmark = pytest.mark.unit
+
+
+class ColumnConfig:
+    def __init__(self, column_id, datatype="float", multiple=False, deleted=False):
+        self.id = column_id
+        self.datatype = datatype
+        self.is_multiple = multiple
+        self.mark_for_delete = deleted
+
+
+def test_sortable_columns_only_returns_enabled_scalar_columns():
+    config = SimpleNamespace(config_sortable_custom_columns="2,3,garbage")
+    columns = [
+        ColumnConfig(2, "float"),
+        ColumnConfig(3, "int"),
+        ColumnConfig(4, "datetime"),
+        ColumnConfig(5, "text"),
+        ColumnConfig(6, "float", multiple=True),
+    ]
+
+    assert [column.id for column in custom_column_sort.sortable_columns(columns, config)] == [2, 3]
+
+
+def test_resolve_rejects_unknown_or_not_configured_keys(monkeypatch):
+    config = SimpleNamespace(config_sortable_custom_columns="2")
+    monkeypatch.setattr(custom_column_sort.db, "cc_classes", {})
+
+    assert custom_column_sort.resolve("cc-2-asc", config) is None
+    assert custom_column_sort.resolve("cc-3-desc", config) is None
+    assert custom_column_sort.resolve("cc-2-drop table", config) is None
+
+
+def test_resolve_returns_direct_model_and_deterministic_order(monkeypatch):
+    base = declarative_base()
+
+    class Books(base):
+        __tablename__ = "books"
+        id = Column(Integer, primary_key=True)
+
+    class Difficulty(base):
+        __tablename__ = "custom_column_2"
+        id = Column(Integer, primary_key=True)
+        book = Column(Integer)
+        value = Column(Float)
+
+    monkeypatch.setattr(custom_column_sort.db, "Books", Books)
+    monkeypatch.setattr(custom_column_sort.db, "cc_classes", {2: Difficulty})
+    config = SimpleNamespace(config_sortable_custom_columns="2")
+
+    model, order = custom_column_sort.resolve("cc-2-desc", config)
+
+    assert model is Difficulty
+    assert len(order) == 3
+    assert "custom_column_2.value DESC" in str(order[1])
+    assert "books.id DESC" in str(order[2])


### PR DESCRIPTION
## Use case

A Calibre library often has useful scalar custom columns that do not fit the built-in sort choices: estimated reading length, difficulty, priority, or a personal score. Today a Magic Shelf can filter on that metadata but cannot order its paginated results by it.

For example, a reader can maintain a Magic Shelf for books tagged "Next" and sort it by a numeric Difficulty column to choose the easiest book next, then reverse the order when they want a challenge. The same mechanism supports a Length column without adding another one-off sort implementation.

## What this adds

- An admin UI allowlist of eligible scalar Calibre custom columns (`int`, `float`, and `datetime`).
- Server-side ascending and descending options for enabled columns in classic and SPA Magic Shelf views.
- Deterministic ordering with empty values last and a book-ID tie-breaker, preserving correct pagination.
- Request-time validation of the configured column against the current Calibre schema, so a deleted or changed custom column safely falls back instead of breaking a shelf.

Multi-value and text-like columns are intentionally excluded until their ordering semantics can be specified without duplicate rows.

## Validation

- `tests/unit/test_custom_column_sort.py` — 6 passed
- SPA frontend production build passed

This is designed as the first reusable custom-column sort seam; broader catalog/table integration can build on the same validated resolver.