### PR TITLE
Fix Safari catalog virtual row columns

### DIFF
--- a/changelog.d/catalog-webkit-virtual-row-columns.md
+++ b/changelog.d/catalog-webkit-virtual-row-columns.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- **The catalog grid no longer collapses to one book per row in Safari.** The
+  windowed catalog now gives each virtual row an explicit copy of the measured
+  column layout instead of relying on WebKit to propagate `auto-fill` tracks
+  through a CSS subgrid. Chromium and Safari-engine checks now verify the cards'
+  rendered row and column positions, not only the healthy parent grid.

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -23,8 +23,10 @@ Env knobs: `E2E_BASE_URL` (default `http://localhost:8086`), `E2E_USER`/`E2E_PAS
 `admin`/`admin123`), `E2E_SUBPATH_URL` (set to the `cwn-nginx-571` rig `http://localhost:8087` to run the
 reverse-proxy project).
 
-The catalog layout watchdog runs once in the normal Chromium lane. Its hostile-load matrix is opt-in so
-the broad suite stays fast: set `E2E_HOSTILE_LOAD=1` and select one or more
+The catalog layout watchdog runs in normal Chromium and WebKit lanes. Besides the parent track/count
+invariant, it checks the first virtual row's rendered card coordinates so an engine can never collapse
+the row to one internal column behind a healthy parent grid. Its hostile-load matrix is opt-in so the
+broad suite stays fast: set `E2E_HOSTILE_LOAD=1` and select one or more
 `hostile-{css-slow,script-slow}-{chromium,webkit}` projects. The profiles delay fulfilled stylesheet and
 JavaScript responses in opposite orders through `page.route`, so the same settling-window reproduction
 works in both engines. CWNG currently uses system fonts and requests no webfont, so this lane makes no
@@ -105,6 +107,7 @@ protecting `cps/api/` added zero historical gate runs in that sample.
 |---|---|---|
 | `setup` | — | logs in once via the real UI, saves session |
 | `catalog-layout-chromium` | 768/1280/1440 + scheduler-gap probe | continuous CSS + accepted-column invariant watchdog without starvation false reds |
+| `catalog-layout-webkit` | 768/1280/1440 | rendered virtual-row placement matches the healthy parent grid in Safari's engine |
 | `hostile-*-{chromium,webkit}` | opt-in staggered CSS/JS arrival | first-load layout convergence under hostile resource order |
 | `desktop` | 1280×800 | full flow + a11y baseline |
 | `mobile` | 375×667 (chromium emulation) | drawer reachability + scroll-lock (#576), no h-overflow (#288) |

--- a/frontend/e2e/catalog-layout-watchdog.spec.ts
+++ b/frontend/e2e/catalog-layout-watchdog.spec.ts
@@ -54,6 +54,24 @@ for (const width of VIEWPORTS) {
     expect(snapshot.latest?.resolvedTracks).toBe(snapshot.latest?.expected);
     expect(snapshot.latest?.acceptedColumns).toBe(snapshot.latest?.expected);
 
+    // The parent grid and React state can both report the right column count
+    // while a virtual row fails to inherit those tracks. In that state every
+    // card in the row is auto-placed into one implicit column, which is the
+    // user-visible one-book-per-row regression this watchdog exists to catch.
+    const firstRowPlacement = await grid.locator('[data-virtual-grid-row]').first().evaluate((row) => {
+      const boxes = Array.from(row.children, (child) => child.getBoundingClientRect());
+      return {
+        count: boxes.length,
+        distinctColumns: new Set(boxes.map(({ left }) => Math.round(left * 10) / 10)).size,
+        distinctRows: new Set(boxes.map(({ top }) => Math.round(top * 10) / 10)).size,
+      };
+    });
+    expect(firstRowPlacement.count, 'the first virtual row should exercise multiple columns')
+      .toBeGreaterThan(1);
+    expect(firstRowPlacement.distinctColumns, JSON.stringify(firstRowPlacement))
+      .toBe(firstRowPlacement.count);
+    expect(firstRowPlacement.distinctRows, JSON.stringify(firstRowPlacement)).toBe(1);
+
     const profile = hostileLoadProfile(testInfo);
     if (profile) {
       expect(hostileEvents.some(({ resourceType }) => resourceType === 'stylesheet'),

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -57,6 +57,12 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'], viewport: { width: 1280, height: 800 }, storageState: STORAGE },
       dependencies: ['setup'],
     },
+    {
+      name: 'catalog-layout-webkit',
+      testMatch: CATALOG_LAYOUT_SPEC,
+      use: { ...devices['Desktop Safari'], viewport: { width: 1280, height: 800 }, storageState: STORAGE },
+      dependencies: ['setup'],
+    },
 
     // Opt-in hostile-load matrix. Response routing—not CDP throttling—keeps the
     // same deterministic arrival profiles meaningful in Chromium and WebKit.

--- a/frontend/src/components/VirtualizedGridRows.tsx
+++ b/frontend/src/components/VirtualizedGridRows.tsx
@@ -18,10 +18,11 @@ interface VirtualizedGridRowsProps<T> {
 
 /** Window complete rows in a document-scrolling CSS grid.
  *
- * The parent owns the real grid tracks. Each mounted row spans those tracks and
- * uses `subgrid`, while spacers preserve the height of unmounted rows. Keeping
- * full rows mounted is load-bearing: slicing arbitrary cards would change CSS
- * auto-placement and no longer match the measured column count.
+ * The parent owns the real grid track count. Each mounted row spans the parent
+ * and recreates that many equal tracks with the shared gap, while spacers
+ * preserve the height of unmounted rows. Keeping full rows mounted is
+ * load-bearing: slicing arbitrary cards would change CSS auto-placement and no
+ * longer match the measured column count.
  *
  * Catalog is the first integration because it already has a reliable measured
  * column count. TODO(#1813): Shelf, AdvancedSearch, and MagicShelfView can adopt
@@ -131,6 +132,9 @@ export function VirtualizedGridRows<T>({
         key={`row-${row}`}
         className={rowClassName}
         data-virtual-grid-row={row}
+        // Do not replace this with subgrid: WebKit can resolve the parent's
+        // auto-fill tracks while exposing only one internal track to this row.
+        style={{ gridTemplateColumns: `repeat(${safeColumnCount}, minmax(0, 1fr))` }}
       >
         {items.slice(first, last).map((item, offset) => (
           <Fragment key={itemKey(item)}>{renderItem(item, first + offset)}</Fragment>

--- a/frontend/src/pages/Catalog.module.css
+++ b/frontend/src/pages/Catalog.module.css
@@ -121,7 +121,7 @@
 .virtualRow {
   display: grid;
   grid-column: 1 / -1;
-  grid-template-columns: subgrid;
+  column-gap: var(--catalog-grid-gap);
   padding-bottom: var(--catalog-grid-gap);
 }
 .virtualSpacer {


### PR DESCRIPTION
## What changed

- replace the catalog virtual row's CSS `subgrid` with an explicit copy of the accepted parent column count
- preserve the catalog gap inside every windowed row
- extend the catalog watchdog to inspect rendered card coordinates, not only the healthy parent track/count state
- add an always-on WebKit catalog-layout project and document the expanded watchdog
- add a changelog fragment

## Root cause

**OBSERVED:** `c33a0eaf5e` introduced `grid-template-columns: subgrid` on each windowed catalog row. In Playwright WebKit, the parent catalog grid correctly resolved 4/7/8 `auto-fill` tracks and React accepted the same count, but the spanning nested row exposed only one internal track. CSS auto-placement therefore put every card at the same x-coordinate on a different y-coordinate. Chromium inherited the expected tracks.

That explains why the existing parent-grid arithmetic fixes and watchdog stayed green while Safari showed one book per row: they measured the parent, while the collapse happened one level below it.

## Discriminating regression

**OBSERVED, pre-fix on current `origin/main`:** the new rendered-placement assertion failed in all three WebKit viewport cases:

```text
768:  {"count":4,"distinctColumns":1,"distinctRows":4}
1280: {"count":7,"distinctColumns":1,"distinctRows":7}
1440: {"count":8,"distinctColumns":1,"distinctRows":8}
3 failed, setup passed, exit 1
```

The same parent-grid assertions passed, which makes this test discriminate the nested-row failure from the earlier measurement bugs.

## Verification

**OBSERVED, post-fix:**

- `npm run build` — passed
- `npm run test:unit` — 30 passed
- normal catalog watchdog, Chromium + WebKit — 20 passed
- hostile CSS/JS response-order matrix, Chromium + WebKit — 13 passed
- catalog/a11y/browse/infinite-scroll/display-options focus — 50 passed, 11 skipped
- book-card actions, desktop/mobile Chromium — passed
- WebKit touch action exploration — 5 passed, 4 failed because the expected action links were absent; an exact product-code A/B produced the same four failures with the fix and with the pre-fix `subgrid`, proving they are baseline fixture failures rather than a result of this change
- full default E2E attempt — 555 passed, 71 skipped, 26 failed, 11 did not run; failures were outside the catalog-layout path (shared-fixture contamination/socket resets plus the same baseline WebKit touch-focus expectations). The catalog watchdog and focused catalog suites passed in that run and again on a clean rig.

**ASSUMED:** the household instance is exercising the same WebKit nested-subgrid failure. The live deployment was intentionally not inspected or changed; the exact one-column geometry was reproduced locally from current `origin/main` and is absent from v4.1.43 because the windowed subgrid landed afterward.

## Accessibility

**OBSERVED:** the change preserves the existing card semantics and one-tab-stop-per-card structure. Focused desktop/mobile accessibility coverage passed.


**OBSERVED, GitHub CI:** frontend build, fast tests, SPA E2E, Test Suite Summary, image classification, and author validation all passed on commit `40c7759ed9`.
