### PR TITLE
fix(admin): align the User administration surface

### DIFF
--- a/changelog.d/admin-alignment-pass.md
+++ b/changelog.d/admin-alignment-pass.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **The User administration page lines up again.** "New user" and "Set up My
+  Library for all users" now sit together as one right-aligned action group
+  instead of scattering across the header (on phones the second button was
+  crushed into a one-word-per-line column); the explanatory notes under Library
+  contents now align with the option text they describe; and the section's
+  separator rule spans the full card width like its neighbors instead of
+  starting after the heading. Device administration's header now matches the
+  same idiom, and the per-user action buttons share one size.

--- a/frontend/src/pages/Admin.module.css
+++ b/frontend/src/pages/Admin.module.css
@@ -4,11 +4,28 @@
   padding: var(--sp-6) var(--sp-5);
 }
 
+/* Same mobile gutters as the other settings pages (Devices, DeviceDetail). */
+@media (max-width: 600px) {
+  .container { padding: var(--sp-4) var(--sp-3); }
+}
+
 .header {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: var(--sp-3);
   margin-bottom: var(--sp-5);
+}
+
+/* One action group absorbing the free space, not an auto margin per button —
+   two auto margins split the space and stranded "New user" mid-page, and on
+   narrow viewports crushed the second button into a one-word-per-line column. */
+.headerActions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--sp-2);
 }
 
 .headerIcon { color: var(--accent); }
@@ -20,7 +37,6 @@
 }
 
 .addBtn {
-  margin-left: auto;
   display: inline-flex;
   align-items: center;
   gap: var(--sp-2);
@@ -117,12 +133,25 @@
   padding: var(--sp-4);
 }
 
-.libraryMode { margin: var(--sp-4) 0 0; padding: var(--sp-3) 0 0; border: 0; border-top: 1px solid var(--border); }
-.libraryMode legend { color: var(--text); font-weight: var(--fw-semi); padding-right: var(--sp-2); }
+.libraryMode { margin: var(--sp-4) 0 0; padding: 0; border: 0; }
+/* The separator rule lives on the legend, not the fieldset border. Punched into
+   the fieldset's border-top it only became visible AFTER the legend text, at a
+   different inset than the card's other separators (e.g. .roles); drawn on a
+   full-width legend it starts at the same content edge. */
+.libraryMode legend {
+  width: 100%;
+  padding-top: var(--sp-3);
+  border-top: 1px solid var(--border);
+  color: var(--text);
+  font-weight: var(--fw-semi);
+}
 .libraryMode label { display: flex; align-items: flex-start; gap: var(--sp-2); margin-top: var(--sp-2); }
 .libraryMode label span { display: flex; flex-direction: column; gap: 2px; }
 .libraryMode small { color: var(--text-muted); }
-.modeWarning { color: var(--warning, var(--accent-text)); font-size: var(--fs-sm); margin-top: var(--sp-2); }
+/* Explanatory prose aligns with the option TEXT (radio 16px + gap), not the
+   control edge, so it keeps the indentation rhythm of the block above it. */
+.libraryMode .settingsHint { margin: var(--sp-2) 0 0 calc(16px + var(--sp-2)); }
+.modeWarning { color: var(--warning, var(--accent-text)); font-size: var(--fs-sm); margin: var(--sp-2) 0 0 calc(16px + var(--sp-2)); }
 .libraryAddForm {
   display: flex;
   align-items: end;
@@ -194,8 +223,9 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 34px;
-  height: 34px;
+  /* Same 32px square as .resetBtn next to it — one icon-button size per row. */
+  width: 32px;
+  height: 32px;
   border-radius: var(--r-md);
   color: var(--text-muted);
   transition: color var(--dur-fast) var(--ease), background var(--dur-fast) var(--ease);

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -213,15 +213,17 @@ export function Admin() {
       <div className={styles.header}>
         <Shield size={22} className={styles.headerIcon} />
         <h1 className={styles.title}>{t('User administration')}</h1>
-        <button
-          type="button"
-          className={styles.addBtn}
-          onClick={() => { setShowNew((v) => !v); setBanner(null); }}
-        >
-          <UserPlus size={16} /> {t('New user')}
-        </button>
-        <button type="button" className={styles.addBtn} onClick={migrateAll}
-          disabled={migrateLibraries.isPending}>{t('Set up My Library for all users')}</button>
+        <div className={styles.headerActions}>
+          <button
+            type="button"
+            className={styles.addBtn}
+            onClick={() => { setShowNew((v) => !v); setBanner(null); }}
+          >
+            <UserPlus size={16} /> {t('New user')}
+          </button>
+          <button type="button" className={styles.addBtn} onClick={migrateAll}
+            disabled={migrateLibraries.isPending}>{t('Set up My Library for all users')}</button>
+        </div>
       </div>
 
       <p className={banner ? (banner.ok ? styles.msgOk : styles.msgErr) : undefined} role="status">{banner?.text}</p>

--- a/frontend/src/pages/AdminDevices.module.css
+++ b/frontend/src/pages/AdminDevices.module.css
@@ -2,9 +2,10 @@
 .back { display: inline-flex; align-items: center; gap: var(--sp-1); margin-bottom: var(--sp-3); color: var(--text-muted); font-size: var(--fs-sm); transition: color var(--dur-fast) var(--ease); }
 .back:hover { color: var(--accent); }
 .heading { display: flex; align-items: center; gap: var(--sp-3); margin-bottom: var(--sp-4); }
-.heading > svg { color: var(--accent); width: 26px; height: 26px; }
+/* Same page-header idiom as User administration: 22px accent icon, display h1. */
+.heading > svg { color: var(--accent); width: 22px; height: 22px; }
 .heading h1, .card h2, .card h3, .card p { margin: 0; }
-.heading h1 { font-size: var(--fs-xl); }
+.heading h1 { font-family: var(--font-display); font-size: var(--fs-xl); }
 .countLine { margin: 0 0 var(--sp-3); color: var(--text-muted); font-size: var(--fs-sm); }
 
 .list { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(340px, 100%), 1fr)); gap: var(--sp-4); margin: 0; padding: 0; }


### PR DESCRIPTION
Alignment/spacing pass over the SPA admin surface (`/app/admin` + `/app/admin/devices`). Pure CSS geometry plus one wrapper `<div>` — no copy, behavior, or string changes; sidebar untouched.

## Defects fixed (all measurements OBSERVED via Playwright at 1440×900, dark theme)

**1. Header action buttons scattered across the page.** Both `.addBtn` buttons carried `margin-left: auto`, and flexbox splits free space across *every* auto margin — so "New user" floated mid-header while "Set up My Library for all users" pinned the right edge.

| element | before x | after x |
|---|---|---|
| h1 "User administration" ends | 582 | 582 |
| "New user" | **748** (mid-page) | **906** (8px left of its sibling) |
| "Set up My Library…" | 1021 (flush right at 1228) | 1021 (unchanged) |

The buttons now live in a `.headerActions` group that owns the single auto margin. On a 390px viewport the old layout crushed the second button into a one-word-per-line column beside a two-line title; the header now wraps so the title takes line one and the button group takes line two.

**2. "Library contents" explanatory hint broke the block's indentation rhythm.** The two-sentence hint sat flush at the fieldset edge (x=293) while the option text it describes starts at x=317 (16px radio + 8px gap). The hint and the same-class warning line now align with the option text: hint before x=**293** → after x=**317**; warning 293 → 317. The add-book form stays at the control edge (x=293), matching the radio inputs.

**3. The legend's separator rule started after the heading text.** The rule was the fieldset's `border-top`, punched out behind the legend — so it became visible only from x≈421 while the card's other separators (e.g. the roles grid rule) span 293→1211. The rule now lives on the full-width legend itself: before legend w=**128** → after w=**918**, same inset as the neighboring separators. Verified in Chromium *and* WebKit (`legend { width: 100% }` renders identically, OBSERVED).

## Same-class sweep

- Per-user action buttons: delete was 34×34px, reset-password 32×32px — now both 32×32 (measured), still ≥ WCAG 2.5.8's 24px minimum.
- `/app/admin` had no mobile gutters; it now follows the house `600px` container padding (`--sp-4`/`--sp-3`) used by Devices, DeviceDetail, and AdminDevices.
- `/app/admin/devices` header: 26px icon → 22px and display font for the h1, matching the User administration header idiom.

Checked and intentionally left: role-checkbox grid columns (regular, measured), YOU badge centering (measured centered), email row icon (measured centered), card paddings (already consistent within the page), `.checkField` bottom alignment in the security forms (label-box bottoms measured equal).

## Verification

- Before/after JPEG screenshot sets at desktop dark, desktop light, and 390px mobile dark (header, user cards incl. the personal-library warning + add-book form, devices page) — geometry above is from those runs.
- `npm run test:unit`: 30/30 pass (includes e2e tsconfig typecheck); `npm run build` (`tsc -b`) clean.
- Playwright against the running container: admin-classic-affordance + account-menu-admin + a11y specs — 18/18 desktop, 13/13 mobile (includes "admin: no critical/serious a11y violations" on the changed page); duplicates-sidebar-role 2/2.
