### PR TITLE
test(e2e): the sign-out spec stops logging every other spec out mid-run

### DIFF
--- a/frontend/e2e/account-menu-no-classic.spec.ts
+++ b/frontend/e2e/account-menu-no-classic.spec.ts
@@ -100,26 +100,78 @@ test.describe('account menu — no Classic switch', () => {
       await trigger.locator('xpath=ancestor::div[1]')
         .getByRole('button', { name: 'Sign out', exact: true }).click();
 
-      // This rig permits anonymous browsing, so /logout returns to the SPA
-      // library as Guest instead of forcing the login route. Prove the identity
-      // transition itself: the account control and its actions must switch from
-      // the authenticated user/Sign out to Guest/Sign in, and remember-me must
-      // be gone.
+      // Anonymous browsing is an instance setting, not an invariant of either
+      // E2E rig. Ask /auth/me after logout because its Guest-vs-401 contract is
+      // the server truth; inferring the setting from whichever control happens
+      // to render would let a broken UI choose the assertion it can pass.
       await expect(page).toHaveURL(/\/app\/?(\?|$)/, { timeout: 20_000 });
-      const guestTrigger = page.getByRole('button', { name: /account: guest/i });
-      await expect(guestTrigger).toBeVisible();
-      await guestTrigger.click();
-      const guestMenu = guestTrigger.locator('xpath=ancestor::div[1]');
-      await expect(guestMenu.getByRole('link', { name: 'Sign in', exact: true })).toBeVisible();
-      await expect(guestMenu.getByRole('button', { name: 'Sign out', exact: true })).toHaveCount(0);
+      const postSignOutMeResponse = await page.request.get('/api/v1/auth/me');
+      const postSignOutMe = await postSignOutMeResponse.json() as {
+        role?: { anonymous?: boolean };
+        features?: { anon_browse?: boolean };
+        error?: { code?: string };
+      };
+      const anonymousBrowsingEnabled = postSignOutMeResponse.status() === 200
+        && postSignOutMe.role?.anonymous === true
+        && postSignOutMe.features?.anon_browse === true;
+      const anonymousBrowsingDisabled = postSignOutMeResponse.status() === 401
+        && postSignOutMe.error?.code === 'unauthenticated';
+      expect(
+        Number(anonymousBrowsingEnabled) + Number(anonymousBrowsingDisabled),
+        `post-sign-out /auth/me must report exactly one server configuration; observed status ${postSignOutMeResponse.status()}, anonymous=${String(postSignOutMe.role?.anonymous)}, anon_browse=${String(postSignOutMe.features?.anon_browse)}, error=${String(postSignOutMe.error?.code)}`,
+      ).toBe(1);
 
-      // Signing out never leaves a Classic selection behind, and the next visit
-      // to the root still opens the new UI.
+      // These are configuration-independent consequences of logout. Keep them
+      // ahead of the UI branch so neither server mode can bypass session and
+      // new-UI persistence checks that are the subject of this test.
+      await expect(page.getByRole('button', { name: 'Sign out', exact: true })).toHaveCount(0);
       const cookies = await context.cookies();
       expect(cookies.find((c) => c.name === 'remember_token')).toBeUndefined();
       expect(cookies.find((c) => c.name === 'cwng_prefer_classic')).toBeUndefined();
       await page.goto('/', { waitUntil: 'domcontentloaded' });
       await expect(page).toHaveURL(/\/app\/?(\?|$)/);
+
+      const guestTrigger = page.getByRole('button', { name: /account: guest/i });
+      const loginButton = page.getByRole('button', { name: 'Sign in', exact: true });
+      const expectedPostSignOutState = anonymousBrowsingEnabled
+        ? 'Guest account menu'
+        : 'login form';
+
+      // Wait for either legitimate tree before describing what rendered. This
+      // keeps a slow app bootstrap from being mislabeled as a third state, while
+      // the message makes a genuine neither-state failure actionable.
+      await expect(
+        guestTrigger.or(loginButton),
+        `post-sign-out state mismatch: server expected ${expectedPostSignOutState}; observed neither the Guest account menu nor the login form`,
+      ).toBeVisible({ timeout: 20_000 });
+      const guestTriggerVisible = await guestTrigger.isVisible();
+      const loginButtonVisible = await loginButton.isVisible();
+      const observedPostSignOutState = guestTriggerVisible && loginButtonVisible
+        ? 'both the Guest account menu and the login form'
+        : guestTriggerVisible
+          ? 'Guest account menu'
+          : loginButtonVisible
+            ? 'login form'
+            : 'neither the Guest account menu nor the login form';
+
+      if (anonymousBrowsingEnabled) {
+        expect(
+          observedPostSignOutState,
+          `post-sign-out state mismatch: server expected Guest account menu; observed ${observedPostSignOutState}`,
+        ).toBe('Guest account menu');
+        await guestTrigger.click();
+        const guestMenu = guestTrigger.locator('xpath=ancestor::div[1]');
+        await expect(guestMenu.getByRole('link', { name: 'Sign in', exact: true })).toBeVisible();
+        await expect(guestMenu.getByRole('button', { name: 'Sign out', exact: true })).toHaveCount(0);
+      } else {
+        expect(
+          observedPostSignOutState,
+          `post-sign-out state mismatch: server expected login form; observed ${observedPostSignOutState}`,
+        ).toBe('login form');
+        await expect(page.locator('input[autocomplete="username"]')).toBeVisible();
+        await expect(loginButton).toBeVisible();
+        await expect(guestTrigger).toHaveCount(0);
+      }
     } finally {
       await context.close();
     }

--- a/frontend/e2e/account-menu-no-classic.spec.ts
+++ b/frontend/e2e/account-menu-no-classic.spec.ts
@@ -48,14 +48,46 @@ test.describe('account menu — no Classic switch', () => {
 
   test('signing out from the menu ends the session and returns to the new UI', async ({
     browser, baseURL,
-  }) => {
+  }, testInfo) => {
     // A DEDICATED context that logs itself in. The shared storageState session is
     // reused by every other spec running in parallel; clicking Sign out on it
     // logs those specs out mid-run, which is a real failure this suite already
     // caused once and which looks exactly like an unrelated login regression.
-    const context = await browser.newContext({ baseURL, storageState: { cookies: [], origins: [] } });
+    //
+    // A separate context is NOT enough, and that is the whole reason for the
+    // userAgent below. The server keys its session rows on Flask-Login's `_id`,
+    // which is sha512(remote address | User-Agent) -- a browser fingerprint, not
+    // a per-context id. An explicit browser.newContext() does not inherit the
+    // project's `use` block, so it runs with the engine default UA, which is
+    // byte-identical to the one global.setup.ts seeded storageState with. Same
+    // address + same UA => same session key, and cps/logout.py deletes by
+    // (user_id, session_key), so Sign out here would delete the shared seeded
+    // row and 401 every spec still running. Giving this context its own UA gives
+    // it its own key. The assertion below is the guard: drop the userAgent and
+    // THIS test fails by name, instead of ~150 unrelated specs failing later.
+    // tests/unit/test_e2e_session_fingerprint_isolation.py pins the mechanism.
+    const defaultContext = await browser.newContext({
+      baseURL,
+      storageState: { cookies: [], origins: [] },
+    });
+    const defaultPage = await defaultContext.newPage();
+    const defaultUserAgent = await defaultPage.evaluate(() => navigator.userAgent);
+    await defaultContext.close();
+    const isolatedUserAgent = `${defaultUserAgent} CWNG-E2E-signout/${testInfo.project.name}`;
+
+    const context = await browser.newContext({
+      baseURL,
+      storageState: { cookies: [], origins: [] },
+      userAgent: isolatedUserAgent,
+    });
     try {
       const page = await context.newPage();
+      const actualUserAgent = await page.evaluate(() => navigator.userAgent);
+      expect(
+        actualUserAgent,
+        'sign-out context must use its own server-side session fingerprint',
+      ).toBe(isolatedUserAgent);
+
       await page.goto('/app/login');
       await page.locator('input[autocomplete="username"]').fill(process.env.E2E_USER || 'admin');
       await page.locator('input[autocomplete="current-password"]').fill(process.env.E2E_PASS || 'admin123');

--- a/tests/unit/test_e2e_session_fingerprint_isolation.py
+++ b/tests/unit/test_e2e_session_fingerprint_isolation.py
@@ -1,0 +1,117 @@
+import flask
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import scoped_session, sessionmaker
+
+import cps.logout
+from cps import constants, ub
+from cps.MyLoginManager import MyLoginManager
+from cps.cw_login import current_user, login_required, login_user
+from cps.cw_login import utils as login_utils
+from cps.logout import cleanup_local_logout
+
+
+REMOTE_ADDR = "192.0.2.10"
+SEEDED_USER_AGENT = "CWNG-E2E-seeded-browser"
+ISOLATED_USER_AGENT = "CWNG-E2E-signout-browser"
+
+
+class _NoopActivityDB:
+    def log_activity(self, **_kwargs):
+        pass
+
+
+@pytest.fixture
+def session_app(monkeypatch):
+    engine = create_engine("sqlite://")
+    ub.User_Sessions.__table__.create(engine)
+    db_session = scoped_session(sessionmaker(bind=engine))
+    monkeypatch.setattr(ub, "session", db_session)
+    monkeypatch.setattr(login_utils, "CWA_DB", _NoopActivityDB)
+    monkeypatch.setattr(cps.logout.config, "config_login_type", 0, raising=False)
+
+    user = ub.User()
+    user.id = 73
+    user.name = "seeded-e2e-user"
+    user.nickname = user.name
+    user.role = constants.ROLE_USER
+
+    app = flask.Flask(__name__)
+    app.config.update(SECRET_KEY="test", SESSION_PROTECTION="basic", TESTING=True)
+    login_manager = MyLoginManager(app)
+
+    @login_manager.user_loader
+    def load_user(user_id, random, session_key):
+        stored = (
+            db_session.query(ub.User_Sessions)
+            .filter(
+                ub.User_Sessions.user_id == int(user_id),
+                ub.User_Sessions.random == random,
+                ub.User_Sessions.session_key == session_key,
+            )
+            .one_or_none()
+        )
+        return user if stored is not None else None
+
+    @app.post("/login")
+    def login():
+        assert login_user(user)
+        return "", 204
+
+    @app.post("/logout")
+    def logout():
+        cleanup_local_logout()
+        return "", 204
+
+    @app.get("/protected")
+    @login_required
+    def protected():
+        return {"user_id": current_user.get_id()}
+
+    yield app, db_session
+
+    db_session.remove()
+    engine.dispose()
+
+
+def _request(client, method, path, user_agent):
+    return getattr(client, method)(
+        path,
+        headers={"User-Agent": user_agent},
+        environ_overrides={"REMOTE_ADDR": REMOTE_ADDR},
+    )
+
+
+@pytest.mark.unit
+def test_same_user_agent_logout_invalidates_both_server_sessions(session_app):
+    app, db_session = session_app
+    first = app.test_client()
+    second = app.test_client()
+
+    assert _request(first, "post", "/login", SEEDED_USER_AGENT).status_code == 204
+    assert _request(second, "post", "/login", SEEDED_USER_AGENT).status_code == 204
+
+    rows = db_session.query(ub.User_Sessions).all()
+    assert len(rows) == 2
+    assert len({row.random for row in rows}) == 2
+    assert len({row.session_key for row in rows}) == 1
+    assert _request(first, "post", "/logout", SEEDED_USER_AGENT).status_code == 204
+    assert db_session.query(ub.User_Sessions).count() == 0
+    assert _request(second, "get", "/protected", SEEDED_USER_AGENT).status_code == 401
+
+
+@pytest.mark.unit
+def test_distinct_user_agents_keep_server_sessions_independent(session_app):
+    app, db_session = session_app
+    seeded = app.test_client()
+    isolated = app.test_client()
+
+    assert _request(seeded, "post", "/login", SEEDED_USER_AGENT).status_code == 204
+    assert _request(isolated, "post", "/login", ISOLATED_USER_AGENT).status_code == 204
+
+    rows = db_session.query(ub.User_Sessions).all()
+    assert len(rows) == 2
+    assert len({row.session_key for row in rows}) == 2
+    assert _request(isolated, "post", "/logout", ISOLATED_USER_AGENT).status_code == 204
+    assert db_session.query(ub.User_Sessions).count() == 1
+    assert _request(seeded, "get", "/protected", SEEDED_USER_AGENT).status_code == 200


### PR DESCRIPTION
## Why

`main` was red on the full SPA E2E lane: **171 failed / 343 passed** (run 33481506162 on `main` @ `7e04907`). The failures were almost entirely `[mobile]` plus the touch projects, only 2 on `[desktop]`, and 16 carried the literal body `{"error":{"code":"unauthorized","message":"Authentication required"}}`. The suite lost authentication partway through a run, and the specs that then failed (`reader-notes`, `auth-expiry`, `annotation-*`, `upload-reachability`, …) were victims, not subjects — none of them assert anything about login.

This blocked every open PR, since none could reach a green E2E.

## Root cause 1 — the sign-out test destroyed the shared session

The sign-out test added in #2090 deleted the seeded session every parallel spec was using.

- `cps/cw_login/utils.py::_create_identifier` defines Flask-Login's `_id` as `sha512(f"{remote_addr}|{User-Agent}")` — a **browser fingerprint, not a session id**.
- `cps/logout.py::cleanup_local_logout` calls `ub.delete_user_session(current_user.id, flask_session['_id'])`, and `cps/ub.py::delete_user_session` deletes **every** `User_Sessions` row matching `(user_id, session_key)`.
- The spec opened `browser.newContext({ storageState: { cookies: [], origins: [] } })` believing that isolated it. It does not: an explicit `newContext` does **not** inherit the project's `use` block, so it ran with the engine default User-Agent — byte-identical to the one `e2e/global.setup.ts` used when it seeded `storageState`.
- Same address + same UA ⇒ same `session_key` ⇒ clicking **Sign out** deleted the seeded row too, and every spec still running 401'd.

**Fix:** give the sign-out context its own server-side fingerprint — derive the engine's default UA at runtime and append `CWNG-E2E-signout/<project name>`, so the desktop and mobile instances also differ from each other. Then assert the context actually carries it, **before** logging in. That assertion is the point, not decoration: today a regression here manifests as ~150 unrelated specs failing somewhere else, which reads as a login regression; after this, dropping the `userAgent` fails *this* test by name at its first line.

**Measured: 171 failed → 2 failed** (run 33510126196).

## Root cause 2 — the test assumed anonymous browsing is on

The residual 2 were this same spec, `[desktop]` and `[mobile]`, both at `expect(guestTrigger).toBeVisible()` for `account: guest`. The preceding URL assertion passed, so the URL was right and only the control was missing.

The spec's own comment claimed *"This rig permits anonymous browsing"*. CI's rig does not. With `config_anonbrowse` off, `/api/v1/auth/me` answers 401 after logout, so `frontend/src/App.tsx` takes its `if (!me)` branch and renders `<Login />` at the same `/app` URL — no `AppShell`, therefore no account menu of any kind to find. Locally, anonymous browsing is on, `AppShell` mounts, and the Guest trigger exists. The test encoded one rig's setting as an invariant.

**Fix:** stop assuming in either direction. After sign-out the spec reads `/api/v1/auth/me` and classifies the instance from the server's own contract — 200 with `role.anonymous` **and** `features.anon_browse` means anonymous browsing is on; 401 with `error.code === "unauthenticated"` means it is off. Deciding this from whichever control happens to render would let a broken UI pick the assertion it can pass.

The assertions are then split by what they actually depend on:

- **Configuration-independent, asserted unconditionally:** the session ended per the server, no `Sign out` control survives, `remember_token` is gone, `cwng_prefer_classic` is gone, and a later visit to `/` still lands on the new UI.
- **Configuration-specific, in exactly one branch:** anonymous on ⇒ the Guest menu offers **Sign in** and no **Sign out**; anonymous off ⇒ the login form renders and no Guest trigger exists.

The branch cannot go vacuous. `Number(enabled) + Number(disabled)` must equal `1`, so a server that is in neither state — including a logout that silently failed and left the old identity authenticated — fails there with the observed status and fields. And each branch asserts its expected state **positively** by name, so a mismatch reports "server expected Guest account menu; observed login form" rather than a bare timeout on a missing element.

## Scope

Test-only. `git diff origin/main --name-only` is exactly:

- `frontend/e2e/account-menu-no-classic.spec.ts`
- `tests/unit/test_e2e_session_fingerprint_isolation.py`

No product or runtime source changed. The `_id`-is-a-fingerprint behaviour is inherited from upstream calibre-web and is deliberately out of scope here — this PR fixes the test that tripped over it, and pins the collision so the next person meets it as a named failure instead of 171 anonymous ones.

## Evidence

- `tests/unit/test_e2e_session_fingerprint_isolation.py` — 2 passed under `.venv/bin/python`; pins both halves (same UA ⇒ one logout invalidates both server sessions; distinct UAs ⇒ they stay independent).
- `npx tsc -p tsconfig.e2e.json --noEmit` — exit 0, no output.
- CI E2E lane on this branch: 171 → 2, then this head takes the residual 2.
