### PR TITLE
docs(wiki): mirror the packager runtime-path section into Installation

### DIFF
--- a/wiki-src/Installation.md
+++ b/wiki-src/Installation.md
@@ -30,4 +30,6 @@ Every guide covers both a **fresh install** and **switching from stock CWA**, an
 
 {{repo:README.md#full-docker-compose-setup|heading}}
 
+{{repo:README.md#runtime-path-overrides-for-packagers|heading}}
+
 **Next:** **[[First Run]]** → **[[Updating]]**.


### PR DESCRIPTION
Clears the wiki-sync DRIFT TRIPWIRE firing since 08:14Z today: README.md#runtime-path-overrides-for-packagers now transcludes into the Installation wiki page (bare-metal/distro packager audience). One-directive change; generator verifies at next sync.