### PR TITLE
fix(kobo): fail closed on collection commit errors (F-5dcb50, F-db823b)

### DIFF
--- a/changelog.d/kobo-commit-acks.md
+++ b/changelog.d/kobo-commit-acks.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- **Kobo collection changes are retried when the database is temporarily busy.**
+  Creating, renaming, deleting, or changing the books in a collection no longer
+  tells the device that the change succeeded after its database write was
+  rolled back. Book removals use the same fail-closed acknowledgement rule.

--- a/cps/api/shelves.py
+++ b/cps/api/shelves.py
@@ -229,10 +229,11 @@ def delete_shelf_api(shelf_id):
     shelf = ub.session.query(ub.Shelf).filter(ub.Shelf.id == shelf_id).first()
     if shelf is None:
         return _err("not_found", "Shelf not found", 404)
-    # delete_shelf_helper re-checks edit permission and returns False if denied.
+    if not check_shelf_edit_permissions(shelf):
+        return _err("forbidden", "You are not allowed to delete this shelf", 403)
     try:
         if not delete_shelf_helper(shelf):
-            return _err("forbidden", "You are not allowed to delete this shelf", 403)
+            return _err("db_error", "Could not delete shelf", 500)
     except InvalidRequestError as e:
         ub.session.rollback()
         return _err("db_error", "Could not delete shelf: %s" % getattr(e, "orig", e), 500)

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -2287,7 +2287,8 @@ def HandleTagCreate():
     items_unknown_to_calibre = add_items_to_shelf(items, shelf)
     if items_unknown_to_calibre:
         log.debug("Received request to add unknown books to a collection. Silently ignoring items.")
-    ub.session_commit()
+    if ub.session_commit() is False:
+        return abort(503)
     return make_response(jsonify(str(shelf.uuid)), 201)
 
 
@@ -2313,8 +2314,10 @@ def HandleTagUpdate(tag_id):
         return redirect_or_proxy_request()
 
     if request.method == "DELETE":
-        if not shelf_lib.delete_shelf_helper(shelf):
+        if not shelf_lib.check_shelf_edit_permissions(shelf):
             abort(401, description="Error deleting Shelf")
+        if not shelf_lib.delete_shelf_helper(shelf):
+            return abort(503)
     else:
         name = None
         try:
@@ -2326,7 +2329,8 @@ def HandleTagUpdate(tag_id):
 
         shelf.name = name
         ub.session.merge(shelf)
-        ub.session_commit()
+        if ub.session_commit() is False:
+            return abort(503)
     return make_response(' ', 200)
 
 
@@ -2385,7 +2389,8 @@ def HandleTagAddItem(tag_id):
         log.debug("Received request to add an unknown book to a collection. Silently ignoring item.")
 
     ub.session.merge(shelf)
-    ub.session_commit()
+    if ub.session_commit() is False:
+        return abort(503)
     return make_response('', 201)
 
 
@@ -2438,7 +2443,8 @@ def HandleTagRemoveItem(tag_id):
             shelf.books.filter(ub.BookShelf.book_id == book.id).delete()
         except KeyError:
             items_unknown_to_calibre.append(item)
-    ub.session_commit()
+    if ub.session_commit() is False:
+        return abort(503)
 
     if items_unknown_to_calibre:
         log.debug("Received request to remove an unknown book to a collecition. Silently ignoring item.")
@@ -3097,9 +3103,14 @@ def HandleBookDeletionRequest(book_uuid):
         pass
     # Otherwise, archive the book if the user has permission to see archived books.
     elif current_user.check_visibility(32768):
-        kobo_sync_status.change_archived_books(book_id, True)
+        kobo_sync_status.change_archived_books(book_id, True, commit=False)
 
-    kobo_sync_status.remove_synced_book(book_id)
+    # The archive marker and delivery-ledger removal describe one device
+    # action. Stage both and let this answer-bearing route own the single
+    # checked commit, so neither a partial write nor a rollback earns a 204.
+    kobo_sync_status.remove_synced_book(book_id, commit=False)
+    if ub.session_commit() is False:
+        return abort(503)
     return "", 204
 
 

--- a/cps/kobo_sync_status.py
+++ b/cps/kobo_sync_status.py
@@ -445,7 +445,7 @@ def record_book_deletion(book_id, book_uuid, session=None):
 
 
 # Select all entries of current book in kobo_synced_books table, which are from current user and delete them
-def remove_synced_book(book_id, all=False, session=None):
+def remove_synced_book(book_id, all=False, session=None, commit=True):
     s = session if session is not None else ub.session
     if not all:
         user = ub.KoboSyncedBooks.user_id == current_user.id
@@ -460,23 +460,26 @@ def remove_synced_book(book_id, all=False, session=None):
     ).filter(device_filter).delete(synchronize_session=False)
     s.query(ub.KoboSyncedBooks).filter(
         ub.KoboSyncedBooks.book_id == book_id).filter(user).delete()
-    if session is None:
-        ub.session_commit()
-    else:
-        ub.session_commit(_session=session)
+    if commit:
+        if session is None:
+            ub.session_commit()
+        else:
+            ub.session_commit(_session=session)
 
 
-def change_archived_books(book_id, state=None, message=None):
-    archived_book = ub.session.query(ub.ArchivedBook).filter(and_(ub.ArchivedBook.user_id == int(current_user.id),
-                                                                  ub.ArchivedBook.book_id == book_id)).first()
+def change_archived_books(book_id, state=None, message=None, session=None, commit=True):
+    s = session if session is not None else ub.session
+    archived_book = s.query(ub.ArchivedBook).filter(and_(ub.ArchivedBook.user_id == int(current_user.id),
+                                                         ub.ArchivedBook.book_id == book_id)).first()
     if not archived_book:
         archived_book = ub.ArchivedBook(user_id=current_user.id, book_id=book_id)
 
     archived_book.is_archived = state if state else not archived_book.is_archived
     archived_book.last_modified = datetime.now(timezone.utc)        # toDo. Check utc timestamp
 
-    ub.session.merge(archived_book)
-    ub.session_commit(message)
+    s.merge(archived_book)
+    if commit:
+        ub.session_commit(message, _session=s)
     return archived_book.is_archived
 
 

--- a/cps/shelf.py
+++ b/cps/shelf.py
@@ -840,8 +840,7 @@ def delete_shelf_helper(cur_shelf):
     ub.session.query(ub.BookShelf).filter(ub.BookShelf.shelf == shelf_id).delete()
     ub.session.query(ub.OpdsShelfExposure).filter(ub.OpdsShelfExposure.shelf_id == shelf_id).delete()
     ub.session.add(ub.ShelfArchive(uuid=cur_shelf.uuid, user_id=cur_shelf.user_id))
-    ub.session_commit("successfully deleted Shelf {}".format(cur_shelf.name))
-    return True
+    return ub.session_commit("successfully deleted Shelf {}".format(cur_shelf.name))
 
 
 def change_shelf_order(shelf_id, order):

--- a/tests/unit/test_api_v1_shelves.py
+++ b/tests/unit/test_api_v1_shelves.py
@@ -196,10 +196,24 @@ def test_delete_forbidden_403():
     from cps.api import shelves as mod
     with _ctx("/api/v1/shelves/1/delete"):
         with patch.object(mod, "ub") as mock_ub, \
-             patch.object(mod, "delete_shelf_helper", return_value=False):
+             patch.object(mod, "check_shelf_edit_permissions", return_value=False), \
+             patch.object(mod, "delete_shelf_helper") as delete:
             mock_ub.session.query.return_value.filter.return_value.first.return_value = _shelf()
             resp = inspect.unwrap(mod.delete_shelf_api)(1)
     assert resp[1] == 403
+    delete.assert_not_called()
+
+
+@pytest.mark.unit
+def test_delete_commit_failure_500():
+    from cps.api import shelves as mod
+    with _ctx("/api/v1/shelves/1/delete"):
+        with patch.object(mod, "ub") as mock_ub, \
+             patch.object(mod, "check_shelf_edit_permissions", return_value=True), \
+             patch.object(mod, "delete_shelf_helper", return_value=False):
+            mock_ub.session.query.return_value.filter.return_value.first.return_value = _shelf()
+            resp = inspect.unwrap(mod.delete_shelf_api)(1)
+    assert resp[1] == 500
 
 
 @pytest.mark.unit
@@ -207,6 +221,7 @@ def test_delete_ok_204():
     from cps.api import shelves as mod
     with _ctx("/api/v1/shelves/1/delete"):
         with patch.object(mod, "ub") as mock_ub, \
+             patch.object(mod, "check_shelf_edit_permissions", return_value=True), \
              patch.object(mod, "delete_shelf_helper", return_value=True):
             mock_ub.session.query.return_value.filter.return_value.first.return_value = _shelf()
             resp = inspect.unwrap(mod.delete_shelf_api)(1)

--- a/tests/unit/test_f5dcb50_kobo_commit_acks.py
+++ b/tests/unit/test_f5dcb50_kobo_commit_acks.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Kobo must retry collection deltas whose database commit rolled back.
+
+Nickel uploads collection mutations once and retires them after a successful
+HTTP response.  ``ub.session_commit()`` deliberately turns a caught transient
+database failure into ``False``, so every answer-bearing route must translate
+that result into a retryable 5xx rather than acknowledge a write that did not
+land (#1318, F-5dcb50 and F-db823b).
+"""
+
+import inspect
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import flask
+import pytest
+
+from cps import kobo
+
+
+USER = SimpleNamespace(
+    id=7,
+    kobo_only_shelves_sync=False,
+    check_visibility=lambda _permission: True,
+)
+
+
+def _client_for(view, rule, method):
+    app = flask.Flask(__name__)
+    app.config["TESTING"] = True
+    app.add_url_rule(
+        rule,
+        view_func=inspect.unwrap(view),
+        methods=[method],
+    )
+    return app.test_client()
+
+
+def _session_returning(value):
+    session = MagicMock()
+    query = session.query.return_value
+    query.filter.return_value = query
+    query.one_or_none.return_value = value
+    query.delete.return_value = 1
+    return session
+
+
+@pytest.mark.unit
+def test_tag_create_refuses_success_when_commit_rolled_back(monkeypatch):
+    session = _session_returning(None)
+    monkeypatch.setattr(kobo.ub, "session", session)
+    monkeypatch.setattr(kobo.ub, "session_commit", lambda *a, **k: False)
+    monkeypatch.setattr(kobo, "add_items_to_shelf", lambda _items, _shelf: [])
+
+    with patch.object(kobo, "current_user", USER):
+        response = _client_for(
+            kobo.HandleTagCreate, "/v1/library/tags", "POST",
+        ).post("/v1/library/tags", json={"Name": "Queued", "Items": []})
+
+    assert response.status_code == 503
+
+
+@pytest.mark.unit
+def test_tag_rename_refuses_success_when_commit_rolled_back(monkeypatch):
+    shelf = SimpleNamespace(id=11, uuid="tag-11", user_id=USER.id, name="Old")
+    session = _session_returning(shelf)
+    monkeypatch.setattr(kobo.ub, "session", session)
+    monkeypatch.setattr(kobo.ub, "session_commit", lambda *a, **k: False)
+
+    with patch.object(kobo, "current_user", USER):
+        response = _client_for(
+            kobo.HandleTagUpdate, "/v1/library/tags/<tag_id>", "PUT",
+        ).put("/v1/library/tags/tag-11", json={"Name": "New"})
+
+    assert response.status_code == 503
+
+
+@pytest.mark.unit
+def test_tag_delete_refuses_success_when_commit_rolled_back(monkeypatch):
+    shelf = SimpleNamespace(
+        id=11,
+        uuid="tag-11",
+        user_id=USER.id,
+        name="Queued",
+        is_public=False,
+    )
+    session = _session_returning(shelf)
+    monkeypatch.setattr(kobo.ub, "session", session)
+    monkeypatch.setattr(kobo.ub, "session_commit", lambda *a, **k: False)
+    monkeypatch.setattr(kobo.shelf_lib, "check_shelf_edit_permissions", lambda _shelf: True)
+
+    with patch.object(kobo, "current_user", USER), \
+            patch.object(kobo.shelf_lib, "current_user", USER):
+        response = _client_for(
+            kobo.HandleTagUpdate, "/v1/library/tags/<tag_id>", "DELETE",
+        ).delete("/v1/library/tags/tag-11")
+
+    assert response.status_code == 503
+
+
+@pytest.mark.unit
+def test_tag_add_item_refuses_success_when_commit_rolled_back(monkeypatch):
+    shelf = SimpleNamespace(id=11, uuid="tag-11", user_id=USER.id)
+    session = _session_returning(shelf)
+    monkeypatch.setattr(kobo.ub, "session", session)
+    monkeypatch.setattr(kobo.ub, "session_commit", lambda *a, **k: False)
+    monkeypatch.setattr(kobo, "add_items_to_shelf", lambda _items, _shelf: [])
+    monkeypatch.setattr(kobo.shelf_lib, "check_shelf_edit_permissions", lambda _shelf: True)
+
+    with patch.object(kobo, "current_user", USER):
+        response = _client_for(
+            kobo.HandleTagAddItem,
+            "/v1/library/tags/<tag_id>/items",
+            "POST",
+        ).post("/v1/library/tags/tag-11/items", json={"Items": []})
+
+    assert response.status_code == 503
+
+
+@pytest.mark.unit
+def test_tag_remove_item_refuses_success_when_commit_rolled_back(monkeypatch):
+    shelf_books = MagicMock()
+    shelf = SimpleNamespace(
+        id=11,
+        uuid="tag-11",
+        user_id=USER.id,
+        books=shelf_books,
+    )
+    session = _session_returning(shelf)
+    monkeypatch.setattr(kobo.ub, "session", session)
+    monkeypatch.setattr(kobo.ub, "session_commit", lambda *a, **k: False)
+    monkeypatch.setattr(kobo.shelf_lib, "check_shelf_edit_permissions", lambda _shelf: True)
+    monkeypatch.setattr(
+        kobo.calibre_db,
+        "get_book_by_uuid_for_kobo",
+        lambda *_args, **_kwargs: SimpleNamespace(id=42),
+    )
+
+    with patch.object(kobo, "current_user", USER):
+        response = _client_for(
+            kobo.HandleTagRemoveItem,
+            "/v1/library/tags/<tag_id>/items/delete",
+            "POST",
+        ).post(
+            "/v1/library/tags/tag-11/items/delete",
+            json={"Items": [{
+                "Type": "ProductRevisionTagItem",
+                "RevisionId": "book-42",
+            }]},
+        )
+
+    assert response.status_code == 503
+
+
+@pytest.mark.unit
+def test_book_delete_refuses_success_when_commit_rolled_back(monkeypatch):
+    book = SimpleNamespace(id=42, uuid="book-42")
+    archive = MagicMock()
+    remove = MagicMock()
+    monkeypatch.setattr(
+        kobo.calibre_db,
+        "get_book_by_uuid_for_kobo",
+        lambda *_args, **_kwargs: book,
+    )
+    monkeypatch.setattr(kobo.kobo_sync_status, "change_archived_books", archive)
+    monkeypatch.setattr(kobo.kobo_sync_status, "remove_synced_book", remove)
+    monkeypatch.setattr(kobo.ub, "session_commit", lambda *a, **k: False)
+
+    with patch.object(kobo, "current_user", USER):
+        response = _client_for(
+            kobo.HandleBookDeletionRequest,
+            "/v1/library/<book_uuid>",
+            "DELETE",
+        ).delete("/v1/library/book-42")
+
+    assert response.status_code == 503
+    archive.assert_called_once_with(42, True, commit=False)
+    remove.assert_called_once_with(42, commit=False)


### PR DESCRIPTION
Fixes findings F-5dcb50 and F-db823b from the 2026-09-01 Kobo audit (#2101): six device-facing routes acknowledged success after `ub.session_commit()` reported a rolled-back write. A Kobo uploads collection deltas once — a false ack converts a transient SQLite lock into permanent loss of the shelf operation.

| Device operation | Before (on failed commit) | After |
|---|---:|---:|
| Create collection | 201 | 503 |
| Rename collection | 200 | 503 |
| Delete collection | 200 | 503 |
| Add collection item | 201 | 503 |
| Remove collection item | 200 | 503 |
| Delete book (F-db823b) | 204 | 503 |

Mirrors the shipped `HandleStateRequest` / annotation-PATCH fail-closed pattern (#1318 contract). Nickel retries on 5xx, so a refused delta stays queued on the device.

Also:
- `delete_shelf_helper` now returns its commit result honestly; the Kobo route checks edit permission first (401 preserved), the REST route splits 403 (denial) from 500 (commit failure), classic keeps its generic error.
- `HandleBookDeletionRequest` stages the archive marker + ledger removal and owns one checked commit — no false 204 and no partially-committed two-step deletion.

**Red→green**: `tests/unit/test_f5dcb50_kobo_commit_acks.py` — all six tests written first and shown failing against the old code with the exact old success codes (201/200/200/201/200/204), green after. REST-surface coverage extended in `test_api_v1_shelves.py` (403/500/204 split).

**Verification**: full unit suite 8,109 passed / 111 skipped / 0 failed; changelog guard green; one commit; diff reviewed by the managing session (permission-check preservation and helper-caller compatibility confirmed against the code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wu7kf5AY8gTzhDGtAEd3QZ