### PR TITLE
fix(kobo): preserve reading-state cursor frontier (F-8cb0c9)

### DIFF
--- a/changelog.d/f8cb0c9-kobo-reading-state-cursor.md
+++ b/changelog.d/f8cb0c9-kobo-reading-state-cursor.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- **Factory-reset Kobo devices receive every saved reading position in large
+  libraries.** Reading progress and read status now drain through one ordered
+  page instead of letting a recently read book skip older pending states.

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -1181,6 +1181,53 @@ def HandleSyncRequest():
     # the joined-load query twice per sync request.
     books_list = changed_entries.limit(SYNC_ITEM_LIMIT).all()
     log.debug("Kobo Sync: selected to sync: {}".format(len(books_list)))
+
+    # Establish one ordered reading-state frontier before rendering any
+    # entitlements. Reading states can travel either embedded in an entitlement
+    # or as standalone ChangedReadingState commands, but the timestamp-only
+    # token cannot represent holes between those two paths.  In particular, an
+    # out-of-order recent state embedded on page one must not advance the token
+    # past older states that did not fit in the standalone page (F-8cb0c9).
+    #
+    # Only rows in this oldest-first page may be embedded below.  Every row in
+    # the page is then emitted exactly once (embedded or standalone), and the
+    # cursor advances only to the maximum row in this fully-covered frontier.
+    changed_reading_states = ub.session.query(ub.KoboReadingState)
+    log.debug("Kobo Sync: rstate last modified: {}".format(
+        sync_token.reading_state_last_modified))
+    if only_kobo_shelves:
+        changed_reading_states = changed_reading_states.outerjoin(
+            ub.BookShelf,
+            ub.KoboReadingState.book_id == ub.BookShelf.book_id,
+        ).outerjoin(
+            ub.Shelf,
+            ub.Shelf.id == ub.BookShelf.shelf,
+        ).filter(
+            ub.KoboReadingState.last_modified
+            > sync_token.reading_state_last_modified,
+        ).filter(or_(
+            and_(
+                current_user.id == ub.Shelf.user_id,
+                ub.Shelf.kobo_sync.is_(True),
+            ),
+            ub.KoboReadingState.book_id.in_(magic_shelf_book_ids)
+            if magic_shelf_book_ids else False,
+        )).distinct()
+    else:
+        changed_reading_states = changed_reading_states.filter(
+            ub.KoboReadingState.last_modified
+            > sync_token.reading_state_last_modified)
+
+    changed_reading_states = changed_reading_states.filter(
+        ub.KoboReadingState.user_id == current_user.id,
+    ).order_by(ub.KoboReadingState.last_modified)
+    log.debug("Kobo Sync: changed states: {}".format(
+        changed_reading_states.count()))
+    reading_state_page = changed_reading_states.limit(SYNC_ITEM_LIMIT).all()
+    reading_state_page_ids = {
+        reading_state.id for reading_state in reading_state_page
+    }
+
     prior_entitlement_fingerprints = (
         kobo_sync_status.get_device_entitlement_fingerprints(
             requesting_device_id,
@@ -1234,7 +1281,7 @@ def HandleSyncRequest():
             refresh_fingerprint_record = False
 
         if (kobo_reading_state is not None
-                and kobo_reading_state.last_modified > sync_token.reading_state_last_modified):
+                and kobo_reading_state.id in reading_state_page_ids):
             reading_state = get_kobo_reading_state_response(
                 book.Books, kobo_reading_state)
             new_reading_state_last_modified = max(
@@ -1244,10 +1291,9 @@ def HandleSyncRequest():
             reading_state_book_ids_emitted.append(book.Books.id)
             if entitlement_is_unchanged:
                 # Replay suppression applies only to the byte-identical base
-                # entitlement. Reading state has its own cursor and must still
-                # be delivered independently; relying on the paged scan below
-                # can withhold it behind a full page of older states and leave
-                # its cursor unadvanced.
+                # entitlement. A state admitted to this response's ordered
+                # frontier must still be emitted independently even when its
+                # unchanged entitlement envelope is suppressed.
                 sync_results.append({
                     "ChangedReadingState": {"ReadingState": reading_state}
                 })
@@ -1433,36 +1479,12 @@ def HandleSyncRequest():
     # starts the next session with that returned token and drains the next page.
     cont_sync = False
     log.debug("Kobo Sync: remaining books to sync: {}".format(book_count))
-    # generate reading state data
-    changed_reading_states = ub.session.query(ub.KoboReadingState)
-
-    log.debug("Kobo Sync: rstate last modified: {}".format(sync_token.reading_state_last_modified))
-    if only_kobo_shelves:
-        changed_reading_states = changed_reading_states.outerjoin(ub.BookShelf,
-                                                                  ub.KoboReadingState.book_id == ub.BookShelf.book_id)\
-            .outerjoin(ub.Shelf, ub.Shelf.id == ub.BookShelf.shelf)\
-            .filter(ub.KoboReadingState.last_modified > sync_token.reading_state_last_modified)\
-            .filter(or_(
-                and_(
-                    current_user.id == ub.Shelf.user_id,
-                    ub.Shelf.kobo_sync.is_(True),
-                ),
-                ub.KoboReadingState.book_id.in_(magic_shelf_book_ids) if magic_shelf_book_ids else False
-            ))\
-            .distinct()
-    else:
-        changed_reading_states = changed_reading_states.filter(
-            ub.KoboReadingState.last_modified > sync_token.reading_state_last_modified)
-
-    changed_reading_states = changed_reading_states.filter(
-        and_(ub.KoboReadingState.user_id == current_user.id,
-             ub.KoboReadingState.book_id.notin_(reading_state_book_ids_emitted)))\
-        .order_by(ub.KoboReadingState.last_modified)
-    log.debug("Kobo Sync: changed states: {}".format(changed_reading_states.count()))
     # Do not set local continuation for a full reading-state page.  It has the
     # same firmware cursor-pinning semantics as the books signal above; ending
     # the session is what lets the returned reading-state cursor take effect.
-    for kobo_reading_state in changed_reading_states.limit(SYNC_ITEM_LIMIT).all():
+    for kobo_reading_state in reading_state_page:
+        if kobo_reading_state.book_id in reading_state_book_ids_emitted:
+            continue
         book = calibre_db.session.query(db.Books).filter(db.Books.id == kobo_reading_state.book_id).one_or_none()
         if book:
             sync_results.append({

--- a/tests/unit/test_1925_kobo_sync_dedownload.py
+++ b/tests/unit/test_1925_kobo_sync_dedownload.py
@@ -1416,10 +1416,10 @@ def test_hard_delete_payload_shape_change_reseeds_without_delivery(
     assert "suppressed_removed=1" in summaries[-1]
 
 
-def test_suppressed_entitlement_emits_newer_reading_state_once_and_advances_cursor(
+def test_suppressed_entitlement_drains_newer_reading_state_after_older_full_page(
     sync_harness, monkeypatch,
 ):
-    """Layer 2 suppression must not suppress or loop reading-state changes."""
+    """Layer 2 suppression preserves the ordered reading-state frontier."""
     from cps import db, kobo, ub
 
     monkeypatch.setattr(
@@ -1434,12 +1434,18 @@ def test_suppressed_entitlement_emits_newer_reading_state_once_and_advances_curs
 
     # Seed the per-device entitlement fingerprint without a reading state.
     assert len(_entitlements(sync_harness.sync())) == 1
+    # This test isolates replay suppression + cursor pagination. The separate
+    # re-download repair channel intentionally has its own delivery semantics.
+    sync_harness.session.query(ub.DeviceReadingPosition).update({
+        ub.DeviceReadingPosition.rehydrate_needed: False,
+    })
+    sync_harness.session.commit()
 
     # Fill the (test-sized) independent reading-state page with an older,
-    # legitimate library state. Before the fix, the suppressed book relied on
-    # that later paged scan; its newer state was therefore withheld until
-    # another sync. Keeping this book out of Data makes it reading-state-only
-    # background, not an additional base entitlement in this regression.
+    # legitimate library state. Keeping this book out of Data makes it
+    # reading-state-only background, not an additional base entitlement in
+    # this regression. The target's newer state must wait for the next ordered
+    # page; embedding it now would move the timestamp cursor past this row.
     background_modified = datetime(2026, 8, 28, 12, 15, 0)
     background_book = db.Books(
         "Background State",
@@ -1519,8 +1525,8 @@ def test_suppressed_entitlement_emits_newer_reading_state_once_and_advances_curs
     sync_harness.session.commit()
     sync_harness.session.expire_all()
 
-    # A valid but stale CWNG token selects the unchanged base entitlement and
-    # the newer reading state together. Layer 2 may suppress only the former.
+    # A valid but stale CWNG token selects the unchanged base entitlement, but
+    # the older background state owns this response's one-row state frontier.
     stale_cwng_token = kobo.SyncToken.SyncToken().build_sync_token()
     changed = sync_harness.sync(stale_cwng_token)
 
@@ -1529,15 +1535,29 @@ def test_suppressed_entitlement_emits_newer_reading_state_once_and_advances_curs
         state for state in _changed_reading_states(changed)
         if state["EntitlementId"] == sync_harness.book.uuid
     ]
-    assert len(target_states) == 1
-    assert target_states[0]["CurrentBookmark"]["ProgressPercent"] == 42
+    assert target_states == []
+    assert [
+        state["EntitlementId"] for state in _changed_reading_states(changed)
+    ] == [background_book.uuid]
 
     advanced_token = kobo.SyncToken.SyncToken.from_headers({
         sync_harness.token_header: changed.headers[sync_harness.token_header],
     })
-    assert advanced_token.reading_state_last_modified == state_modified
+    assert advanced_token.reading_state_last_modified == background_modified
 
-    unchanged = sync_harness.sync(changed.headers[sync_harness.token_header])
+    target_page = sync_harness.sync(changed.headers[sync_harness.token_header])
+    target_states = [
+        state for state in _changed_reading_states(target_page)
+        if state["EntitlementId"] == sync_harness.book.uuid
+    ]
+    assert len(target_states) == 1
+    assert target_states[0]["CurrentBookmark"]["ProgressPercent"] == 42
+    target_token = kobo.SyncToken.SyncToken.from_headers({
+        sync_harness.token_header: target_page.headers[sync_harness.token_header],
+    })
+    assert target_token.reading_state_last_modified == state_modified
+
+    unchanged = sync_harness.sync(target_page.headers[sync_harness.token_header])
     target_states_again = [
         state for state in _changed_reading_states(unchanged)
         if state["EntitlementId"] == sync_harness.book.uuid

--- a/tests/unit/test_f8cb0c9_kobo_reading_state_cursor.py
+++ b/tests/unit/test_f8cb0c9_kobo_reading_state_cursor.py
@@ -1,0 +1,328 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Regression coverage for F-8cb0c9's reading-state cursor gap.
+
+The sync response may carry a reading state inside an entitlement and may also
+carry a bounded page of standalone ChangedReadingState commands.  Those two
+delivery paths must share one ordered frontier: otherwise a recently-read book
+on the first entitlement page can move the timestamp cursor beyond standalone
+states that did not fit in that response.
+"""
+
+from collections import Counter
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask, g
+from sqlalchemy import create_engine, event, true
+from sqlalchemy.orm import sessionmaker
+
+
+pytestmark = pytest.mark.unit
+
+
+def _state_book_ids(response, uuid_to_id):
+    delivered = []
+    for item in response.get_json():
+        if "ChangedReadingState" in item:
+            state = item["ChangedReadingState"]["ReadingState"]
+        else:
+            entitlement = (
+                item.get("NewEntitlement") or item.get("ChangedEntitlement")
+            )
+            state = entitlement.get("ReadingState") if entitlement else None
+        if state is not None:
+            delivered.append(uuid_to_id[state["EntitlementId"]])
+    return delivered
+
+
+def _entitlement_count(response):
+    return sum(
+        "NewEntitlement" in item or "ChangedEntitlement" in item
+        for item in response.get_json()
+    )
+
+
+def _entitlement_book_ids(response):
+    return [
+        int(entitlement["BookEntitlement"]["Id"])
+        for item in response.get_json()
+        if (entitlement := (
+            item.get("NewEntitlement") or item.get("ChangedEntitlement")
+        )) is not None
+        and "BookMetadata" in entitlement
+    ]
+
+
+@pytest.fixture
+def reading_state_sync(monkeypatch):
+    """Real handler + SQLAlchemy harness with 250 state-bearing books."""
+    from cps import db, kobo, kobo_sync_status, ub
+
+    engine = create_engine("sqlite://")
+    event.listen(
+        engine,
+        "connect",
+        lambda connection, _record: connection.execute(
+            "ATTACH DATABASE ':memory:' AS calibre"
+        ),
+    )
+    db.Base.metadata.create_all(engine)
+    ub.Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+
+    total_books = 250
+    base = datetime(2026, 8, 1)
+    books = []
+    for offset in range(1, total_books + 1):
+        modified = base + timedelta(seconds=offset)
+        book = db.Books(
+            f"Book {offset}",
+            f"Book {offset}",
+            "Author",
+            modified,
+            db.Books.DEFAULT_PUBDATE,
+            "1.0",
+            modified,
+            f"book-{offset}",
+            0,
+            [],
+            [],
+        )
+        books.append(book)
+    session.add_all(books)
+    session.flush()
+
+    states = []
+    for book in books:
+        book.uuid = f"00000000-0000-0000-0000-{book.id:012d}"
+        session.add(db.Data(book.id, "EPUB", 1, f"book-{book.id}"))
+
+        # Book 1 is the recently-read page-one trigger.  Its state is newer
+        # than every other state, while the remaining clocks ascend by id.
+        state_clock = (
+            base + timedelta(seconds=1000)
+            if book.id == 1
+            else base + timedelta(seconds=book.id)
+        )
+        read = ub.ReadBook(
+            user_id=8009,
+            book_id=book.id,
+            read_status=ub.ReadBook.STATUS_IN_PROGRESS,
+        )
+        state = ub.KoboReadingState(
+            user_id=8009,
+            book_id=book.id,
+            priority_timestamp=state_clock,
+        )
+        state.current_bookmark = ub.KoboBookmark(
+            last_modified=state_clock,
+            progress_percent=float(book.id % 100),
+        )
+        state.statistics = ub.KoboStatistics(last_modified=state_clock)
+        read.kobo_reading_state = state
+        session.add(read)
+        states.append((state, state_clock))
+
+    device = ub.Device(
+        user_id=8009,
+        kind="kobo",
+        display_name="Reading-state cursor Kobo",
+        model="Kobo",
+        active=True,
+        created_by="auto",
+    )
+    session.add(device)
+    session.commit()
+
+    # The before_flush listener intentionally stamps a parent state whenever
+    # its child rows change.  Restore the deterministic clocks after the
+    # initial insert so the regression's ordering is exact.
+    for state, state_clock in states:
+        state.last_modified = state_clock
+        state.priority_timestamp = state_clock
+    session.commit()
+
+    user = SimpleNamespace(
+        id=8009,
+        name="f8cb0c9-reading-state-cursor",
+        kobo_only_shelves_sync=False,
+        role_download=lambda: True,
+    )
+    fake_calibre_db = SimpleNamespace(
+        session=session,
+        reconnect_db=lambda *_args, **_kwargs: None,
+        refresh_for_new_data=lambda: None,
+        common_filters=lambda **_kwargs: true(),
+        get_book=lambda book_id: session.query(db.Books).filter_by(
+            id=book_id
+        ).one_or_none(),
+    )
+
+    monkeypatch.setattr(ub, "session", session)
+    monkeypatch.setattr(ub, "session_commit", lambda *_args, **_kwargs: session.commit())
+    monkeypatch.setattr(kobo, "calibre_db", fake_calibre_db)
+    monkeypatch.setattr(kobo, "current_user", user)
+    monkeypatch.setattr(kobo_sync_status, "current_user", user)
+    monkeypatch.setattr(kobo.config, "config_kobo_proxy", False, raising=False)
+    monkeypatch.setattr(
+        kobo.config,
+        "config_kobo_suppress_replayed_entitlements",
+        True,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        kobo.config,
+        "config_kobo_sync_magic_shelves",
+        False,
+        raising=False,
+    )
+    monkeypatch.setattr(kobo, "get_download_url_for_book", lambda *_args: "/download")
+    monkeypatch.setattr(
+        kobo,
+        "get_magic_shelf_book_ids_for_kobo",
+        lambda _user_id: (set(), True),
+    )
+    monkeypatch.setattr(
+        kobo,
+        "get_magic_shelf_membership_added_at",
+        lambda _user_id: None,
+    )
+    monkeypatch.setattr(kobo, "sync_shelves", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        kobo,
+        "create_book_entitlement",
+        lambda book, archived=False: {"Id": str(book.id), "IsRemoved": archived},
+    )
+    monkeypatch.setattr(
+        kobo,
+        "get_metadata",
+        lambda book: {"EntitlementId": str(book.id)},
+    )
+
+    app = Flask(__name__)
+    app.secret_key = "f8cb0c9-test-key"
+    app.wsgi_app = SimpleNamespace(is_proxied=True)
+
+    def sync(token=None, *, physical_device=True):
+        headers = {}
+        if token is not None:
+            headers[kobo.SyncToken.SyncToken.SYNC_TOKEN_HEADER] = token
+        with app.test_request_context("/v1/library/sync", headers=headers):
+            if physical_device:
+                g.annotation_origin_device_id = device.id
+            response = kobo.HandleSyncRequest.__wrapped__()
+            # Promote the response before the next request so the test models
+            # a device that accepted each page.  In production that promotion
+            # occurs when the next request presents this returned token.
+            if physical_device and response.status_code == 200:
+                pending = kobo_sync_status.get_pending_sync_page(device.id)
+                if pending is not None:
+                    assert kobo._acknowledge_pending_page(pending, device.id)
+                    session.commit()
+            return response
+
+    try:
+        yield SimpleNamespace(
+            books=books,
+            device=device,
+            session=session,
+            states=[state for state, _clock in states],
+            sync=sync,
+            token_header=kobo.SyncToken.SyncToken.SYNC_TOKEN_HEADER,
+            uuid_to_id={str(book.uuid): book.id for book in books},
+            user=user,
+        )
+    finally:
+        session.close()
+        engine.dispose()
+
+
+def test_factory_reset_sync_delivers_every_reading_state_exactly_once(
+    reading_state_sync,
+):
+    """The embedded page-one maximum cannot close over the last 50 states."""
+    from cps import kobo
+
+    harness = reading_state_sync
+    delivered = []
+    pages = []
+    entitlement_pages = []
+    token = None
+
+    for _request_number in range(1, 7):
+        # The no-device fallback keeps this regression focused on the cursor
+        # carried by the real handler response; it still takes the exact
+        # KoboSyncedBooks-empty factory-reset branch on the first request.
+        response = harness.sync(token, physical_device=False)
+        page_states = _state_book_ids(response, harness.uuid_to_id)
+        pages.append(page_states)
+        entitlement_pages.append(_entitlement_book_ids(response))
+        delivered.extend(page_states)
+        token = response.headers[harness.token_header]
+        if not page_states and _entitlement_count(response) == 0:
+            break
+    else:
+        pytest.fail("factory-reset sync did not drain within six requests")
+
+    counts = Counter(delivered)
+    assert len(entitlement_pages[0]) == kobo.SYNC_ITEM_LIMIT
+    assert harness.books[0].id in entitlement_pages[0], (
+        "the newest reading state must belong to a book on entitlement page one"
+    )
+    stored_ids = {state.book_id for state in harness.states}
+    missing = stored_ids - counts.keys()
+    duplicates = {book_id: count for book_id, count in counts.items() if count != 1}
+    assert not missing and not duplicates, (
+        f"every stored state must be delivered exactly once; lost={len(missing)} "
+        f"missing_ids={sorted(missing)} duplicate_counts={duplicates} "
+        f"pages={[page[:5] + page[-5:] for page in pages]}"
+    )
+
+    final_cursor = kobo.SyncToken.SyncToken.from_headers({
+        harness.token_header: token,
+    }).reading_state_last_modified
+    max_delivered = max(
+        state.last_modified for state in harness.states
+        if state.book_id in counts
+    )
+    assert final_cursor == max_delivered
+
+
+def test_full_standalone_page_advances_cursor_instead_of_stalling(
+    reading_state_sync,
+):
+    """A terminal response persists the full page's own maximum timestamp."""
+    from cps import kobo, ub
+
+    harness = reading_state_sync
+    # Avoid the factory-reset cursor rewrite and suppress the entitlement path;
+    # this isolates two consecutive full standalone reading-state pages.
+    harness.session.add(ub.KoboSyncedBooks(
+        user_id=harness.user.id,
+        book_id=harness.books[0].id,
+        book_uuid=str(harness.books[0].uuid),
+    ))
+    harness.session.commit()
+    initial = kobo.SyncToken.SyncToken(
+        books_last_created=max(book.timestamp for book in harness.books),
+        books_last_modified=max(book.last_modified for book in harness.books),
+        books_last_id=harness.books[-1].id,
+    ).build_sync_token()
+
+    first = harness.sync(initial, physical_device=False)
+    first_token = first.headers[harness.token_header]
+    first_cursor = kobo.SyncToken.SyncToken.from_headers({
+        harness.token_header: first_token,
+    }).reading_state_last_modified
+    second = harness.sync(first_token, physical_device=False)
+    second_cursor = kobo.SyncToken.SyncToken.from_headers({
+        harness.token_header: second.headers[harness.token_header],
+    }).reading_state_last_modified
+
+    assert len(_state_book_ids(first, harness.uuid_to_id)) == kobo.SYNC_ITEM_LIMIT
+    assert len(_state_book_ids(second, harness.uuid_to_id)) == kobo.SYNC_ITEM_LIMIT
+    assert datetime.min < first_cursor < second_cursor

--- a/tests/unit/test_kobo_cont_sync_batch_cap.py
+++ b/tests/unit/test_kobo_cont_sync_batch_cap.py
@@ -97,9 +97,10 @@ def test_reading_states_stay_page_capped_without_continuation_writer():
     """A full reading-state page must also let its returned cursor persist."""
     source = _handle_sync_request_source()
     assert (
-        "for kobo_reading_state in "
-        "changed_reading_states.limit(SYNC_ITEM_LIMIT).all():"
+        "reading_state_page = "
+        "changed_reading_states.limit(SYNC_ITEM_LIMIT).all()"
     ) in source
+    assert "for kobo_reading_state in reading_state_page:" in source
     assert "cont_sync |= bool(changed_reading_states" not in source
     assert "cont_sync = bool(changed_reading_states" not in source
 


### PR DESCRIPTION
Fixes F-8cb0c9: an out-of-order recent reading state embedded in a page-one entitlement advanced the timestamp-only reading-state cursor past older states that had not fit in the standalone page, so those states were never delivered (measured red: 250 stored states, 200 delivered, 50 lost).

The sync handler now establishes one oldest-first reading-state page before rendering entitlements. A state may be embedded only when it belongs to that page; every other row in the page is emitted standalone; the cursor advances only to the page's maximum. Embedded and standalone delivery share the frontier, so nothing is skipped and nothing is re-emitted.

- Red→green regression: `tests/unit/test_f8cb0c9_kobo_reading_state_cursor.py` (250-state exact-once drain; consecutive full pages still progress).
- `test_1925…suppressed_entitlement…` reworked: the suppressed book's newer state now waits for the next ordered page instead of jumping the cursor; still delivered exactly once, no loop.
- Full unit suite: 8,118 passed, 111 skipped (Sol, OBSERVED). No physical-Kobo run (ASSUMED wire behaviour per existing firmware-shaped tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016HTQrgFiyGnVJU2MxXTkJ2