### PR TITLE
fix(kobo): honor expired page acknowledgments (F-802720)

### DIFF
--- a/changelog.d/f802720-kobo-idle-page-ack.md
+++ b/changelog.d/f802720-kobo-idle-page-ack.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- **Kobo sync confirmations survive long periods offline.** Returning after
+  more than seven days now records the final page as delivered instead of
+  sending its books again and risking a Nickel re-download.

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -717,14 +717,37 @@ def HandleSyncRequest():
     sync_token = SyncToken.SyncToken.from_headers(request.headers)
     sync_cursor_in = _sync_cursor_summary(sync_token)
     requesting_device_id = getattr(g, "annotation_origin_device_id", None)
-    pruned_pending_pages = kobo_sync_status.prune_expired_pending_sync_pages(
-        current_user.id,
-    )
-    if pruned_pending_pages and ub.session_commit() is False:
-        return abort(503)
     pending_page = kobo_sync_status.get_pending_sync_page(
         requesting_device_id,
     )
+    acknowledged_pending_page = False
+    if (pending_page is not None
+            and raw_sync_token == pending_page.outgoing_token):
+        # TTL is a garbage-collection bound, not a validity window for direct
+        # token evidence. A Kobo may accept its final page and then stay idle
+        # beyond the TTL, so promote that returned-token acknowledgment before
+        # expiry can discard the page's confirmation payload (F-802720).
+        if not _acknowledge_pending_page(
+            pending_page, requesting_device_id,
+        ):
+            return abort(503)
+        acknowledged_pending_page = True
+        pending_page = None
+
+    pruned_pending_pages = kobo_sync_status.prune_expired_pending_sync_pages(
+        current_user.id,
+    )
+    # Keep a successful acknowledgment in the caller-owned transaction: it
+    # must commit atomically with the replacement page at the response boundary.
+    if (pruned_pending_pages
+            and not acknowledged_pending_page
+            and ub.session_commit() is False):
+        return abort(503)
+    if not acknowledged_pending_page:
+        # Pruning may have removed the row loaded for the pre-prune ack lookup.
+        pending_page = kobo_sync_status.get_pending_sync_page(
+            requesting_device_id,
+        )
     if pending_page is not None:
         if pending_page.incoming_token_hash == _sync_token_hash(raw_sync_token):
             replay = _pending_response(pending_page)
@@ -735,12 +758,7 @@ def HandleSyncRequest():
                 requesting_device_id,
             )
             return replay
-        if raw_sync_token == pending_page.outgoing_token:
-            if not _acknowledge_pending_page(
-                pending_page, requesting_device_id,
-            ):
-                return abort(503)
-        elif not sync_token.is_cwng_token:
+        if not sync_token.is_cwng_token:
             # An official-store/malformed token is a reset boundary.  The old
             # response remains unconfirmed, but it must not block a fresh
             # device from starting a new serial page chain.

--- a/tests/unit/test_1925_kobo_sync_dedownload.py
+++ b/tests/unit/test_1925_kobo_sync_dedownload.py
@@ -393,9 +393,56 @@ def test_interrupted_sync_token_loss_does_not_redeliver_unchanged_entitlement(
     assert "cursors in=" in summaries[-1] and " out=" in summaries[-1]
 
 
-def test_expired_pending_page_is_pruned_before_same_token_rebuild(sync_harness):
-    """An abandoned response body expires without confirming its delivery."""
-    from cps import kobo_sync_status, ub
+def test_expired_pending_page_ack_is_honoured_before_ttl_prune(
+    sync_harness, monkeypatch,
+):
+    """An idle Kobo's returned token remains authoritative after the TTL."""
+    from cps import kobo, kobo_sync_status, ub
+
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+
+    first = sync_harness.sync(acknowledge=False)
+    pending = sync_harness.session.query(
+        ub.KoboDevicePendingSyncPage,
+    ).filter_by(device_id=sync_harness.device.id).one()
+    outgoing_token = pending.outgoing_token
+    pending.created_at = (
+        datetime.now(timezone.utc)
+        - kobo_sync_status.PENDING_SYNC_PAGE_TTL
+        - timedelta(seconds=1)
+    )
+    sync_harness.session.commit()
+
+    acknowledged = sync_harness.sync(
+        outgoing_token,
+        acknowledge=False,
+    )
+
+    assert len(_entitlements(first)) == 1
+    assert _entitlements(acknowledged) == [], (
+        "the final page must not be re-emitted after its returned token "
+        "acknowledges delivery"
+    )
+    ledger = sync_harness.session.query(
+        ub.KoboDeviceBookEntitlement,
+    ).filter_by(
+        device_id=sync_harness.device.id,
+        book_id=sync_harness.book.id,
+    ).one()
+    assert ledger.fingerprint
+    assert sync_harness.session.query(ub.KoboSyncedBooks).filter_by(
+        user_id=sync_harness.user.id,
+        book_id=sync_harness.book.id,
+    ).count() == 1
+
+
+def test_expired_orphan_pending_page_is_pruned_after_device_moves_on(
+    sync_harness,
+):
+    """A never-acknowledged page expires when the Kobo presents another token."""
+    from cps import kobo, kobo_sync_status, ub
 
     first = sync_harness.sync(acknowledge=False)
     pending = sync_harness.session.query(
@@ -409,7 +456,11 @@ def test_expired_pending_page_is_pruned_before_same_token_rebuild(sync_harness):
     pending.created_at = expired_at
     sync_harness.session.commit()
 
-    rebuilt = sync_harness.sync(acknowledge=False)
+    moved_on_token = kobo.SyncToken.SyncToken(
+        books_last_id=sync_harness.book.id + 100,
+    ).build_sync_token()
+    assert moved_on_token != pending.outgoing_token
+    rebuilt = sync_harness.sync(moved_on_token, acknowledge=False)
     replacement = sync_harness.session.query(
         ub.KoboDevicePendingSyncPage,
     ).filter_by(device_id=sync_harness.device.id).one()


### PR DESCRIPTION
Fixes F-802720: HandleSyncRequest pruned pending sync pages past the 7-day TTL before looking up the page the incoming token acknowledges, so a Kobo idle for more than a week lost the ack of its session's final page: no ledger fingerprint, no KoboSyncedBooks marker, byte-identical re-emission of the page (the Nickel de-download trigger #1925 fixed), and possible re-entry into the empty-ledger full reset.

Invariant adopted: a returned outgoing token is direct delivery evidence regardless of page age; the TTL is a storage bound, not a validity window. The exact-token acknowledgment is now promoted before pruning, staged in the request transaction so it commits atomically with the replacement page. Pages nobody acknowledges still expire in the existing bounded batches once the device presents a different token.

- Red→green in `tests/unit/test_1925_kobo_sync_dedownload.py`: stage a final page, age it past the TTL, present its outgoing token. Pre-fix: NewEntitlement re-emitted, ledger empty. Post-fix: no re-emission, fingerprint + delivery marker recorded. Separate test proves an orphan page is still pruned and replaced.
- Focused Kobo suite 85 passed; full unit suite 8,156 passed, 111 skipped (Sol, OBSERVED). No physical-Kobo run (ASSUMED that preserved ledger evidence keeps replay suppression effective, per #1925).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016HTQrgFiyGnVJU2MxXTkJ2