### PR TITLE
fix(kosync): arbitrate Kobo bookmark mirrors (F-6f9187)

### DIFF
--- a/changelog.d/f-6f9187-kosync-bookmark-arbitration.md
+++ b/changelog.d/f-6f9187-kosync-bookmark-arbitration.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- **KOReader sync no longer moves a Kobo back to an earlier page.** Progress
+  shared between the two readers now preserves the furthest portable position,
+  including on a KOReader device's deliberate rewind.

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -2637,9 +2637,6 @@ def HandleStateRequest(book_uuid):
                 )
 
                 stored_progress = current_bookmark.progress_percent
-                incoming_is_newer = device_positions.timestamp_is_newer(
-                    request_lm, current_bookmark.last_modified,
-                )
                 cover_reset_suppressed = bool(
                     rehydrate_pending
                     and incoming_progress is not None
@@ -2648,14 +2645,13 @@ def HandleStateRequest(book_uuid):
                     and incoming_progress
                     <= KOB0_COVER_RESET_PROGRESS_EPSILON
                 )
-                resolved_bookmark_accepted = not cover_reset_suppressed and (
-                    incoming_is_newer
-                    or (
-                        incoming_progress is not None
-                        and (
-                            stored_progress is None
-                            or incoming_progress >= stored_progress
-                        )
+                resolved_bookmark_accepted = (
+                    not cover_reset_suppressed
+                    and device_positions.resolved_position_accepts(
+                        incoming_progress=incoming_progress,
+                        stored_progress=stored_progress,
+                        incoming_clock=request_lm,
+                        stored_clock=current_bookmark.last_modified,
                     )
                 )
                 if resolved_bookmark_accepted:

--- a/cps/progress_syncing/protocols/kosync.py
+++ b/cps/progress_syncing/protocols/kosync.py
@@ -45,7 +45,8 @@ from typing import Dict, Optional, Any, Tuple
 from urllib.parse import quote
 
 from ...services import SyncToken as SyncToken, hardcover
-from ...services import device_capabilities, device_delivery
+from ...services import (device_capabilities, device_delivery,
+                         device_reading_position as device_positions)
 from ...kobo import push_reading_state_to_hardcover
 
 from flask import Blueprint, request, jsonify, send_from_directory
@@ -583,12 +584,10 @@ def update_book_read_status(user, book_id: int, percentage: float) -> None:
 
         book_read.last_modified = datetime.now(timezone.utc)
 
-        # Keep the independent book-detail/UI carrier in lockstep with the
-        # accepted KOSync position, including legacy ReadBook rows that have no
-        # KoboReadingState yet (#627).
+        # Complete the independent book-detail/UI carrier, including legacy
+        # ReadBook rows that have no KoboReadingState yet (#627). Its position
+        # is resolved below after both ReadBook branches converge.
         bookmark = _ensure_visible_reading_state(book_read, user_id, book_id)
-        bookmark.progress_percent = percentage
-        bookmark.last_modified = datetime.now(timezone.utc)
 
     else:
         # Create new ReadBook record
@@ -610,11 +609,33 @@ def update_book_read_status(user, book_id: int, percentage: float) -> None:
         # Create the same complete visible state graph as the existing-row
         # path. Keeping one constructor prevents the two branches drifting.
         bookmark = _ensure_visible_reading_state(book_read, user_id, book_id)
-        bookmark.progress_percent = percentage
 
         ub.session.add(book_read)
         log.info(f"User {user_id} book {book_id} created with status {new_status} "
                 f"(progress: {percentage:.1f}%)")
+
+    # KOSync and KoboBookmark are independent carriers. Reuse the resolved
+    # bookmark's clock/furthest arbiter rather than assuming that acceptance by
+    # KOSync also permits this cross-carrier write. KOReader supplies no
+    # trustworthy source observation clock; its row timestamp is server receipt
+    # time. Passing no incoming clock therefore selects the arbiter's furthest
+    # leg: an honest forward position crosses to Kobo, while a same-device
+    # rewind remains valid in KOSync but cannot drag the Kobo-visible frontier
+    # backwards. An explicit mark-unread/reset remains the action that clears
+    # every carrier for a deliberate restart.
+    stored_percentage = bookmark.progress_percent
+    if device_positions.resolved_position_accepts(
+        incoming_progress=percentage,
+        stored_progress=stored_percentage,
+    ):
+        bookmark.progress_percent = percentage
+        bookmark.last_modified = datetime.now(timezone.utc)
+    else:
+        log.info(
+            "Preserved furthest Kobo bookmark during KOSync mirror: "
+            "user=%s, book=%s, incoming=%.2f%%, stored=%.2f%%",
+            user_id, book_id, percentage, stored_percentage,
+        )
 
     # Merge the record (caller commits)
     ub.session.merge(book_read)

--- a/cps/services/device_reading_position.py
+++ b/cps/services/device_reading_position.py
@@ -45,6 +45,27 @@ def timestamp_is_newer(candidate, current):
     return candidate > current
 
 
+def resolved_position_accepts(
+    *, incoming_progress, stored_progress, incoming_clock=None, stored_clock=None
+):
+    """Apply the resolved-carrier clock/furthest arbitration policy.
+
+    A source observation replaces the resolved bookmark when its trustworthy
+    source clock is newer, or when its portable percentage is equal/further.
+    Callers without a comparable source clock pass ``None`` and therefore use
+    the furthest leg only. In particular, a KOSync receipt timestamp is a
+    server clock, not the KOReader observation clock, so it must not authorize
+    a cross-carrier rewind merely because the request arrived later.
+    """
+    return timestamp_is_newer(incoming_clock, stored_clock) or (
+        incoming_progress is not None
+        and (
+            stored_progress is None
+            or incoming_progress >= stored_progress
+        )
+    )
+
+
 def stage_position(
     *,
     device_id,

--- a/tests/unit/test_f6f9187_kosync_bookmark_mirror_arbitration.py
+++ b/tests/unit/test_f6f9187_kosync_bookmark_mirror_arbitration.py
@@ -1,0 +1,156 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""F-6f9187 — KOSync must not regress the Kobo-visible bookmark.
+
+The KOSync row and ``KoboBookmark`` are separate position carriers. A KOReader
+push is first arbitrated against the KOSync row, then mirrored onto the bookmark
+that the Kobo sync feed serves. The second write needs its own invocation of the
+shared resolved-position arbiter: an accepted KOSync position is not necessarily
+allowed to replace a further position learned from another carrier.
+
+Pinned here:
+  * a first low KOReader push cannot erase a pre-bridge Kobo position;
+  * a same-device rewind remains accepted by KOSync but stays device-local;
+  * genuinely further KOReader progress still reaches the Kobo carrier.
+"""
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from cps import calibre_db, ub
+from cps.progress_syncing.models import AppBase, KOSyncProgress
+
+USER_ID = 3
+BOOK_ID = 1031
+DEVICE_ID = "tablet-device-id"
+
+
+def _kosync_module():
+    import cps.progress_syncing.protocols.kosync  # noqa: F401
+    return sys.modules["cps.progress_syncing.protocols.kosync"]
+
+
+@pytest.fixture
+def progress_api(monkeypatch):
+    module = _kosync_module()
+    engine = create_engine("sqlite:///:memory:")
+    ub.Base.metadata.create_all(engine)
+    AppBase.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+
+    user = SimpleNamespace(id=USER_ID, name="PocketBook")
+    monkeypatch.setattr(ub, "session", session)
+    monkeypatch.setattr(module, "is_koreader_sync_enabled", lambda: True)
+    monkeypatch.setattr(module, "authenticate_user", lambda: user)
+    monkeypatch.setattr(module, "get_book_checksums", lambda _book_id: [])
+    monkeypatch.setattr(module, "push_reading_state_to_hardcover", lambda *_args: None)
+    monkeypatch.setattr(calibre_db, "get_book", lambda _book_id: SimpleNamespace())
+    monkeypatch.setattr(module.config, "config_read_column", 0, raising=False)
+    monkeypatch.setattr(
+        module,
+        "enrich_response_with_book_info",
+        lambda response, _document: (
+            {**response, "calibre_book_id": BOOK_ID},
+            BOOK_ID,
+            "EPUB",
+            "Fixture",
+            "filename",
+        ),
+    )
+
+    app = Flask(__name__)
+    app.register_blueprint(module.kosync)
+    yield SimpleNamespace(module=module, client=app.test_client(), session=session)
+
+    session.close()
+    engine.dispose()
+
+
+def _seed_visible_progress(session, percentage):
+    book_read = ub.ReadBook(
+        user_id=USER_ID,
+        book_id=BOOK_ID,
+        read_status=ub.ReadBook.STATUS_IN_PROGRESS,
+    )
+    state = ub.KoboReadingState(user_id=USER_ID, book_id=BOOK_ID)
+    state.current_bookmark = ub.KoboBookmark(progress_percent=percentage)
+    state.statistics = ub.KoboStatistics()
+    book_read.kobo_reading_state = state
+    session.add(book_read)
+    session.commit()
+
+
+def _push(progress_api, percentage, *, device_id=DEVICE_ID):
+    response = progress_api.client.put(
+        "/kosync/syncs/progress",
+        json={
+            "document": "filename-digest-for-book-1031",
+            "progress": "cre://fixture-position",
+            "percentage": percentage / 100.0,
+            "device": "PocketBook",
+            "device_id": device_id,
+        },
+    )
+    assert response.status_code == 200
+    progress_api.session.expire_all()
+
+
+def _visible_percentage(session):
+    state = session.query(ub.KoboReadingState).filter_by(
+        user_id=USER_ID,
+        book_id=BOOK_ID,
+    ).one()
+    return state.current_bookmark.progress_percent
+
+
+@pytest.mark.unit
+def test_first_low_koreader_push_does_not_regress_existing_kobo_bookmark(
+    progress_api,
+):
+    """No KOSync row exists, but the Kobo carrier already holds 70%."""
+    _seed_visible_progress(progress_api.session, 70.0)
+
+    _push(progress_api, 5.0)
+
+    assert progress_api.session.query(KOSyncProgress).one().percentage == pytest.approx(5.0)
+    assert _visible_percentage(progress_api.session) == pytest.approx(70.0)
+
+
+@pytest.mark.unit
+def test_same_device_koreader_rewind_stays_local_to_kosync(progress_api):
+    """The device owns its KOSync locator, not the cross-carrier frontier."""
+    _seed_visible_progress(progress_api.session, 70.0)
+    progress_api.session.add(KOSyncProgress(
+        user_id=USER_ID,
+        document=str(BOOK_ID),
+        progress="cre://further-position",
+        percentage=70.0,
+        device="PocketBook",
+        device_id=DEVICE_ID,
+    ))
+    progress_api.session.commit()
+
+    _push(progress_api, 20.0)
+
+    stored = progress_api.session.query(KOSyncProgress).one()
+    assert stored.percentage == pytest.approx(20.0), "same-device rewind remains accepted"
+    assert _visible_percentage(progress_api.session) == pytest.approx(70.0)
+
+
+@pytest.mark.unit
+def test_further_koreader_push_still_advances_kobo_bookmark(progress_api):
+    _seed_visible_progress(progress_api.session, 70.0)
+
+    _push(progress_api, 85.0)
+
+    assert progress_api.session.query(KOSyncProgress).one().percentage == pytest.approx(85.0)
+    assert _visible_percentage(progress_api.session) == pytest.approx(85.0)


### PR DESCRIPTION
Fixes F-6f9187: `update_book_read_status` mirrored the accepted KOReader percentage onto `KoboBookmark` unconditionally. With no KOSyncProgress row for a book the Kobo was deep into, or on a same-device KOReader rewind, the mirror dragged the Kobo-visible bookmark backwards, `before_flush` stamped the parent reading state newer, and the next Kobo sync delivered the regressed position.

The Kobo PUT path's existing clock-or-furthest decision is centralised as `resolved_position_accepts()` in `cps/services/device_reading_position.py`; both the Kobo PUT and the KOSync→Kobo mirror now call it. KOReader supplies no trustworthy source clock (its row timestamp is server receipt time), so the mirror passes no clock and uses the furthest leg only: a genuinely further KOReader position still crosses to Kobo; a same-device rewind stays valid on the KOSync row but no longer moves the Kobo carrier back. Mark-unread/reset remains the deliberate restart path.

- Red→green in `tests/unit/test_f6f9187_kosync_bookmark_mirror_arbitration.py`: no-row 70%→5% push (pre-fix bookmark 5.0, now 70.0); same-device rewind 70%→20% (KOSync row 20.0, bookmark stays 70.0); forward 70%→85% passes before and after.
- Kobo backward-jump-with-newer-clock and #627 visible-progress tests still pass; full unit suite 8,158 passed, 111 skipped (Sol, OBSERVED).
- Left out on purpose: F-b521d3, F-fe2b1c, F-2ff8ac (distinct writers/races).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016HTQrgFiyGnVJU2MxXTkJ2