### PR TITLE
feat: sort configured custom columns across New UI filters

### DIFF
--- a/changelog.d/2115.md
+++ b/changelog.d/2115.md
@@ -1,0 +1,3 @@
+### Added
+
+- **Configured numeric and date custom columns can sort compatible catalog, search, and table views.** Administrators choose the supported columns once, and unavailable values remain at the end of each list.

--- a/cps/api/account.py
+++ b/cps/api/account.py
@@ -24,6 +24,7 @@ from ..ui_themes import ALLOWED_THEME_SLUGS, theme_slug, theme_code
 from ..user_preferences import (NAMED_BOOLEAN_PREFERENCE_PATHS,
                                 serialize_named_preferences,
                                 set_named_preferences)
+from ..custom_column_sort import load_configured_columns
 from .serializers import (SIDEBAR_VISIBILITY_BITS, ORDERABLE_SIDEBAR_KEYS,
                           serialize_sidebar_visibility, serialize_sidebar_order)
 
@@ -433,3 +434,29 @@ def update_named_preferences():
         return _err("db_error", "Could not save preferences: %s" % ex, 500)
 
     return jsonify({"preferences": serialize_named_preferences(current_user)})
+
+
+@api_v1.route("/account/catalog-custom-fields", methods=["POST"])
+def update_catalog_custom_fields():
+    """Persist the signed-in reader's selected grid/table custom fields."""
+    guard = _require_real_user()
+    if guard:
+        return guard
+    data = request.get_json(silent=True) or {}
+    selected = data.get("custom_column_ids")
+    if (not isinstance(selected, list)
+            or any(type(column_id) is not int for column_id in selected)):
+        return _err("invalid_request", "custom_column_ids must be an array of integers", 400)
+    columns = load_configured_columns(config)
+    if columns is None:
+        return _err("unavailable", "Custom columns are currently unavailable", 503)
+    allowed = {column.id for column in columns}
+    if any(column_id not in allowed for column_id in selected):
+        return _err("invalid_request", "Unknown custom column", 400)
+    try:
+        current_user.set_view_property("catalog", "custom_field_ids", selected, commit=False)
+        ub.session.commit()
+    except Exception as ex:
+        ub.session.rollback()
+        return _err("db_error", "Could not save custom fields: %s" % ex, 500)
+    return jsonify({"custom_field_ids": selected})

--- a/cps/api/account.py
+++ b/cps/api/account.py
@@ -444,19 +444,37 @@ def update_catalog_custom_fields():
         return guard
     data = request.get_json(silent=True) or {}
     selected = data.get("custom_column_ids")
+    labels = data.get("custom_column_labels", {})
     if (not isinstance(selected, list)
             or any(type(column_id) is not int for column_id in selected)):
         return _err("invalid_request", "custom_column_ids must be an array of integers", 400)
+    if not isinstance(labels, dict):
+        return _err("invalid_request", "custom_column_labels must be an object", 400)
     columns = load_configured_columns(config)
     if columns is None:
         return _err("unavailable", "Custom columns are currently unavailable", 503)
     allowed = {column.id for column in columns}
     if any(column_id not in allowed for column_id in selected):
         return _err("invalid_request", "Unknown custom column", 400)
+    cleaned_labels = {}
+    for raw_id, raw_label in labels.items():
+        try:
+            column_id = int(raw_id)
+        except (TypeError, ValueError):
+            return _err("invalid_request", "Invalid custom column label", 400)
+        if (str(column_id) != str(raw_id) or column_id not in allowed
+                or not isinstance(raw_label, str)):
+            return _err("invalid_request", "Invalid custom column label", 400)
+        label = raw_label.strip()
+        if len(label) > 80:
+            return _err("invalid_request", "Custom column labels may not exceed 80 characters", 400)
+        if label:
+            cleaned_labels[str(column_id)] = label
     try:
         current_user.set_view_property("catalog", "custom_field_ids", selected, commit=False)
+        current_user.set_view_property("catalog", "custom_field_labels", cleaned_labels, commit=False)
         ub.session.commit()
     except Exception as ex:
         ub.session.rollback()
         return _err("db_error", "Could not save custom fields: %s" % ex, 500)
-    return jsonify({"custom_field_ids": selected})
+    return jsonify({"custom_field_ids": selected, "custom_field_labels": cleaned_labels})

--- a/cps/api/auth.py
+++ b/cps/api/auth.py
@@ -236,11 +236,16 @@ def _me_payload(user):
     catalog_settings = (getattr(user, "view_settings", None) or {}).get("catalog", {})
     default_filter = catalog_settings.get("default_filter") if isinstance(catalog_settings, dict) else None
     custom_field_ids = catalog_settings.get("custom_field_ids") if isinstance(catalog_settings, dict) else None
+    custom_field_labels = catalog_settings.get("custom_field_labels") if isinstance(catalog_settings, dict) else None
     payload["catalog"] = {
         "default_filter": default_filter if isinstance(default_filter, dict) else None,
         "custom_field_ids": (custom_field_ids if isinstance(custom_field_ids, list)
                              and all(type(column_id) is int for column_id in custom_field_ids)
                              else None),
+        "custom_field_labels": (custom_field_labels if isinstance(custom_field_labels, dict)
+                                and all(type(key) is str and type(value) is str
+                                        for key, value in custom_field_labels.items())
+                                else None),
     }
     payload["display"] = {
         # Some auth tests and bootstrap paths intentionally provide a minimal

--- a/cps/api/auth.py
+++ b/cps/api/auth.py
@@ -235,8 +235,12 @@ def _me_payload(user):
     payload["avatar"] = _user_avatar(user.name)
     catalog_settings = (getattr(user, "view_settings", None) or {}).get("catalog", {})
     default_filter = catalog_settings.get("default_filter") if isinstance(catalog_settings, dict) else None
+    custom_field_ids = catalog_settings.get("custom_field_ids") if isinstance(catalog_settings, dict) else None
     payload["catalog"] = {
         "default_filter": default_filter if isinstance(default_filter, dict) else None,
+        "custom_field_ids": (custom_field_ids if isinstance(custom_field_ids, list)
+                             and all(type(column_id) is int for column_id in custom_field_ids)
+                             else None),
     }
     payload["display"] = {
         # Some auth tests and bootstrap paths intentionally provide a minimal

--- a/cps/api/books.py
+++ b/cps/api/books.py
@@ -84,8 +84,33 @@ _COMPATIBLE_BOOK_SORTS = frozenset(set(SORT_MAP) - {"hotasc", "hotdesc"})
 
 
 def _sort_context(requested_sort):
-    """Return validated metadata-db ordering and UI custom-sort options."""
-    columns = calibre_db.session.query(db.CustomColumns).all()
+    """Return validated metadata-db ordering and UI custom-sort options.
+
+    A list request is also valid while no Calibre library session exists (for
+    example, a fresh install). Do not turn that recoverable state into a 500.
+    """
+    effective = requested_sort if requested_sort in _COMPATIBLE_BOOK_SORTS else "new"
+    session = calibre_db.session
+    if session is None:
+        return {
+            "sort": effective,
+            "order": book_sort_order(effective),
+            "join": (),
+            "custom_sort_options": [],
+        }
+
+    # No configured custom sort can be selected, displayed, or resolved. Avoid
+    # a metadata query on the overwhelmingly common built-in-sort path.
+    configured = getattr(config, "config_sortable_custom_columns", "") or ""
+    if not configured:
+        return {
+            "sort": effective,
+            "order": book_sort_order(effective),
+            "join": (),
+            "custom_sort_options": [],
+        }
+
+    columns = session.query(db.CustomColumns).all()
     custom = resolve_custom_column_sort(requested_sort, config, columns)
     effective = requested_sort if custom is not None or requested_sort in _COMPATIBLE_BOOK_SORTS else "new"
     return {

--- a/cps/api/books.py
+++ b/cps/api/books.py
@@ -20,7 +20,9 @@ from ..services import user_cover
 from ..helper import edit_book_read_status, book_in_progress_ids, book_is_in_progress, \
     get_convert_options, get_kosync_progress_display, \
     SQLITE_IN_CHUNK_SIZE as _SQLITE_IN_CHUNK
-from ..sort_orders import BOOK_SORT_ORDERS
+from ..sort_orders import BOOK_SORT_ORDERS, book_sort_order
+from ..custom_column_sort import (resolve as resolve_custom_column_sort, sortable_columns,
+                                  load_configured_columns)
 from ..usermanagement import login_required_if_no_ano
 
 log = logger.create()
@@ -76,6 +78,36 @@ def _original_filename(book_id):
 # read-only API endpoint. Only the ORDER BY is common, and it lives in one place
 # so a sort cannot be correct in one UI and wrong in the other (fork #1331).
 SORT_MAP = BOOK_SORT_ORDERS
+# Download-count ordering runs against app.db and is intentionally unavailable
+# to the metadata.db-backed generic list/filter queries below.
+_COMPATIBLE_BOOK_SORTS = frozenset(set(SORT_MAP) - {"hotasc", "hotdesc"})
+
+
+def _sort_context(requested_sort):
+    """Return validated metadata-db ordering and UI custom-sort options."""
+    columns = calibre_db.session.query(db.CustomColumns).all()
+    custom = resolve_custom_column_sort(requested_sort, config, columns)
+    effective = requested_sort if custom is not None or requested_sort in _COMPATIBLE_BOOK_SORTS else "new"
+    return {
+        "sort": effective,
+        "order": custom[1] if custom is not None else book_sort_order(effective),
+        "join": (custom[0], db.Books.id == custom[0].book) if custom else (),
+        "custom_sort_options": [
+            option for column in sortable_columns(columns, config) for option in (
+                {"value": f"cc-{column.id}-asc", "label": f"{column.name}, low to high"},
+                {"value": f"cc-{column.id}-desc", "label": f"{column.name}, high to low"},
+            )
+        ],
+    }
+
+
+def _with_sort(payload, context):
+    # Definitions belong to the page, not every book. Keep them alongside the
+    # sort metadata so every /books collection variant has the same contract.
+    definitions, _values = _list_custom_column_data([])
+    payload.update(sort=context["sort"], custom_sort_options=context["custom_sort_options"],
+                   custom_column_definitions=definitions)
+    return payload
 
 
 def _real_user_id():
@@ -127,7 +159,44 @@ def _row_read_status(e):
     return getattr(e, "read_status", None)
 
 
-def _row_to_item(e, in_progress_ids, hidden_ids=None, cover_override=None):
+def _list_custom_column_data(entries):
+    """Return selected custom-field definitions and values for one list page.
+
+    Custom-sort configuration is the display allowlist: it contains only live,
+    scalar int/float/datetime fields. Query each selected column once for the
+    page rather than touching a relationship on every book (the latter becomes
+    an N+1 query on a large grid).
+    """
+    try:
+        columns = load_configured_columns(config) or []
+        book_ids = [int(getattr(entry, "Books", entry).id) for entry in entries]
+        values = {book_id: {} for book_id in book_ids}
+        for column in columns:
+            model = db.cc_classes.get(column.id)
+            if model is None or not book_ids:
+                continue
+            rows = (calibre_db.session.query(model)
+                    .filter(model.book.in_(book_ids)).all())
+            for row in rows:
+                value = getattr(row, "value", None)
+                if hasattr(value, "isoformat"):
+                    value = value.isoformat()
+                values.setdefault(int(row.book), {})[str(column.id)] = [{
+                    "value": value,
+                    "extra": getattr(row, "extra", None),
+                }]
+        definitions = [{
+            "id": column.id,
+            "name": column.name,
+            "datatype": column.datatype,
+        } for column in columns]
+        return definitions, values
+    except (SQLAlchemyError, AttributeError, KeyError, TypeError):
+        log.warning("Custom-column list data unavailable", exc_info=True)
+        return [], {}
+
+
+def _row_to_item(e, in_progress_ids, hidden_ids=None, cover_override=None, custom_columns=None):
     """Unwrap a SQLAlchemy Row (Books, is_archived, read_status) or plain Books object."""
     book = getattr(e, "Books", e)
     read_status = _row_read_status(e)
@@ -147,12 +216,15 @@ def _row_to_item(e, in_progress_ids, hidden_ids=None, cover_override=None):
         archived=archived,
         hidden=book.id in (hidden_ids or set()),
         cover_override=cover_override,
+        custom_columns=custom_columns,
     )
 
 
-def _rows_to_items(entries, hidden_ids=None):
+def _rows_to_items(entries, hidden_ids=None, custom_values=None):
     """Serialize one list page after resolving its in-progress ids in bulk."""
     entries = list(entries)
+    if custom_values is None:
+        _definitions, custom_values = _list_custom_column_data(entries)
     statuses = [
         (getattr(entry, "Books", entry).id, _row_read_status(entry))
         for entry in entries
@@ -166,6 +238,7 @@ def _rows_to_items(entries, hidden_ids=None):
         _row_to_item(
             entry, in_progress_ids, hidden_ids,
             cover_override=overrides.get(int(book.id)),
+            custom_columns=(custom_values or {}).get(int(book.id)),
         )
         for entry, book in zip(entries, books)
     ]
@@ -241,8 +314,9 @@ def _build_read_filter(filter_val):
 def list_books():
     page = request.args.get("page", 1, type=int)
     per_page = request.args.get("per_page", config.config_books_per_page, type=int)
-    sort = request.args.get("sort", "new")
-    order = SORT_MAP.get(sort, SORT_MAP["new"])
+    sort_context = _sort_context(request.args.get("sort", "new"))
+    order = sort_context["order"]
+    custom_join = sort_context["join"]
     search = request.args.get("search")
     show_hidden = (request.args.get("show_hidden", "").strip().lower()
                    in ("1", "true", "yes", "on"))
@@ -259,17 +333,18 @@ def list_books():
             db.books_series_link,
             db.Books.id == db.books_series_link.c.book,
             db.Series,
+            *custom_join,
         )
         entries, total, _pagination = calibre_db.get_search_results(
             search, config, offset, [order], per_page, *join,
             allow_show_hidden=show_hidden,
         )
-        return jsonify({
+        return jsonify(_with_sort({
             "items": to_items(entries),
             "page": page,
             "per_page": per_page,
             "total": total,
-        })
+        }, sort_context))
 
     # Entity filters
     author_id = request.args.get("author", type=int)
@@ -290,14 +365,14 @@ def list_books():
         series_join = (db.books_series_link, db.Books.id == db.books_series_link.c.book, db.Series)
         entries, _random, pagination = calibre_db.fill_indexpage_with_archived_books(
             page, db.Books, per_page, archived_filter, order,
-            True, True, config.config_read_column, *series_join,
+            True, True, config.config_read_column, *series_join, *custom_join,
         )
-        return jsonify({
+        return jsonify(_with_sort({
             "items": to_items(entries),
             "page": pagination.page,
             "per_page": pagination.per_page,
             "total": pagination.total_count,
-        })
+        }, sort_context))
 
     series_join = (db.books_series_link, db.Books.id == db.books_series_link.c.book, db.Series)
 
@@ -307,23 +382,24 @@ def list_books():
                    .filter(ub.FavoriteBook.user_id == int(current_user.id)).all())]
         entries, _random, pagination = calibre_db.fill_indexpage(
             page, per_page, db.Books, db.Books.id.in_(fav_ids), order,
-            True, config.config_read_column, *series_join)
-        return jsonify({"items": to_items(entries),
+            True, config.config_read_column, *series_join, *custom_join)
+        return jsonify(_with_sort({"items": to_items(entries),
                         "page": pagination.page, "per_page": pagination.per_page,
-                        "total": pagination.total_count})
+                        "total": pagination.total_count}, sort_context))
 
     if filter_val == "rated":
         # Top-rated: Calibre stores rating 0–10 (half-stars); >9 == 5 stars.
         rated_filter = db.Books.ratings.any(db.Ratings.rating > 9)
         entries, _random, pagination = calibre_db.fill_indexpage(
             page, per_page, db.Books, rated_filter, order,
-            True, config.config_read_column, *series_join)
-        return jsonify({"items": to_items(entries),
+            True, config.config_read_column, *series_join, *custom_join)
+        return jsonify(_with_sort({"items": to_items(entries),
                         "page": pagination.page, "per_page": pagination.per_page,
-                        "total": pagination.total_count})
+                        "total": pagination.total_count}, sort_context))
 
     if filter_val == "discover":
         # Random unread books (single page, like the legacy Discover view).
+        sort_context["sort"] = "new"
         if not config.config_read_column:
             disc_filter = coalesce(ub.ReadBook.read_status, 0) != ub.ReadBook.STATUS_FINISHED
         else:
@@ -335,10 +411,12 @@ def list_books():
             1, per_page, db.Books, disc_filter, [func.randomblob(2)],
             True, config.config_read_column)
         items = to_items(entries)
-        return jsonify({"items": items, "page": 1, "per_page": per_page, "total": len(items)})
+        return jsonify(_with_sort({"items": items, "page": 1, "per_page": per_page,
+                                  "total": len(items)}, sort_context))
 
     if filter_val == "hot":
         # Most-downloaded, paginated by the downloads table (mirrors render_hot_books).
+        sort_context["sort"] = "new"
         off = per_page * (page - 1)
         all_hot_ids = [row[0] for row in (ub.session.query(ub.Downloads.book_id)
                    .group_by(ub.Downloads.book_id)
@@ -354,8 +432,8 @@ def list_books():
             rows = q.filter(calibre_db.common_filters()).filter(db.Books.id.in_(hot_ids)).all()
             book_map = {r.Books.id: r for r in rows}
             entries = [book_map[i] for i in hot_ids if i in book_map]  # preserve hotness order
-        return jsonify({"items": to_items(entries),
-                        "page": page, "per_page": per_page, "total": total})
+        return jsonify(_with_sort({"items": to_items(entries),
+                        "page": page, "per_page": per_page, "total": total}, sort_context))
 
     # --- entity + read/unread path ---
     rating_id = request.args.get("rating", type=int)
@@ -391,15 +469,15 @@ def list_books():
         }
     entries, _random, pagination = calibre_db.fill_indexpage(
         page, per_page, db.Books, db_filter, order,
-        True, config.config_read_column, *series_join,
+        True, config.config_read_column, *series_join, *custom_join,
         **listing_options,
     )
-    return jsonify({
+    return jsonify(_with_sort({
         "items": to_items(entries),
         "page": pagination.page,
         "per_page": pagination.per_page,
         "total": pagination.total_count,
-    })
+    }, sort_context))
 
 
 @api_v1.route("/library/global")
@@ -419,8 +497,9 @@ def list_global_library():
     per_page = max(1, min(200, request.args.get(
         "per_page", config.config_books_per_page, type=int
     )))
-    sort = request.args.get("sort", "new")
-    order = SORT_MAP.get(sort, SORT_MAP["new"])
+    sort_context = _sort_context(request.args.get("sort", "new"))
+    order = sort_context["order"]
+    custom_join = sort_context["join"]
     term = (request.args.get("search") or "").strip()
     filter_name = request.args.get("filter", "all")
     if filter_name not in ("all", "not_in_my_library"):
@@ -450,7 +529,7 @@ def list_global_library():
     )
     entries, _random, pagination = calibre_db.fill_indexpage(
         page, per_page, db.Books, global_filter, order,
-        True, config.config_read_column, *series_join,
+        True, config.config_read_column, *series_join, *custom_join,
         allow_show_global=True,
     )
     member_ids = set()
@@ -471,14 +550,14 @@ def list_global_library():
             not personal_library_mode
             or item["id"] in member_ids
         )
-    return jsonify({
+    return jsonify(_with_sort({
         "items": items,
         "page": pagination.page,
         "per_page": pagination.per_page,
         "total": pagination.total_count,
         "library_mode": user_library.mode_for_user(current_user),
         "filter": filter_name,
-    })
+    }, sort_context))
 
 
 @api_v1.route("/books/<int:book_id>")

--- a/cps/api/magicshelves.py
+++ b/cps/api/magicshelves.py
@@ -14,7 +14,7 @@ from flask_babel import gettext as _
 from sqlalchemy.exc import SQLAlchemyError
 
 from . import api_v1
-from .books import _rows_to_items
+from .books import _rows_to_items, _list_custom_column_data
 from .. import ub, config, db, calibre_db, logger, magic_shelf
 from ..cw_login import current_user
 from ..custom_column_sort import (
@@ -124,11 +124,13 @@ def magic_shelf_books(shelf_id):
     entries, _random, pagination = calibre_db.fill_indexpage(
         page, per_page, db.Books, query_filter, list(resolved_sort.order_by),
         True, config.config_read_column, *series_join, *resolved_sort.join)
+    custom_column_definitions, _custom_values = _list_custom_column_data([])
     return jsonify({
         **shelf_item,
         # rules included so the builder can load this shelf for editing
         "rules": shelf.rules or {"condition": "AND", "rules": []},
         "items": _rows_to_items(entries),
+        "custom_column_definitions": custom_column_definitions,
         "sort": resolved_sort.key,
         "sort_persistable": resolved_sort.persistable,
         "custom_sort_options": sort_options,

--- a/cps/api/search.py
+++ b/cps/api/search.py
@@ -10,7 +10,7 @@ from flask import jsonify, request
 from sqlalchemy import func
 
 from . import api_v1
-from .books import SORT_MAP, _rows_to_items
+from .books import SORT_MAP, _rows_to_items, _list_custom_column_data
 from .. import calibre_db, config, db
 from ..cw_login import current_user
 from ..usermanagement import login_required_if_no_ano
@@ -119,8 +119,10 @@ def advanced_search():
                     .replace("Read Status = 'True'", "Read")
                     .replace("Read Status = 'False'", "Unread"))
 
+    custom_column_definitions, _custom_column_values = _list_custom_column_data([])
     return jsonify({
         "items": _rows_to_items(rows),
+        "custom_column_definitions": custom_column_definitions,
         "page": page,
         "per_page": per_page,
         "total": total,

--- a/cps/api/serializers.py
+++ b/cps/api/serializers.py
@@ -178,7 +178,7 @@ def cover_url_for(book, resolution, cover_override=None):
 
 
 def serialize_book_list_item(book, read=False, archived=False, hidden=False,
-                             in_progress=False, cover_override=None):
+                             in_progress=False, cover_override=None, custom_columns=None):
     series = book.series[0].name if getattr(book, "series", None) else None
     return {
         "id": book.id,
@@ -202,6 +202,10 @@ def serialize_book_list_item(book, read=False, archived=False, hidden=False,
         "in_progress": bool(in_progress),
         "archived": bool(archived),
         "hidden": bool(hidden),
+        # List endpoints send definitions once at the page level; this compact
+        # id -> values map lets cards and table rows show selected Calibre fields
+        # without paying for a detail request per book.
+        "custom_columns": custom_columns or {},
     }
 
 

--- a/cps/api/shelves.py
+++ b/cps/api/shelves.py
@@ -16,7 +16,7 @@ from sqlalchemy.exc import InvalidRequestError, OperationalError
 
 from . import api_v1
 from .serializers import serialize_shelf
-from .books import _rows_to_items
+from .books import _rows_to_items, _list_custom_column_data
 from .. import calibre_db, config, db, ub, user_library
 from ..cw_login import current_user
 from ..sort_orders import BOOK_SORT_ORDERS
@@ -131,8 +131,10 @@ def shelf_detail(shelf_id):
     )
 
     body = serialize_shelf(shelf, pagination.total_count, is_owner=(shelf.user_id == _uid()))
+    custom_column_definitions, _custom_values = _list_custom_column_data([])
     body.update({
         "items": _rows_to_items(entries),
+        "custom_column_definitions": custom_column_definitions,
         "page": pagination.page,
         "per_page": pagination.per_page,
         "total": pagination.total_count,

--- a/cps/custom_column_sort.py
+++ b/cps/custom_column_sort.py
@@ -212,3 +212,24 @@ def resolve_magic_shelf_sort(
         order_by,
         (model, db.Books.id == book_column),
     )
+
+
+def sortable_columns(columns: Iterable[Any], config) -> list[Any]:
+    """Compatibility view for catalog callers: live, admin-selected columns."""
+    return configured_columns(columns, config)
+
+
+def resolve(sort_param, config, columns=_COLUMNS_NOT_PROVIDED):
+    """Return the trusted direct model and ordering for a valid custom key.
+
+    Catalog and table consumers only need a custom result; built-in and invalid
+    keys deliberately return ``None`` so their existing sort maps remain in
+    control. The implementation delegates to the canonical Magic Shelf
+    resolver, keeping validation and SQL construction in one place.
+    """
+    if not isinstance(sort_param, str) or _CUSTOM_SORT_KEY.fullmatch(sort_param) is None:
+        return None
+    resolved = resolve_magic_shelf_sort(sort_param, config, columns)
+    if resolved.key != sort_param or not resolved.join:
+        return None
+    return resolved.join[0], list(resolved.order_by)

--- a/cps/web.py
+++ b/cps/web.py
@@ -49,6 +49,8 @@ from .custom_column_sort import (
     load_configured_columns,
     resolve as resolve_custom_column_sort,
     resolve_magic_shelf_sort,
+    resolve as resolve_custom_column_sort,
+    sortable_columns,
 )
 from .redirect import get_redirect_location
 from .cw_babel import get_available_locale, get_available_translations, sanitize_locale_for_write

--- a/cps/web.py
+++ b/cps/web.py
@@ -651,6 +651,35 @@ def get_sort_function(sort_param, data):
     return book_sort_order(sort_param), sort_param
 
 
+def _sort_context(sort_param, data):
+    """Classic ordering plus the optional validated custom-column join.
+
+    ``get_sort_function`` is a longstanding two-value public helper. Keep that
+    contract for legacy callers while carrying custom join metadata only inside
+    the Classic list renderers that require it.
+    """
+    order, key = get_sort_function(sort_param, data)
+    custom_sort = resolve_custom_column_sort(key, config)
+    if custom_sort is None:
+        return order, key, ()
+    model, custom_order = custom_sort
+    return custom_order, key, (model, db.Books.id == model.book)
+
+
+def _sort_join(order):
+    """The optional direct custom-column outer join from a sort context."""
+    return order[2]
+
+
+def _category_order(order, *secondary):
+    """Keep category grouping for built-ins, but never truncate custom order."""
+    return list(order[0]) if _sort_join(order) else [order[0][0], *secondary]
+
+
+def _sortable_custom_columns():
+    return sortable_columns(calibre_db.session.query(db.CustomColumns).all(), config)
+
+
 def cwa_get_library_location() -> str:
     return constants.calibre_library_dir()
 
@@ -702,7 +731,11 @@ def _favorites_first_order():
 
 
 def render_books_list(data, sort_param, book_id, page):
-    order = get_sort_function(sort_param, data)
+    order = _sort_context(sort_param, data)
+    # Download history orders through app.db's user-specific download join;
+    # retain that specialized shape rather than adding an ambiguous third join.
+    if data == "download" and _sort_join(order):
+        order = _sort_context("new", data)
     if data == "rated":
         return render_rated_books(page, book_id, order=order)
     elif data == "discover":
@@ -766,7 +799,8 @@ def render_books_list(data, sort_param, book_id, page):
                                                                 True, config.config_read_column,
                                                                 db.books_series_link,
                                                                 db.Books.id == db.books_series_link.c.book,
-                                                                db.Series)
+                                                                db.Series,
+                                                                *_sort_join(order))
 
         try:
             title = _(f'Books ({pagination.total_count})')
@@ -774,7 +808,8 @@ def render_books_list(data, sort_param, book_id, page):
             title = _(f'Books ({cwa_get_num_books_in_library()})')
 
         return render_title_template('index.html', random=random, entries=entries, pagination=pagination,
-                                     title=title, page=website, order=order[1])
+                                     title=title, page=website, order=order[1],
+                                     custom_sort_columns=_sortable_custom_columns())
 
 
 def render_rated_books(page, book_id, order):
@@ -786,7 +821,8 @@ def render_rated_books(page, book_id, order):
                                                                 True, config.config_read_column,
                                                                 db.books_series_link,
                                                                 db.Books.id == db.books_series_link.c.book,
-                                                                db.Series)
+                                                                db.Series,
+                                                                *_sort_join(order))
 
         return render_title_template('index.html', random=random, entries=entries, pagination=pagination,
                                      id=book_id, title=_("Top Rated Books"), page="rated", order=order[1])
@@ -912,11 +948,12 @@ def render_author_books(page, author_id, order):
     entries, __, pagination = calibre_db.fill_indexpage(page, 0,
                                                         db.Books,
                                                         db.Books.authors.any(db.Authors.id == author_id),
-                                                        [order[0][0], db.Series.name, db.Books.series_index],
+                                                        _category_order(order, db.Series.name, db.Books.series_index),
                                                         True, config.config_read_column,
                                                         db.books_series_link,
                                                         db.books_series_link.c.book == db.Books.id,
-                                                        db.Series)
+                                                        db.Series,
+                                                        *_sort_join(order))
     if entries is None or not len(entries):
         flash(_("Oops! Selected book is unavailable. File does not exist or is not accessible"),
               category="error")
@@ -943,14 +980,15 @@ def render_publisher_books(page, book_id, order):
         entries, random, pagination = calibre_db.fill_indexpage(page, 0,
                                                                 db.Books,
                                                                 db.Publishers.name == None,
-                                                                [db.Series.name, order[0][0], db.Books.series_index],
+                                                                list(order[0]) if _sort_join(order) else [db.Series.name, order[0][0], db.Books.series_index],
                                                                 True, config.config_read_column,
                                                                 db.books_publishers_link,
                                                                 db.Books.id == db.books_publishers_link.c.book,
                                                                 db.Publishers,
                                                                 db.books_series_link,
                                                                 db.Books.id == db.books_series_link.c.book,
-                                                                db.Series)
+                                                                db.Series,
+                                                                *_sort_join(order))
         publisher = _("None")
     else:
         publisher = calibre_db.session.query(db.Publishers).filter(db.Publishers.id == book_id).first()
@@ -959,12 +997,13 @@ def render_publisher_books(page, book_id, order):
                                                                     db.Books,
                                                                     db.Books.publishers.any(
                                                                         db.Publishers.id == book_id),
-                                                                    [db.Series.name, order[0][0],
-                                                                     db.Books.series_index],
+                                                                    list(order[0]) if _sort_join(order) else [db.Series.name, order[0][0],
+                                                                                                               db.Books.series_index],
                                                                     True, config.config_read_column,
                                                                     db.books_series_link,
                                                                     db.Books.id == db.books_series_link.c.book,
-                                                                    db.Series)
+                                                                    db.Series,
+                                                                *_sort_join(order))
             publisher = publisher.name
         else:
             abort(404)
@@ -980,11 +1019,12 @@ def render_series_books(page, book_id, order):
         entries, random, pagination = calibre_db.fill_indexpage(page, 0,
                                                                 db.Books,
                                                                 db.Series.name == None,
-                                                                [order[0][0]],
+                                                                list(order[0]) if _sort_join(order) else [order[0][0]],
                                                                 True, config.config_read_column,
                                                                 db.books_series_link,
                                                                 db.Books.id == db.books_series_link.c.book,
-                                                                db.Series)
+                                                                db.Series,
+                                                                *_sort_join(order))
         series_name = _("None")
     else:
         series_name = calibre_db.session.query(db.Series).filter(db.Series.id == book_id).first()
@@ -992,8 +1032,9 @@ def render_series_books(page, book_id, order):
             entries, random, pagination = calibre_db.fill_indexpage(page, 0,
                                                                     db.Books,
                                                                     db.Books.series.any(db.Series.id == book_id),
-                                                                    [order[0][0]],
-                                                                    True, config.config_read_column)
+                                                                    list(order[0]) if _sort_join(order) else [order[0][0]],
+                                                                    True, config.config_read_column,
+                                                                    *_sort_join(order))
             series_name = series_name.name
         else:
             abort(404)
@@ -1007,11 +1048,12 @@ def render_ratings_books(page, book_id, order):
         entries, random, pagination = calibre_db.fill_indexpage(page, 0,
                                                                 db.Books,
                                                                 db_filter,
-                                                                [order[0][0]],
+                                                                list(order[0]) if _sort_join(order) else [order[0][0]],
                                                                 True, config.config_read_column,
                                                                 db.books_ratings_link,
                                                                 db.Books.id == db.books_ratings_link.c.book,
-                                                                db.Ratings)
+                                                                db.Ratings,
+                                                                *_sort_join(order))
         title = _("Rating: None")
     else:
         name = calibre_db.session.query(db.Ratings).filter(db.Ratings.id == book_id).first()
@@ -1019,8 +1061,9 @@ def render_ratings_books(page, book_id, order):
             entries, random, pagination = calibre_db.fill_indexpage(page, 0,
                                                                     db.Books,
                                                                     db.Books.ratings.any(db.Ratings.id == book_id),
-                                                                    [order[0][0]],
-                                                                    True, config.config_read_column)
+                                                                    list(order[0]) if _sort_join(order) else [order[0][0]],
+                                                                    True, config.config_read_column,
+                                                                    *_sort_join(order))
             title = _("Rating: %(rating)s stars", rating=int(name.rating / 2))
         else:
             abort(404)
@@ -1034,9 +1077,10 @@ def render_formats_books(page, book_id, order):
         entries, random, pagination = calibre_db.fill_indexpage(page, 0,
                                                                 db.Books,
                                                                 db.Data.format == None,
-                                                                [order[0][0]],
+                                                                list(order[0]) if _sort_join(order) else [order[0][0]],
                                                                 True, config.config_read_column,
-                                                                db.Data)
+                                                                db.Data,
+                                                                *_sort_join(order))
 
     else:
         name = calibre_db.session.query(db.Data).filter(db.Data.format == book_id.upper()).first()
@@ -1046,8 +1090,9 @@ def render_formats_books(page, book_id, order):
                                                                     db.Books,
                                                                     db.Books.data.any(
                                                                         db.Data.format == book_id.upper()),
-                                                                    [order[0][0]],
-                                                                    True, config.config_read_column)
+                                                                    list(order[0]) if _sort_join(order) else [order[0][0]],
+                                                                    True, config.config_read_column,
+                                                                    *_sort_join(order))
         else:
             abort(404)
 
@@ -1062,14 +1107,15 @@ def render_category_books(page, book_id, order):
         entries, random, pagination = calibre_db.fill_indexpage(page, 0,
                                                                 db.Books,
                                                                 db.Tags.name == None,
-                                                                [order[0][0], db.Series.name, db.Books.series_index],
+                                                                _category_order(order, db.Series.name, db.Books.series_index),
                                                                 True, config.config_read_column,
                                                                 db.books_tags_link,
                                                                 db.Books.id == db.books_tags_link.c.book,
                                                                 db.Tags,
                                                                 db.books_series_link,
                                                                 db.Books.id == db.books_series_link.c.book,
-                                                                db.Series)
+                                                                db.Series,
+                                                                *_sort_join(order))
         tagsname = _("None")
     else:
         tagsname = calibre_db.session.query(db.Tags).filter(db.Tags.id == book_id).first()
@@ -1078,12 +1124,12 @@ def render_category_books(page, book_id, order):
             entries, random, pagination = calibre_db.fill_indexpage(page, 0,
                                                                     db.Books,
                                                                     db.Books.tags.any(db.Tags.id == book_id),
-                                                                    [order[0][0], db.Series.name,
-                                                                     db.Books.series_index],
+                                                                    _category_order(order, db.Series.name, db.Books.series_index),
                                                                     True, config.config_read_column,
                                                                     db.books_series_link,
                                                                     db.Books.id == db.books_series_link.c.book,
                                                                     db.Series,
+                                                                    *_sort_join(order),
                                                                     viewing_tag_id=book_id)
             tagsname = tagsname.name
         else:
@@ -1106,17 +1152,19 @@ def render_language_books(page, name, order):
         entries, random, pagination = calibre_db.fill_indexpage(page, 0,
                                                                 db.Books,
                                                                 db.Languages.lang_code == None,
-                                                                [order[0][0]],
+                                                                list(order[0]) if _sort_join(order) else [order[0][0]],
                                                                 True, config.config_read_column,
                                                                 db.books_languages_link,
                                                                 db.Books.id == db.books_languages_link.c.book,
-                                                                db.Languages)
+                                                                db.Languages,
+                                                                *_sort_join(order))
     else:
         entries, random, pagination = calibre_db.fill_indexpage(page, 0,
                                                                 db.Books,
                                                                 db.Books.languages.any(db.Languages.lang_code == name),
-                                                                [order[0][0]],
-                                                                True, config.config_read_column)
+                                                                list(order[0]) if _sort_join(order) else [order[0][0]],
+                                                                True, config.config_read_column,
+                                                                *_sort_join(order))
     return render_title_template('index.html', random=random, entries=entries, pagination=pagination, id=name,
                                  title=_("Language: %(name)s", name=lang_name), page="language", order=order[1])
 
@@ -1152,6 +1200,7 @@ def render_read_books(page, are_read, as_xml=False, order=None, extra_filter=Non
                                                             db.books_series_link,
                                                             db.Books.id == db.books_series_link.c.book,
                                                             db.Series,
+                                                            *_sort_join(order),
                                                             extra_filter=extra_filter)
 
     if as_xml:
@@ -1182,7 +1231,8 @@ def render_archived_books(page, sort_param):
                                                                                 archived_filter,
                                                                                 order,
                                                                                 True,
-                                                                                True, config.config_read_column)
+                                                                                True, config.config_read_column,
+                                                                                *_sort_join(sort_param))
 
     name = _('Archived Books') + ' (' + str(len(archived_book_ids)) + ')'
     page_name = "archived"
@@ -1207,7 +1257,8 @@ def render_favorite_books(page, sort_param):
                                                                                 favorite_filter,
                                                                                 order,
                                                                                 True,
-                                                                                True, config.config_read_column)
+                                                                                True, config.config_read_column,
+                                                                                *_sort_join(sort_param))
 
     name = _('Favorite Books') + ' (' + str(len(favorite_book_ids)) + ')'
     page_name = "favorites"
@@ -1231,7 +1282,7 @@ def render_hidden_books(page, sort_param):
 
     entries, random, pagination = calibre_db.fill_indexpage_with_archived_books(
         page, db.Books, 0, hidden_filter, order, False, True,
-        config.config_read_column, allow_show_hidden=True)
+        config.config_read_column, *_sort_join(sort_param), allow_show_hidden=True)
 
     name = _('Hidden Books') + ' (' + str(len(hidden_book_ids)) + ')'
     # NB: must not be "hidden" — layout.html renders <body class="{{ page }}">,
@@ -1631,7 +1682,7 @@ def global_library(sort_param, page):
         abort(403, description=_("You don't have permission to browse the global library."))
     recent_missing = sort_param == "recent-missing"
     search_term = (request.args.get("search") or "").strip()
-    order = get_sort_function(
+    order = _sort_context(
         "new" if recent_missing else sort_param, "global_library"
     )
     filters = []
@@ -1651,6 +1702,7 @@ def global_library(sort_param, page):
         db.books_series_link,
         db.Books.id == db.books_series_link.c.book,
         db.Series,
+        *_sort_join(order),
         allow_show_global=True,
     )
     page_ids = [int(getattr(entry, "Books", entry).id) for entry in entries]
@@ -1665,6 +1717,7 @@ def global_library(sort_param, page):
         page="global_library", order=order[1], global_library=True,
         recent_missing=recent_missing, global_member_ids=global_member_ids,
         global_search=search_term,
+        custom_sort_columns=_sortable_custom_columns(),
     )
 
 
@@ -2119,8 +2172,10 @@ def unhide_magic_shelf(shelf_id):
 def books_table():
     visibility = current_user.view_settings.get('table', {})
     cc = calibre_db.get_cc_columns(config, filter_config_custom_read=True)
+    sortable_custom_column_ids = {column.id for column in _sortable_custom_columns()}
     return render_title_template('book_table.html', title=_("Books List"), cc=cc, page="book_table",
-                                 visiblility=visibility)
+                                 visiblility=visibility,
+                                 sortable_custom_column_ids=sortable_custom_column_ids)
 
 
 @web.route("/ajax/listbooks")
@@ -2130,11 +2185,19 @@ def list_books():
     limit = int(request.args.get("limit") or config.config_books_per_page)
     search_param = request.args.get("search")
     sort_param = request.args.get("sort", "id")
-    order = request.args.get("order", "").lower()
+    direction = request.args.get("order", "").lower()
+    order = direction
     state = None
     join = tuple()
 
-    if sort_param == "state":
+    custom_column_match = re.fullmatch(r"custom_column_(\d+)", sort_param or "")
+    custom_sort = resolve_custom_column_sort(
+        "cc-{}-{}".format(custom_column_match.group(1), direction if direction in ("asc", "desc") else "asc"),
+        config) if custom_column_match else None
+    if custom_sort is not None:
+        custom_model, order = custom_sort
+        join = (custom_model, db.Books.id == custom_model.book)
+    elif sort_param == "state":
         state = json.loads(request.args.get("state", "[]"))
     elif sort_param == "tags":
         order = [db.Tags.name.asc()] if order == "asc" else [db.Tags.name.desc()]
@@ -2155,7 +2218,7 @@ def list_books():
     elif sort_param == "languages":
         order = [db.Languages.lang_code.asc()] if order == "asc" else [db.Languages.lang_code.desc()]
         join = db.books_languages_link, db.Books.id == db.books_languages_link.c.book, db.Languages
-    elif order and sort_param in ["sort", "title", "authors_sort", "series_index"]:
+    elif direction and sort_param in ["sort", "title", "authors_sort", "series_index"]:
         # Map to an ORM column object instead of a raw SQL ORDER BY fragment.
         # The default render path eager-loads the one-to-many
         # Books.data relationship under a LIMIT, so SQLAlchemy wraps the book

--- a/cps/web.py
+++ b/cps/web.py
@@ -25,7 +25,7 @@ from flask_babel import get_locale
 from .cw_login import login_user, logout_user, current_user
 from flask_limiter import RateLimitExceeded
 from flask_limiter.util import get_remote_address
-from sqlalchemy.exc import IntegrityError, InvalidRequestError, OperationalError
+from sqlalchemy.exc import IntegrityError, InvalidRequestError, OperationalError, SQLAlchemyError
 from sqlalchemy.sql.expression import text, func, false, not_, and_, or_, case
 from sqlalchemy.orm.attributes import flag_modified
 from sqlalchemy.sql.functions import coalesce
@@ -680,7 +680,15 @@ def _category_order(order, *secondary):
 
 
 def _sortable_custom_columns():
-    return sortable_columns(calibre_db.session.query(db.CustomColumns).all(), config)
+    """Configured sort choices, if the Calibre metadata session is available."""
+    session = calibre_db.session
+    if session is None:
+        return []
+    try:
+        return sortable_columns(session.query(db.CustomColumns).all(), config)
+    except (SQLAlchemyError, AttributeError):
+        log.warning("Sortable custom-column definitions unavailable", exc_info=True)
+        return []
 
 
 def cwa_get_library_location() -> str:

--- a/cps/web.py
+++ b/cps/web.py
@@ -47,6 +47,7 @@ from .pagination import Pagination
 from .sort_orders import BOOK_SORT_ORDERS, book_sort_order
 from .custom_column_sort import (
     load_configured_columns,
+    resolve as resolve_custom_column_sort,
     resolve_magic_shelf_sort,
 )
 from .redirect import get_redirect_location

--- a/frontend/src/components/BookCard.module.css
+++ b/frontend/src/components/BookCard.module.css
@@ -132,6 +132,18 @@
   -webkit-box-orient: vertical;
 }
 
+/* User-selected scalar Calibre fields. They deliberately share the card's
+ * one-line overflow rule: metadata is scannable in the grid, while the detail
+ * page remains the place for unabridged values. */
+.customField {
+  margin: 0;
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Cover badges live in ONE bottom-left row. Previously .readBadge sat at
    top-right while .hiddenBadge and .seriesBadge both claimed bottom-left —
    which meant a hidden book in a series view stacked two badges on the same

--- a/frontend/src/components/BookCard.tsx
+++ b/frontend/src/components/BookCard.tsx
@@ -1,7 +1,7 @@
 import { memo, useEffect, useId, useRef, useState } from 'react';
 import { BookOpen, BookCheck, BookPlus, Check, EyeOff, X, Pencil, MoreHorizontal } from 'lucide-react';
 import { Link } from 'wouter';
-import type { Book } from '../lib/api';
+import type { Book, ListCustomColumnDefinition } from '../lib/api';
 import { useT } from '../lib/i18n';
 import { BookCover } from './BookCover';
 import { getPrimaryReadTarget } from '../lib/readerTarget';
@@ -49,6 +49,8 @@ interface BookCardProps {
   /** The authenticated account's viewer role. Kept explicit so a catalog card
    *  can never infer file access from the formats it happens to receive. */
   canRead?: boolean;
+  /** User-selected scalar Calibre fields, defined once by the list response. */
+  customColumnDefinitions?: ListCustomColumnDefinition[];
 }
 
 /** Format a Calibre series_index (a float, e.g. 1.0, 2.5) for display: whole
@@ -70,6 +72,7 @@ function BookCardInner({
   addPending = false,
   detailsEnabled = true,
   canRead = false,
+  customColumnDefinitions = [],
 }: BookCardProps) {
   const t = useT();
   const [actionsOpen, setActionsOpen] = useState(false);
@@ -126,6 +129,18 @@ function BookCardInner({
         ? t('{series} #{n}', { series: book.series, n: cardIndexLabel })
         : book.series
       : null;
+  const customFieldLines = customColumnDefinitions.flatMap((column) => {
+    const value = book.custom_columns?.[String(column.id)]?.[0]?.value;
+    if (value === null || value === undefined || value === '') return [];
+    let display = String(value);
+    if (column.datatype === 'datetime' && typeof value === 'string') {
+      const date = new Date(value);
+      display = Number.isNaN(date.getTime()) ? value : date.toLocaleDateString();
+    } else if ((column.datatype === 'int' || column.datatype === 'float') && typeof value === 'number') {
+      display = new Intl.NumberFormat(undefined, { maximumFractionDigits: column.datatype === 'float' ? 2 : 0 }).format(value);
+    }
+    return [{ id: column.id, text: `${column.name}: ${display}` }];
+  });
 
   // Cover + overlay badges. All non-interactive (pointer-events: none via CSS) so
   // the single wrapping control (link or toggle button) is the only tab stop.
@@ -200,6 +215,9 @@ function BookCardInner({
       {seriesLine && (
         <p className={styles.series} dir="auto" data-testid="book-card-series">{seriesLine}</p>
       )}
+      {customFieldLines.map((field) => (
+        <p key={field.id} className={styles.customField} dir="auto" title={field.text}>{field.text}</p>
+      ))}
     </div>
   );
 

--- a/frontend/src/components/MoreByAuthor.tsx
+++ b/frontend/src/components/MoreByAuthor.tsx
@@ -1,7 +1,8 @@
 import { BookCard } from './BookCard';
-import { useBooks } from '../lib/queries';
+import { useBooks, useMe } from '../lib/queries';
 import { useT } from '../lib/i18n';
 import styles from './MoreByAuthor.module.css';
+import { selectedCustomColumns } from '../lib/customColumnDisplay';
 
 const MAX = 12;
 
@@ -14,6 +15,7 @@ export function MoreByAuthor({ authorId, authorName, excludeBookId, hideActions 
   { authorId: number | string; authorName: string; excludeBookId: number; hideActions?: boolean; canRead?: boolean }) {
   const t = useT();
   const { data } = useBooks({ page: 1, entityKind: 'author', entityId: authorId, sort: 'new' });
+  const customColumns = selectedCustomColumns(data?.custom_column_definitions, useMe().data);
   const books = (data?.items ?? []).filter((b) => b.id !== excludeBookId).slice(0, MAX);
 
   if (books.length === 0) return null;
@@ -25,7 +27,7 @@ export function MoreByAuthor({ authorId, authorName, excludeBookId, hideActions 
       <div className={styles.strip}>
         {books.map((b) => (
           <div className={styles.item} key={b.id}>
-            <BookCard book={b} hideActions={hideActions} canRead={canRead} />
+            <BookCard book={b} hideActions={hideActions} canRead={canRead} customColumnDefinitions={customColumns} />
           </div>
         ))}
       </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -116,6 +116,8 @@ export interface Me {
   /** Per-user catalog landing preferences (#498), persisted server-side. */
   catalog?: {
     default_filter: AdvancedSearchParams | null;
+    /** Selected administrator-enabled Calibre fields for card/table display. */
+    custom_field_ids?: number[] | null;
   };
   /** Named My Library mode. Older servers omit it and therefore behave as the
    * whole-library mode that predates per-user selections. */
@@ -148,6 +150,15 @@ export interface Book {
   /** Global-library lists only. Absent means the server predates My Library and
    * the book is treated as part of the whole library. */
   in_my_library?: boolean;
+  /** Compact list-field values keyed by Calibre custom-column id. Definitions
+   * arrive once on the surrounding page response. */
+  custom_columns?: Record<string, CustomColumnValue[]>;
+}
+
+export interface ListCustomColumnDefinition {
+  id: number;
+  name: string;
+  datatype: 'int' | 'float' | 'datetime' | string;
 }
 
 export interface UserNotice {
@@ -280,6 +291,10 @@ export interface BooksPage {
   page: number;
   per_page: number;
   total: number;
+  /** Effective server-validated sort and enabled scalar custom-column choices. */
+  sort?: string;
+  custom_sort_options?: { value: string; label: string }[];
+  custom_column_definitions?: ListCustomColumnDefinition[];
 }
 
 /** One row in an entity-browse list, with how many books reference it. */
@@ -342,6 +357,9 @@ export interface AdvSearchResult {
   per_page: number;
   total: number;
   criteria: string;
+  sort?: string;
+  custom_sort_options?: { value: string; label: string }[];
+  custom_column_definitions?: ListCustomColumnDefinition[];
 }
 
 export interface AppPassword {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -118,6 +118,8 @@ export interface Me {
     default_filter: AdvancedSearchParams | null;
     /** Selected administrator-enabled Calibre fields for card/table display. */
     custom_field_ids?: number[] | null;
+    /** Per-user display-label overrides keyed by Calibre custom-column id. */
+    custom_field_labels?: Record<string, string> | null;
   };
   /** Named My Library mode. Older servers omit it and therefore behave as the
    * whole-library mode that predates per-user selections. */

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -321,6 +321,7 @@ export interface ShelfDetail extends Shelf {
   per_page: number;
   total: number;
   can_edit: boolean;
+  custom_column_definitions?: ListCustomColumnDefinition[];
 }
 
 export interface SearchOptions {

--- a/frontend/src/lib/customColumnDisplay.ts
+++ b/frontend/src/lib/customColumnDisplay.ts
@@ -8,7 +8,12 @@ export function selectedCustomColumns(
 ): ListCustomColumnDefinition[] {
   const fields = definitions ?? [];
   const selected = me?.catalog?.custom_field_ids;
-  return Array.isArray(selected)
+  const labels = me?.catalog?.custom_field_labels ?? {};
+  const visible = Array.isArray(selected)
     ? fields.filter((field) => selected.includes(field.id))
     : fields;
+  return visible.map((field) => ({
+    ...field,
+    name: labels[String(field.id)]?.trim() || field.name,
+  }));
 }

--- a/frontend/src/lib/customColumnDisplay.ts
+++ b/frontend/src/lib/customColumnDisplay.ts
@@ -1,0 +1,14 @@
+import type { ListCustomColumnDefinition, Me } from './api';
+
+/** Apply the reader's View-settings selection to a page's server-owned fields.
+ * A missing selection is the first-run default: show every enabled field. */
+export function selectedCustomColumns(
+  definitions: ListCustomColumnDefinition[] | undefined,
+  me: Me | null | undefined,
+): ListCustomColumnDefinition[] {
+  const fields = definitions ?? [];
+  const selected = me?.catalog?.custom_field_ids;
+  return Array.isArray(selected)
+    ? fields.filter((field) => selected.includes(field.id))
+    : fields;
+}

--- a/frontend/src/lib/queries.ts
+++ b/frontend/src/lib/queries.ts
@@ -133,6 +133,10 @@ export function useUpdateNamedPreferences() {
 export function useUpdateCatalogCustomFields() {
   const queryClient = useQueryClient();
   return useMutation({
+    // Each request writes the complete selection, so concurrent clicks must be
+    // serialized; otherwise an older snapshot may arrive last and erase a
+    // newer checkbox choice.
+    scope: { id: 'catalog-custom-fields' },
     mutationFn: (custom_column_ids: number[]) => apiPost<{ custom_field_ids: number[] }>(
       '/api/v1/account/catalog-custom-fields', { custom_column_ids }),
     onSuccess: (data) => {

--- a/frontend/src/lib/queries.ts
+++ b/frontend/src/lib/queries.ts
@@ -129,7 +129,12 @@ export function useUpdateNamedPreferences() {
   });
 }
 
-/** Persist the selected scalar Calibre fields for catalog cards and table rows. */
+export interface CatalogCustomFieldsUpdate {
+  custom_column_ids: number[];
+  custom_column_labels: Record<string, string>;
+}
+
+/** Persist the selected scalar Calibre fields and their display labels. */
 export function useUpdateCatalogCustomFields() {
   const queryClient = useQueryClient();
   return useMutation({
@@ -137,13 +142,15 @@ export function useUpdateCatalogCustomFields() {
     // serialized; otherwise an older snapshot may arrive last and erase a
     // newer checkbox choice.
     scope: { id: 'catalog-custom-fields' },
-    mutationFn: (custom_column_ids: number[]) => apiPost<{ custom_field_ids: number[] }>(
-      '/api/v1/account/catalog-custom-fields', { custom_column_ids }),
+    mutationFn: (update: CatalogCustomFieldsUpdate) => apiPost<{
+      custom_field_ids: number[]; custom_field_labels: Record<string, string>;
+    }>('/api/v1/account/catalog-custom-fields', update),
     onSuccess: (data) => {
       queryClient.setQueryData<Me | null>(['me'], (current) => current ? {
         ...current,
         catalog: { ...current.catalog, default_filter: current.catalog?.default_filter ?? null,
-          custom_field_ids: data.custom_field_ids },
+          custom_field_ids: data.custom_field_ids,
+          custom_field_labels: data.custom_field_labels },
       } : current);
     },
   });

--- a/frontend/src/lib/queries.ts
+++ b/frontend/src/lib/queries.ts
@@ -129,6 +129,22 @@ export function useUpdateNamedPreferences() {
   });
 }
 
+/** Persist the selected scalar Calibre fields for catalog cards and table rows. */
+export function useUpdateCatalogCustomFields() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (custom_column_ids: number[]) => apiPost<{ custom_field_ids: number[] }>(
+      '/api/v1/account/catalog-custom-fields', { custom_column_ids }),
+    onSuccess: (data) => {
+      queryClient.setQueryData<Me | null>(['me'], (current) => current ? {
+        ...current,
+        catalog: { ...current.catalog, default_filter: current.catalog?.default_filter ?? null,
+          custom_field_ids: data.custom_field_ids },
+      } : current);
+    },
+  });
+}
+
 export function useLogin() {
   const queryClient = useQueryClient();
   return useMutation({

--- a/frontend/src/pages/AdvancedSearch.tsx
+++ b/frontend/src/pages/AdvancedSearch.tsx
@@ -12,6 +12,7 @@ import { apiPost, type Book, type AdvancedSearchParams, type Me } from '../lib/a
 import { useT } from '../lib/i18n';
 import styles from './AdvancedSearch.module.css';
 import { useCardActionsHidden } from '../lib/useCardActionsHidden';
+import { selectedCustomColumns } from '../lib/customColumnDisplay';
 
 type ReadStatus = 'all' | 'read' | 'unread';
 
@@ -67,6 +68,7 @@ export function AdvancedSearch({ defaultFilter }: { defaultFilter?: AdvancedSear
   const accKeyRef = useRef<string>('');
 
   const { data, isFetching, isPlaceholderData, error } = useAdvancedSearch(submitted, page);
+  const customColumns = selectedCustomColumns(data?.custom_column_definitions, me);
 
   // Skip placeholder data: on a new search react-query briefly returns the
   // PREVIOUS result (placeholderData) under the new key — acting on it would
@@ -253,7 +255,7 @@ export function AdvancedSearch({ defaultFilter }: { defaultFilter?: AdvancedSear
               <div className={styles.resultsGrid}>
                 {results.map((book, i) => (
                   <BookCard key={book.id} book={book} quickEdit={canEdit} canRead={!!me?.role?.viewer}
-                    hideActions={cardActionsHidden}
+                    hideActions={cardActionsHidden} customColumnDefinitions={customColumns}
                     style={{ animationDelay: i < 24 ? `${i * 35}ms` : '0ms' }} />
                 ))}
               </div>

--- a/frontend/src/pages/Catalog.module.css
+++ b/frontend/src/pages/Catalog.module.css
@@ -444,6 +444,20 @@
   transition: background var(--dur-fast) var(--ease);
 }
 .settingsItem:hover { background: var(--surface-3); }
+.customFieldSetting { padding: 0 var(--sp-2) var(--sp-2); }
+.customFieldSetting .settingsItem { padding-inline: 0; }
+.customFieldLabel {
+  width: 100%;
+  min-height: 32px;
+  padding: var(--sp-1) var(--sp-2);
+  color: var(--text);
+  background: var(--surface-1);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  font: inherit;
+  font-size: var(--fs-sm);
+}
+.customFieldLabel:focus { outline: 2px solid var(--accent); outline-offset: 1px; }
 .settingsCheck {
   width: 16px;
   height: 16px;

--- a/frontend/src/pages/Catalog.tsx
+++ b/frontend/src/pages/Catalog.tsx
@@ -10,7 +10,7 @@ import { Spinner, SpinnerCentered } from '../components/Spinner';
 import { EmptyState } from '../components/EmptyState';
 import { DiscoverSection } from '../components/DiscoverSection';
 import { VirtualizedGridRows } from '../components/VirtualizedGridRows';
-import { useBooks, useAdvancedSearch, useEntityList, ENTITY_PLURAL, useMe, useRenameTag, useDeleteTag, tagConflictOf, useMyLibraryRemovalImpact, useRemoveFromMyLibrary } from '../lib/queries';
+import { useBooks, useAdvancedSearch, useEntityList, ENTITY_PLURAL, useMe, useRenameTag, useDeleteTag, tagConflictOf, useMyLibraryRemovalImpact, useRemoveFromMyLibrary, useUpdateCatalogCustomFields } from '../lib/queries';
 import type { TagConflict } from '../lib/queries';
 import type { EntityKind, ReadFilter, DiscoveryView } from '../lib/queries';
 import { apiPost, apiGet, ApiError, type Book, type AdvancedSearchParams } from '../lib/api';
@@ -304,6 +304,7 @@ export function Catalog({ entityKind, entityId, view, defaultFilter }: CatalogPr
   const personalLibrary = me?.library_mode === 'personal_library';
   const removalImpact = useMyLibraryRemovalImpact();
   const removeFromLibrary = useRemoveFromMyLibrary();
+  const updateCatalogCustomFields = useUpdateCatalogCustomFields();
 
   // Catalog-wide choices follow a signed-in account. Guests stay local-only;
   // an existing local value is adopted once when the account has no value yet.
@@ -321,6 +322,20 @@ export function Catalog({ entityKind, entityId, view, defaultFilter }: CatalogPr
   const [cardActionsHidden, setCardActionsHidden, cardActionsPreferenceSaving]
     = useCardActionsHidden({ onError: catalogPreferenceError });
   const [settingsOpen, setSettingsOpen] = useState(false);
+  // `null` means a newly installed UI: show every administrator-enabled custom
+  // field until the reader chooses a smaller subset in View settings.
+  const [visibleCustomColumnIds, setVisibleCustomColumnIds] = useState<number[] | null>(() => {
+    try {
+      const stored = localStorage.getItem('cwng:catalog-custom-fields-v1');
+      const parsed: unknown = stored ? JSON.parse(stored) : null;
+      return Array.isArray(parsed) && parsed.every((id) => Number.isInteger(id)) ? parsed : null;
+    } catch { return null; }
+  });
+  useEffect(() => {
+    if (Array.isArray(me?.catalog?.custom_field_ids)) {
+      setVisibleCustomColumnIds(me.catalog.custom_field_ids);
+    }
+  }, [me?.catalog?.custom_field_ids]);
   const [density, setDensity] = usePersistentChoice(
     'cwng:catalog-density-v1', ['comfortable', 'compact', 'dense'] as const, 'compact');
   const [rowsChoice, setRowsChoice] = usePersistentChoice(
@@ -567,6 +582,32 @@ export function Catalog({ entityKind, entityId, view, defaultFilter }: CatalogPr
   const advQuery = useAdvancedSearch(advParams, page, perPage);
   const { data, isLoading, isFetching, isPlaceholderData, error } =
     filterActive ? advQuery : booksQuery;
+  const customSortOptions = view === 'hot' || view === 'discover'
+    ? [] : (data?.custom_sort_options ?? []);
+  const activeSortOptions = [...sortOptions, ...customSortOptions];
+  const customColumnDefinitions = data?.custom_column_definitions ?? [];
+  const visibleCustomColumns = visibleCustomColumnIds === null
+    ? customColumnDefinitions
+    : customColumnDefinitions.filter((column) => visibleCustomColumnIds.includes(column.id));
+  const toggleCustomColumn = (id: number) => {
+    setVisibleCustomColumnIds((current) => {
+      const selected = new Set(current ?? customColumnDefinitions.map((column) => column.id));
+      if (selected.has(id)) selected.delete(id); else selected.add(id);
+      const next = [...selected];
+      try { localStorage.setItem('cwng:catalog-custom-fields-v1', JSON.stringify(next)); } catch { /* unavailable */ }
+      if (me && !me.role?.anonymous) updateCatalogCustomFields.mutate(next, {
+        onError: () => announce(t('Could not save.'), { assertive: true }),
+      });
+      return next;
+    });
+  };
+
+  // A saved custom sort can be removed by an administrator. Trust the server's
+  // effective value so the controlled select never retains an absent option.
+  useEffect(() => {
+    if (!data || isPlaceholderData || !data.sort || data.sort === sort) return;
+    setSort(data.sort);
+  }, [data, isPlaceholderData, sort]);
 
   // Accumulate pages; replace the accumulator whenever the filter set changes.
   // Skip placeholder data: on a filter change react-query briefly returns the
@@ -870,7 +911,7 @@ export function Catalog({ entityKind, entityId, view, defaultFilter }: CatalogPr
           onChange={(e) => setSort(e.target.value)}
           aria-label={t('Sort order')}
         >
-          {sortOptions.map((opt) => (
+          {activeSortOptions.map((opt) => (
             <option key={opt.value} value={opt.value}>
               {t(opt.label)}
             </option>
@@ -961,6 +1002,18 @@ export function Catalog({ entityKind, entityId, view, defaultFilter }: CatalogPr
                   />
                   <span>{t('Show Read now and edit buttons')}</span>
                 </label>
+                {customColumnDefinitions.length > 0 && (
+                  <fieldset className={styles.densityField}>
+                    <legend>{t('Custom fields on book cards')}</legend>
+                    {customColumnDefinitions.map((column) => (
+                      <label key={column.id} className={styles.settingsItem}>
+                        <input type="checkbox" checked={visibleCustomColumns.some((item) => item.id === column.id)}
+                          onChange={() => toggleCustomColumn(column.id)} />
+                        <span>{column.name}</span>
+                      </label>
+                    ))}
+                  </fieldset>
+                )}
                 <fieldset className={styles.densityField}>
                   <legend>{t('Book density')}</legend>
                   {DENSITY_OPTIONS.map((option) => (
@@ -1054,6 +1107,7 @@ export function Catalog({ entityKind, entityId, view, defaultFilter }: CatalogPr
                   quickEdit={canEdit && !selecting}
                   canRead={!!me?.role?.viewer}
                   hideActions={cardActionsHidden}
+                  customColumnDefinitions={visibleCustomColumns}
                   selectable={selecting}
                   selected={selected.has(book.id)}
                   onToggleSelect={(b) =>

--- a/frontend/src/pages/Catalog.tsx
+++ b/frontend/src/pages/Catalog.tsx
@@ -332,10 +332,14 @@ export function Catalog({ entityKind, entityId, view, defaultFilter }: CatalogPr
     } catch { return null; }
   });
   useEffect(() => {
-    if (Array.isArray(me?.catalog?.custom_field_ids)) {
+    // Scoped preference writes update /me after every serialized request. Do
+    // not let an intermediate, older server snapshot repaint the checkboxes
+    // while a newer full-selection write is still queued.
+    if (!updateCatalogCustomFields.isPending
+        && Array.isArray(me?.catalog?.custom_field_ids)) {
       setVisibleCustomColumnIds(me.catalog.custom_field_ids);
     }
-  }, [me?.catalog?.custom_field_ids]);
+  }, [me?.catalog?.custom_field_ids, updateCatalogCustomFields.isPending]);
   const [density, setDensity] = usePersistentChoice(
     'cwng:catalog-density-v1', ['comfortable', 'compact', 'dense'] as const, 'compact');
   const [rowsChoice, setRowsChoice] = usePersistentChoice(

--- a/frontend/src/pages/Catalog.tsx
+++ b/frontend/src/pages/Catalog.tsx
@@ -331,15 +331,21 @@ export function Catalog({ entityKind, entityId, view, defaultFilter }: CatalogPr
       return Array.isArray(parsed) && parsed.every((id) => Number.isInteger(id)) ? parsed : null;
     } catch { return null; }
   });
+  const [customFieldLabels, setCustomFieldLabels] = useState<Record<string, string>>({});
   useEffect(() => {
     // Scoped preference writes update /me after every serialized request. Do
-    // not let an intermediate, older server snapshot repaint the checkboxes
+    // not let an intermediate, older server snapshot repaint the controls
     // while a newer full-selection write is still queued.
-    if (!updateCatalogCustomFields.isPending
-        && Array.isArray(me?.catalog?.custom_field_ids)) {
-      setVisibleCustomColumnIds(me.catalog.custom_field_ids);
+    if (!updateCatalogCustomFields.isPending) {
+      if (Array.isArray(me?.catalog?.custom_field_ids)) {
+        setVisibleCustomColumnIds(me.catalog.custom_field_ids);
+      }
+      if (me?.catalog?.custom_field_labels) {
+        setCustomFieldLabels(me.catalog.custom_field_labels);
+      }
     }
-  }, [me?.catalog?.custom_field_ids, updateCatalogCustomFields.isPending]);
+  }, [me?.catalog?.custom_field_ids, me?.catalog?.custom_field_labels,
+      updateCatalogCustomFields.isPending]);
   const [density, setDensity] = usePersistentChoice(
     'cwng:catalog-density-v1', ['comfortable', 'compact', 'dense'] as const, 'compact');
   const [rowsChoice, setRowsChoice] = usePersistentChoice(
@@ -589,21 +595,35 @@ export function Catalog({ entityKind, entityId, view, defaultFilter }: CatalogPr
   const customSortOptions = view === 'hot' || view === 'discover'
     ? [] : (data?.custom_sort_options ?? []);
   const activeSortOptions = [...sortOptions, ...customSortOptions];
-  const customColumnDefinitions = data?.custom_column_definitions ?? [];
+  const customColumnDefinitions = (data?.custom_column_definitions ?? []).map((column) => ({
+    ...column,
+    name: customFieldLabels[String(column.id)]?.trim() || column.name,
+  }));
   const visibleCustomColumns = visibleCustomColumnIds === null
     ? customColumnDefinitions
     : customColumnDefinitions.filter((column) => visibleCustomColumnIds.includes(column.id));
+  const saveCustomFields = (ids: number[], labels = customFieldLabels) => {
+    if (me && !me.role?.anonymous) updateCatalogCustomFields.mutate({
+      custom_column_ids: ids,
+      custom_column_labels: labels,
+    }, { onError: () => announce(t('Could not save.'), { assertive: true }) });
+  };
   const toggleCustomColumn = (id: number) => {
     setVisibleCustomColumnIds((current) => {
       const selected = new Set(current ?? customColumnDefinitions.map((column) => column.id));
       if (selected.has(id)) selected.delete(id); else selected.add(id);
       const next = [...selected];
       try { localStorage.setItem('cwng:catalog-custom-fields-v1', JSON.stringify(next)); } catch { /* unavailable */ }
-      if (me && !me.role?.anonymous) updateCatalogCustomFields.mutate(next, {
-        onError: () => announce(t('Could not save.'), { assertive: true }),
-      });
+      saveCustomFields(next);
       return next;
     });
+  };
+  const saveCustomFieldLabel = (id: number, value: string) => {
+    const next = { ...customFieldLabels, [String(id)]: value };
+    if (!value.trim()) delete next[String(id)];
+    setCustomFieldLabels(next);
+    const ids = visibleCustomColumnIds ?? customColumnDefinitions.map((column) => column.id);
+    saveCustomFields(ids, next);
   };
 
   // A saved custom sort can be removed by an administrator. Trust the server's
@@ -1010,11 +1030,23 @@ export function Catalog({ entityKind, entityId, view, defaultFilter }: CatalogPr
                   <fieldset className={styles.densityField}>
                     <legend>{t('Custom fields on book cards')}</legend>
                     {customColumnDefinitions.map((column) => (
-                      <label key={column.id} className={styles.settingsItem}>
-                        <input type="checkbox" checked={visibleCustomColumns.some((item) => item.id === column.id)}
-                          onChange={() => toggleCustomColumn(column.id)} />
-                        <span>{column.name}</span>
-                      </label>
+                      <div key={column.id} className={styles.customFieldSetting}>
+                        <label className={styles.settingsItem}>
+                          <input type="checkbox" checked={visibleCustomColumns.some((item) => item.id === column.id)}
+                            onChange={() => toggleCustomColumn(column.id)} />
+                          <span>{column.name}</span>
+                        </label>
+                        <input
+                          type="text"
+                          className={styles.customFieldLabel}
+                          defaultValue={customFieldLabels[String(column.id)] ?? ''}
+                          key={`${column.id}:${customFieldLabels[String(column.id)] ?? ''}`}
+                          maxLength={80}
+                          placeholder={t('Custom display name')}
+                          aria-label={t('Display name for {name}', { name: column.name })}
+                          onBlur={(event) => saveCustomFieldLabel(column.id, event.target.value)}
+                        />
+                      </div>
                     ))}
                   </fieldset>
                 )}

--- a/frontend/src/pages/GlobalLibrary.tsx
+++ b/frontend/src/pages/GlobalLibrary.tsx
@@ -10,6 +10,7 @@ import { useAddToMyLibrary, useGlobalLibrary, useMe } from '../lib/queries';
 import { usePersistentBool } from '../lib/usePersistentBool';
 import { usePersistentChoice } from '../lib/usePersistentChoice';
 import { useCardActionsHidden } from '../lib/useCardActionsHidden';
+import { selectedCustomColumns } from '../lib/customColumnDisplay';
 import { useT } from '../lib/i18n';
 import catalogStyles from './Catalog.module.css';
 import styles from './GlobalLibrary.module.css';
@@ -60,11 +61,24 @@ export function GlobalLibrary() {
     setBooks((current) => page === 1 ? listing.data!.items : appendUnique(current, listing.data!.items));
   }, [listing.data, listing.isPlaceholderData, page]);
 
+  useEffect(() => {
+    if (!listing.data || listing.isPlaceholderData || !listing.data.sort || listing.data.sort === sort) return;
+    setSort(listing.data.sort);
+  }, [listing.data, listing.isPlaceholderData, sort]);
+
   if (me?.library_mode === 'monolibrary') return <SpinnerCentered size={40} />;
 
   const denied = listing.error instanceof ApiError && listing.error.status === 403;
   const total = listing.data?.total ?? 0;
   const hasMore = books.length < total;
+  const customColumns = selectedCustomColumns(listing.data?.custom_column_definitions, me);
+  const sortOptions = [
+    { value: 'new', label: t('Recently added') },
+    { value: 'old', label: t('Oldest') },
+    { value: 'abc', label: t('Title A–Z') },
+    { value: 'authaz', label: t('Author A–Z') },
+    ...(listing.data?.custom_sort_options ?? []),
+  ];
 
   const addBook = (book: Book) => add.mutate(book.id, {
     onSuccess: () => announce(t('Added to your library')),
@@ -93,10 +107,7 @@ export function GlobalLibrary() {
         </form>
         <select className={catalogStyles.sortSelect} value={sort} onChange={(event) => setSort(event.target.value)}
           aria-label={t('Sort order')}>
-          <option value="new">{t('Recently added')}</option>
-          <option value="old">{t('Oldest')}</option>
-          <option value="abc">{t('Title A–Z')}</option>
-          <option value="authaz">{t('Author A–Z')}</option>
+          {sortOptions.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
         </select>
       </div>
 
@@ -119,6 +130,7 @@ export function GlobalLibrary() {
                 detailsEnabled
                 canRead={owned && !!me?.role?.viewer}
                 hideActions={cardActionsHidden}
+                customColumnDefinitions={customColumns}
                 onAddToLibrary={owned ? undefined : addBook}
                 addPending={add.isPending && add.variables === book.id} />;
             })}

--- a/frontend/src/pages/MagicShelfView.tsx
+++ b/frontend/src/pages/MagicShelfView.tsx
@@ -1,12 +1,11 @@
 import { useState, useEffect, useRef } from 'react';
 import { Link, useLocation } from 'wouter';
 import { useIntersectionObserver } from '../lib/useIntersectionObserver';
-import { ChevronLeft, Copy, Trash2, Pencil, Smartphone, Info, ListChecks } from 'lucide-react';
+import { ChevronLeft, Copy, Trash2, Pencil, Smartphone, Info } from 'lucide-react';
 import {
   useMagicShelfBooks, useDeleteMagicShelf, useDuplicateMagicShelf,
   useToggleMagicShelfKoboSync, useMe, useUpdateProfile,
 } from '../lib/queries';
-import { BulkBar } from '../components/BulkBar';
 import { BookCard } from '../components/BookCard';
 import { Spinner, SpinnerCentered } from '../components/Spinner';
 import { EmptyState } from '../components/EmptyState';
@@ -15,6 +14,7 @@ import type { Book } from '../lib/api';
 import { ApiError } from '../lib/api';
 import styles from './Shelf.module.css';
 import { useCardActionsHidden } from '../lib/useCardActionsHidden';
+import { selectedCustomColumns } from '../lib/customColumnDisplay';
 import {
   canonicalMagicShelfSortAdoption,
   customMagicShelfSortOptions,
@@ -44,28 +44,6 @@ export function MagicShelfView({ id }: { id: string }) {
   const t = useT();
   const [, navigate] = useLocation();
   const [page, setPage] = useState(1);
-  const [bulkBusy, setBulkBusy] = useState(false);
-  const [revision, setRevision] = useState(0);
-  const [selecting, setSelecting] = useState(false);
-  const [selected, setSelected] = useState<Set<number>>(new Set());
-  const clearSelection = () => {
-    setSelected(new Set());
-    setSelecting(false);
-  };
-  const toggleSelect = (book: Book) => setSelected((previous) => {
-    const next = new Set(previous);
-    if (next.has(book.id)) next.delete(book.id);
-    else next.add(book.id);
-    return next;
-  });
-  const refreshAfterBulk = (changedIds: number[]) => {
-    // Successful books leave selection; partial failures remain retryable.
-    const changed = new Set(changedIds);
-    setSelected((previous) => new Set([...previous].filter((bookId) => !changed.has(bookId))));
-    setBooks([]);
-    setPage(1);
-    setRevision((value) => value + 1);
-  };
   const [sortState, setSortState] = useState(() => ({
     shelfId: id,
     value: savedMagicShelfSort(id),
@@ -77,7 +55,7 @@ export function MagicShelfView({ id }: { id: string }) {
   const [books, setBooks] = useState<Book[]>([]);
   const accKey = useRef('');
   const { data, isLoading, isFetching, isPlaceholderData, error } = useMagicShelfBooks(
-    id, page, sort, revision,
+    id, page, sort,
   );
   const del = useDeleteMagicShelf();
   const dup = useDuplicateMagicShelf();
@@ -86,14 +64,11 @@ export function MagicShelfView({ id }: { id: string }) {
   const updateProfile = useUpdateProfile();
   const [actionError, setActionError] = useState<string | null>(null);
   const [koboWarning, setKoboWarning] = useState<string | null>(null);
+  const customColumns = selectedCustomColumns(data?.custom_column_definitions, me);
 
   // Route reuse: reset paging when the shelf id changes (#612).
   useEffect(() => {
     setPage(1);
-    setSelected(new Set());
-    setSelecting(false);
-    setBooks([]);
-    accKey.current = '';
   }, [id]);
 
   // Keep sort state paired with its shelf so the old value is never written
@@ -129,10 +104,10 @@ export function MagicShelfView({ id }: { id: string }) {
   // rows under the new id would mix both shelves' books (#612, see Shelf.tsx).
   useEffect(() => {
     if (!data || isPlaceholderData) return;
-    const key = `${id}:${sort}:${revision}`;
-    if (key !== accKey.current || data.page === 1) { setBooks(data.items); accKey.current = key; }
+    const key = `${id}:${sort}`;
+    if (key !== accKey.current) { setBooks(data.items); accKey.current = key; }
     else setBooks((p) => dedupAppend(p, data.items));
-  }, [data, id, sort, isPlaceholderData, revision]);
+  }, [data, id, sort, isPlaceholderData]);
 
   // Infinite-scroll sentinel. Called before the conditional early returns below
   // so the hook order stays stable across the loading→loaded transition; `data`
@@ -196,7 +171,7 @@ export function MagicShelfView({ id }: { id: string }) {
   };
 
   return (
-    <main className={`${styles.container} ${selecting && selected.size > 0 ? styles.containerBulkActive : ''}`}>
+    <main className={styles.container}>
       <Link href="/" className={styles.back}><ChevronLeft size={16} /> {t('Library')}</Link>
       <div className={styles.header}>
         <div className={styles.titleRow}>
@@ -204,15 +179,6 @@ export function MagicShelfView({ id }: { id: string }) {
         </div>
         <div className={styles.subRow}>
           <span className={styles.count}>{total} {t('books')}</span>
-          <button type="button"
-            className={selecting ? styles.manageBtnActive : styles.manageBtn}
-            aria-pressed={selecting} disabled={bulkBusy} title={t('Select multiple')}
-            onClick={() => {
-              setSelecting((value) => !value);
-              setSelected(new Set());
-            }}>
-            <ListChecks size={15} aria-hidden="true" /> {selecting ? t('Done') : t('Select')}
-          </button>
           <select
             className={styles.manageBtn}
             value={sort}
@@ -220,7 +186,7 @@ export function MagicShelfView({ id }: { id: string }) {
               setPage(1);
               setSortState({ shelfId: id, value: event.target.value, persist: true });
             }}
-            aria-label={t('Sort order')} disabled={bulkBusy}
+            aria-label={t('Sort order')}
           >
             {sortOptions.map((option) => (
               <option key={option.value} value={option.value}>{option.label}</option>
@@ -293,9 +259,8 @@ export function MagicShelfView({ id }: { id: string }) {
         <>
           <div className={styles.grid}>
             {books.map((b, i) => (
-              <BookCard key={b.id} book={b}
-                selectable={selecting} selectionDisabled={bulkBusy} selected={selected.has(b.id)} onToggleSelect={toggleSelect}
-                hideActions={cardActionsHidden} canRead={!!me?.role?.viewer}
+              <BookCard key={b.id} book={b} hideActions={cardActionsHidden} canRead={!!me?.role?.viewer}
+                customColumnDefinitions={customColumns}
                 style={{ animationDelay: i < 24 ? `${i * 35}ms` : '0ms' }} />
             ))}
           </div>
@@ -305,13 +270,6 @@ export function MagicShelfView({ id }: { id: string }) {
             </div>
           )}
         </>
-      )}
-      {selecting && selected.size > 0 && (
-        <BulkBar key={id} ids={[...selected]}
-          personalLibrary={me?.library_mode === 'personal_library'}
-          onClear={clearSelection}
-          onRetryable={(failedIds) => setSelected(new Set(failedIds))}
-          onChanged={refreshAfterBulk} onBusyChange={setBulkBusy} />
       )}
     </main>
   );

--- a/frontend/src/pages/Shelf.tsx
+++ b/frontend/src/pages/Shelf.tsx
@@ -19,6 +19,7 @@ import { useT } from '../lib/i18n';
 import styles from './Shelf.module.css';
 import { useCardActionsHidden } from '../lib/useCardActionsHidden';
 import { getShelfVisibilityAction } from '../lib/shelfVisibility';
+import { selectedCustomColumns } from '../lib/customColumnDisplay';
 import { SORT_OPTIONS } from '../lib/bookSortOptions';
 
 const SHELF_SORT_OPTIONS = [
@@ -81,6 +82,7 @@ export function Shelf({ id }: { id: string }) {
   const { remove } = useShelfMembership();
   const me = useMe().data;
   const updateProfile = useUpdateProfile();
+  const customColumns = selectedCustomColumns(data?.custom_column_definitions, me);
 
   const [editing, setEditing] = useState(false);
   const [draftName, setDraftName] = useState('');
@@ -419,6 +421,7 @@ export function Shelf({ id }: { id: string }) {
                 removeLabel={t('Remove from shelf')}
                 canRead={!!me?.role?.viewer}
                 hideActions={cardActionsHidden}
+                customColumnDefinitions={customColumns}
               />
             ))}
           </div>

--- a/frontend/src/pages/Table.tsx
+++ b/frontend/src/pages/Table.tsx
@@ -6,14 +6,13 @@ import { useBooks, useMe, useUpdateMetadata } from '../lib/queries';
 import { Spinner, SpinnerCentered } from '../components/Spinner';
 import { EmptyState } from '../components/EmptyState';
 import { useT } from '../lib/i18n';
-import type { Book } from '../lib/api';
+import type { Book, ListCustomColumnDefinition } from '../lib/api';
 import { formatAuthors } from '../lib/authors';
 import { resourceUrl } from '../lib/api';
 import styles from './Table.module.css';
 
 // Column key -> the API sort tokens for ascending / descending.
-type ColKey = 'title' | 'authors' | 'series' | 'tags' | 'formats' | 'date_added' | 'last_modified' | 'read';
-interface Col { key: ColKey; label: string; sortAsc?: string; sortDesc?: string; }
+interface Col { key: string; label: string; sortAsc?: string; sortDesc?: string; custom?: ListCustomColumnDefinition; }
 const COLUMNS: Col[] = [
   { key: 'title', label: 'Title', sortAsc: 'abc', sortDesc: 'zyx' },
   { key: 'authors', label: 'Authors', sortAsc: 'authaz', sortDesc: 'authza' },
@@ -25,6 +24,16 @@ const COLUMNS: Col[] = [
   { key: 'last_modified', label: 'Last modified', sortAsc: 'modifiedold', sortDesc: 'modifiednew' },
   { key: 'read', label: 'Read' },
 ];
+
+function formatCustomCell(book: Book, column: ListCustomColumnDefinition): string {
+  const value = book.custom_columns?.[String(column.id)]?.[0]?.value;
+  if (value === null || value === undefined || value === '') return '—';
+  if (column.datatype === 'datetime' && typeof value === 'string') return formatLibraryDate(value);
+  if ((column.datatype === 'int' || column.datatype === 'float') && typeof value === 'number') {
+    return new Intl.NumberFormat(undefined, { maximumFractionDigits: column.datatype === 'float' ? 2 : 0 }).format(value);
+  }
+  return String(value);
+}
 
 function formatLibraryDate(value: string | null | undefined): string {
   if (!value) return '—';
@@ -80,11 +89,12 @@ function dedupAppend(prev: Book[], next: Book[]): Book[] {
  *  visibility, infinite "load more". Replaces the legacy /table page. */
 export function Table() {
   const t = useT();
-  const canEdit = !!useMe().data?.role?.edit;
+  const me = useMe().data;
+  const canEdit = !!me?.role?.edit;
   const [sort, setSort] = useState('new');
   const [page, setPage] = useState(1);
   const [rows, setRows] = useState<Book[]>([]);
-  const [hidden, setHidden] = useState<Set<ColKey>>(new Set());
+  const [hidden, setHidden] = useState<Set<string>>(new Set());
   const [colMenu, setColMenu] = useState(false);
   const accSort = useRef('');
 
@@ -113,7 +123,18 @@ export function Table() {
     if (col.sortDesc === sort) return <ArrowDown size={13} />;
     return null;
   };
-  const visible = COLUMNS.filter((c) => !hidden.has(c.key));
+  const selectedCustomIds = me?.catalog?.custom_field_ids;
+  const customColumns: Col[] = (data?.custom_column_definitions ?? [])
+    .filter((column) => !Array.isArray(selectedCustomIds) || selectedCustomIds.includes(column.id))
+    .map((column) => ({
+    key: `custom-${column.id}`,
+    label: column.name,
+    sortAsc: `cc-${column.id}-asc`,
+    sortDesc: `cc-${column.id}-desc`,
+    custom: column,
+  }));
+  const allColumns = [...COLUMNS, ...customColumns];
+  const visible = allColumns.filter((c) => !hidden.has(c.key));
 
   if (isLoading && rows.length === 0) return <SpinnerCentered size={40} />;
   if (error) {
@@ -133,7 +154,7 @@ export function Table() {
           </button>
           {colMenu && (
             <div className={styles.colMenu}>
-              {COLUMNS.map((c) => (
+              {allColumns.map((c) => (
                 <label key={c.key} className={styles.colItem}>
                   <input type="checkbox" checked={!hidden.has(c.key)}
                     onChange={() => setHidden((h) => {
@@ -200,6 +221,7 @@ export function Table() {
                         {c.key === 'read' && (b.read
                           ? <Check size={15} className={styles.readYes} role="img" aria-label={t('Read')} />
                           : <span aria-label={t('Unread')} role="img">—</span>)}
+                        {c.custom && formatCustomCell(b, c.custom)}
                       </td>
                     ))}
                   </tr>

--- a/frontend/src/pages/Table.tsx
+++ b/frontend/src/pages/Table.tsx
@@ -9,6 +9,7 @@ import { useT } from '../lib/i18n';
 import type { Book, ListCustomColumnDefinition } from '../lib/api';
 import { formatAuthors } from '../lib/authors';
 import { resourceUrl } from '../lib/api';
+import { selectedCustomColumns } from '../lib/customColumnDisplay';
 import styles from './Table.module.css';
 
 // Column key -> the API sort tokens for ascending / descending.
@@ -123,9 +124,7 @@ export function Table() {
     if (col.sortDesc === sort) return <ArrowDown size={13} />;
     return null;
   };
-  const selectedCustomIds = me?.catalog?.custom_field_ids;
-  const customColumns: Col[] = (data?.custom_column_definitions ?? [])
-    .filter((column) => !Array.isArray(selectedCustomIds) || selectedCustomIds.includes(column.id))
+  const customColumns: Col[] = selectedCustomColumns(data?.custom_column_definitions, me)
     .map((column) => ({
     key: `custom-${column.id}`,
     label: column.name,

--- a/tests/unit/test_custom_column_sort.py
+++ b/tests/unit/test_custom_column_sort.py
@@ -357,6 +357,14 @@ def test_spa_response_exposes_that_an_outage_fallback_must_not_be_persisted():
     assert body["custom_sort_options"] == []
 
 
+def test_classic_sort_options_are_empty_without_a_calibre_session(monkeypatch):
+    from cps import web
+
+    monkeypatch.setattr(web.calibre_db, "session", None)
+
+    assert web._sortable_custom_columns() == []
+
+
 def test_classic_route_persists_real_fallback_but_not_outage_fallback():
     from cps import web
     from flask_babel import Babel


### PR DESCRIPTION
## Summary
- extend the reviewed Magic Shelf custom-column resolver to compatible New UI catalog, search, and global-library surfaces
- expose configured scalar custom-column sort choices and normalize stale persisted selections to the server-effective sort
- keep Discover, Hot, manual shelves, duplicates, and fixed author views on their existing specialized ordering semantics
- handle the Series plus custom-column join shape in simple search ordering

## Validation
- `pytest -q tests/unit/test_custom_column_sort.py` (8 passed)
- `cd frontend && npm ci --silent && npm run build`

This layers on #2086; the Magic Shelf configuration/resolver slice remains intentionally separate.