### PR TITLE
fix(progress): arbitrate furthest position in SQL (F-9073e5, F-fe2b1c, F-b521d3)

### DIFF
--- a/changelog.d/furthest-wins-conditional-update.md
+++ b/changelog.d/furthest-wins-conditional-update.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- **Simultaneous reading-position syncs now preserve the furthest real
+  bookmark.** KOReader, Kobo, and browser writers now arbitrate each position
+  update inside the database, so a delayed lower percentage cannot replace
+  newer progress or discard a KOReader locator.

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -2628,11 +2628,11 @@ def HandleStateRequest(book_uuid):
             lm_str = request_reading_state.get("LastModified")
             request_lm = parse_kobo_timestamp(lm_str)
             g.kobo_reading_state_lm = request_lm
-            if request_lm is None:
-                # ``None`` is an observation rejection, not permission to
-                # manufacture an ordering clock. Keep the parent's last
-                # accepted clock so the before_flush hook does not replace it
-                # with server ``now`` while the position itself is preserved.
+            if not device_positions.timestamp_is_newer(
+                    request_lm, kobo_reading_state.last_modified):
+                # The ORM hook also touches the parent for accepted statistics
+                # and status writes. Give it a monotonic clock even when the
+                # device's observation is missing or trails the stored row.
                 g.kobo_reading_state_lm = getattr(
                     kobo_reading_state, "last_modified", None)
 
@@ -2648,43 +2648,45 @@ def HandleStateRequest(book_uuid):
                     content_source_progress_percent=request_bookmark.get(
                         "ContentSourceProgressPercent",
                     ),
-                    location_value=location.get("Value") if location else None,
-                    location_type=location.get("Type") if location else None,
-                    location_source=location.get("Source") if location else None,
+                    location_value=location["Value"] if location else None,
+                    location_type=location["Type"] if location else None,
+                    location_source=location["Source"] if location else None,
                     client_modified_at=request_lm,
                 )
 
-                stored_progress = current_bookmark.progress_percent
+                bookmark_outcome = device_positions.advance_kobo_bookmark(
+                    current_bookmark,
+                    incoming_progress,
+                    content_source_progress_percent=request_bookmark.get(
+                        "ContentSourceProgressPercent",
+                    ),
+                    content_source_supplied=(
+                        "ContentSourceProgressPercent" in request_bookmark
+                    ),
+                    location_value=location["Value"] if location else None,
+                    location_type=location["Type"] if location else None,
+                    location_source=location["Source"] if location else None,
+                    location_supplied=bool(location),
+                    incoming_clock=request_lm,
+                    clock_accepts=True,
+                    equal_accepts=True,
+                    preserve_clock_when_missing=True,
+                    block_lower_at_or_below=(
+                        KOB0_COVER_RESET_PROGRESS_EPSILON
+                        if rehydrate_pending else None
+                    ),
+                    session=ub.session,
+                )
+                resolved_bookmark_accepted = bookmark_outcome.accepted
                 cover_reset_suppressed = bool(
-                    rehydrate_pending
+                    not bookmark_outcome.accepted
+                    and rehydrate_pending
                     and incoming_progress is not None
-                    and stored_progress is not None
-                    and incoming_progress < stored_progress
-                    and incoming_progress
-                    <= KOB0_COVER_RESET_PROGRESS_EPSILON
+                    and incoming_progress <= KOB0_COVER_RESET_PROGRESS_EPSILON
+                    and bookmark_outcome.percentage is not None
+                    and bookmark_outcome.percentage > incoming_progress
                 )
-                resolved_bookmark_accepted = (
-                    not cover_reset_suppressed
-                    and device_positions.resolved_position_accepts(
-                        incoming_progress=incoming_progress,
-                        stored_progress=stored_progress,
-                        incoming_clock=request_lm,
-                        stored_clock=current_bookmark.last_modified,
-                    )
-                )
-                if resolved_bookmark_accepted:
-                    if incoming_progress is not None:
-                        current_bookmark.progress_percent = incoming_progress
-                    if "ContentSourceProgressPercent" in request_bookmark:
-                        current_bookmark.content_source_progress_percent = (
-                            request_bookmark["ContentSourceProgressPercent"]
-                        )
-                    if location:
-                        current_bookmark.location_value = location["Value"]
-                        current_bookmark.location_type = location["Type"]
-                        current_bookmark.location_source = location["Source"]
-                    _apply_kobo_last_modified(current_bookmark, request_lm)
-                elif cover_reset_suppressed:
+                if cover_reset_suppressed:
                     log.info(
                         "Kobo cover reset suppressed for device %s book %s "
                         "(rehydrate_pending=%s): %.2f%% < %.2f%%",
@@ -2692,7 +2694,7 @@ def HandleStateRequest(book_uuid):
                         book.id,
                         rehydrate_pending,
                         incoming_progress,
-                        stored_progress,
+                        bookmark_outcome.percentage,
                     )
                 update_results_response["CurrentBookmarkResult"] = {"Result": "Success"}
 
@@ -2731,13 +2733,14 @@ def HandleStateRequest(book_uuid):
 
         if resolved_bookmark_accepted:
             if request_bookmark and request_bookmark.get("ProgressPercent") is not None:
+                accepted_progress = bookmark_outcome.percentage
                 push_reading_state_to_hardcover(
-                    current_user, book, request_bookmark["ProgressPercent"],
+                    current_user, book, accepted_progress,
                 )
                 share_kobo_progress_with_koreader(
                     current_user.id,
                     book.id,
-                    request_bookmark["ProgressPercent"],
+                    accepted_progress,
                 )
 
         ub.session.merge(kobo_reading_state)

--- a/cps/progress_syncing/models.py
+++ b/cps/progress_syncing/models.py
@@ -16,7 +16,8 @@ Handles database tables for progress syncing functionality:
 
 from datetime import datetime, timezone
 import time
-from sqlalchemy import Column, Integer, String, TIMESTAMP, ForeignKey, Float, text
+from sqlalchemy import (Column, Float, ForeignKey, Integer, String, TIMESTAMP,
+                        UniqueConstraint, text)
 
 from .. import logger
 from ..db import Base as CalibreBase  # For metadata.db tables (books)
@@ -286,13 +287,91 @@ def ensure_checksum_table(conn):
         log.error(traceback.format_exc())
 
 
+_KOSYNC_CONFLICT_INDEX = "uq_kosync_progress_user_document"
+_KOSYNC_CONFLICT_COLUMNS = ("user_id", "document")
+
+
+class KOSyncProgressSchemaError(RuntimeError):
+    """The KOReader progress table cannot support its atomic writers."""
+
+
+def _kosync_index_definitions(execute_sql):
+    """Return ``name -> (unique, ordered columns, partial)`` from PRAGMAs."""
+    definitions = {}
+    for row in execute_sql("PRAGMA index_list(kosync_progress)").fetchall():
+        name = row[1]
+        quoted_name = name.replace("'", "''")
+        columns = tuple(
+            info[2]
+            for info in execute_sql(
+                "PRAGMA index_info('{}')".format(quoted_name)
+            ).fetchall()
+        )
+        definitions[name] = (
+            bool(row[2]),
+            columns,
+            bool(row[4]) if len(row) > 4 else False,
+        )
+    return definitions
+
+
+def _ensure_kosync_conflict_target(execute_sql):
+    """Deduplicate rows and require SQLite's exact ON CONFLICT target."""
+    definitions = _kosync_index_definitions(execute_sql)
+    named_definition = definitions.get(_KOSYNC_CONFLICT_INDEX)
+    expected_definition = (True, _KOSYNC_CONFLICT_COLUMNS, False)
+    if named_definition is not None and named_definition != expected_definition:
+        execute_sql(
+            'DROP INDEX "{}"'.format(
+                _KOSYNC_CONFLICT_INDEX.replace('"', '""'),
+            )
+        )
+
+    # This correlated winner query intentionally avoids ROW_NUMBER(), because
+    # source installs may link Python to SQLite older than 3.25. For every
+    # exact key it keeps the furthest row, preferring a real locator to the
+    # percentage-only sentinel and then the newest timestamp/id.
+    execute_sql("""
+        DELETE FROM kosync_progress
+        WHERE id <> (
+            SELECT winner.id
+            FROM kosync_progress AS winner
+            WHERE winner.user_id = kosync_progress.user_id
+              AND winner.document = kosync_progress.document
+            ORDER BY
+                winner.percentage DESC,
+                CASE WHEN winner.progress = 'cwng:percentage'
+                     THEN 0 ELSE 1 END DESC,
+                CASE WHEN winner.timestamp IS NULL THEN 0 ELSE 1 END DESC,
+                winner.timestamp DESC,
+                winner.id DESC
+            LIMIT 1
+        )
+    """)
+
+    definitions = _kosync_index_definitions(execute_sql)
+    if expected_definition not in definitions.values():
+        execute_sql(
+            "CREATE UNIQUE INDEX {} "
+            "ON kosync_progress(user_id, document)".format(
+                _KOSYNC_CONFLICT_INDEX,
+            )
+        )
+
+    definitions = _kosync_index_definitions(execute_sql)
+    if expected_definition not in definitions.values():
+        raise KOSyncProgressSchemaError(
+            "kosync_progress requires a unique (user_id, document) index"
+        )
+
+
 def ensure_kosync_progress_table(conn):
     """
     Ensure the kosync_progress table exists with the correct schema.
 
     This function is called during database initialization to create the KOSync
     progress table if it doesn't exist. If the table exists with a different schema,
-    a warning is logged and the table is left as-is to allow for proper migration.
+    startup fails loudly because every writer requires the exact conflict target.
     If the schema matches but the foreign key is missing ON DELETE CASCADE,
     the table is rebuilt in-place to add CASCADE and orphan rows are dropped.
 
@@ -319,7 +398,8 @@ def ensure_kosync_progress_table(conn):
             expected_columns = {'id', 'user_id', 'document', 'progress', 'percentage', 'device', 'device_id', 'timestamp'}
             actual_columns = set(columns)
 
-            # If schema doesn't match, log warning and skip (requires migration)
+            # A mismatched table cannot provide the conflict target every
+            # conditional writer depends on, so startup must not continue.
             if actual_columns != expected_columns:
                 missing = expected_columns - actual_columns
                 extra = actual_columns - expected_columns
@@ -329,7 +409,9 @@ def ensure_kosync_progress_table(conn):
                     f"Missing: {missing}. Extra: {extra}. "
                     f"Migration required."
                 )
-                return  # Skip creation, table exists but needs migration
+                raise KOSyncProgressSchemaError(
+                    "kosync_progress schema mismatch; migration required"
+                )
 
             # Check if foreign keys have CASCADE DELETE
             has_cascade = check_cascade_delete_on_fk(conn, "kosync_progress", {'user_id': 'user'})
@@ -388,8 +470,20 @@ def ensure_kosync_progress_table(conn):
             """)
             execute_sql("CREATE INDEX idx_kosync_user_document ON kosync_progress(user_id, document)")
             execute_sql("CREATE INDEX idx_kosync_document ON kosync_progress(document)")
-            conn.commit()
             log.info("Created kosync_progress table with indexes")
+
+        # F-9073e5: ON CONFLICT needs a verified uniqueness guarantee. Repair a
+        # same-named incompatible index, deduplicate legacy rows without a
+        # window function, and verify the ordered unique columns before return.
+        try:
+            _ensure_kosync_conflict_target(execute_sql)
+        except KOSyncProgressSchemaError:
+            raise
+        except Exception as error:
+            raise KOSyncProgressSchemaError(
+                "could not establish the kosync_progress conflict target"
+            ) from error
+        conn.commit()
 
     except Exception as e:
         log.error(f"Could not create kosync_progress table: {e}")
@@ -398,8 +492,11 @@ def ensure_kosync_progress_table(conn):
                 "app.db is locked while creating KOReader progress tables. "
                 "A restart may be required if another writer is holding a lock."
             )
-        import traceback
-        log.error(traceback.format_exc())
+        try:
+            conn.rollback()
+        except Exception:
+            pass
+        raise
 
 
 class BookFormatChecksum(CalibreBase):
@@ -474,6 +571,13 @@ class KOSyncProgress(AppBase):
     device_id = Column(String)
     timestamp = Column(TIMESTAMP, default=lambda: datetime.now(timezone.utc),
                        onupdate=lambda: datetime.now(timezone.utc))
+
+    __table_args__ = (
+        UniqueConstraint(
+            'user_id', 'document',
+            name='uq_kosync_progress_user_document',
+        ),
+    )
 
     def __repr__(self):
         return f'<KOSyncProgress user={self.user_id} doc={self.document}>'

--- a/cps/progress_syncing/protocols/kosync.py
+++ b/cps/progress_syncing/protocols/kosync.py
@@ -523,7 +523,7 @@ def read_status_for_percentage(percentage: float) -> int:
     return ub.ReadBook.STATUS_UNREAD
 
 
-def update_book_read_status(user, book_id: int, percentage: float) -> None:
+def update_book_read_status(user, book_id: int, percentage: float):
     """
     Update the user's ReadBook status based on reading progress percentage.
 
@@ -549,12 +549,11 @@ def update_book_read_status(user, book_id: int, percentage: float) -> None:
     Note:
         Caller is responsible for committing the session.
     """
-    new_status = read_status_for_percentage(percentage)
-
-    user_id = user.id
-
-    log.debug(f"update_book_read_status: user {user_id}, book {book_id}, "
-              f"percentage {percentage:.2f}% -> status {new_status}")
+    user_id = int(user.id)
+    log.debug(
+        "update_book_read_status: user %s, book %s, proposed %.2f%%",
+        user_id, book_id, percentage,
+    )
 
     # Query for existing ReadBook record
     book_read = ub.session.query(ub.ReadBook).filter(
@@ -562,79 +561,77 @@ def update_book_read_status(user, book_id: int, percentage: float) -> None:
         ub.ReadBook.book_id == book_id
     ).first()
 
-    if book_read:
-        # Update existing record
-        old_status = book_read.read_status
-        log.debug(f"Found existing ReadBook: old_status={old_status}, new_status={new_status}")
-
-        # Increment times_started_reading when transitioning to IN_PROGRESS
-        if new_status == ub.ReadBook.STATUS_IN_PROGRESS and old_status != ub.ReadBook.STATUS_IN_PROGRESS:
-            book_read.times_started_reading += 1
-            book_read.last_time_started_reading = datetime.now(timezone.utc)
-            log.info(f"User {user_id} started reading book {book_id} "
-                    f"(times started: {book_read.times_started_reading})")
-
-        # Update status if changed
-        if old_status != new_status:
-            book_read.read_status = new_status
-            log.info(f"User {user_id} book {book_id} status changed: "
-                    f"{old_status} -> {new_status} (progress: {percentage:.1f}%)")
-        else:
-            log.debug(f"ReadBook status unchanged: {old_status}")
-
-        book_read.last_modified = datetime.now(timezone.utc)
-
-        # Complete the independent book-detail/UI carrier, including legacy
-        # ReadBook rows that have no KoboReadingState yet (#627). Its position
-        # is resolved below after both ReadBook branches converge.
-        bookmark = _ensure_visible_reading_state(book_read, user_id, book_id)
-
-    else:
-        # Create new ReadBook record
+    is_new = book_read is None
+    if is_new:
         book_read = ub.ReadBook(
             user_id=user_id,
             book_id=book_id,
-            read_status=new_status
+            read_status=ub.ReadBook.STATUS_UNREAD,
+            times_started_reading=0,
         )
-
-        # Set started reading fields for IN_PROGRESS books
-        # Note: Following Kobo/CWA convention, times_started_reading only increments
-        # when status is IN_PROGRESS. Books that jump straight to FINISHED (e.g.,
-        # syncing at 100% without intermediate syncs) will have times_started_reading=0
-        if new_status == ub.ReadBook.STATUS_IN_PROGRESS:
-            book_read.times_started_reading = 1
-            book_read.last_time_started_reading = datetime.now(timezone.utc)
-            log.info(f"User {user_id} started reading book {book_id} (new entry)")
-
-        # Create the same complete visible state graph as the existing-row
-        # path. Keeping one constructor prevents the two branches drifting.
+        ub.session.add(book_read)
+    reading_state = book_read.kobo_reading_state
+    bookmark = (
+        reading_state.current_bookmark
+        if reading_state is not None else None
+    )
+    graph_was_incomplete = bookmark is None
+    if graph_was_incomplete:
         bookmark = _ensure_visible_reading_state(book_read, user_id, book_id)
 
-        ub.session.add(book_read)
-        log.info(f"User {user_id} book {book_id} created with status {new_status} "
-                f"(progress: {percentage:.1f}%)")
+    # Materialize the graph so the shared primitive can target the bookmark by
+    # primary key. First-write races remain contained by each caller's existing
+    # savepoint/transaction boundary; position acceptance itself is SQL-only.
+    ub.session.flush()
+    outcome = device_positions.advance_kobo_bookmark(
+        bookmark,
+        percentage,
+        clock_accepts=False,
+        session=ub.session,
+    )
+    if outcome.percentage is None:
+        # The primitive could not find a row that survived arbitration. Do not
+        # derive status, counters, or custom-column state from the proposal.
+        log.warning(
+            "KOSync mirror found no surviving Kobo bookmark: "
+            "user=%s, book=%s, incoming=%.2f%%",
+            user_id, book_id, percentage,
+        )
+        return device_positions.PositionWriteOutcome(False, None)
+    accepted_percentage = outcome.percentage
+    if outcome.accepted:
+        # Completing a partial legacy graph is useful only for an accepted
+        # write. A rejected equal/backward sample must not add Statistics or
+        # churn the parent feed clock; existing derived state may still be
+        # reconciled from the bookmark that survived arbitration below.
+        _ensure_visible_reading_state(book_read, user_id, book_id)
+    new_status = read_status_for_percentage(accepted_percentage)
+    old_status = book_read.read_status
 
-    # KOSync and KoboBookmark are independent carriers. Reuse the resolved
-    # bookmark's clock/furthest arbiter rather than assuming that acceptance by
-    # KOSync also permits this cross-carrier write. KOReader supplies no
-    # trustworthy source observation clock; its row timestamp is server receipt
-    # time. Passing no incoming clock therefore selects the arbiter's furthest
-    # leg: an honest forward position crosses to Kobo, while a same-device
-    # rewind remains valid in KOSync but cannot drag the Kobo-visible frontier
-    # backwards. An explicit mark-unread/reset remains the action that clears
-    # every carrier for a deliberate restart.
-    stored_percentage = bookmark.progress_percent
-    if device_positions.resolved_position_accepts(
-        incoming_progress=percentage,
-        stored_progress=stored_percentage,
-    ):
-        bookmark.progress_percent = percentage
-        bookmark.last_modified = datetime.now(timezone.utc)
-    else:
+    if new_status == ub.ReadBook.STATUS_IN_PROGRESS and (
+            is_new or old_status != ub.ReadBook.STATUS_IN_PROGRESS):
+        book_read.times_started_reading = (book_read.times_started_reading or 0) + 1
+        book_read.last_time_started_reading = datetime.now(timezone.utc)
+        log.info(
+            "User %s started reading book %s (times started: %s)",
+            user_id, book_id, book_read.times_started_reading,
+        )
+    if old_status != new_status:
+        book_read.read_status = new_status
+        book_read.last_modified = datetime.now(timezone.utc)
+        log.info(
+            "User %s book %s status changed: %s -> %s "
+            "(accepted progress: %.1f%%)",
+            user_id, book_id, old_status, new_status, accepted_percentage,
+        )
+    elif outcome.accepted:
+        book_read.last_modified = datetime.now(timezone.utc)
+
+    if not outcome.accepted:
         log.info(
             "Preserved furthest Kobo bookmark during KOSync mirror: "
-            "user=%s, book=%s, incoming=%.2f%%, stored=%.2f%%",
-            user_id, book_id, percentage, stored_percentage,
+            "user=%s, book=%s, incoming=%.2f%%, accepted=%.2f%%",
+            user_id, book_id, percentage, accepted_percentage,
         )
 
     # Merge the record (caller commits)
@@ -650,6 +647,7 @@ def update_book_read_status(user, book_id: int, percentage: float) -> None:
     # it — un-marking stays a manual web toggle, matching "mark as read" intent.
     if config.config_read_column and new_status == ub.ReadBook.STATUS_FINISHED:
         _mark_custom_read_column(book_id)
+    return outcome
 
 
 def _mark_custom_read_column(book_id: int) -> None:
@@ -769,7 +767,8 @@ def get_progress_record(user_id, document_checksum, book_id,
 
 
 def record_percentage_only_progress(user_id, book_id, percentage: float,
-                                    device: str, device_id=None) -> bool:
+                                    device: str, device_id=None,
+                                    _return_outcome=False):
     """Publish a percentage-only reading position onto the carrier KOReader reads.
 
     KOReader pulls from ``KOSyncProgress``; until now the only writer was
@@ -792,47 +791,73 @@ def record_percentage_only_progress(user_id, book_id, percentage: float,
     if percentage is None or not book_id:
         return False
 
-    record = get_progress_record(user_id, None, book_id, include_percentage_only=True)
     now = datetime.now(timezone.utc)
 
-    if record is not None:
-        if percentage < record.percentage:
-            log.debug("Percentage-only progress not shared for user %s book %s: "
-                      "incoming %.2f%% < stored %.2f%%",
-                      user_id, book_id, percentage, record.percentage)
-            return False
-        # Equal is not evidence that the browser has the better position. The
-        # web reader opens the book AT the last synced percentage, so a save
-        # without moving lands here exactly. Overwriting a real locator with
-        # the sentinel would cost an already-installed plugin its row
-        # entirely, since those clients are served locator rows only.
-        if (percentage == record.percentage
-                and record.progress
-                and record.progress != PERCENTAGE_ONLY_LOCATOR):
-            log.debug("Percentage-only progress not shared for user %s book %s: "
-                      "incoming %.2f%% ties stored %.2f%% which holds a locator",
-                      user_id, book_id, percentage, record.percentage)
-            return False
-        record.progress = PERCENTAGE_ONLY_LOCATOR
-        record.percentage = percentage
-        record.device = device
-        record.device_id = device_id
-        record.timestamp = now
-        record.document = str(book_id)
-    else:
-        ub.session.add(KOSyncProgress(
-            user_id=user_id,
-            document=str(book_id),
-            progress=PERCENTAGE_ONLY_LOCATOR,
-            percentage=percentage,
-            device=device,
-            device_id=device_id,
-            timestamp=now,
-        ))
+    outcome = _conditional_kosync_progress(
+        user_id=user_id,
+        document=str(book_id),
+        progress=PERCENTAGE_ONLY_LOCATOR,
+        percentage=percentage,
+        device=device,
+        device_id=device_id,
+        timestamp=now,
+        equal_accepts=False,
+    )
+    if not outcome.accepted:
+        log.debug(
+            "Percentage-only progress not shared for user %s book %s: "
+            "incoming %.2f%% <= accepted %.2f%%",
+            user_id, book_id, percentage, outcome.percentage,
+        )
+        return outcome if _return_outcome else False
 
     log.debug("Shared percentage-only progress for user %s book %s at %.2f%% from %s",
               user_id, book_id, percentage, device)
-    return True
+    return outcome if _return_outcome else True
+
+
+def _conditional_kosync_progress(
+    *, user_id, document, progress, percentage, device, device_id, timestamp,
+    equal_accepts, same_device_rewind=False,
+):
+    """Run the shared SQL arbiter for the KOReader position carrier."""
+    document = str(document)
+    payload = {
+        "user_id": user_id,
+        "document": document,
+        "progress": progress,
+        "device": device,
+        "device_id": device_id,
+        "timestamp": timestamp,
+    }
+    return device_positions.conditional_position_update(
+        model=KOSyncProgress,
+        identity={
+            KOSyncProgress.user_id: user_id,
+            KOSyncProgress.document: document,
+        },
+        incoming_percentage=percentage,
+        values={
+            "progress": progress,
+            "device": device,
+            "device_id": device_id,
+            "timestamp": timestamp,
+        },
+        insert_values=payload,
+        conflict_columns=(
+            KOSyncProgress.user_id,
+            KOSyncProgress.document,
+        ),
+        percentage_column=KOSyncProgress.percentage,
+        clock_column=KOSyncProgress.timestamp,
+        incoming_clock=timestamp,
+        equal_accepts=equal_accepts,
+        same_source_column=(
+            KOSyncProgress.device_id if same_device_rewind else None
+        ),
+        incoming_source=device_id,
+        session=ub.session,
+    )
 
 
 ################################################################################
@@ -2000,65 +2025,54 @@ def update_progress():
             response_data, document
         )
 
-        # Check if progress record exists
-        progress_record = get_progress_record(user.id, document, book_id)
-
         # Prefer the book_id as the identifier (if we have it) to ensure that all documents associated with the same
         # Calibre book share the same progress record even if they have different checksums.
-        document = book_id or document
+        canonical_document = str(book_id or document)
 
-        if progress_record:
-            # KOReader devices push their current location on suspend/close,
-            # including after navigating backwards.  A later push therefore
-            # does not necessarily represent the furthest reading position.
-            # A named device is authoritative for its own position, including
-            # deliberate rewinds and restarting a finished book. Missing/empty
-            # device IDs cannot establish identity and are therefore never
-            # treated as same-device pushes. Across devices, preserve the
-            # furthest percentage; equal values may refresh the exact locator.
-            same_device = bool(device_id) and device_id == progress_record.device_id
-            if same_device or percentage_float >= progress_record.percentage:
-                progress_record.progress = progress
-                progress_record.percentage = percentage_float
-                progress_record.device = device
-                progress_record.device_id = device_id
-                progress_record.timestamp = timestamp
-            else:
-                log.info(
-                    "Preserved furthest kosync progress: user=%s, document=%s, "
-                    "incoming=%.2f%%, stored=%.2f%%, incoming_device_id=%r, "
-                    "stored_device_id=%r",
-                    user.id, document, percentage_float,
-                    progress_record.percentage, device_id,
-                    progress_record.device_id,
-                )
-                # The response and downstream Kobo/ReadBook mirror must
-                # describe the accepted server position, not the rejected
-                # backwards push.
-                percentage_float = progress_record.percentage
-                timestamp = progress_record.timestamp
-                response_data["timestamp"] = int(timestamp.timestamp())
-            # #633 self-heal: if the book resolved to a book_id, converge the
-            # record onto the book_id key. A record first stored under a raw
-            # file checksum (book_id didn't resolve at the time) is thereby
-            # re-keyed, so every device that resolves this book shares it from
-            # now on instead of fragmenting into per-checksum orphans.
-            if book_id:
-                progress_record.document = str(book_id)
-            log.debug(f"Updated kosync progress for user {user.id}, document {document}")
-        else:
-            # Create new record
-            progress_record = KOSyncProgress(
+        # #633 legacy convergence remains a key-resolution read, not an
+        # acceptance decision. Seed the canonical key through the same SQL
+        # primitive so an already-existing canonical row can only move forward.
+        # Legacy checksum rows are retained for compatibility; all current
+        # writers target the unique canonical key from this point onward.
+        progress_record = get_progress_record(user.id, document, book_id)
+        if (progress_record is not None
+                and str(progress_record.document) != canonical_document):
+            _conditional_kosync_progress(
                 user_id=user.id,
-                document=document,
-                progress=progress,
-                percentage=percentage_float,
-                device=device,
-                device_id=device_id,
-                timestamp=timestamp
+                document=canonical_document,
+                progress=progress_record.progress,
+                percentage=progress_record.percentage,
+                device=progress_record.device,
+                device_id=progress_record.device_id,
+                timestamp=progress_record.timestamp,
+                equal_accepts=(
+                    progress_record.progress != PERCENTAGE_ONLY_LOCATOR
+                ),
             )
-            ub.session.add(progress_record)
-            log.debug(f"Created kosync progress for user {user.id}, document {document}")
+
+        proposed_percentage = percentage_float
+        outcome = _conditional_kosync_progress(
+            user_id=user.id,
+            document=canonical_document,
+            progress=progress,
+            percentage=percentage_float,
+            device=device,
+            device_id=device_id,
+            timestamp=timestamp,
+            equal_accepts=True,
+            same_device_rewind=True,
+        )
+        if not outcome.accepted:
+            log.info(
+                "Preserved furthest kosync progress: user=%s, document=%s, "
+                "incoming=%.2f%%, accepted=%.2f%%, incoming_device_id=%r",
+                user.id, canonical_document, proposed_percentage,
+                outcome.percentage, device_id,
+            )
+        percentage_float = outcome.percentage
+        timestamp = _aware_datetime(outcome.clock) or timestamp
+        document = canonical_document
+        response_data["timestamp"] = int(timestamp.timestamp())
 
         # CRITICAL: Always commit kosync_progress first before attempting ReadBook updates
         # This ensures sync location is persisted even if ReadBook update fails
@@ -2102,10 +2116,18 @@ def update_progress():
         # This is done AFTER kosync_progress is committed, so sync location is always safe
         if book_id:
             try:
-                update_book_read_status(user, book_id, percentage_float)
+                bookmark_outcome = update_book_read_status(
+                    user, book_id, percentage_float,
+                )
+                resolved_percentage = (
+                    bookmark_outcome.percentage
+                    if (bookmark_outcome is not None
+                        and bookmark_outcome.percentage is not None)
+                    else percentage_float
+                )
                 ub.session.commit()
                 log.info(f"Updated ReadBook status: user={user.id}, book={book_id} "
-                        f"({book_title}), status based on {percentage_float:.1f}%")
+                        f"({book_title}), status based on {resolved_percentage:.1f}%")
 
                 # Push to Hardcover
                 from ... import calibre_db
@@ -2116,7 +2138,9 @@ def update_progress():
 
                 if user is not None:
                     log.debug(f"Going to sync book {book_id} to Hardcover.")
-                    push_reading_state_to_hardcover(user, book, int(percentage_float))
+                    push_reading_state_to_hardcover(
+                        user, book, int(resolved_percentage),
+                    )
                 else:
                     log.debug(f"Book {book_id} not syncing to Hardcover, no matched user.")
 

--- a/cps/services/device_reading_position.py
+++ b/cps/services/device_reading_position.py
@@ -11,8 +11,10 @@ device's own observation without committing; request handlers retain ownership
 of their existing transaction boundaries.
 """
 
+from dataclasses import dataclass
 from datetime import datetime, timezone
 
+from sqlalchemy import and_, case, false, or_, select, update
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
 from .. import ub
@@ -45,25 +47,243 @@ def timestamp_is_newer(candidate, current):
     return candidate > current
 
 
-def resolved_position_accepts(
-    *, incoming_progress, stored_progress, incoming_clock=None, stored_clock=None
-):
-    """Apply the resolved-carrier clock/furthest arbitration policy.
+@dataclass(frozen=True)
+class PositionWriteOutcome:
+    """Database verdict and the position that actually survived arbitration."""
 
-    A source observation replaces the resolved bookmark when its trustworthy
-    source clock is newer, or when its portable percentage is equal/further.
-    Callers without a comparable source clock pass ``None`` and therefore use
-    the furthest leg only. In particular, a KOSync receipt timestamp is a
-    server clock, not the KOReader observation clock, so it must not authorize
-    a cross-carrier rewind merely because the request arrived later.
+    accepted: bool
+    percentage: object
+    clock: object = None
+    row_id: object = None
+
+
+def conditional_position_update(
+    *,
+    model,
+    identity,
+    incoming_percentage,
+    values,
+    insert_values=None,
+    conflict_columns=None,
+    percentage_column=None,
+    clock_column=None,
+    incoming_clock=None,
+    clock_accepts=False,
+    equal_accepts=False,
+    same_source_column=None,
+    incoming_source=None,
+    block_lower_at_or_below=None,
+    session=None,
+):
+    """Atomically advance one reading-position row and return the DB verdict.
+
+    The acceptance comparison lives wholly in the UPDATE's WHERE clause.  A
+    row is writable when its percentage is NULL/lower, when an explicitly
+    enabled source clock is newer, when an equal-value locator refresh is
+    allowed, or when a named source is updating its own row.  ``rowcount`` is
+    the verdict; the SELECT afterwards reports the value that actually won so
+    callers derive status and fan-out from accepted state rather than input.
+
+    When no row matches, ``INSERT .. ON CONFLICT DO NOTHING`` closes the
+    first-writer race without surfacing a duplicate-key ``IntegrityError``.
+    The app database is SQLite, so this uses its native SQLAlchemy insert.
     """
-    return timestamp_is_newer(incoming_clock, stored_clock) or (
-        incoming_progress is not None
-        and (
-            stored_progress is None
-            or incoming_progress >= stored_progress
+    s = session if session is not None else ub.session
+    if percentage_column is None:
+        percentage_column = model.percentage
+    table = model.__table__
+
+    identity_terms = [column == value for column, value in identity.items()]
+    acceptance_terms = []
+    if incoming_percentage is not None:
+        acceptance_terms.extend([
+            percentage_column.is_(None),
+            percentage_column < incoming_percentage,
+        ])
+    if clock_accepts and clock_column is not None and incoming_clock is not None:
+        acceptance_terms.append(or_(
+            clock_column.is_(None),
+            clock_column < incoming_clock,
+        ))
+    if equal_accepts and incoming_percentage is not None:
+        acceptance_terms.append(percentage_column == incoming_percentage)
+    if same_source_column is not None and incoming_source:
+        acceptance_terms.append(same_source_column == incoming_source)
+
+    acceptance = or_(*acceptance_terms) if acceptance_terms else false()
+    if (block_lower_at_or_below is not None
+            and incoming_percentage is not None
+            and incoming_percentage <= block_lower_at_or_below):
+        # A rehydrate latch may identify a cover reset. Keep the stored-value
+        # comparison in SQL: a blank row/equal-forward write is harmless, but a
+        # newer device clock cannot authorize a lower reset while armed.
+        acceptance = and_(
+            acceptance,
+            or_(
+                percentage_column.is_(None),
+                percentage_column <= incoming_percentage,
+            ),
         )
+
+    update_values = dict(values)
+    if incoming_percentage is not None:
+        update_values[percentage_column.key] = incoming_percentage
+    if clock_column is not None and incoming_clock is not None:
+        update_values[clock_column.key] = case(
+            (
+                or_(clock_column.is_(None), clock_column < incoming_clock),
+                incoming_clock,
+            ),
+            else_=clock_column,
+        )
+
+    statement = (
+        update(table)
+        .where(*identity_terms, acceptance)
+        .values(**update_values)
     )
+    result = s.execute(statement)
+    accepted = result.rowcount == 1
+
+    conflict_identity = identity
+    if not accepted and insert_values is not None:
+        insert_payload = dict(insert_values)
+        if incoming_percentage is not None:
+            insert_payload[percentage_column.key] = incoming_percentage
+        if clock_column is not None and incoming_clock is not None:
+            insert_payload[clock_column.key] = incoming_clock
+        conflict_columns = tuple(conflict_columns or identity.keys())
+        insert_statement = sqlite_insert(
+            table,
+        ).values(**insert_payload).on_conflict_do_nothing(
+            index_elements=[column.name for column in conflict_columns],
+        )
+        insert_result = s.execute(insert_statement)
+        accepted = insert_result.rowcount == 1
+        conflict_identity = {
+            column: insert_payload[column.key]
+            for column in conflict_columns
+        }
+        if not accepted:
+            # Another transaction inserted after our first UPDATE observed no
+            # row. Re-run the same conditional UPDATE against that winner so a
+            # concurrent higher first write is not spuriously discarded.
+            retry_result = s.execute(statement)
+            accepted = retry_result.rowcount == 1
+
+    read_terms = [
+        column == value for column, value in conflict_identity.items()
+    ]
+    selected = [percentage_column]
+    if clock_column is not None:
+        selected.append(clock_column)
+    primary_key = tuple(table.primary_key.columns)
+    if primary_key:
+        selected.append(primary_key[0])
+    row = s.execute(select(*selected).where(*read_terms)).first()
+    if row is None and conflict_identity is not identity:
+        row = s.execute(select(*selected).where(*identity_terms)).first()
+
+    if row is None:
+        return PositionWriteOutcome(False, None)
+    mapping = row._mapping
+    return PositionWriteOutcome(
+        accepted=accepted,
+        percentage=mapping[percentage_column],
+        clock=mapping[clock_column] if clock_column is not None else None,
+        row_id=mapping[primary_key[0]] if primary_key else None,
+    )
+
+
+def advance_kobo_bookmark(
+    bookmark,
+    incoming_percentage,
+    *,
+    content_source_progress_percent=None,
+    content_source_supplied=False,
+    location_source=None,
+    location_type=None,
+    location_value=None,
+    location_supplied=False,
+    incoming_clock=None,
+    clock_accepts=False,
+    equal_accepts=False,
+    preserve_clock_when_missing=False,
+    block_lower_at_or_below=None,
+    session=None,
+):
+    """Apply the shared SQL arbiter to the resolved Kobo bookmark carrier."""
+    s = session if session is not None else ub.session
+    if getattr(bookmark, "id", None) is None:
+        s.flush()
+
+    now = _now()
+    write_clock = incoming_clock
+    if write_clock is None and not preserve_clock_when_missing:
+        write_clock = now
+    values = {
+        "last_modified": (
+            write_clock
+            if write_clock is not None else ub.KoboBookmark.last_modified
+        ),
+    }
+    if content_source_supplied:
+        values["content_source_progress_percent"] = content_source_progress_percent
+    if location_supplied:
+        values.update({
+            "location_source": location_source,
+            "location_type": location_type,
+            "location_value": location_value,
+        })
+    if incoming_percentage is not None and incoming_percentage > 0:
+        values["created_at"] = case(
+            (ub.KoboBookmark.created_at.is_(None), write_clock or now),
+            else_=ub.KoboBookmark.created_at,
+        )
+
+    outcome = conditional_position_update(
+        model=ub.KoboBookmark,
+        identity={ub.KoboBookmark.id: bookmark.id},
+        incoming_percentage=incoming_percentage,
+        values=values,
+        percentage_column=ub.KoboBookmark.progress_percent,
+        clock_column=ub.KoboBookmark.last_modified,
+        incoming_clock=write_clock,
+        clock_accepts=clock_accepts,
+        equal_accepts=equal_accepts,
+        block_lower_at_or_below=block_lower_at_or_below,
+        session=s,
+    )
+
+    if outcome.accepted:
+        parent_id = bookmark.kobo_reading_state_id
+        if parent_id is not None:
+            parent_clock = outcome.clock or write_clock or now
+            monotonic_clock = case(
+                (
+                    or_(
+                        ub.KoboReadingState.last_modified.is_(None),
+                        ub.KoboReadingState.last_modified < parent_clock,
+                    ),
+                    parent_clock,
+                ),
+                else_=ub.KoboReadingState.last_modified,
+            )
+            s.execute(
+                update(ub.KoboReadingState)
+                .where(ub.KoboReadingState.id == parent_id)
+                .values(
+                    last_modified=monotonic_clock,
+                    priority_timestamp=monotonic_clock,
+                )
+            )
+
+    if hasattr(bookmark, "_sa_instance_state"):
+        s.expire(bookmark)
+        parent = getattr(bookmark, "kobo_reading_state", None)
+        if parent is not None:
+            s.expire(parent)
+    return outcome
 
 
 def stage_position(

--- a/cps/services/reading_position.py
+++ b/cps/services/reading_position.py
@@ -132,32 +132,9 @@ def record_web_reader_progress(user, book_id: int, percentage: float,
         except Exception:
             log.warning("Best-effort web-reader device observation failed", exc_info=True)
 
-    # ``ub.session`` is a single long-lived Session shared across requests
-    # (``init_db`` builds it once), so a plain query can answer from the identity
-    # map rather than the row. ``populate_existing`` + ``refresh`` make this read
-    # authoritative *within this transaction* — cheap, and strictly better than
-    # comparing against whatever happens to be in memory.
-    #
-    # ``no_autoflush`` is load-bearing, not tidiness. Should a caller still have
-    # a pending write on this session, a bare query would autoflush it here, so
-    # a failure belonging to that REQUIRED write would surface inside this
-    # best-effort helper and be logged (and swallowed) by the routes as an
-    # optional progress-sharing failure. Reading without flushing keeps a read
-    # from being the thing that trips someone else's write.
-    #
-    # Honest limit: this is not cross-connection atomicity. The read-then-write
-    # below can still interleave with a writer on another connection, because
-    # acceptance is decided in Python rather than by the UPDATE itself. So the
-    # guarantee this gives is "never regresses a position it can observe", NOT
-    # an absolute no-regression guarantee: a device that commits a further
-    # position inside this window can still be rolled back to ours, and it only
-    # recovers if that device pushes again. That is a pre-existing property of
-    # this subsystem, not something introduced here — KOSync's own furthest-wins
-    # check (kosync.py:1106) has exactly the same shape. Closing it means one
-    # shared conditional-UPDATE primitive (accept in the WHERE clause, then
-    # check the affected-row count) used by BOTH writers, so the two cannot
-    # drift; that is tracked separately rather than half-done here.
-    stored = None
+    # Status remains an independent manual-intent guard. Position acceptance is
+    # deliberately absent from this read: the shared primitive decides that in
+    # its UPDATE WHERE clause after the caller's required write is settled.
     already_finished = False
     with ub.session.no_autoflush:
         read_row = (ub.session.query(ub.ReadBook)
@@ -167,15 +144,6 @@ def record_web_reader_progress(user, book_id: int, percentage: float,
                     .first())
         already_finished = (read_row is not None
                             and read_row.read_status == ub.ReadBook.STATUS_FINISHED)
-
-        state = (ub.session.query(ub.KoboReadingState)
-                 .populate_existing()
-                 .filter(ub.KoboReadingState.user_id == user_id,
-                         ub.KoboReadingState.book_id == book_id)
-                 .first())
-        if state is not None and state.current_bookmark is not None:
-            ub.session.refresh(state.current_bookmark)
-            stored = state.current_bookmark.progress_percent
 
     # The device journal records what this browser actually reported even when
     # its percentage loses the resolved furthest-wins comparison below. Its
@@ -237,12 +205,6 @@ def record_web_reader_progress(user, book_id: int, percentage: float,
                   user_id, book_id, percentage)
         return False
 
-    if stored is not None and percentage <= stored:
-        log.debug("Web reader position not advanced for user %s book %s: "
-                  "incoming %.2f%% <= stored %.2f%%",
-                  user_id, book_id, percentage, stored)
-        return False
-
     # Sharing a position must never cost the user their bookmark, so this write
     # goes in a SAVEPOINT: ``update_book_read_status`` creates ReadBook and
     # KoboReadingState rows carrying UNIQUE(user_id, book_id), and a first-ever
@@ -264,10 +226,29 @@ def record_web_reader_progress(user, book_id: int, percentage: float,
     # neither being updated, which is a state the next save corrects.
     try:
         with ub.begin_contained_nested(ub.session):
-            update_book_read_status(user, book_id, percentage)
-            record_percentage_only_progress(
-                user_id, book_id, percentage, device="Web reader",
+            bookmark_outcome = update_book_read_status(
+                user, book_id, percentage,
             )
+            if not bookmark_outcome.accepted:
+                log.debug(
+                    "Web reader position not advanced for user %s book %s: "
+                    "incoming %.2f%% <= accepted %.2f%%",
+                    user_id, book_id, percentage,
+                    bookmark_outcome.percentage,
+                )
+                return False
+            kosync_outcome = record_percentage_only_progress(
+                user_id, book_id, percentage, device="Web reader",
+                _return_outcome=True,
+            )
+            if not kosync_outcome.accepted:
+                # A device may have advanced the KOReader carrier between the
+                # two SQL verdicts. Resolve the derived status/bookmark from
+                # the value that actually survived that second verdict.
+                update_book_read_status(
+                    user, book_id, kosync_outcome.percentage,
+                )
+                return False
     except Exception as e:
         log.warning("Could not share web reader progress for user %s book %s: %s",
                     user_id, book_id, e)

--- a/tests/unit/test_1366_web_reader_to_koreader.py
+++ b/tests/unit/test_1366_web_reader_to_koreader.py
@@ -69,7 +69,11 @@ def protocol(monkeypatch):
     monkeypatch.setattr(module, "ub", MagicMock(session=session))
     monkeypatch.setattr(module, "is_koreader_sync_enabled", lambda: True)
     monkeypatch.setattr(module, "authenticate_user", lambda: SimpleNamespace(id=USER_ID))
-    monkeypatch.setattr(module, "update_book_read_status", lambda *_a: None)
+    monkeypatch.setattr(
+        module,
+        "update_book_read_status",
+        lambda *_a: SimpleNamespace(accepted=True, percentage=45.67),
+    )
     monkeypatch.setattr(module, "push_reading_state_to_hardcover", lambda *_a: None)
     monkeypatch.setattr(module, "get_book_checksums",
                         lambda book_id: ["digest-a"] if book_id else [])
@@ -254,7 +258,11 @@ def test_record_web_reader_progress_writes_the_kosync_row(monkeypatch):
 
     # Both modules resolve the session off the shared ``ub`` module object.
     monkeypatch.setattr(ub, "session", session)
-    monkeypatch.setattr(module, "update_book_read_status", lambda *_a: None)
+    monkeypatch.setattr(
+        module,
+        "update_book_read_status",
+        lambda *_a: SimpleNamespace(accepted=True, percentage=45.67),
+    )
 
     advanced = reading_position.record_web_reader_progress(
         SimpleNamespace(id=USER_ID), BOOK_ID, 45.67)

--- a/tests/unit/test_1425_kobo_to_koreader.py
+++ b/tests/unit/test_1425_kobo_to_koreader.py
@@ -33,6 +33,7 @@ Pinned here:
 """
 
 import inspect
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -41,6 +42,7 @@ from flask import Flask
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+from cps import ub
 from cps.progress_syncing.models import AppBase, KOSyncProgress
 
 BOOK_ID = 42
@@ -208,35 +210,22 @@ def kobo_put(monkeypatch):
     AppBase.metadata.create_all(engine)
     session = sessionmaker(bind=engine)()
 
-    bookmark = SimpleNamespace(progress_percent=None, content_source_progress_percent=None,
-                               location_value=None, location_type=None, location_source=None,
-                               last_modified=None)
-    reading_state = SimpleNamespace(
-        current_bookmark=bookmark,
-        statistics=SimpleNamespace(spent_reading_minutes=None, remaining_time_minutes=None,
-                                   last_modified=None),
-        book_read_link=SimpleNamespace(read_status=0, times_started_reading=0,
-                                       last_time_started_reading=None, last_modified=None),
+    book_read = ub.ReadBook(
+        user_id=USER_ID,
+        book_id=BOOK_ID,
+        read_status=ub.ReadBook.STATUS_UNREAD,
+        times_started_reading=0,
     )
+    reading_state = ub.KoboReadingState(user_id=USER_ID, book_id=BOOK_ID)
+    reading_state.current_bookmark = ub.KoboBookmark(
+        last_modified=datetime(2020, 1, 1, tzinfo=timezone.utc),
+    )
+    reading_state.statistics = ub.KoboStatistics()
+    book_read.kobo_reading_state = reading_state
+    session.add(book_read)
+    session.commit()
     book = SimpleNamespace(id=BOOK_ID, data=[SimpleNamespace(format="KEPUB")])
 
-    class _SessionProxy:
-        """The real session, minus ``merge`` — the reading-state graph is a stub.
-
-        ``HandleStateRequest`` merges the ORM graph it was handed; that graph is
-        faked here so the test can stay at unit scope. Everything the fix uses
-        (flush, begin_nested, add, query) is the real session, and it is the
-        same object ``kosync`` writes through, so the savepoint is genuine.
-        """
-
-        def merge(self, obj):
-            return obj
-
-        def __getattr__(self, name):
-            return getattr(session, name)
-
-    kobo_ub = MagicMock(session=_SessionProxy())
-    kobo_ub.session_flush = lambda *a, **k: session.flush()
     def _session_commit(*_a, **_k):
         # Mirror the real ``ub.session_commit`` contract: True when the write
         # landed. The old stub returned ``session.commit()``, i.e. None — so
@@ -245,10 +234,9 @@ def kobo_put(monkeypatch):
         session.commit()
         return True
 
-    kobo_ub.session_commit = _session_commit
-    kobo_ub.ReadBook = SimpleNamespace(STATUS_UNREAD=0, STATUS_IN_PROGRESS=1, STATUS_FINISHED=2)
-
-    monkeypatch.setattr(kobo_module, "ub", kobo_ub)
+    monkeypatch.setattr(ub, "session", session)
+    monkeypatch.setattr(ub, "session_flush", lambda *a, **k: session.flush())
+    monkeypatch.setattr(ub, "session_commit", _session_commit)
     monkeypatch.setattr(kobo_module, "calibre_db",
                         SimpleNamespace(get_book_by_uuid_for_kobo=lambda *a, **k: book))
     monkeypatch.setattr(kobo_module, "get_or_create_reading_state", lambda _bid: reading_state)
@@ -256,7 +244,6 @@ def kobo_put(monkeypatch):
     monkeypatch.setattr(kobo_module, "push_reading_state_to_hardcover", lambda *a, **k: None)
     monkeypatch.setattr(kobo_module, "get_ub_read_status", lambda _s: 1)
 
-    monkeypatch.setattr(kosync, "ub", MagicMock(session=session))
     monkeypatch.setattr(kosync, "get_book_checksums", lambda _bid: [])
 
     app = Flask(__name__)
@@ -329,8 +316,6 @@ def test_bookmark_only_put_still_records_the_devices_own_state(kobo_put):
 ])
 def test_state_put_preserves_stored_clocks_when_device_clock_is_rejected(kobo_put, clock):
     """A rejected device observation must not be replaced with server ``now``."""
-    from datetime import datetime, timezone
-
     kobo_module, app, _session = kobo_put
     reading_state = kobo_module.get_or_create_reading_state(BOOK_ID)
     old_bookmark_clock = datetime(2020, 1, 2, tzinfo=timezone.utc)
@@ -343,14 +328,15 @@ def test_state_put_preserves_stored_clocks_when_device_clock_is_rejected(kobo_pu
 
     assert response.get_json()["RequestResult"] == "Success"
     assert reading_state.current_bookmark.progress_percent == 64.5
-    assert reading_state.current_bookmark.last_modified == old_bookmark_clock
+    stored_clock = reading_state.current_bookmark.last_modified
+    if stored_clock.tzinfo is None:
+        old_bookmark_clock = old_bookmark_clock.replace(tzinfo=None)
+    assert stored_clock == old_bookmark_clock
 
 
 @pytest.mark.unit
 def test_state_put_still_applies_a_valid_device_clock(kobo_put):
     """The rejected-clock branch must not change valid-input behaviour."""
-    from datetime import datetime, timezone
-
     kobo_module, app, _session = kobo_put
     reading_state = kobo_module.get_or_create_reading_state(BOOK_ID)
 
@@ -358,9 +344,11 @@ def test_state_put_still_applies_a_valid_device_clock(kobo_put):
         response = _handler(kobo_module)("uuid-under-test")
 
     assert response.get_json()["RequestResult"] == "Success"
-    assert reading_state.current_bookmark.last_modified == datetime(
-        2026, 8, 14, 6, 0, tzinfo=timezone.utc,
-    )
+    stored_clock = reading_state.current_bookmark.last_modified
+    expected = datetime(2026, 8, 14, 6, 0, tzinfo=timezone.utc)
+    if stored_clock.tzinfo is None:
+        expected = expected.replace(tzinfo=None)
+    assert stored_clock == expected
 
 
 # ── the call site, because the bug was a call that was never made ────────────

--- a/tests/unit/test_1942_device_reading_position.py
+++ b/tests/unit/test_1942_device_reading_position.py
@@ -10,6 +10,7 @@ import pytest
 from flask import Flask, g
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.orm import sessionmaker
+from werkzeug.exceptions import BadRequest
 
 from cps import ub
 
@@ -17,6 +18,7 @@ from cps import ub
 pytestmark = pytest.mark.unit
 USER_ID = 17
 BOOK_ID = 42
+_DEFAULT_LOCATION = object()
 
 
 def _clock(hour):
@@ -206,17 +208,21 @@ def state_harness(monkeypatch):
 
     app = Flask(__name__)
 
-    def put(percent, *, clock, status="Reading", spent=10):
+    def put(
+            percent, *, clock, status="Reading", spent=10,
+            location=_DEFAULT_LOCATION):
+        if location is _DEFAULT_LOCATION:
+            location = {
+                "Value": "device.{}".format(percent),
+                "Type": "KoboSpan",
+                "Source": "kepub",
+            }
         payload = {"ReadingStates": [{
             "LastModified": clock,
             "CurrentBookmark": {
                 "ProgressPercent": percent,
                 "ContentSourceProgressPercent": percent,
-                "Location": {
-                    "Value": "device.{}".format(percent),
-                    "Type": "KoboSpan",
-                    "Source": "kepub",
-                },
+                "Location": location,
             },
             "Statistics": {
                 "SpentReadingMinutes": spent,
@@ -278,6 +284,112 @@ def test_newer_backward_jump_updates_resolved_row_and_both_fanouts(
         ("hardcover", 90.0),
         ("kosync", 90.0),
     ]
+
+
+def test_stored_80_and_older_device_70_stays_80(state_harness):
+    """F-b521d3: a trailing Kobo cannot rewind the resolved carrier."""
+    harness = state_harness
+
+    response = harness.put(70.0, clock="2026-08-29T09:00:00Z")
+    assert response.get_json()["RequestResult"] == "Success"
+    harness.session.expire_all()
+
+    assert harness.state.current_bookmark.progress_percent == 80.0
+    assert harness.state.current_bookmark.location_value == "resolved.80"
+    assert harness.fanout == []
+
+
+def test_stored_70_and_older_device_80_becomes_80(state_harness):
+    """F-b521d3: greater progress wins even when its source clock is older."""
+    harness = state_harness
+    harness.state.current_bookmark.progress_percent = 70.0
+    harness.state.current_bookmark.content_source_progress_percent = 70.0
+    harness.state.current_bookmark.location_value = "resolved.70"
+    harness.session.commit()
+
+    response = harness.put(80.0, clock="2026-08-29T09:00:00Z")
+    assert response.get_json()["RequestResult"] == "Success"
+    harness.session.expire_all()
+
+    assert harness.state.current_bookmark.progress_percent == 80.0
+    assert harness.state.current_bookmark.location_value == "device.80.0"
+    assert harness.fanout == [("hardcover", 80.0), ("kosync", 80.0)]
+
+
+def test_older_device_clock_cannot_move_resolved_clocks_backwards(
+        state_harness):
+    """F-b521d3: even an accepted further position keeps monotonic clocks."""
+    harness = state_harness
+    bookmark_clock = harness.state.current_bookmark.last_modified
+    state_clock = harness.state.last_modified
+
+    response = harness.put(90.0, clock="2026-08-29T09:00:00Z")
+    assert response.get_json()["RequestResult"] == "Success"
+    harness.session.expire_all()
+
+    assert harness.state.current_bookmark.progress_percent == 90.0
+    assert harness.state.current_bookmark.last_modified >= bookmark_clock
+    assert harness.state.last_modified >= state_clock
+
+
+@pytest.mark.parametrize(
+    "clock",
+    ["2026-08-29T10:00:00Z", "2026-08-29T09:00:00Z"],
+)
+def test_equal_progress_refreshes_location_without_regressing_clocks(
+        state_harness, clock):
+    """Equal percentage accepts a Kobo locator with an equal/older clock."""
+    harness = state_harness
+    bookmark_clock = harness.state.current_bookmark.last_modified
+    state_clock = harness.state.last_modified
+
+    response = harness.put(80.0, clock=clock)
+    assert response.get_json()["RequestResult"] == "Success"
+    harness.session.expire_all()
+
+    assert harness.state.current_bookmark.progress_percent == 80.0
+    assert harness.state.current_bookmark.location_value == "device.80.0"
+    assert harness.state.current_bookmark.last_modified >= bookmark_clock
+    assert harness.state.last_modified >= state_clock
+    assert harness.fanout == [("hardcover", 80.0), ("kosync", 80.0)]
+
+
+def test_malformed_nonempty_location_is_rejected(state_harness):
+    """Kobo's non-empty Location contract requires Value, Type, and Source."""
+    harness = state_harness
+
+    with pytest.raises(BadRequest):
+        harness.put(
+            80.0,
+            clock="2026-08-29T10:00:00Z",
+            location={"Type": "KoboSpan", "Source": "kepub"},
+        )
+
+    harness.session.expire_all()
+    assert harness.state.current_bookmark.location_value == "resolved.80"
+
+
+def test_supplied_null_location_value_clears_the_stored_value(state_harness):
+    """A valid supplied Location with Value:null remains an explicit clear."""
+    harness = state_harness
+
+    response = harness.put(
+        80.0,
+        clock="2026-08-29T09:00:00Z",
+        location={
+            "Value": None,
+            "Type": "KoboPage",
+            "Source": "application/epub+zip",
+        },
+    )
+    assert response.get_json()["RequestResult"] == "Success"
+    harness.session.expire_all()
+
+    bookmark = harness.state.current_bookmark
+    assert bookmark.progress_percent == 80.0
+    assert bookmark.location_value is None
+    assert bookmark.location_type == "KoboPage"
+    assert bookmark.location_source == "application/epub+zip"
 
 
 def test_rehydrate_latch_survives_cover_reset_until_sync_clears_it(

--- a/tests/unit/test_324_web_reader_progress_writeback.py
+++ b/tests/unit/test_324_web_reader_progress_writeback.py
@@ -34,6 +34,7 @@ Pinned here:
 import inspect
 import re
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -208,6 +209,57 @@ def test_completion_marks_the_book_finished(monkeypatch):
     read = (session.query(ub.ReadBook)
             .filter(ub.ReadBook.user_id == 7, ub.ReadBook.book_id == 42).first())
     assert read.read_status == ub.ReadBook.STATUS_FINISHED
+
+
+@pytest.mark.unit
+def test_missing_survivor_does_not_derive_state_from_proposed_value(
+        monkeypatch):
+    """No arbiter row means rejection, never permission to use the proposal."""
+    session = _session()
+    _service(monkeypatch, session)
+    read = _seed_progress(session, user_id=7, book_id=42, percent=40.0)
+    read.read_status = ub.ReadBook.STATUS_IN_PROGRESS
+    read.times_started_reading = 3
+    read.last_time_started_reading = datetime(2026, 1, 2, tzinfo=timezone.utc)
+    read.last_modified = datetime(2026, 1, 3, tzinfo=timezone.utc)
+    session.commit()
+    before = (
+        read.read_status,
+        read.times_started_reading,
+        read.last_time_started_reading,
+        read.last_modified,
+    )
+
+    kosync = sys.modules["cps.progress_syncing.protocols.kosync"]
+    monkeypatch.setattr(
+        kosync.device_positions,
+        "advance_kobo_bookmark",
+        lambda *_args, **_kwargs: kosync.device_positions.PositionWriteOutcome(
+            False, None,
+        ),
+    )
+    custom_column_writes = []
+    monkeypatch.setattr(kosync.config, "config_read_column", 9, raising=False)
+    monkeypatch.setattr(
+        kosync,
+        "_mark_custom_read_column",
+        lambda book_id: custom_column_writes.append(book_id),
+    )
+
+    outcome = kosync.update_book_read_status(
+        SimpleNamespace(id=7), 42, 100.0,
+    )
+    session.flush()
+
+    assert outcome.accepted is False
+    assert outcome.percentage is None
+    assert (
+        read.read_status,
+        read.times_started_reading,
+        read.last_time_started_reading,
+        read.last_modified,
+    ) == before
+    assert custom_column_writes == []
 
 
 @pytest.mark.unit
@@ -511,7 +563,7 @@ def test_spa_reader_is_keyed_by_book_id():
 
 
 @pytest.mark.unit
-def test_progress_lookup_does_not_autoflush_the_callers_bookmark():
+def test_status_lookup_does_not_autoflush_the_callers_bookmark():
     """A bare query here would autoflush whatever the caller still has pending,
     making a failure of the user's REQUIRED write surface inside this
     best-effort helper — where both routes log and swallow it as an optional
@@ -527,12 +579,12 @@ def test_progress_lookup_does_not_autoflush_the_callers_bookmark():
     """
     src = (REPO / "cps/services/reading_position.py").read_text(encoding="utf-8")
     assert "with ub.session.no_autoflush:" in src, \
-        "the KoboReadingState lookup must not autoflush a caller's pending write"
-    lookup = src.index("query(ub.KoboReadingState)")
+        "the ReadBook status lookup must not autoflush a caller's pending write"
+    lookup = src.index("query(ub.ReadBook)")
     guard = src.index("with ub.session.no_autoflush:")
     savepoint = src.index("with ub.begin_contained_nested(ub.session):")
     assert guard < lookup < savepoint, \
-        "the no_autoflush guard must wrap the lookup, which must precede the savepoint"
+        "the no_autoflush guard must wrap the status lookup before the savepoint"
 
 
 # ── a book the user marked Read must stay Read (regression, v4.1.29 gate) ────

--- a/tests/unit/test_633_kosync_cross_device_orphan.py
+++ b/tests/unit/test_633_kosync_cross_device_orphan.py
@@ -210,21 +210,27 @@ class TestGetBookChecksumsRealDB:
 
 @pytest.mark.unit
 class TestPutRekeysOrphanToBookId:
-    """kosync Fix C — a PUT that resolves a book_id must converge the found
-    record onto the book_id key so the table self-heals."""
+    """kosync Fix C — a resolved PUT converges onto the canonical book key."""
 
     def test_put_source_rekeys_found_record_to_book_id(self):
-        """Source-pin: the PUT handler assigns the resolved book_id back to
-        the progress record's document so future lookups from any device
-        share it. Guards against reverting to checksum-only keying."""
+        """Source-pin the canonical conditional-upsert self-heal.
+
+        Exact-key uniqueness means a legacy checksum row cannot safely be
+        renamed when the canonical row already exists. The handler now seeds
+        the canonical book key through the shared conditional primitive, which
+        keeps the same convergence contract without a duplicate-key race.
+        """
         src = (REPO_ROOT / "cps" / "progress_syncing" / "protocols"
                / "kosync.py").read_text(encoding="utf-8")
-        # The PUT handler must, when book_id resolves, set the record's
-        # document to the book_id (str). Look for an assignment onto
-        # .document guarded by book_id within the PUT region.
-        assert re.search(r"\.document\s*=\s*str\(book_id\)", src), (
-            "PUT handler must re-key the found record onto str(book_id) when "
-            "the book resolves (#633 self-heal)"
+        assert "canonical_document = str(book_id or document)" in src
+        legacy_guard = "str(progress_record.document) != canonical_document"
+        assert legacy_guard in src
+        guard_at = src.index(legacy_guard)
+        seed_at = src.index("document=canonical_document", guard_at)
+        incoming_at = src.index("proposed_percentage = percentage_float", guard_at)
+        assert guard_at < seed_at < incoming_at, (
+            "the legacy winner must seed the canonical key before the incoming "
+            "PUT is arbitrated (#633 self-heal)"
         )
 
 

--- a/tests/unit/test_furthest_wins_conditional_update.py
+++ b/tests/unit/test_furthest_wins_conditional_update.py
@@ -1,0 +1,199 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2018-2026 Calibre-Web contributors
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""F-9073e5/F-fe2b1c: the database, not a stale ORM read, picks furthest."""
+
+import sqlite3
+import sys
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from cps import ub
+from cps.progress_syncing.models import AppBase, KOSyncProgress
+
+
+def _kosync_module():
+    import cps.progress_syncing.protocols.kosync  # noqa: F401
+    return sys.modules["cps.progress_syncing.protocols.kosync"]
+
+
+@pytest.mark.unit
+def test_two_real_connections_preserve_furthest_locator(
+        tmp_path, monkeypatch):
+    """A stale percentage-only writer cannot erase a later device locator.
+
+    Connection A reads 40% and approves a browser write to 50%. Connection B
+    then commits 60% plus a real KOReader xpointer. A's Session still holds the
+    stale 40% object when its writer runs, exactly reproducing F-fe2b1c without
+    a mocked connection or row. The final conditional UPDATE must see B's 60%
+    in the database and reject A's sentinel write.
+    """
+    module = _kosync_module()
+    database = tmp_path / "furthest-wins.db"
+    engine = create_engine(
+        "sqlite:///{}".format(database),
+        connect_args={"timeout": 5},
+    )
+    AppBase.metadata.create_all(engine)
+    sessions = sessionmaker(bind=engine)
+    seed = sessions()
+    connection_a = sessions()
+    connection_b = sessions()
+    try:
+        seed.add(KOSyncProgress(
+            user_id=7,
+            document="42",
+            progress="/body/DocFragment[4]/body/p[1].0",
+            percentage=40.0,
+            device="KOReader seed",
+            device_id="seed-device",
+        ))
+        seed.commit()
+
+        monkeypatch.setattr(ub, "session", connection_a)
+        monkeypatch.setattr(module, "get_book_checksums", lambda _book_id: [])
+
+        stale = module.get_progress_record(7, None, 42)
+        assert stale.percentage == pytest.approx(40.0)
+
+        device_row = connection_b.query(KOSyncProgress).one()
+        device_row.progress = "/body/DocFragment[12]/body/p[9].0"
+        device_row.percentage = 60.0
+        device_row.device = "KOReader winner"
+        device_row.device_id = "winner-device"
+        connection_b.commit()
+
+        module.record_percentage_only_progress(
+            7, 42, 50.0, device="Web reader",
+        )
+        connection_a.commit()
+
+        verify = sessions()
+        try:
+            winner = verify.query(KOSyncProgress).one()
+            assert winner.percentage == pytest.approx(60.0)
+            assert winner.progress == "/body/DocFragment[12]/body/p[9].0"
+            assert winner.device == "KOReader winner"
+        finally:
+            verify.close()
+    finally:
+        connection_b.close()
+        connection_a.close()
+        seed.close()
+        engine.dispose()
+
+
+@pytest.mark.unit
+def test_legacy_exact_duplicates_migrate_to_unique_furthest_row(tmp_path):
+    """Ordinary legacy duplicates are reduced to the correct unique winner."""
+    from cps.progress_syncing.models import ensure_kosync_progress_table
+
+    database = tmp_path / "legacy-kosync.db"
+    connection = sqlite3.connect(str(database))
+    try:
+        connection.execute("""
+            CREATE TABLE kosync_progress (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL,
+                document TEXT NOT NULL,
+                progress TEXT NOT NULL,
+                percentage REAL NOT NULL,
+                device TEXT NOT NULL,
+                device_id TEXT,
+                timestamp TIMESTAMP
+            )
+        """)
+        connection.executemany(
+            "INSERT INTO kosync_progress "
+            "(user_id, document, progress, percentage, device, timestamp) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            [
+                (7, "42", "lower-locator", 40.0, "lower", "2026-01-01"),
+                (7, "42", "cwng:percentage", 60.0, "sentinel", "2026-01-03"),
+                (7, "42", "real-winner", 60.0, "locator", "2026-01-02"),
+            ],
+        )
+        connection.commit()
+
+        ensure_kosync_progress_table(connection)
+
+        rows = connection.execute(
+            "SELECT progress, percentage, device FROM kosync_progress"
+        ).fetchall()
+        assert rows == [("real-winner", 60.0, "locator")]
+        indexes = connection.execute(
+            "PRAGMA index_list(kosync_progress)"
+        ).fetchall()
+        unique = {row[1] for row in indexes if row[2]}
+        assert "uq_kosync_progress_user_document" in unique
+        with pytest.raises(sqlite3.IntegrityError):
+            connection.execute(
+                "INSERT INTO kosync_progress "
+                "(user_id, document, progress, percentage, device) "
+                "VALUES (7, '42', 'duplicate', 70, 'duplicate')"
+            )
+    finally:
+        connection.close()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("unique_keyword", ["", "UNIQUE "])
+def test_incompatible_named_index_is_replaced_before_startup_continues(
+        tmp_path, unique_keyword):
+    """Neither a non-unique nor wrongly keyed named index is sufficient."""
+    from cps.progress_syncing.models import ensure_kosync_progress_table
+
+    database = tmp_path / "wrong-kosync-index.db"
+    connection = sqlite3.connect(str(database))
+    try:
+        connection.execute("""
+            CREATE TABLE kosync_progress (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL,
+                document TEXT NOT NULL,
+                progress TEXT NOT NULL,
+                percentage REAL NOT NULL,
+                device TEXT NOT NULL,
+                device_id TEXT,
+                timestamp TIMESTAMP
+            )
+        """)
+        connection.execute(
+            "CREATE {}INDEX uq_kosync_progress_user_document "
+            "ON kosync_progress(document)".format(unique_keyword)
+        )
+        connection.commit()
+
+        ensure_kosync_progress_table(connection)
+
+        indexes = {
+            row[1]: bool(row[2])
+            for row in connection.execute(
+                "PRAGMA index_list(kosync_progress)"
+            ).fetchall()
+        }
+        assert indexes["uq_kosync_progress_user_document"] is True
+        columns = tuple(
+            row[2]
+            for row in connection.execute(
+                "PRAGMA index_info('uq_kosync_progress_user_document')"
+            ).fetchall()
+        )
+        assert columns == ("user_id", "document")
+        with pytest.raises(sqlite3.IntegrityError):
+            connection.executemany(
+                "INSERT INTO kosync_progress "
+                "(user_id, document, progress, percentage, device) "
+                "VALUES (?, ?, ?, ?, ?)",
+                [
+                    (7, "42", "first", 20.0, "reader"),
+                    (7, "42", "second", 30.0, "reader"),
+                ],
+            )
+    finally:
+        connection.close()

--- a/tests/unit/test_kosync_book_id_keyed_lookup.py
+++ b/tests/unit/test_kosync_book_id_keyed_lookup.py
@@ -138,15 +138,15 @@ class TestGetProgressRecordCrossKeyLookup:
         )
 
     def test_orders_by_timestamp_desc(self, in_memory_session):
-        """If two records exist under the same key set, return the newer one."""
+        """Equal percentages on legacy keys return the newer locator."""
         kosync_mod = _kosync_module()
         old = KOSyncProgress(
-            user_id=7, document="42", progress="p1", percentage=10.0,
+            user_id=7, document="42", progress="p1", percentage=99.0,
             device="d1", device_id="i1",
             timestamp=datetime.now(timezone.utc) - timedelta(days=1),
         )
         new = KOSyncProgress(
-            user_id=7, document="42", progress="p2", percentage=99.0,
+            user_id=7, document="abc123checksum", progress="p2", percentage=99.0,
             device="d2", device_id="i2",
             timestamp=datetime.now(timezone.utc),
         )
@@ -154,7 +154,7 @@ class TestGetProgressRecordCrossKeyLookup:
         in_memory_session.commit()
         with patch.object(kosync_mod, "ub", MagicMock(session=in_memory_session)):
             record = kosync_mod.get_progress_record(
-                user_id=7, document_checksum="anything", book_id=42,
+                user_id=7, document_checksum="abc123checksum", book_id=42,
             )
         assert record is not None
-        assert record.percentage == 99.0, "expected most-recent record"
+        assert record.progress == "p2", "expected most-recent tied locator"

--- a/tests/unit/test_progress_syncing_models.py
+++ b/tests/unit/test_progress_syncing_models.py
@@ -191,8 +191,8 @@ class TestEnsureKosyncProgressTable:
         columns = {row[1] for row in cursor.fetchall()}
         assert columns == {'id', 'user_id', 'document', 'progress', 'percentage', 'device', 'device_id', 'timestamp'}
 
-    def test_handles_schema_mismatch(self, tmp_path, caplog):
-        """Verify schema mismatch triggers warning (production-safe behavior)."""
+    def test_rejects_schema_mismatch(self, tmp_path, caplog):
+        """A table without the writers' conflict target must stop startup."""
         db = tmp_path / "test.db"
         conn = sqlite3.connect(str(db))
         # Create table with wrong schema
@@ -200,7 +200,8 @@ class TestEnsureKosyncProgressTable:
         conn.commit()
 
         from cps.progress_syncing.models import ensure_kosync_progress_table
-        ensure_kosync_progress_table(conn)
+        with pytest.raises(RuntimeError, match="schema mismatch"):
+            ensure_kosync_progress_table(conn)
 
         # Should log warning about schema mismatch
         assert any('schema mismatch' in record.message.lower() for record in caplog.records)


### PR DESCRIPTION
Closes the "furthest wins is decided in Python, not by the UPDATE" family: F-9073e5 (the primitive), F-fe2b1c (the lost update on the shared KOSync row, where a percentage-only sentinel replaced a real KOReader locator), and the remainder of F-b521d3 (Kobo clock regression; the two percentage cases already passed at HEAD after #2114 and are pinned).

**What changed**
- One primitive, `conditional_position_update()` in `cps/services/device_reading_position.py`: acceptance is decided in the `UPDATE … WHERE` clause (percentage IS NULL OR < incoming, plus the existing policy legs: newer trusted Kobo clock, equal-percentage locator refresh, same-device rewind, cover-reset suppression), `rowcount` is the verdict, and the no-row case is `INSERT … ON CONFLICT DO NOTHING` followed by one retry of the conditional UPDATE. The Python-side arbiter is gone.
- Every writer uses it: KOSync `update_progress`, `record_percentage_only_progress`, the carrier adapter, `record_web_reader_progress`, `update_book_read_status`, Kobo `HandleStateRequest`. Derived state (read status, started counters, custom read column, Hardcover and Kobo→KOReader fan-out) comes from the accepted value; a missing survivor is treated as rejected.
- Bookmark and parent reading-state clocks are monotonic: an accepted further position with an older device clock no longer moves `last_modified` backwards.
- Startup migration on `kosync_progress`: dedup exact `(user_id, document)` rows (furthest, then real locator over sentinel, then newest), then establish a validated unique index. A same-named incompatible index is replaced; failure to end up with a usable conflict target raises instead of log-and-continue. No window functions, so no SQLite version floor. SQLite is the only app DB; the PostgreSQL branch that claimed otherwise was removed.

**Evidence**
- Two real SQLite connections reproduce F-fe2b1c's interleaving (A reads 40, B commits 60 + xpointer, A writes 50 sentinel): red on the old code (50 + sentinel), green now (60 + xpointer).
- Independent Sol review (MERGE WITH FIXES, 5 items) applied in full: Kobo equal-percentage refresh restored with test; index validation with tests; portable dedup; strict `Location` validation (400 on malformed, `Value: null` clears) with tests; no proposed-value fallback with test; prose corrected.
- Full unit suite post-rebase: 8,178 passed, 111 skipped (Sol, OBSERVED). Focused 70 re-run by the pilot (OBSERVED). No physical Kobo run (ASSUMED wire behaviour per the existing handler-level tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016HTQrgFiyGnVJU2MxXTkJ2