### PR TITLE
fix(spa): align reader and delete role gates with classic (F-ed109c, F-f6a8bf)

### DIFF
--- a/changelog.d/spa-reader-delete-role-gates.md
+++ b/changelog.d/spa-reader-delete-role-gates.md
@@ -1,0 +1,3 @@
+### Security
+
+- **Browser reading and book deletion now follow the same roles in both interfaces.** Viewer-only accounts can read in the new interface without download permission, while download-only accounts can no longer open the browser reader. Permanently deleting a book, deleting one format, or bulk-deleting books now requires both “Delete books” and “Edit books”.

--- a/cps/api/edit.py
+++ b/cps/api/edit.py
@@ -63,6 +63,20 @@ def _require_edit():
     return None
 
 
+def _require_book_delete():
+    """Mirror Classic's effective destructive-book policy.
+
+    Whole-book controls on the detail page require both roles. Format and bulk
+    deletion live behind Classic's edit-only surfaces and then pass through the
+    delete-role core, so those paths have the same effective conjunction.
+    """
+    if not current_user.is_authenticated or current_user.is_anonymous:
+        return _err("unauthorized", "You must be signed in", 401)
+    if not current_user.role_delete_books() or not current_user.role_edit():
+        return _err("forbidden", "You are not allowed to delete books", 403)
+    return None
+
+
 def _parse_edit_result(result):
     """edit_book_param returns a JSON Response, an empty string, or a
     ``(message, status)`` tuple. Normalize to ``(ok: bool, message: str)``."""
@@ -495,10 +509,9 @@ def update_metadata(book_id):
 @api_v1.route("/books/<int:book_id>/delete", methods=["POST"])
 @login_required_if_no_ano
 def delete_book(book_id):
-    if not current_user.is_authenticated or current_user.is_anonymous:
-        return _err("unauthorized", "You must be signed in", 401)
-    if not current_user.role_delete_books() or not current_user.role_edit():
-        return _err("forbidden", "You are not allowed to delete books", 403)
+    guard = _require_book_delete()
+    if guard:
+        return guard
     # Authorize against the caller's VISIBLE library, not the raw table: a user
     # with the (global) delete role but a language/tag/custom-column visibility
     # restriction must not be able to enumerate and delete a book they cannot
@@ -519,10 +532,9 @@ def delete_format(book_id, fmt):
     The shared core re-checks the role, performs the sole visibility-scoped
     lookup, and stages storage deletion reversibly across the metadata commit.
     """
-    if not current_user.is_authenticated or current_user.is_anonymous:
-        return _err("unauthorized", "You must be signed in", 401)
-    if not current_user.role_delete_books():
-        return _err("forbidden", "You are not allowed to delete books", 403)
+    guard = _require_book_delete()
+    if guard:
+        return guard
     return _delete_api_response(delete_book_from_table(book_id, fmt.upper(), True))
 
 

--- a/frontend/src/components/BulkBar.tsx
+++ b/frontend/src/components/BulkBar.tsx
@@ -6,6 +6,7 @@ import { useAnnouncer } from '../lib/a11y/announcer';
 import { Spinner } from './Spinner';
 import { ApiError, type MetadataListMode, type MetadataUpdate } from '../lib/api';
 import { uniqueBulkRemovalFailureReasons } from '../lib/bulkRemoval';
+import { canDeleteBooks } from '../lib/permissions';
 import styles from './BulkBar.module.css';
 
 interface BulkBarProps {
@@ -91,7 +92,7 @@ export function BulkBar({ ids, personalLibrary, onClear, onChanged }: BulkBarPro
     };
   }, [shelfOpen]);
 
-  const canDelete = !!me?.role?.delete_books && !!me?.role?.edit;
+  const canDelete = canDeleteBooks(me);
   const canEditPublic = !!me?.role?.edit_shelfs;
   const editableShelves = (shelvesData?.items ?? []).filter(
     (s) => s.is_owner || (s.is_public && canEditPublic),

--- a/frontend/src/lib/permissions.ts
+++ b/frontend/src/lib/permissions.ts
@@ -36,3 +36,14 @@ export function canReadBooks(me: Me | undefined | null): boolean {
 export function canDownloadBooks(me: Me | undefined | null): boolean {
   return !!me?.role?.download;
 }
+
+/**
+ * May this user permanently delete a whole book or one of its formats?
+ *
+ * Classic's detail control checks both roles directly. Its format and bulk
+ * controls sit behind edit-only routes and then call the delete-role core, so
+ * their effective policy is the same conjunction.
+ */
+export function canDeleteBooks(me: Me | undefined | null): boolean {
+  return !!me?.role?.delete_books && !!me?.role?.edit;
+}

--- a/frontend/src/pages/BookDetail.tsx
+++ b/frontend/src/pages/BookDetail.tsx
@@ -21,7 +21,7 @@ import type { CustomColumn, CustomColumnValue, EntityRef, DeliveryDevice } from 
 import { ApiError, resourceUrl, resourceSrcSet } from '../lib/api';
 import { useT } from '../lib/i18n';
 import { getPrimaryReadTarget } from '../lib/readerTarget';
-import { canDownloadBooks, canReadBooks } from '../lib/permissions';
+import { canDeleteBooks, canDownloadBooks, canReadBooks } from '../lib/permissions';
 import styles from './BookDetail.module.css';
 import { useCardActionsHidden } from '../lib/useCardActionsHidden';
 import { BookUserNotices } from '../components/UserNotices';
@@ -372,6 +372,7 @@ export function BookDetail() {
     book.formats.map((f) => f.format),
     canReadBooks(me),
   );
+  const canDelete = canDeleteBooks(me);
 
   // The membership endpoint returns ids only, and both it and the shelf list
   // apply the same server-side visibility filter (own shelves + public ones),
@@ -738,7 +739,7 @@ export function BookDetail() {
                 separated region below renders instead (both share
                 requestDeleteBook, so behaviour is identical). Placed last so
                 the primary actions keep their positions. */}
-            {narrowLayout && me?.role?.delete_books && me?.role?.edit && (
+            {narrowLayout && canDelete && (
               <button
                 type="button"
                 data-testid="book-delete-icon"
@@ -761,7 +762,7 @@ export function BookDetail() {
               INSTEAD of this region (#1828) — neither is ever hidden in the DOM.
               This uses the same delete-and-edit policy as the server;
               this gate and grouping are the discoverability/UX layer. */}
-          {!narrowLayout && me?.role?.delete_books && me?.role?.edit && (
+          {!narrowLayout && canDelete && (
             <section className={styles.dangerZone} data-testid="book-destructive-actions"
               aria-label={t('Delete from the global library')}>
               <button

--- a/frontend/src/pages/EditBook.tsx
+++ b/frontend/src/pages/EditBook.tsx
@@ -18,7 +18,7 @@ import { formatAuthors } from '../lib/authors';
 import { ApiError, resourceUrl } from '../lib/api';
 import { useT } from '../lib/i18n';
 import styles from './EditBook.module.css';
-import { canDownloadBooks, canUploadBooks } from '../lib/permissions';
+import { canDeleteBooks, canDownloadBooks, canUploadBooks } from '../lib/permissions';
 
 interface Ident { type: string; val: string }
 
@@ -247,7 +247,7 @@ export function EditBook({ id }: { id: string }) {
       </Link>
       <div className={styles.pageHeader}>
         <h1 className={styles.title}>{t('Edit metadata')}</h1>
-        {me?.role?.delete_books && (
+        {canDeleteBooks(me) && (
           <Button type="button" variant="danger" data-testid="edit-book-delete"
             aria-label={t('Delete book')} disabled={deleteBook.isPending} onClick={onDeleteBook}>
             <Trash2 size={16} aria-hidden="true" focusable={false} />
@@ -800,7 +800,7 @@ function FormatsManager({ id }: { id: string }) {
   const sources = (convertOptions?.sources.length ? convertOptions.sources : formats.map((f) => f.toLowerCase()));
   const targets = convertOptions?.targets ?? [];
   if (!book) return null;
-  const canDelete = !!me?.role?.delete_books;
+  const canDelete = canDeleteBooks(me);
   // #1288: "Add a format" POSTs to /api/v1/books/<id>/formats, which requires
   // role_upload and now honours the admin's "Enable Uploads" switch. Gate the
   // control on the same pair, or the switch turns a hidden button into a 403.

--- a/frontend/unit/roleGates.test.ts
+++ b/frontend/unit/roleGates.test.ts
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+import type { Me } from '../src/lib/api.ts';
+import {
+  canDeleteBooks, canDownloadBooks, canReadBooks,
+} from '../src/lib/permissions.ts';
+import { getPrimaryReadTarget, getReaderContentUrl } from '../src/lib/readerTarget.ts';
+
+function account(role: Record<string, boolean>): Me {
+  return {
+    id: 1,
+    name: 'role-probe',
+    locale: 'en',
+    theme: 'light',
+    role,
+  };
+}
+
+function source(path: string): string {
+  return readFileSync(new URL(path, import.meta.url), 'utf8');
+}
+
+test('reader CTA and content route use viewer independently of download', () => {
+  const probes = [
+    { name: 'download-only', me: account({ viewer: false, download: true }), canRead: false },
+    { name: 'viewer-only', me: account({ viewer: true, download: false }), canRead: true },
+    { name: 'viewer-and-download', me: account({ viewer: true, download: true }), canRead: true },
+  ];
+
+  for (const probe of probes) {
+    assert.equal(canReadBooks(probe.me), probe.canRead, probe.name);
+    assert.equal(
+      getPrimaryReadTarget(197, ['EPUB'], canReadBooks(probe.me)),
+      probe.canRead ? '/read/197' : null,
+      probe.name,
+    );
+  }
+
+  assert.equal(canDownloadBooks(probes[0].me), true);
+  assert.equal(canDownloadBooks(probes[1].me), false);
+  assert.equal(getReaderContentUrl(197, 'EPUB'), '/show/197/epub');
+
+  const detail = source('../src/pages/BookDetail.tsx');
+  const card = source('../src/components/BookCard.tsx');
+  assert.match(detail, /getPrimaryReadTarget\([\s\S]*?canReadBooks\(me\),\s*\)/);
+  assert.match(detail, /inLibrary && primaryReadTarget \? \(/);
+  assert.match(card, /getPrimaryReadTarget\(book\.id, book\.formats, canRead\)/);
+});
+
+test('all destructive book CTAs require delete-books and edit together', () => {
+  assert.equal(canDeleteBooks(account({ delete_books: true, edit: false })), false);
+  assert.equal(canDeleteBooks(account({ delete_books: false, edit: true })), false);
+  assert.equal(canDeleteBooks(account({ delete_books: true, edit: true })), true);
+
+  const detail = source('../src/pages/BookDetail.tsx');
+  const edit = source('../src/pages/EditBook.tsx');
+  const bulk = source('../src/components/BulkBar.tsx');
+  assert.match(detail, /const canDelete = canDeleteBooks\(me\)/);
+  assert.match(detail, /narrowLayout && canDelete/);
+  assert.match(detail, /!narrowLayout && canDelete/);
+  assert.match(edit, /\{canDeleteBooks\(me\) && \(/);
+  assert.match(edit, /const canDelete = canDeleteBooks\(me\)/);
+  assert.match(bulk, /const canDelete = canDeleteBooks\(me\)/);
+});

--- a/tests/unit/test_api_v1_comic_viewer_role.py
+++ b/tests/unit/test_api_v1_comic_viewer_role.py
@@ -15,14 +15,32 @@ from werkzeug.exceptions import Forbidden
     ("comic_info", (197,)),
     ("comic_page", (197, 0)),
 ])
-def test_comic_content_rejects_user_without_viewer_before_file_access(endpoint, args):
+@pytest.mark.parametrize(("viewer", "download", "allowed"), [
+    pytest.param(False, True, False, id="download-only"),
+    pytest.param(True, False, True, id="viewer-only"),
+    pytest.param(True, True, True, id="viewer-and-download"),
+])
+def test_comic_content_uses_viewer_not_download_role(
+        endpoint, args, viewer, download, allowed):
     from cps.api import comic
 
     app = flask.Flask(__name__)
     with app.test_request_context("/api/v1/books/197/comic"):
-        user = SimpleNamespace(role_viewer=lambda: False)
+        user = SimpleNamespace(
+            role_viewer=lambda: viewer,
+            role_download=lambda: download,
+        )
         with patch.object(comic, "current_user", user), \
-                patch.object(comic, "_comic_file") as comic_file:
-            with pytest.raises(Forbidden):
-                inspect.unwrap(getattr(comic, endpoint))(*args)
-    comic_file.assert_not_called()
+                patch.object(comic, "_comic_file", return_value=("/books/197.cbz", "cbz")) as comic_file, \
+                patch.object(comic.os.path, "isfile", return_value=True), \
+                patch.object(comic, "_list_pages", return_value=["001.jpg"]), \
+                patch.object(comic, "_read_entry", return_value=b"page"):
+            if allowed:
+                response = inspect.unwrap(getattr(comic, endpoint))(*args)
+                status = response.status_code if hasattr(response, "status_code") else response[1]
+                assert status == 200
+                comic_file.assert_called_once_with(197)
+            else:
+                with pytest.raises(Forbidden):
+                    inspect.unwrap(getattr(comic, endpoint))(*args)
+                comic_file.assert_not_called()

--- a/tests/unit/test_api_v1_edit.py
+++ b/tests/unit/test_api_v1_edit.py
@@ -124,16 +124,6 @@ def test_delete_book_requires_edit_role_as_well_as_delete_role():
 
 
 @pytest.mark.unit
-def test_spa_whole_book_delete_controls_require_both_roles():
-    root = Path(__file__).parents[2]
-    detail = (root / "frontend" / "src" / "pages" / "BookDetail.tsx").read_text()
-    bulk = (root / "frontend" / "src" / "components" / "BulkBar.tsx").read_text()
-    assert "me?.role?.delete_books && me?.role?.edit" in detail
-    assert "!!me?.role?.delete_books && !!me?.role?.edit" in bulk
-    assert "same delete-and-edit policy as the server" in detail
-
-
-@pytest.mark.unit
 def test_delete_book_not_found_404():
     from cps.api import edit as mod
     with _ctx("/api/v1/books/999/delete"):
@@ -297,6 +287,17 @@ def test_delete_format_requires_delete_role():
         with patch.object(mod, "current_user", _editor(role_delete=False)):
             resp = inspect.unwrap(mod.delete_format)(5, "epub")
     assert resp[1] == 403
+
+
+@pytest.mark.unit
+def test_delete_format_requires_edit_role_as_well_as_delete_role():
+    from cps.api import edit as mod
+    with _ctx("/api/v1/books/5/formats/epub/delete"):
+        with patch.object(mod, "current_user", _editor(role_edit=False, role_delete=True)), \
+             patch.object(mod, "delete_book_from_table") as core:
+            resp = inspect.unwrap(mod.delete_format)(5, "epub")
+    assert resp[1] == 403
+    core.assert_not_called()
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Closes F-ed109c and F-f6a8bf.

At HEAD, the viewer-role reader gate and the whole-book delete conjunction had already landed (8f04590003, d8bdb1cb88). What remained:

- `/api/v1/books/<id>/formats/<fmt>/delete` required `delete_books` alone; it now requires `delete_books` AND `edit`, through the same `_require_book_delete()` guard as whole-book delete, enforced before the destructive core.
- The SPA's destructive controls (BookDetail desktop + mobile, EditBook whole-book and per-format, BulkBar) use one shared `canDeleteBooks()` predicate instead of scattered inline checks; the reassuring comment at BookDetail now matches the server.
- Comic content endpoints pinned to `viewer` with a three-user matrix (download-only 403, viewer-only 200, both 200); reader-target unit tests pin the CTA rules.

Policy (pilot decision, flagged to the operator): classic's conjunction is the intended rule. Delete-but-not-edit accounts lose format deletion in the New UI; changelog states it plainly.

Evidence: format-delete probe returned 500-via-core before, 403 now (red→green); full unit suite 8,190 passed, 91 skipped; `npm run build` + `npm run test:unit` 36 passed (Sol, OBSERVED). Playwright lanes run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016HTQrgFiyGnVJU2MxXTkJ2