### PR TITLE
fix(covers): stage cover writes until metadata commits (F-50a5cb)

### DIFF
--- a/changelog.d/f50a5cb-cover-write-staging.md
+++ b/changelog.d/f50a5cb-cover-write-staging.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **Cover writes are staged and decoded before publication.** A failed write,
+  image validation, or metadata commit never touches the existing local or
+  Google Drive cover. After a successful metadata commit, local covers publish
+  with an atomic rename and existing Drive covers update on the same file ID;
+  publication failures trigger metadata compensation.
+- A process death between the metadata commit and cover publication can still
+  leave metadata claiming a cover that was not published. On the next startup,
+  the orphan stage is logged and removed without guessing whether to publish it.

--- a/cps/__init__.py
+++ b/cps/__init__.py
@@ -237,6 +237,14 @@ def create_app():
     from .calibre_init import init_calibre_db_from_config
     init_calibre_db_from_config(config, cli_param.settings_path)
     calibre_db.init_db()
+    # A process can die after staging or after committing cover metadata but
+    # before publication. The stage alone cannot tell us which occurred, so
+    # startup logs and removes it rather than guessing at publication.
+    try:
+        from . import helper
+        helper.scavenge_staged_cover_files()
+    except Exception as ex:
+        log.error("Cover stage startup scavenging failed: %s", ex)
     # The annotation content-id backfill needs both databases: app.db owns the
     # annotation, while metadata.db is authoritative for book UUID. Running it
     # earlier would let a filename choose the book and can cross-link rows.

--- a/cps/api/edit.py
+++ b/cps/api/edit.py
@@ -600,15 +600,15 @@ def set_cover(book_id):
         )
 
     if request.files.get("file"):
-        ok, message = save_cover(request.files["file"], book.path)
+        staged_cover, message = save_cover(request.files["file"], book.path)
     else:
         data = request.get_json(silent=True) or {}
         url = (data.get("url") or "").strip()
         if not url:
             return _err("invalid_request", "Provide an image file or a cover URL", 400)
-        ok, message = save_cover_from_url(url, book.path)
+        staged_cover, message = save_cover_from_url(url, book.path)
 
-    if not ok:
+    if not staged_cover:
         return _err("cover_failed", str(message), 400)
 
     # A new cover IS a book change and has to be recorded as one. Writing
@@ -628,25 +628,42 @@ def set_cover(book_id):
     # raises — and adopting it here would turn a working cover upload into a 500
     # on exactly those installs. Recorded as a finding rather than papered over;
     # the fix belongs in the lock's path resolution, not in this caller.
+    previous_has_cover = book.has_cover
+    previous_last_modified = book.last_modified
     try:
         book.has_cover = 1
         mark_book_modified(book)
         calibre_db.session.commit()
     except Exception as exc:
-        # The bytes are already on disk — save_cover writes the library file
-        # before anything touches the database — so this is a PARTIALLY APPLIED
-        # change: the library file has changed, while has_cover/last_modified/
-        # Kobo state still describe the old cover. Which of the two a client
-        # then sees depends on the book: for a replacement, a fresh fetch gets
-        # the new image under the old version token; for a book that had no
-        # cover, the rolled-back has_cover=0 makes the route answer with the
-        # placeholder even though the file exists. Reporting success would hide
-        # either, so the caller is told the save failed and can retry.
         log.error("set_cover: failed to record cover change for book %s: %s", book_id, exc)
+        staged_cover.discard()
         try:
             calibre_db.session.rollback()
         except Exception:
             pass
+        book.has_cover = previous_has_cover
+        book.last_modified = previous_last_modified
+        return _err("cover_failed", "Cover save failed", 500)
+
+    published, publish_error = staged_cover.publish()
+    if not published:
+        staged_cover.discard()
+        book.has_cover = previous_has_cover
+        book.last_modified = previous_last_modified
+        try:
+            calibre_db.session.commit()
+        except Exception as compensation_exc:
+            log.error(
+                "set_cover: metadata compensation failed for book %s after "
+                "publish failure %s: %s",
+                book_id,
+                publish_error,
+                compensation_exc,
+            )
+            try:
+                calibre_db.session.rollback()
+            except Exception:
+                pass
         return _err("cover_failed", "Cover save failed", 500)
 
     # Post-commit housekeeping, mirroring cover_picker's apply path. Runs AFTER

--- a/cps/cover_picker.py
+++ b/cps/cover_picker.py
@@ -259,8 +259,8 @@ def cover_picker_apply(book_id):
 
     # Multipart upload from the picker's file panel.
     if request.files.get("file"):
-        ok, message = _apply_uploaded_file(book, request.files["file"])
-        return _apply_response(ok, message, book)
+        staged_cover, message = _apply_uploaded_file(book, request.files["file"])
+        return _apply_response(staged_cover, message, book)
 
     body = request.get_json(silent=True) or {}
     kind = body.get("kind") or "url"
@@ -269,15 +269,15 @@ def cover_picker_apply(book_id):
         url = (body.get("url") or "").strip()
         if not url:
             return _json_error("empty_url", _(u"Provide a cover URL."), 400)
-        ok, message = helper.save_cover_from_url(url, book.path)
-        return _apply_response(ok, message, book)
+        staged_cover, message = helper.save_cover_from_url(url, book.path)
+        return _apply_response(staged_cover, message, book)
 
     if kind == "embedded":
         extracted = cover_extract.extract_embedded_cover(book)
         if extracted is None:
             return _json_error("no_embedded", _(u"This book doesn't have an embedded cover we can extract."), 400)
-        ok, message = _apply_bytes(book, extracted.data, extracted.extension)
-        return _apply_response(ok, message, book)
+        staged_cover, message = _apply_bytes(book, extracted.data, extracted.extension)
+        return _apply_response(staged_cover, message, book)
 
     return _json_error("bad_kind", _(u"Unknown cover source."), 400)
 
@@ -561,8 +561,10 @@ def _apply_bytes(book, raw: bytes, extension: str):
     return helper.save_cover(storage, book.path)
 
 
-def _apply_response(ok: bool, message, book):
-    if ok:
+def _apply_response(staged_cover, message, book):
+    if staged_cover:
+        previous_has_cover = book.has_cover
+        previous_last_modified = book.last_modified
         try:
             book.has_cover = 1
             # A new cover IS a metadata change: bump last_modified (drives the
@@ -571,33 +573,58 @@ def _apply_response(ok: bool, message, book):
             # runs post-commit below (best-effort) so a commit failure can't
             # leave it half-applied. Single source of truth: helper.mark_book_modified.
             helper.mark_book_modified(book)
-            # #707: a cover change must also embed into the book file, not just
-            # update cover.jpg. mark_book_modified only stamps last_modified +
-            # the dirty bit; the file-level cover embed is driven by the metadata
-            # enforcer, which fires off a change-log entry. Without this the
-            # download/embedded cover (and the picker's "Currently embedded"
-            # preview) stayed on the old image.
-            helper.log_metadata_change(book, {'cover': True})
             calibre_db.session.commit()
         except Exception as exc:
-            # The cover bytes are on disk but we could not record the change.
-            # Do NOT report success — the UI must not show a stale "saved"
-            # state when last_modified never persisted.
             log.error("cover apply: failed to record cover change for book %s: %s", book.id, exc)
+            staged_cover.discard()
             try:
                 calibre_db.session.rollback()
             except Exception:
                 pass
+            book.has_cover = previous_has_cover
+            book.last_modified = previous_last_modified
             return _json_error("commit_failed", _(u"Cover save failed."), 500)
+
+        published, publish_error = staged_cover.publish()
+        if not published:
+            staged_cover.discard()
+            book.has_cover = previous_has_cover
+            book.last_modified = previous_last_modified
+            try:
+                calibre_db.session.commit()
+            except Exception as compensation_exc:
+                log.error(
+                    "cover apply: metadata compensation failed for book %s "
+                    "after publish failure %s: %s",
+                    book.id,
+                    publish_error,
+                    compensation_exc,
+                )
+                try:
+                    calibre_db.session.rollback()
+                except Exception:
+                    pass
+            return _json_error("publish_failed", _(u"Cover save failed."), 500)
+
+        # #707: enqueue file-level embedding only after both metadata and the
+        # canonical cover are visible.  A pre-publish record could be consumed
+        # against the old cover bytes.
+        try:
+            helper.log_metadata_change(book, {'cover': True})
+        except Exception as exc:
+            log.error("cover apply: enforcement record failed for book %s: %s", book.id, exc)
         # Post-commit best-effort: the cover is applied and the last_modified
         # bump above already drives both the web cache-bust and Kobo
         # re-selection, so a failure here self-heals on the next sync /
         # thumbnail access. Log loudly but still report success.
         try:
             kobo_sync_status.remove_synced_book(book.id, all=True)
+        except Exception as exc:
+            log.error("post-apply Kobo housekeeping failed for book %s: %s", book.id, exc)
+        try:
             helper.replace_cover_thumbnail_cache(book.id)
         except Exception as exc:
-            log.error("post-apply cover housekeeping failed for book %s: %s", book.id, exc)
+            log.error("post-apply thumbnail housekeeping failed for book %s: %s", book.id, exc)
         return jsonify({
             "ok": True,
             "cover_url": url_for("web.get_cover", book_id=book.id, resolution="og") + f"?ts={int(datetime.now(timezone.utc).timestamp())}",

--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -1004,6 +1004,7 @@ def do_edit_book(book_id, upload_formats=None):
     modify_date = False
     edit_error = False
     refresh_cover_thumbnail_after_commit = False
+    cover_stage = None
 
     # allow_show_hidden=True: the metadata-save POST must succeed against
     # a user's own hidden book — droM4X reported the metadata icon on
@@ -1015,6 +1016,8 @@ def do_edit_book(book_id, upload_formats=None):
         flash(_("Oops! Selected book is unavailable. File does not exist or is not accessible"),
               category="error")
         return redirect(url_for("web.index"))
+
+    previous_cover_metadata = (book.has_cover, book.last_modified)
 
     to_save = request.form.to_dict()
 
@@ -1046,6 +1049,7 @@ def do_edit_book(book_id, upload_formats=None):
 
         cover_upload_success = upload_cover(request, book)
         if cover_upload_success or to_save.get("format_cover"):
+            cover_stage = cover_upload_success or cover_stage
             book.has_cover = 1
             modify_date = True
 
@@ -1078,10 +1082,12 @@ def do_edit_book(book_id, upload_formats=None):
                 result, error = parallel.run_blocking(copy_current_request_context(partial(
                     helper.save_cover_from_url, to_save["cover_url"].strip(), book.path)))
                 if result:
+                    if cover_stage is not None:
+                        cover_stage.discard()
+                    cover_stage = result
                     book.has_cover = 1
                     modify_date = True
-                    refresh_cover_thumbnail_after_commit = True
-                    log.debug("[edit_book] cover saved book_id=%s duration=%.3fs", book.id, time.monotonic() - cover_start)
+                    log.debug("[edit_book] cover staged book_id=%s duration=%.3fs", book.id, time.monotonic() - cover_start)
                 else:
                     log.warning("[edit_book] cover save failed book_id=%s duration=%.3fs error=%s", book.id, time.monotonic() - cover_start, error)
                     edit_error = True
@@ -1132,7 +1138,7 @@ def do_edit_book(book_id, upload_formats=None):
 
         # Stage 3: Commit all changes to the database.
         if modify_date:
-            helper.mark_book_modified(book, unsync=True)
+            helper.mark_book_modified(book)
 
         # Hold the process-shared metadata.db write lock for the
         # duration of the commit. Coordinates with the ingest_processor
@@ -1162,12 +1168,49 @@ def do_edit_book(book_id, upload_formats=None):
                 calibre_db.session.commit()
             log.debug("[edit_book] db commit retry ok book_id=%s duration=%.3fs", book.id, time.monotonic() - request_start)
 
+        if cover_stage is not None:
+            published, publish_error = cover_stage.publish()
+            if not published:
+                cover_stage.discard()
+                cover_stage = None
+                book.has_cover, book.last_modified = previous_cover_metadata
+                try:
+                    with metadata_db_write_lock():
+                        calibre_db.session.merge(book)
+                        calibre_db.session.commit()
+                except Exception as compensation_error:
+                    log.error_or_exception(
+                        "Cover metadata compensation failed for book %s after "
+                        "publish failure %s: %s",
+                        book.id,
+                        publish_error,
+                        compensation_error,
+                    )
+                    try:
+                        calibre_db.session.rollback()
+                    except Exception:
+                        pass
+                flash(_("Cover-file is not a valid image file, or could not be stored"), category="error")
+                return redirect(url_for('web.show_book', book_id=book.id))
+            cover_stage = None
+            refresh_cover_thumbnail_after_commit = True
+
         if refresh_cover_thumbnail_after_commit:
-            helper.replace_cover_thumbnail_cache(
-                book.id,
-                book_path=book.path,
-                last_modified=book.last_modified,
-            )
+            try:
+                from . import kobo_sync_status
+                kobo_sync_status.remove_synced_book(book.id, all=True)
+            except Exception as ex:
+                log.error_or_exception("Failed to invalidate Kobo cover state for book %s: %s",
+                                       book.id, ex)
+            try:
+                helper.replace_cover_thumbnail_cache(
+                    book.id,
+                    book_path=book.path,
+                    last_modified=book.last_modified,
+                )
+            except Exception as ex:
+                log.error_or_exception("Failed to replace cover thumbnail cache for book %s: %s",
+                                       book.id, ex)
 
         # CWA: Export of changed Metadata after commit, to avoid race conditions with folder renames
         # Only create log if there were actual meaningful metadata changes
@@ -1243,11 +1286,17 @@ def do_edit_book(book_id, upload_formats=None):
     except (ValueError, OperationalError, IntegrityError, StaleDataError, InterfaceError, InvalidRequestError) as e:
         log.error_or_exception("Database or Value error: {}".format(e))
         calibre_db.session.rollback()
+        if cover_stage is not None:
+            cover_stage.discard()
+            book.has_cover, book.last_modified = previous_cover_metadata
         flash(_("Oops! Database Error: %(error)s.", error=e.orig if hasattr(e, "orig") else e), category="error")
         return redirect(url_for('web.show_book', book_id=book.id))
     except Exception as ex:
         log.error_or_exception(ex)
         calibre_db.session.rollback()
+        if cover_stage is not None:
+            cover_stage.discard()
+            book.has_cover, book.last_modified = previous_cover_metadata
         flash(_("Error editing book: {}".format(ex)), category="error")
         return redirect(url_for('web.show_book', book_id=book.id))
 
@@ -2373,11 +2422,9 @@ def upload_cover(cover_request, book):
             if not current_user.role_edit():
                 flash(_("User has no rights to upload cover"), category="error")
                 return False
-            ret, message = helper.save_cover_with_thumbnail_update(requested_file, book.path, book.id)
-            if ret is True:
-                # Note: save_cover_with_thumbnail_update already triggers thumbnail generation
-                # No need to call replace_cover_thumbnail_cache here (would create duplicate tasks)
-                return True
+            staged_cover, message = helper.save_cover(requested_file, book.path)
+            if staged_cover:
+                return staged_cover
             else:
                 flash(message, category="error")
                 return False

--- a/cps/gdriveutils.py
+++ b/cps/gdriveutils.py
@@ -330,6 +330,19 @@ def getFileFromEbooksFolder(path, fileName, nocase=False):
         return None
 
 
+def prepareCoverUpload(path):
+    """Resolve a Drive cover target without changing its remote contents.
+
+    The returned file object, when present, must be retained by the caller so
+    PyDrive2 publishes replacement bytes with ``files.update`` on the same ID.
+    """
+    drive = getDrive(Gdrive.Instance().drive)
+    folder_id = getFolderId(path, drive) if path else getEbooksFolderId(drive)
+    if not folder_id:
+        raise RuntimeError("Google Drive book folder could not be resolved")
+    return drive, folder_id, getFile(folder_id, "cover.jpg", drive, False)
+
+
 def moveGdriveFileRemote(origin_file_id, new_title):
     origin_file_id['title'] = new_title
     origin_file_id.Upload()

--- a/cps/helper.py
+++ b/cps/helper.py
@@ -9,6 +9,7 @@ import os
 import random
 import io
 import mimetypes
+import tempfile
 import time
 import re
 import regex
@@ -20,6 +21,8 @@ from datetime import datetime, timedelta, timezone
 import requests
 import unidecode
 from uuid import uuid4
+
+from PIL import Image as PILImage
 
 from flask import send_from_directory, make_response, abort, url_for, Response, after_this_request, has_request_context
 from flask_babel import gettext as _
@@ -2181,8 +2184,155 @@ def save_cover_from_url(url, book_path):
             pass
 
 
-def save_cover_from_filestorage(filepath, saved_filename, img):
-    # check if file path exists, otherwise create it, copy file to calibre path and delete temp file
+class StagedCoverWrite:
+    """A validated sibling file that does not touch the live cover until publish.
+
+    The metadata owner calls :meth:`publish` only after its transaction commits
+    and attempts :meth:`discard` on ordinary rollback/error paths. Local stages
+    are siblings so ``os.replace`` is an atomic same-filesystem rename and the
+    previous cover remains intact until it succeeds. Startup scavenging logs
+    and removes stages left by process death; it never guesses whether to
+    publish them because the metadata commit may or may not have landed.
+    """
+
+    def __init__(self, staged_path, target_path):
+        self.staged_path = staged_path
+        self.target_path = target_path
+        self._published = False
+
+    def publish(self):
+        if self._published:
+            return True, None
+        try:
+            os.replace(self.staged_path, self.target_path)
+            self._published = True
+        except (IOError, OSError) as ex:
+            log.error(
+                "Publishing staged cover failed target=%s: %s: %s",
+                self.target_path,
+                type(ex).__name__,
+                ex,
+            )
+            return False, str(ex)
+
+        # The rename is already complete.  Directory fsync is best-effort on
+        # filesystems that support it; network shares commonly reject it even
+        # though their atomic rename succeeded.
+        try:
+            directory_fd = os.open(os.path.dirname(self.target_path), os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+        except OSError as ex:
+            log.warning("Could not fsync published cover directory: %s", ex)
+        return True, None
+
+    def discard(self):
+        if self._published or not os.path.exists(self.staged_path):
+            return True, None
+        try:
+            os.remove(self.staged_path)
+            return True, None
+        except OSError as ex:
+            log.error("Removing staged cover %s failed: %s", self.staged_path, ex)
+            return False, str(ex)
+
+
+class GDriveStagedCoverWrite(StagedCoverWrite):
+    """Locally validated cover bytes awaiting a post-commit Drive upload."""
+
+    def __init__(self, staged_path, drive, parent_id, existing_file=None):
+        super().__init__(staged_path, "Google Drive cover.jpg")
+        self.drive = drive
+        self.parent_id = parent_id
+        self.existing_file = existing_file
+
+    def publish(self):
+        if self._published:
+            return True, None
+        drive_file = self.existing_file
+        try:
+            if drive_file is None:
+                drive_file = self.drive.CreateFile({
+                    "title": "cover.jpg",
+                    "parents": [{"kind": "drive#fileLink", "id": self.parent_id}],
+                })
+            drive_file.SetContentFile(self.staged_path)
+            drive_file.Upload()
+            self._published = True
+            self.existing_file = drive_file
+        except Exception as ex:
+            log.error(
+                "Publishing staged Google Drive cover failed: %s: %s",
+                type(ex).__name__,
+                ex,
+            )
+            return False, str(ex)
+
+        try:
+            os.remove(self.staged_path)
+        except OSError as ex:
+            # Remote publication has committed. Local cleanup cannot roll it
+            # back and is left to the startup scavenger.
+            log.warning("Could not remove published Google Drive cover stage %s: %s",
+                        self.staged_path, ex)
+        return True, None
+
+
+def _write_all(fd, content):
+    """Write every byte or raise; ``os.write`` is allowed to short-write."""
+    remaining = memoryview(content)
+    while remaining:
+        written = os.write(fd, remaining)
+        if not written:
+            raise OSError("short write while staging cover")
+        remaining = remaining[written:]
+
+
+def _write_stream(fd, stream):
+    while True:
+        chunk = stream.read(1024 * 1024)
+        if not chunk:
+            break
+        _write_all(fd, chunk)
+
+
+def _validate_and_normalize_staged_cover(staged_path):
+    """Decode accepted image bytes and normalize non-JPEG stages to JPEG."""
+    with PILImage.open(staged_path) as decoded:
+        image_format = decoded.format
+        width, height = decoded.size
+        decoded.load()
+        if image_format not in {"JPEG", "PNG", "WEBP", "BMP"} or width < 1 or height < 1:
+            raise ValueError("staged cover is not a supported decodable image")
+        if image_format == "JPEG":
+            return
+        # Work from the decoded pixels, not the declared MIME type. Flatten
+        # transparency onto white because JPEG has no alpha channel.
+        if decoded.mode in ("RGBA", "LA") or "transparency" in decoded.info:
+            rgba = decoded.convert("RGBA")
+            normalized = PILImage.new("RGB", rgba.size, "white")
+            normalized.paste(rgba, mask=rgba.getchannel("A"))
+        else:
+            normalized = decoded.convert("RGB")
+
+    normalized.save(staged_path, format="JPEG")
+    with open(staged_path, "rb") as staged_file:
+        os.fsync(staged_file.fileno())
+    with PILImage.open(staged_path) as verified:
+        if verified.format != "JPEG":
+            raise ValueError("normalized cover is not JPEG")
+        verified.load()
+
+
+def save_cover_from_filestorage(filepath, saved_filename, img, handle_factory=None):
+    """Write and validate a temporary sibling, returning a publish handle.
+
+    Despite the historical name, this function deliberately does not replace
+    ``saved_filename``.  It is the single storage primitive used by every cover
+    surface; callers own the surrounding metadata transaction.
+    """
     if not os.path.exists(filepath):
         try:
             os.makedirs(filepath)
@@ -2190,8 +2340,19 @@ def save_cover_from_filestorage(filepath, saved_filename, img):
             log.error("Failed to create cover path %s: %s", filepath, e)
             return False, _("Failed to create path for cover")
     target = os.path.join(filepath, saved_filename)
+    staged_path = None
+    fd = None
     try:
-        # upload of jpg file without wand
+        fd, staged_path = tempfile.mkstemp(
+            prefix=".{}.cwng-".format(saved_filename),
+            suffix=".stage",
+            dir=filepath,
+        )
+        try:
+            staged_mode = os.stat(target).st_mode & 0o777
+        except OSError:
+            staged_mode = 0o644
+        os.fchmod(fd, staged_mode)
         if isinstance(img, requests.Response):
             content_len = len(img.content) if img.content is not None else 0
             ct = img.headers.get("content-type") if hasattr(img, "headers") else None
@@ -2199,78 +2360,98 @@ def save_cover_from_filestorage(filepath, saved_filename, img):
                 log.error("Cover save aborted: empty response body (url=%s, content-type=%s, http=%s)",
                           getattr(getattr(img, "request", None), "url", "?"), ct,
                           getattr(img, "status_code", "?"))
-                return False, _("Cover-file is not a valid image file, or could not be stored")
-            with open(target, 'wb') as f:
-                f.write(img.content)
+                raise ValueError("empty response body")
+            _write_all(fd, img.content)
+            os.fsync(fd)
         else:
             if hasattr(img, "metadata"):
-                # upload of jpg/png... via url
-                img.save(filename=target)
+                os.close(fd)
+                fd = None
+                img.save(filename=staged_path)
                 img.close()
+            elif hasattr(img, "stream"):
+                _write_stream(fd, img.stream)
+                os.fsync(fd)
             else:
-                # upload of jpg/png... from hdd
-                img.save(target)
-    except (IOError, OSError) as e:
-        log.error("Cover save failed (filesystem) target=%s: %s: %s", target, type(e).__name__, e)
-        return False, _("Cover-file is not a valid image file, or could not be stored")
+                os.close(fd)
+                fd = None
+                img.save(staged_path)
+
+        if fd is not None:
+            os.close(fd)
+            fd = None
+        else:
+            sync_fd = os.open(staged_path, os.O_RDONLY)
+            try:
+                os.fsync(sync_fd)
+            finally:
+                os.close(sync_fd)
+        _validate_and_normalize_staged_cover(staged_path)
+        if handle_factory is not None:
+            return handle_factory(staged_path), None
+        return StagedCoverWrite(staged_path, target), None
+    except (IOError, OSError, ValueError) as e:
+        log.error("Cover staging failed target=%s: %s: %s", target, type(e).__name__, e)
     except Exception as e:
-        log.error("Cover save failed (unexpected) target=%s: %s: %s", target, type(e).__name__, e)
-        return False, _("Cover-file is not a valid image file, or could not be stored")
-    return True, None
+        log.error("Cover staging failed (unexpected) target=%s: %s: %s", target, type(e).__name__, e)
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+    if staged_path:
+        try:
+            os.remove(staged_path)
+        except OSError:
+            pass
+    return None, _("Cover-file is not a valid image file, or could not be stored")
 
 
 # saves book cover to gdrive or locally
 def save_cover(img, book_path):
-    content_type = img.headers.get('content-type')
-
-    # Clean content-type by removing charset and other parameters
-    if content_type:
-        separator = ';' if ';' in content_type else ',' if ',' in content_type else None
-        if separator:
-            content_type = content_type.split(separator)[0].strip()
-
-    if use_IM:
-        if content_type not in ('image/jpeg', 'image/jpg', 'image/png', 'image/webp', 'image/bmp'):
-            log.error("Only jpg/jpeg/png/webp/bmp files are supported as coverfile")
-            return False, _("Only jpg/jpeg/png/webp/bmp files are supported as coverfile")
-        # Skip conversion for JPEG to avoid unnecessary ImageMagick work
-        if content_type not in ('image/jpeg', 'image/jpg'):
-            # convert to jpg because calibre only supports jpg
-            try:
-                if hasattr(img, 'stream'):
-                    imgc = Image(blob=img.stream)
-                else:
-                    imgc = Image(blob=io.BytesIO(img.content))
-                imgc.format = 'jpeg'
-                imgc.transform_colorspace("srgb")
-                img = imgc
-            except (BlobError, MissingDelegateError) as e:
-                log.error("Invalid cover file content (content-type=%s, bytes=%s): %s: %s",
-                          content_type, len(img.content) if hasattr(img, "content") else "?",
-                          type(e).__name__, e)
-                return False, _("Invalid cover file content")
-            except Exception as e:
-                log.error("Cover conversion failed (content-type=%s, bytes=%s): %s: %s",
-                          content_type, len(img.content) if hasattr(img, "content") else "?",
-                          type(e).__name__, e)
-                return False, _("Invalid cover file content")
-    else:
-        if content_type not in ['image/jpeg', 'image/jpg']:
-            log.error("Only jpg/jpeg files are supported as coverfile")
-            return False, _("Only jpg/jpeg files are supported as coverfile")
-
     if config.config_use_google_drive:
-        tmp_dir = get_temp_dir()
-        ret, message = save_cover_from_filestorage(tmp_dir, "uploaded_cover.jpg", img)
-        if ret is True:
-            gd.uploadFileToEbooksFolder(os.path.join(book_path, 'cover.jpg').replace("\\", "/"),
-                                        os.path.join(tmp_dir, "uploaded_cover.jpg"))
-            log.info("Cover is saved on Google Drive")
-            return True, None
-        else:
-            return False, message
-    else:
-        return save_cover_from_filestorage(os.path.join(config.get_book_path(), book_path), "cover.jpg", img)
+        def create_drive_handle(staged_path):
+            drive, parent_id, existing_file = gd.prepareCoverUpload(book_path)
+            return GDriveStagedCoverWrite(staged_path, drive, parent_id, existing_file)
+
+        return save_cover_from_filestorage(
+            get_temp_dir(),
+            "cover.jpg",
+            img,
+            handle_factory=create_drive_handle,
+        )
+
+    return save_cover_from_filestorage(
+        os.path.join(config.get_book_path(), book_path), "cover.jpg", img
+    )
+
+
+def scavenge_staged_cover_files():
+    """Log and remove orphan cover stages without attempting publication."""
+    roots = []
+    for root in (config.get_book_path(), get_temp_dir()):
+        if root and os.path.isdir(root) and root not in roots:
+            roots.append(root)
+
+    removed = 0
+    for root in roots:
+        for directory, _subdirs, filenames in os.walk(root):
+            for filename in filenames:
+                if not (filename.startswith(".cover.jpg.cwng-") and filename.endswith(".stage")):
+                    continue
+                staged_path = os.path.join(directory, filename)
+                log.warning(
+                    "Removing orphan cover stage after interrupted update; metadata may "
+                    "already reference an unpublished cover: %s",
+                    staged_path,
+                )
+                try:
+                    os.remove(staged_path)
+                    removed += 1
+                except OSError as ex:
+                    log.error("Could not remove orphan cover stage %s: %s", staged_path, ex)
+    return removed
 
 
 def trigger_thumbnail_generation_for_book(book_id):
@@ -2297,15 +2478,8 @@ def trigger_thumbnail_generation_for_book(book_id):
 
 
 def save_cover_with_thumbnail_update(img, book_path, book_id=None):
-    """Save cover and force thumbnail regeneration."""
-    result, message = save_cover(img, book_path)
-
-    # If cover save was successful and we have a book_id, force thumbnail regeneration
-    # Use replace_cover_thumbnail_cache to ensure fresh thumbnails even if generation is pending
-    if result and book_id:
-        replace_cover_thumbnail_cache(book_id)
-
-    return result, message
+    """Compatibility wrapper: stage only; transaction owners publish/cache."""
+    return save_cover(img, book_path)
 
 
 def do_download_file(book, book_format, client, data, headers):

--- a/cps/metadata_helper.py
+++ b/cps/metadata_helper.py
@@ -153,6 +153,12 @@ def _apply_metadata_to_book(book, metadata, calibre_db_instance) -> bool:
     Returns:
         bool: True if metadata was successfully applied
     """
+    cover_stage = None
+    previous_cover_metadata = (
+        getattr(book, 'has_cover', 0),
+        getattr(book, 'last_modified', None),
+    )
+    updated_without_cover = False
     try:
         # Get CWA settings to check smart application preference and field selections
         cwa_db = CWA_DB()
@@ -333,9 +339,12 @@ def _apply_metadata_to_book(book, metadata, calibre_db_instance) -> bool:
         cover_updated = False
         if (cwa_settings.get('auto_metadata_update_cover', True) and
                 not (use_smart_application and getattr(book, 'has_cover', 0))):
-            if _apply_cover_from_metadata(book, metadata):
+            cover_stage = _apply_cover_from_metadata(book, metadata)
+            if cover_stage:
+                updated_without_cover = updated
                 updated = True
                 cover_updated = True
+                book.has_cover = 1
 
         if cover_updated:
             # A replaced cover IS a book change and has to be recorded as one.
@@ -360,6 +369,21 @@ def _apply_metadata_to_book(book, metadata, calibre_db_instance) -> bool:
             calibre_db_instance.session.commit()
             if cover_updated:
                 from cps import helper
+                published, publish_error = cover_stage.publish()
+                if not published:
+                    cover_stage.discard()
+                    cover_stage = None
+                    book.has_cover, book.last_modified = previous_cover_metadata
+                    try:
+                        calibre_db_instance.session.commit()
+                    except Exception as compensation_error:
+                        log.error(
+                            f"Cover metadata compensation failed for book {book.id} "
+                            f"after publish failure {publish_error}: {compensation_error}"
+                        )
+                        calibre_db_instance.session.rollback()
+                    return updated_without_cover
+                cover_stage = None
                 # #707: the new cover must also be embedded into the book file,
                 # not only written to cover.jpg. Best-effort by design — it
                 # queues an enforcement record, it does not perform the embed.
@@ -383,17 +407,20 @@ def _apply_metadata_to_book(book, metadata, calibre_db_instance) -> bool:
         
     except Exception as e:
         log.error(f"Error applying metadata to book {getattr(book, 'id', 'unknown')}: {e}")
+        if cover_stage is not None:
+            cover_stage.discard()
         calibre_db_instance.session.rollback()
+        book.has_cover, book.last_modified = previous_cover_metadata
         return False
 
 
-def _apply_cover_from_metadata(book, metadata) -> bool:
-    """Download the provider's cover and store it for ``book`` (fork #404).
+def _apply_cover_from_metadata(book, metadata):
+    """Download and validate a staged provider cover for ``book`` (fork #404).
 
     Routed through ``helper.save_cover_from_url`` so the ingest auto-fetch
     gets the exact safeguards of the manual editor: advocate SSRF guard,
-    download size cap, and image-format validation. Returns True only when
-    the cover was actually written (and sets ``book.has_cover``).
+    download size cap, and image-format validation. Returns a staged-cover
+    handle; the caller publishes it only after the metadata commit.
 
     Fully self-contained failure boundary: this runs in the ingest
     processor (no Flask app context, where the error-path ``_()`` calls in
@@ -412,8 +439,7 @@ def _apply_cover_from_metadata(book, metadata) -> bool:
             return False
         result, error = helper.save_cover_from_url(cover_url, book.path)
         if result:
-            book.has_cover = 1
-            return True
+            return result
         log.warning(f"Auto metadata fetch: cover download failed for book {book.id}: {error}")
     except Exception as e:
         log.warning(f"Auto metadata fetch: cover apply failed for book {book.id}: {e}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "iso-639>=0.4.5,<0.5.0;python_version<'3.12'",
     "pycountry>=24.6.1,<25.0.0;python_version>='3.12'",
     "pypdf>=6.0.0",
+    "Pillow>=11.0.0,<13.0.0",
     "pytz>=2016.10",
     "requests>=2.32.4,<2.33.0",
     "SQLAlchemy>=1.3.0,<2.1.0",

--- a/tests/unit/test_404_auto_cover_fetch.py
+++ b/tests/unit/test_404_auto_cover_fetch.py
@@ -62,6 +62,14 @@ class _FakeCDB:
         self.session = _FakeSession()
 
 
+class _StagedCover:
+    def publish(self):
+        return True, None
+
+    def discard(self):
+        return True, None
+
+
 def _metadata(cover):
     return types.SimpleNamespace(title="", cover=cover)
 
@@ -90,7 +98,7 @@ def harness(monkeypatch):
     state = {
         "settings": _settings(),
         "save_calls": [],
-        "save_result": (True, None),
+        "save_result": (_StagedCover(), None),
         "locked": False,
         "thumb_calls": [],
     }

--- a/tests/unit/test_api_v1_edit.py
+++ b/tests/unit/test_api_v1_edit.py
@@ -430,6 +430,13 @@ def _cover_book():
     return SimpleNamespace(id=5, path="p", has_cover=0, last_modified=None)
 
 
+def _staged_cover():
+    staged = MagicMock()
+    staged.publish.return_value = (True, None)
+    staged.discard.return_value = (True, None)
+    return staged
+
+
 @pytest.mark.unit
 def test_set_cover_from_url_calls_core_and_returns_cover_url():
     from cps.api import edit as mod
@@ -440,7 +447,7 @@ def test_set_cover_from_url_calls_core_and_returns_cover_url():
              patch.object(mod, "mark_book_modified"), \
              patch.object(mod, "log_metadata_change"), \
              patch.object(mod, "replace_cover_thumbnail_cache"), \
-             patch.object(mod, "save_cover_from_url", return_value=(True, "ok")) as core:
+             patch.object(mod, "save_cover_from_url", return_value=(_staged_cover(), "ok")) as core:
             resp = inspect.unwrap(mod.set_cover)(5)
     body = json.loads(resp.get_data())
     assert body["ok"] is True
@@ -472,7 +479,7 @@ def test_set_cover_records_the_change_so_every_cover_url_rebusts():
              patch.object(mod, "log_metadata_change") as logged, \
              patch.object(mod, "replace_cover_thumbnail_cache") as thumbs, \
              patch("cps.kobo_sync_status.remove_synced_book") as unsync, \
-             patch.object(mod, "save_cover_from_url", return_value=(True, "ok")):
+             patch.object(mod, "save_cover_from_url", return_value=(_staged_cover(), "ok")):
             resp = inspect.unwrap(mod.set_cover)(5)
     assert json.loads(resp.get_data())["ok"] is True
     assert book.has_cover == 1
@@ -488,8 +495,8 @@ def test_set_cover_records_the_change_so_every_cover_url_rebusts():
 
 @pytest.mark.unit
 def test_set_cover_reports_failure_when_the_change_cannot_be_recorded():
-    """The bytes are on disk but nothing else can see them — never report
-    success, or the UI shows "saved" for a change no other surface will have."""
+    """The bytes are staged, then discarded when metadata cannot be recorded;
+    never report success for a cover that was not published."""
     from cps.api import edit as mod
     session = MagicMock()
     session.commit.side_effect = RuntimeError("db gone")
@@ -500,7 +507,7 @@ def test_set_cover_reports_failure_when_the_change_cannot_be_recorded():
              patch.object(mod, "mark_book_modified"), \
              patch.object(mod, "log_metadata_change"), \
              patch.object(mod, "replace_cover_thumbnail_cache"), \
-             patch.object(mod, "save_cover_from_url", return_value=(True, "ok")):
+             patch.object(mod, "save_cover_from_url", return_value=(_staged_cover(), "ok")):
             resp = inspect.unwrap(mod.set_cover)(5)
     assert resp[1] == 500
     session.rollback.assert_called_once()

--- a/tests/unit/test_cover_picker_apply_marks_modified.py
+++ b/tests/unit/test_cover_picker_apply_marks_modified.py
@@ -61,7 +61,11 @@ def _patched_apply(book, ok, message):
                  "cps.cover_picker.url_for",
                  side_effect=lambda ep, **kw: f"/cover/{kw.get('book_id')}/{kw.get('resolution')}",
              ):
-            resp = cover_picker._apply_response(ok, message, book)
+            staged = MagicMock() if ok else None
+            if staged:
+                staged.publish.return_value = (True, None)
+                staged.discard.return_value = (True, None)
+            resp = cover_picker._apply_response(staged, message, book)
     return resp, set_dirty, remove_synced
 
 
@@ -101,8 +105,8 @@ class TestCoverApplyMarksModified:
 
     def test_commit_failure_reports_error_and_skips_post_commit(self):
         """If recording the cover change fails, the apply must NOT report
-        success (the cover bytes are on disk but last_modified never
-        persisted) and must not run the post-commit Kobo/thumbnail steps."""
+        success (the staged cover is discarded) and must not run the
+        post-commit Kobo/thumbnail steps."""
         from cps import cover_picker
 
         book = _fake_book()
@@ -119,7 +123,10 @@ class TestCoverApplyMarksModified:
                      "cps.cover_picker.url_for",
                      side_effect=lambda ep, **kw: f"/cover/{kw.get('book_id')}/{kw.get('resolution')}",
                  ):
-                resp = cover_picker._apply_response(True, None, book)
+                staged = MagicMock()
+                staged.publish.return_value = (True, None)
+                staged.discard.return_value = (True, None)
+                resp = cover_picker._apply_response(staged, None, book)
 
         assert resp.status_code == 500
         body = json.loads(resp.get_data(as_text=True))

--- a/tests/unit/test_f50a5cb_cover_write_staging.py
+++ b/tests/unit/test_f50a5cb_cover_write_staging.py
@@ -1,0 +1,801 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""F-50a5cb: cover bytes and metadata must cross one commit boundary safely."""
+
+from contextlib import nullcontext
+from datetime import datetime, timezone
+import errno
+import inspect
+import io
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import flask
+from flask_babel import Babel
+from PIL import Image
+import pytest
+import requests
+from werkzeug.datastructures import FileStorage
+
+
+pytestmark = pytest.mark.unit
+
+
+OLD_COVER = b"the byte-identical previous cover"
+OLD_MODIFIED = datetime(2020, 1, 2, tzinfo=timezone.utc)
+NEW_MODIFIED = datetime(2026, 8, 18, tzinfo=timezone.utc)
+
+
+def _jpeg_bytes(color=(21, 84, 160)):
+    output = io.BytesIO()
+    Image.new("RGB", (8, 11), color).save(output, format="JPEG")
+    return output.getvalue()
+
+
+def _storage(data=None):
+    return FileStorage(
+        stream=io.BytesIO(data or _jpeg_bytes()),
+        filename="cover.jpg",
+        content_type="image/jpeg",
+    )
+
+
+def _book(path="Author/Book (7)"):
+    return SimpleNamespace(
+        id=7,
+        path=path,
+        has_cover=0,
+        last_modified=OLD_MODIFIED,
+        title="Book",
+        authors=[SimpleNamespace(name="Author")],
+        identifiers=[],
+        comments=[],
+        publishers=[],
+        tags=[],
+        series=[],
+        series_index="1.0",
+        pubdate=None,
+        ratings=[],
+    )
+
+
+def _install_local_library(monkeypatch, helper, tmp_path, book):
+    library = tmp_path / "library"
+    cover = library / book.path / "cover.jpg"
+    cover.parent.mkdir(parents=True)
+    cover.write_bytes(OLD_COVER)
+    monkeypatch.setattr(helper.config, "config_use_google_drive", False, raising=False)
+    monkeypatch.setattr(helper.config, "get_book_path", lambda: str(library))
+    return cover
+
+
+class _FailingSession:
+    def __init__(self):
+        self.commits = 0
+        self.rollbacks = 0
+
+    def merge(self, _book):
+        return None
+
+    def commit(self):
+        self.commits += 1
+        raise RuntimeError("simulated metadata commit failure")
+
+    def rollback(self):
+        self.rollbacks += 1
+
+
+class _SuccessfulSession:
+    def __init__(self, events):
+        self.events = events
+
+    def commit(self):
+        self.events.append("commit")
+
+    def rollback(self):
+        raise AssertionError("successful cover update must not roll back")
+
+
+class _DiskFullImage:
+    headers = {"content-type": "image/jpeg"}
+
+    def save(self, filename):
+        with open(filename, "wb") as target:
+            target.write(b"short")
+        raise OSError(errno.ENOSPC, "simulated disk full")
+
+
+def _mark_modified(book, *args, **kwargs):
+    book.last_modified = NEW_MODIFIED
+
+
+def _editor():
+    return SimpleNamespace(
+        id=3,
+        name="cover-editor",
+        is_authenticated=True,
+        is_anonymous=False,
+        role_edit=lambda: True,
+        role_admin=lambda: False,
+    )
+
+
+def test_short_write_stages_away_from_existing_cover(tmp_path, monkeypatch):
+    """Pre-fix, _DiskFullImage.save receives cover.jpg and truncates OLD_COVER."""
+    from cps import helper
+
+    book = _book()
+    cover = _install_local_library(monkeypatch, helper, tmp_path, book)
+
+    staged, error = helper.save_cover(_DiskFullImage(), book.path)
+
+    assert not staged
+    assert error
+    assert cover.read_bytes() == OLD_COVER
+    assert not list(cover.parent.glob(".cover.jpg.cwng-*.stage"))
+
+
+def test_undecodable_stage_is_rejected_without_touching_existing_cover(
+    tmp_path, monkeypatch
+):
+    from cps import helper
+
+    book = _book()
+    cover = _install_local_library(monkeypatch, helper, tmp_path, book)
+    junk = _storage(b"not actually a JPEG")
+
+    staged, error = helper.save_cover(junk, book.path)
+
+    assert not staged
+    assert error
+    assert cover.read_bytes() == OLD_COVER
+    assert not list(cover.parent.glob(".cover.jpg.cwng-*.stage"))
+
+
+@pytest.mark.parametrize("existing", [True, False], ids=["same-id-update", "insert"])
+def test_google_drive_cover_publish_updates_same_id_or_inserts(
+    tmp_path, monkeypatch, existing
+):
+    from cps import helper
+
+    monkeypatch.setattr(helper.config, "config_use_google_drive", True, raising=False)
+    monkeypatch.setattr(helper, "get_temp_dir", lambda: str(tmp_path))
+
+    class RemoteFile(dict):
+        def __init__(self, metadata):
+            super().__init__(metadata)
+            self.content_path = None
+            self.uploads = 0
+
+        def SetContentFile(self, path):
+            assert Image.open(path).format == "JPEG"
+            self.content_path = path
+
+        def Upload(self):
+            assert self.content_path
+            self.uploads += 1
+
+    previous = RemoteFile({"id": "cover-file-id", "title": "cover.jpg"}) if existing else None
+    created = []
+    def create_file(metadata):
+        created.append(RemoteFile(metadata))
+        return created[-1]
+    drive = SimpleNamespace(CreateFile=MagicMock(side_effect=create_file))
+    monkeypatch.setattr(
+        helper.gd,
+        "prepareCoverUpload",
+        MagicMock(return_value=(drive, "book-folder-id", previous)),
+    )
+
+    staged, error = helper.save_cover(_storage(), "Author/Book (7)")
+
+    assert staged and error is None
+    assert previous is None or previous.uploads == 0
+    published, publish_error = staged.publish()
+    assert published and publish_error is None
+    if existing:
+        drive.CreateFile.assert_not_called()
+        assert previous["id"] == "cover-file-id"
+        assert previous.uploads == 1
+    else:
+        drive.CreateFile.assert_called_once_with({
+            "title": "cover.jpg",
+            "parents": [{"kind": "drive#fileLink", "id": "book-folder-id"}],
+        })
+        assert created[0].uploads == 1
+    assert not list(tmp_path.glob(".cover.jpg.cwng-*.stage"))
+
+
+def test_google_drive_publish_failure_uses_api_metadata_compensation(tmp_path, monkeypatch):
+    from cps import helper, kobo_sync_status
+    from cps.api import edit as api_edit
+
+    book = _book()
+    events = []
+    session = _SequencedSession(events)
+    app = flask.Flask(__name__)
+
+    class FailingRemoteFile(dict):
+        def SetContentFile(self, path):
+            assert Image.open(path).format == "JPEG"
+            events.append("remote-content")
+
+        def Upload(self):
+            events.append("remote-update")
+            raise OSError("simulated Drive update failure")
+
+    existing = FailingRemoteFile(id="same-cover-id", title="cover.jpg")
+    drive = SimpleNamespace(CreateFile=MagicMock())
+    monkeypatch.setattr(helper.config, "config_use_google_drive", True, raising=False)
+    monkeypatch.setattr(helper, "get_temp_dir", lambda: str(tmp_path))
+    monkeypatch.setattr(helper.gd, "prepareCoverUpload",
+                        lambda _path: (drive, "book-folder-id", existing))
+    monkeypatch.setattr(api_edit, "current_user", _editor())
+    monkeypatch.setattr(api_edit.calibre_db, "get_filtered_book", lambda *a, **k: book)
+    monkeypatch.setattr(api_edit.calibre_db, "session", session)
+    monkeypatch.setattr(api_edit, "book_cover_is_locked", lambda _book_id: False)
+    monkeypatch.setattr(api_edit, "mark_book_modified", _mark_modified)
+    monkeypatch.setattr(kobo_sync_status, "remove_synced_book", MagicMock())
+    monkeypatch.setattr(api_edit, "replace_cover_thumbnail_cache", MagicMock())
+
+    with app.test_request_context(
+        "/api/v1/books/7/cover", method="POST",
+        data={"file": (_storage().stream, "cover.jpg")},
+        content_type="multipart/form-data",
+    ):
+        response, status = inspect.unwrap(api_edit.set_cover)(book.id)
+
+    assert status == 500
+    assert response.get_json()
+    assert events == ["commit", "remote-content", "remote-update", "compensate"]
+    assert existing["id"] == "same-cover-id"
+    drive.CreateFile.assert_not_called()
+    assert book.has_cover == 0
+    assert book.last_modified == OLD_MODIFIED
+    assert not list(tmp_path.glob(".cover.jpg.cwng-*.stage"))
+
+
+@pytest.mark.parametrize("actual_format", ["PNG", "WEBP", "BMP"])
+def test_decoded_non_jpeg_is_normalized_regardless_of_declared_mime(
+    tmp_path, monkeypatch, actual_format
+):
+    from cps import helper
+
+    output = io.BytesIO()
+    Image.new("RGBA" if actual_format == "PNG" else "RGB", (8, 11), (10, 20, 30, 128)
+              if actual_format == "PNG" else (10, 20, 30)).save(output, format=actual_format)
+    book = _book()
+    cover = _install_local_library(monkeypatch, helper, tmp_path, book)
+
+    staged, error = helper.save_cover(_storage(output.getvalue()), book.path)
+    assert staged and error is None
+    assert cover.read_bytes() == OLD_COVER
+    assert staged.publish() == (True, None)
+    with Image.open(cover) as decoded:
+        assert decoded.format == "JPEG"
+        decoded.load()
+
+
+@pytest.mark.parametrize("variant", ["progressive", "cmyk", "exif"])
+def test_jpeg_variants_are_fully_decoded_and_preserved(
+    tmp_path, monkeypatch, variant
+):
+    from cps import helper
+
+    output = io.BytesIO()
+    image = Image.new("CMYK" if variant == "cmyk" else "RGB", (8, 11), 10)
+    options = {"progressive": True} if variant == "progressive" else {}
+    if variant == "exif":
+        exif = Image.Exif()
+        exif[274] = 6
+        options["exif"] = exif
+    image.save(output, format="JPEG", **options)
+    original = output.getvalue()
+    book = _book()
+    cover = _install_local_library(monkeypatch, helper, tmp_path, book)
+
+    staged, error = helper.save_cover(_storage(original), book.path)
+    assert staged and error is None
+    assert staged.publish() == (True, None)
+    assert cover.read_bytes() == original
+    with Image.open(cover) as decoded:
+        decoded.load()
+
+
+def test_startup_scavenger_logs_and_removes_only_cover_stages(tmp_path, monkeypatch):
+    from cps import helper
+
+    library = tmp_path / "library"
+    temp_dir = tmp_path / "temp"
+    book_dir = library / "Author" / "Book (7)"
+    book_dir.mkdir(parents=True)
+    temp_dir.mkdir()
+    canonical = book_dir / "cover.jpg"
+    canonical.write_bytes(OLD_COVER)
+    local_stage = book_dir / ".cover.jpg.cwng-local.stage"
+    drive_stage = temp_dir / ".cover.jpg.cwng-drive.stage"
+    unrelated = book_dir / ".cover.jpg.other.stage"
+    for path in (local_stage, drive_stage, unrelated):
+        path.write_bytes(b"staged")
+    warnings = []
+    monkeypatch.setattr(helper.config, "get_book_path", lambda: str(library))
+    monkeypatch.setattr(helper, "get_temp_dir", lambda: str(temp_dir))
+    monkeypatch.setattr(helper.log, "warning", lambda message, *args: warnings.append(message % args))
+
+    assert helper.scavenge_staged_cover_files() == 2
+    assert not local_stage.exists()
+    assert not drive_stage.exists()
+    assert unrelated.exists()
+    assert canonical.read_bytes() == OLD_COVER
+    assert len(warnings) == 2
+    assert all("metadata may already reference an unpublished cover" in warning for warning in warnings)
+    from cps import create_app
+    assert "helper.scavenge_staged_cover_files()" in inspect.getsource(create_app)
+
+
+def test_classic_upload_commit_failure_keeps_cover_and_metadata(
+    tmp_path, monkeypatch
+):
+    from cps import editbooks, helper
+
+    book = _book()
+    cover = _install_local_library(monkeypatch, helper, tmp_path, book)
+    session = _FailingSession()
+    app = flask.Flask(__name__)
+    app.secret_key = "classic-cover-staging"
+    Babel(app)
+    app.add_url_rule(
+        "/book/<int:book_id>",
+        endpoint="web.show_book",
+        view_func=lambda book_id: str(book_id),
+    )
+
+    monkeypatch.setattr(editbooks, "current_user", _editor())
+    monkeypatch.setattr(editbooks.calibre_db, "get_filtered_book", lambda *a, **k: book)
+    monkeypatch.setattr(editbooks.calibre_db, "session", session)
+    monkeypatch.setattr(editbooks, "metadata_db_write_lock", nullcontext)
+    monkeypatch.setattr(editbooks, "handle_author_on_edit", lambda *a, **k: (["Author"], False))
+    for name in (
+        "edit_book_ratings",
+        "edit_book_series_index",
+        "edit_book_comments",
+        "edit_book_tags",
+        "edit_book_series",
+        "edit_book_publisher",
+        "edit_book_languages",
+        "edit_all_cc_data",
+    ):
+        monkeypatch.setattr(editbooks, name, lambda *a, **k: False)
+    monkeypatch.setattr(editbooks, "identifier_list", lambda *a, **k: [])
+    monkeypatch.setattr(editbooks, "modify_identifiers", lambda *a, **k: (False, False))
+    monkeypatch.setattr(editbooks.helper, "mark_book_modified", _mark_modified)
+    monkeypatch.setattr(editbooks.config, "config_kobo_sync", False, raising=False)
+    monkeypatch.setattr(editbooks.config, "config_use_google_drive", False, raising=False)
+    monkeypatch.setattr(editbooks.helper, "replace_cover_thumbnail_cache", MagicMock())
+
+    with app.test_request_context(
+        "/admin/book/7",
+        method="POST",
+        data={"authors": "Author", "btn-upload-cover": (_storage().stream, "cover.jpg")},
+        content_type="multipart/form-data",
+    ):
+        response = editbooks.do_edit_book(book.id)
+
+    assert response.status_code == 302
+    assert session.rollbacks == 1
+    assert cover.read_bytes() == OLD_COVER
+    assert book.has_cover == 0
+    assert book.last_modified == OLD_MODIFIED
+
+
+def test_cover_picker_commit_failure_keeps_cover_and_metadata(
+    tmp_path, monkeypatch
+):
+    from cps import cover_picker, helper
+
+    book = _book()
+    cover = _install_local_library(monkeypatch, helper, tmp_path, book)
+    session = _FailingSession()
+    app = flask.Flask(__name__)
+    Babel(app)
+
+    monkeypatch.setattr(cover_picker, "current_user", _editor())
+    monkeypatch.setattr(cover_picker, "_load_book", lambda _book_id: book)
+    monkeypatch.setattr(cover_picker, "_get_lock_state", lambda _book_id: False)
+    monkeypatch.setattr(cover_picker.calibre_db, "session", session)
+    monkeypatch.setattr(cover_picker.helper, "mark_book_modified", _mark_modified)
+    monkeypatch.setattr(cover_picker.helper, "log_metadata_change", MagicMock())
+
+    with app.test_request_context(
+        "/book/7/cover/apply",
+        method="POST",
+        data={"file": (_storage().stream, "cover.jpg")},
+        content_type="multipart/form-data",
+    ):
+        response = inspect.unwrap(cover_picker.cover_picker_apply)(book.id)
+
+    assert response.status_code == 500
+    assert session.rollbacks == 1
+    assert cover.read_bytes() == OLD_COVER
+    assert book.has_cover == 0
+    assert book.last_modified == OLD_MODIFIED
+
+
+def test_spa_cover_commit_failure_keeps_cover_and_metadata(tmp_path, monkeypatch):
+    from cps import helper
+    from cps.api import edit as api_edit
+
+    book = _book()
+    cover = _install_local_library(monkeypatch, helper, tmp_path, book)
+    session = _FailingSession()
+    app = flask.Flask(__name__)
+
+    monkeypatch.setattr(api_edit, "current_user", _editor())
+    monkeypatch.setattr(api_edit.calibre_db, "get_filtered_book", lambda *a, **k: book)
+    monkeypatch.setattr(api_edit.calibre_db, "session", session)
+    monkeypatch.setattr(api_edit, "book_cover_is_locked", lambda _book_id: False)
+    monkeypatch.setattr(api_edit, "mark_book_modified", _mark_modified)
+
+    with app.test_request_context(
+        "/api/v1/books/7/cover",
+        method="POST",
+        data={"file": (_storage().stream, "cover.jpg")},
+        content_type="multipart/form-data",
+    ):
+        response, status = inspect.unwrap(api_edit.set_cover)(book.id)
+
+    assert status == 500
+    assert session.rollbacks == 1
+    assert cover.read_bytes() == OLD_COVER
+    assert book.has_cover == 0
+    assert book.last_modified == OLD_MODIFIED
+
+
+def test_ingest_cover_commit_failure_keeps_cover_and_metadata(tmp_path, monkeypatch):
+    from cps import helper, metadata_helper
+
+    book = _book()
+    cover = _install_local_library(monkeypatch, helper, tmp_path, book)
+    session = _FailingSession()
+    cdb = SimpleNamespace(session=session)
+    settings = {
+        "auto_metadata_smart_application": False,
+        "auto_metadata_update_title": False,
+        "auto_metadata_update_authors": False,
+        "auto_metadata_update_description": False,
+        "auto_metadata_update_publisher": False,
+        "auto_metadata_update_tags": False,
+        "auto_metadata_update_series": False,
+        "auto_metadata_update_published_date": False,
+        "auto_metadata_update_rating": False,
+        "auto_metadata_update_identifiers": False,
+        "auto_metadata_update_cover": True,
+    }
+    monkeypatch.setattr(
+        metadata_helper,
+        "CWA_DB",
+        lambda: SimpleNamespace(get_cwa_settings=lambda: settings),
+    )
+    monkeypatch.setattr(helper, "book_cover_is_locked", lambda _book_id: False)
+    monkeypatch.setattr(helper.cli_param, "allow_localhost", True)
+
+    response = requests.Response()
+    response.status_code = 200
+    response.headers["content-type"] = "image/jpeg"
+    response._content = _jpeg_bytes()
+    response._content_consumed = True
+    response.request = requests.Request(
+        "GET", "https://covers.example/7.jpg"
+    ).prepare()
+    monkeypatch.setattr(helper.requests, "get", lambda *a, **k: response)
+    monkeypatch.setattr(helper, "mark_book_modified", _mark_modified)
+
+    metadata = SimpleNamespace(title="", cover="https://covers.example/7.jpg")
+    assert metadata_helper._apply_metadata_to_book(book, metadata, cdb) is False
+
+    assert session.rollbacks == 1
+    assert cover.read_bytes() == OLD_COVER
+    assert book.has_cover == 0
+    assert book.last_modified == OLD_MODIFIED
+
+
+def test_spa_success_commits_then_publishes_then_invalidates_thumbnail(
+    tmp_path, monkeypatch
+):
+    from cps import helper
+    from cps.api import edit as api_edit
+
+    book = _book()
+    cover = _install_local_library(monkeypatch, helper, tmp_path, book)
+    events = []
+    session = _SuccessfulSession(events)
+    app = flask.Flask(__name__)
+    real_replace = helper.os.replace
+
+    def observed_replace(source, target):
+        assert str(target) == str(cover)
+        assert cover.read_bytes() == OLD_COVER
+        events.append("publish")
+        return real_replace(source, target)
+
+    monkeypatch.setattr(helper.os, "replace", observed_replace)
+    monkeypatch.setattr(api_edit, "current_user", _editor())
+    monkeypatch.setattr(api_edit.calibre_db, "get_filtered_book", lambda *a, **k: book)
+    monkeypatch.setattr(api_edit.calibre_db, "session", session)
+    monkeypatch.setattr(api_edit, "book_cover_is_locked", lambda _book_id: False)
+    monkeypatch.setattr(api_edit, "mark_book_modified", _mark_modified)
+    monkeypatch.setattr(api_edit, "log_metadata_change", lambda *a, **k: events.append("enforce"))
+    monkeypatch.setattr(api_edit, "replace_cover_thumbnail_cache", lambda *a, **k: events.append("thumb"))
+    monkeypatch.setattr(api_edit, "cover_url_for", lambda *a, **k: "/cover/7/md")
+    monkeypatch.setattr("cps.kobo_sync_status.remove_synced_book", lambda *a, **k: events.append("unsync"))
+
+    with app.test_request_context(
+        "/api/v1/books/7/cover",
+        method="POST",
+        data={"file": (_storage().stream, "cover.jpg")},
+        content_type="multipart/form-data",
+    ):
+        response = inspect.unwrap(api_edit.set_cover)(book.id)
+
+    assert response.status_code == 200
+    assert events[:3] == ["commit", "publish", "enforce"]
+    assert events.index("thumb") > events.index("publish")
+    assert cover.read_bytes() == _jpeg_bytes()
+    with Image.open(cover) as decoded:
+        decoded.verify()
+    assert not list(cover.parent.glob(".cover.jpg.cwng-*.stage"))
+
+
+class _SequencedSession:
+    def __init__(self, events, fail_compensation=False):
+        self.events = events
+        self.fail_compensation = fail_compensation
+        self.commits = 0
+        self.rollbacks = 0
+
+    def merge(self, book):
+        return book
+
+    def add(self, _value):
+        return None
+
+    def commit(self):
+        self.commits += 1
+        self.events.append("commit" if self.commits == 1 else "compensate")
+        if self.commits == 2 and self.fail_compensation:
+            raise RuntimeError("simulated compensation failure")
+
+    def rollback(self):
+        self.rollbacks += 1
+
+
+def _ingest_settings():
+    return {
+        "auto_metadata_smart_application": False,
+        "auto_metadata_update_title": False,
+        "auto_metadata_update_authors": False,
+        "auto_metadata_update_description": False,
+        "auto_metadata_update_publisher": False,
+        "auto_metadata_update_tags": False,
+        "auto_metadata_update_series": False,
+        "auto_metadata_update_published_date": False,
+        "auto_metadata_update_rating": False,
+        "auto_metadata_update_identifiers": False,
+        "auto_metadata_update_cover": True,
+    }
+
+
+def _invoke_surface(
+    surface,
+    tmp_path,
+    monkeypatch,
+    *,
+    publish_failure=False,
+    compensation_failure=False,
+    housekeeping_failure=False,
+):
+    """Exercise a real cover entry point with observable transaction events."""
+    from cps import helper, kobo_sync_status
+
+    book = _book()
+    cover = _install_local_library(monkeypatch, helper, tmp_path, book)
+    events = []
+    session = _SequencedSession(events, compensation_failure)
+    app = flask.Flask(__name__)
+    app.secret_key = "cover-surface-matrix"
+    Babel(app)
+    app.add_url_rule(
+        "/book/<int:book_id>", endpoint="web.show_book", view_func=lambda book_id: str(book_id)
+    )
+    app.add_url_rule(
+        "/cover/<int:book_id>/<resolution>",
+        endpoint="web.get_cover",
+        view_func=lambda book_id, resolution: str(book_id),
+    )
+    real_replace = helper.os.replace
+
+    def observed_replace(source, target):
+        assert str(target) == str(cover)
+        assert cover.read_bytes() == OLD_COVER
+        events.append("publish")
+        if publish_failure:
+            raise OSError(errno.EIO, "simulated atomic publish failure")
+        return real_replace(source, target)
+
+    def mark_modified(target_book, *args, **kwargs):
+        events.append("mark")
+        target_book.last_modified = NEW_MODIFIED
+        mark_modified.calls.append((args, kwargs))
+
+    mark_modified.calls = []
+
+    def housekeeping(name):
+        events.append(name)
+        if housekeeping_failure:
+            raise RuntimeError("simulated {} failure".format(name))
+
+    monkeypatch.setattr(helper.os, "replace", observed_replace)
+    monkeypatch.setattr(kobo_sync_status, "remove_synced_book", lambda *a, **k: housekeeping("kobo"))
+
+    if surface == "classic":
+        from cps import editbooks
+
+        monkeypatch.setattr(editbooks, "current_user", _editor())
+        monkeypatch.setattr(editbooks.calibre_db, "get_filtered_book", lambda *a, **k: book)
+        monkeypatch.setattr(editbooks.calibre_db, "session", session)
+        monkeypatch.setattr(editbooks, "metadata_db_write_lock", nullcontext)
+        monkeypatch.setattr(editbooks, "handle_author_on_edit", lambda *a, **k: (["Author"], False))
+        for name in (
+            "edit_book_ratings", "edit_book_series_index", "edit_book_comments",
+            "edit_book_tags", "edit_book_series", "edit_book_publisher",
+            "edit_book_languages", "edit_all_cc_data",
+        ):
+            monkeypatch.setattr(editbooks, name, lambda *a, **k: False)
+        monkeypatch.setattr(editbooks, "identifier_list", lambda *a, **k: [])
+        monkeypatch.setattr(editbooks, "modify_identifiers", lambda *a, **k: (False, False))
+        monkeypatch.setattr(editbooks.helper, "mark_book_modified", mark_modified)
+        monkeypatch.setattr(editbooks.helper, "replace_cover_thumbnail_cache",
+                            lambda *a, **k: housekeeping("thumb"))
+        monkeypatch.setattr(editbooks, "_queue_duplicate_scan_after_change", lambda *a, **k: None)
+        monkeypatch.setattr(editbooks.constants, "CWA_METADATA_CHANGE_LOGS_DIR", str(tmp_path / "logs"))
+        monkeypatch.setattr(editbooks.config, "config_kobo_sync", False, raising=False)
+        monkeypatch.setattr(editbooks.config, "config_use_google_drive", False, raising=False)
+        with app.test_request_context(
+            "/admin/book/7",
+            method="POST",
+            data={
+                "authors": "Author",
+                "detail_view": "1",
+                "btn-upload-cover": (_storage().stream, "cover.jpg"),
+            },
+            content_type="multipart/form-data",
+        ):
+            result = editbooks.do_edit_book(book.id)
+        succeeded = result.status_code == 302 and not publish_failure
+
+    elif surface == "picker":
+        from cps import cover_picker
+
+        monkeypatch.setattr(cover_picker, "current_user", _editor())
+        monkeypatch.setattr(cover_picker, "_load_book", lambda _book_id: book)
+        monkeypatch.setattr(cover_picker, "_get_lock_state", lambda _book_id: False)
+        monkeypatch.setattr(cover_picker.calibre_db, "session", session)
+        monkeypatch.setattr(cover_picker.helper, "mark_book_modified", mark_modified)
+        monkeypatch.setattr(cover_picker.helper, "log_metadata_change",
+                            lambda *a, **k: housekeeping("enforce"))
+        monkeypatch.setattr(cover_picker.helper, "replace_cover_thumbnail_cache",
+                            lambda *a, **k: housekeeping("thumb"))
+        with app.test_request_context(
+            "/book/7/cover/apply", method="POST",
+            data={"file": (_storage().stream, "cover.jpg")},
+            content_type="multipart/form-data",
+        ):
+            result = inspect.unwrap(cover_picker.cover_picker_apply)(book.id)
+        succeeded = result.status_code == 200
+
+    elif surface == "api":
+        from cps.api import edit as api_edit
+
+        monkeypatch.setattr(api_edit, "current_user", _editor())
+        monkeypatch.setattr(api_edit.calibre_db, "get_filtered_book", lambda *a, **k: book)
+        monkeypatch.setattr(api_edit.calibre_db, "session", session)
+        monkeypatch.setattr(api_edit, "book_cover_is_locked", lambda _book_id: False)
+        monkeypatch.setattr(api_edit, "mark_book_modified", mark_modified)
+        monkeypatch.setattr(api_edit, "log_metadata_change",
+                            lambda *a, **k: housekeeping("enforce"))
+        monkeypatch.setattr(api_edit, "replace_cover_thumbnail_cache",
+                            lambda *a, **k: housekeeping("thumb"))
+        monkeypatch.setattr(api_edit, "cover_url_for", lambda *a, **k: "/cover/7/md")
+        with app.test_request_context(
+            "/api/v1/books/7/cover", method="POST",
+            data={"file": (_storage().stream, "cover.jpg")},
+            content_type="multipart/form-data",
+        ):
+            result = inspect.unwrap(api_edit.set_cover)(book.id)
+        succeeded = getattr(result, "status_code", None) == 200
+
+    elif surface == "ingest":
+        from cps import metadata_helper
+
+        monkeypatch.setattr(metadata_helper, "CWA_DB",
+                            lambda: SimpleNamespace(get_cwa_settings=_ingest_settings))
+        monkeypatch.setattr(helper, "book_cover_is_locked", lambda _book_id: False)
+        monkeypatch.setattr(helper.cli_param, "allow_localhost", True)
+        response = requests.Response()
+        response.status_code = 200
+        response.headers["content-type"] = "image/jpeg"
+        response._content = _jpeg_bytes()
+        response._content_consumed = True
+        response.request = requests.Request("GET", "https://covers.example/7.jpg").prepare()
+        monkeypatch.setattr(helper.requests, "get", lambda *a, **k: response)
+        monkeypatch.setattr(helper, "mark_book_modified", mark_modified)
+        monkeypatch.setattr(helper, "log_metadata_change",
+                            lambda *a, **k: housekeeping("enforce"))
+        monkeypatch.setattr(helper, "replace_cover_thumbnail_cache",
+                            lambda *a, **k: housekeeping("thumb"))
+        metadata = SimpleNamespace(title="", cover="https://covers.example/7.jpg")
+        result = metadata_helper._apply_metadata_to_book(
+            book, metadata, SimpleNamespace(session=session)
+        )
+        succeeded = result is True
+    else:  # pragma: no cover - test helper guard
+        raise AssertionError(surface)
+
+    return SimpleNamespace(
+        book=book,
+        cover=cover,
+        events=events,
+        session=session,
+        mark_calls=mark_modified.calls,
+        succeeded=succeeded,
+    )
+
+
+@pytest.mark.parametrize("surface", ["classic", "picker", "api", "ingest"])
+@pytest.mark.parametrize("compensation_failure", [False, True], ids=["compensated", "compensation-fails"])
+def test_atomic_publish_failure_compensates_each_surface(
+    surface, compensation_failure, tmp_path, monkeypatch
+):
+    result = _invoke_surface(
+        surface, tmp_path, monkeypatch,
+        publish_failure=True,
+        compensation_failure=compensation_failure,
+    )
+
+    assert result.succeeded is False
+    assert result.cover.read_bytes() == OLD_COVER
+    assert result.book.has_cover == 0
+    assert result.book.last_modified == OLD_MODIFIED
+    assert result.session.commits == 2
+    assert result.events.index("commit") < result.events.index("publish") < result.events.index("compensate")
+    assert not {"kobo", "thumb", "enforce"}.intersection(result.events)
+    assert not list(result.cover.parent.glob(".cover.jpg.cwng-*.stage"))
+    assert result.session.rollbacks == (1 if compensation_failure else 0)
+
+
+@pytest.mark.parametrize("surface", ["classic", "picker", "ingest"])
+def test_success_order_commit_publish_then_housekeeping(surface, tmp_path, monkeypatch):
+    result = _invoke_surface(surface, tmp_path, monkeypatch)
+
+    assert result.succeeded is True
+    assert result.events.index("commit") < result.events.index("publish")
+    for event in ({"kobo", "thumb"} if surface != "ingest" else {"enforce", "thumb"}):
+        assert result.events.index("publish") < result.events.index(event)
+    assert result.cover.read_bytes() == _jpeg_bytes()
+    assert not list(result.cover.parent.glob(".cover.jpg.cwng-*.stage"))
+    if surface == "classic":
+        assert result.mark_calls == [((), {})]
+        assert result.events.index("publish") < result.events.index("kobo")
+
+
+@pytest.mark.parametrize("surface", ["classic", "picker", "api", "ingest"])
+def test_housekeeping_failure_after_publish_does_not_reverse_success(
+    surface, tmp_path, monkeypatch
+):
+    result = _invoke_surface(surface, tmp_path, monkeypatch, housekeeping_failure=True)
+
+    assert result.succeeded is True
+    assert result.cover.read_bytes() == _jpeg_bytes()
+    assert result.session.commits == 1
+    assert result.events.index("commit") < result.events.index("publish")
+    assert "thumb" in result.events


### PR DESCRIPTION
Resolves F-50a5cb: cover bytes were written straight over `cover.jpg` before the metadata transaction committed, so a failed commit, a short write, or an undecodable upload left the canonical cover replaced (or truncated) while `has_cover`/`last_modified` said otherwise.

## What changes
- Every cover input (classic editor upload, cover picker, SPA `POST /api/v1/.../cover`, ingest auto-fetch) goes through one staged-write primitive: write to `.cover.jpg.cwng-*.stage`, fsync, decode with Pillow, then publish with `os.replace()` only **after** the metadata commit. Publish failure runs a metadata compensation transaction.
- Google Drive mode publishes the same way: an existing remote `cover.jpg` is updated **under its existing id** (no `CreateFile` on replacement); `CreateFile` only when no remote cover exists. The earlier "refuse cover writes on Drive" regression is gone.
- Classic editor: `mark_book_modified(book)` no longer forces `unsync`; Kobo `remove_synced_book` and thumbnail replacement run best-effort only after a successful publish (order asserted: commit < publish < housekeeping).
- Startup scavenger removes orphan `.stage` files left by process death and logs the possible metadata/cover mismatch. It never auto-publishes, because the transaction outcome cannot be inferred from the stage.
- Validation is decode-based (Pillow `format`), not declared MIME: JPEG passes through byte-for-byte (progressive/CMYK/EXIF variants tested); PNG/WebP/BMP are normalized to JPEG with alpha flattened to white. Mislabeled-but-decodable uploads work again.

## Honest boundary
Process death between metadata commit and publish can leave metadata ahead of the canonical cover. The changelog says so; the scavenger surfaces it on the next boot.

## Verification (OBSERVED)
- Red against pre-fix `origin/main`: 16/16 selected tests fail (truncated cover observed, old bytes replaced on failed commit, missing publish events).
- Green: focused + adjacent cover suites 94/94; full `tests/unit` 8,225 passed, 111 skipped.
- ASSUMED: live authenticated Drive mutation (verified at the PyDrive2 object boundary only; no Drive credentials in the checkout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016HTQrgFiyGnVJU2MxXTkJ2
