### PR TITLE
fix(kobo): de-download forensics — per-sync INFO summary + opt-in sync exchange capture

### DIFF
--- a/changelog.d/kobo-sync-forensics-observability.md
+++ b/changelog.d/kobo-sync-forensics-observability.md
@@ -1,0 +1,11 @@
+### Changed
+
+- **Kobo sync logs now explain every entitlement response without exposing a
+  device identifier.** One structured INFO line records the short device hash,
+  incoming and outgoing cursors, new, changed, removed, and replay-suppressed
+  counts, and why any book already in the device ledger was re-emitted. This
+  makes an unexpected download loss diagnosable without a raw traffic capture.
+  When the existing private Kobo exchange capture is explicitly enabled,
+  library-sync requests now use the same bounded, rotating store as annotation
+  exchanges to retain the exact response body and opaque cursors, a hashed
+  device label, and a link to those INFO counters.

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -39,7 +39,7 @@ from werkzeug.datastructures import Headers
 from sqlalchemy import String, case, cast, func, literal
 from sqlalchemy.sql.expression import and_, or_
 from sqlalchemy.exc import StatementError
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import joinedload, sessionmaker
 from sqlalchemy.sql import select
 import requests
 
@@ -557,6 +557,98 @@ def _entitlement_reemit_reason(
     return prefix + detail
 
 
+def _observe_entitlement_reemit(
+    reasons,
+    record,
+    fingerprint,
+    change_basis,
+    *,
+    eligible,
+    is_cwng_token,
+    prefix,
+):
+    """Record diagnostic-only re-emission detail without affecting sync."""
+    try:
+        reasons[_entitlement_reemit_reason(
+            record,
+            fingerprint,
+            change_basis,
+            eligible=eligible,
+            is_cwng_token=is_cwng_token,
+            prefix=prefix,
+        )] += 1
+        return int(record.fingerprint != fingerprint)
+    except Exception:
+        log.warning(
+            "Kobo Sync observability failed reason=reason_classification_failed",
+            exc_info=True,
+        )
+        return 0
+
+
+def _observe_live_scope_removal(reasons, record, entitlement):
+    """Record the explicit removal reason behind the fail-open boundary."""
+    try:
+        reasons["live_scope_removal"] += 1
+        return int(
+            record.fingerprint != _entitlement_fingerprint(entitlement)
+        )
+    except Exception:
+        log.warning(
+            "Kobo Sync observability failed reason=reason_classification_failed",
+            exc_info=True,
+        )
+        return 0
+
+
+def _diagnostic_ledger_lookup(loader, device_id, identities, *, scope):
+    """Read diagnostic-only ledger state without sharing request rollback.
+
+    Production's file-backed SQLite database receives a separate read session.
+    SQLAlchemy cannot open an independent connection to the harness's in-memory
+    SQLite database, so tests use a read-only SAVEPOINT whose rollback cannot
+    discard caller-owned acknowledgment work.
+    """
+    if not device_id or not identities:
+        return {}
+
+    owned_session = None
+    try:
+        bind = ub.session.get_bind()
+        database = getattr(getattr(bind, "url", None), "database", None)
+        in_memory_sqlite = (
+            getattr(getattr(bind, "dialect", None), "name", None) == "sqlite"
+            and database in {None, "", ":memory:"}
+        )
+        if in_memory_sqlite:
+            with ub.begin_contained_nested(ub.session):
+                return loader(
+                    device_id, identities, _session=ub.session,
+                )
+
+        owned_session = sessionmaker(bind=bind)()
+        return loader(device_id, identities, _session=owned_session)
+    except Exception:
+        log.warning(
+            "Kobo Sync observability failed "
+            "reason=diagnostic_ledger_read_failed scope=%s",
+            scope,
+            exc_info=True,
+        )
+        return {}
+    finally:
+        if owned_session is not None:
+            try:
+                owned_session.close()
+            except Exception:
+                log.warning(
+                    "Kobo Sync observability failed "
+                    "reason=diagnostic_ledger_reader_close_failed scope=%s",
+                    scope,
+                    exc_info=True,
+                )
+
+
 def _sync_observability(
     sync_results,
     *,
@@ -583,6 +675,17 @@ def _sync_observability(
         "replay_suppression_enabled": bool(replay_suppression_enabled),
         "replay_suppression_eligible": bool(replay_suppression_eligible),
     }
+
+
+def _sync_observability_fail_open(sync_results, **kwargs):
+    try:
+        return _sync_observability(sync_results, **kwargs)
+    except Exception:
+        log.warning(
+            "Kobo Sync observability failed reason=counter_build_failed",
+            exc_info=True,
+        )
+        return _empty_sync_observability()
 
 
 def _empty_sync_observability():
@@ -620,41 +723,59 @@ def _log_sync_observability(
     capture_session=None,
 ):
     """Emit the PII-free one-line incident record for one response attempt."""
-    capture_id = getattr(capture_session, "capture_id", "none")
-    incoming_cursor_log = _sync_cursor_log_value(incoming_cursor)
-    outgoing_cursor_log = _sync_cursor_log_value(outgoing_cursor)
-    log.info(
-        "Kobo Sync summary: device=%s capture_id=%s response_mode=%s "
-        "entitlements new=%d changed=%d removed=%d "
-        "suppressed_replay=%d suppressed_unchanged=%d "
-        "suppressed_removed=%d fingerprint_mismatch_reemitted=%d "
-        "reemit_reasons=%s reseeded_shape_change=%d "
-        "replay_suppression enabled=%s eligible=%s "
-        "cursors in=%s out=%s",
-        _sync_device_log_id(requesting_device_id),
-        capture_id,
-        response_mode,
-        observability.get("new", 0),
-        observability.get("changed", 0),
-        observability.get("removed", 0),
-        observability.get("suppressed_replay", 0),
-        observability.get("suppressed_replay", 0),
-        observability.get("suppressed_removed", 0),
-        observability.get("fingerprint_mismatch_reemitted", 0),
-        _format_reemit_reasons(observability.get("reemit_reasons", {})),
-        observability.get("reseeded_shape_change", 0),
-        observability.get("replay_suppression_enabled", False),
-        observability.get("replay_suppression_eligible", False),
-        incoming_cursor_log,
-        outgoing_cursor_log,
-    )
-    if capture_session is not None:
-        capture_session.record_sync_info_summary(
-            response_mode=response_mode,
-            incoming_cursor=incoming_cursor_log,
-            outgoing_cursor=outgoing_cursor_log,
-            counters=observability,
+    incoming_cursor_log = None
+    outgoing_cursor_log = None
+    try:
+        capture_id = getattr(capture_session, "capture_id", "none")
+        incoming_cursor_log = _sync_cursor_log_value(incoming_cursor)
+        outgoing_cursor_log = _sync_cursor_log_value(outgoing_cursor)
+        log.info(
+            "Kobo Sync summary: device=%s capture_id=%s response_mode=%s "
+            "entitlements new=%d changed=%d removed=%d "
+            "suppressed_replay=%d suppressed_unchanged=%d "
+            "suppressed_removed=%d fingerprint_mismatch_reemitted=%d "
+            "reemit_reasons=%s reseeded_shape_change=%d "
+            "replay_suppression enabled=%s eligible=%s "
+            "cursors in=%s out=%s",
+            _sync_device_log_id(requesting_device_id),
+            capture_id,
+            response_mode,
+            observability.get("new", 0),
+            observability.get("changed", 0),
+            observability.get("removed", 0),
+            observability.get("suppressed_replay", 0),
+            observability.get("suppressed_replay", 0),
+            observability.get("suppressed_removed", 0),
+            observability.get("fingerprint_mismatch_reemitted", 0),
+            _format_reemit_reasons(observability.get("reemit_reasons", {})),
+            observability.get("reseeded_shape_change", 0),
+            observability.get("replay_suppression_enabled", False),
+            observability.get("replay_suppression_eligible", False),
+            incoming_cursor_log,
+            outgoing_cursor_log,
         )
+    except Exception:
+        log.warning(
+            "Kobo Sync observability failed reason=summary_emission_failed",
+            exc_info=True,
+        )
+
+    if (capture_session is not None
+            and incoming_cursor_log is not None
+            and outgoing_cursor_log is not None):
+        try:
+            capture_session.record_sync_info_summary(
+                response_mode=response_mode,
+                incoming_cursor=incoming_cursor_log,
+                outgoing_cursor=outgoing_cursor_log,
+                counters=observability,
+            )
+        except Exception:
+            log.warning(
+                "Kobo Sync observability failed "
+                "reason=capture_summary_record_failed",
+                exc_info=True,
+            )
 
 
 def _pending_page_observability(page):
@@ -689,17 +810,40 @@ def _pending_page_observability(page):
 def _log_pending_page_observability(
     page, requesting_device_id, incoming_cursor, capture_session=None,
 ):
-    outgoing = SyncToken.SyncToken.from_headers({
-        SyncToken.SyncToken.SYNC_TOKEN_HEADER: page.outgoing_token,
-    })
-    _log_sync_observability(
-        requesting_device_id,
-        incoming_cursor,
-        _sync_cursor_summary(outgoing),
-        _pending_page_observability(page),
-        response_mode="pending_replay",
-        capture_session=capture_session,
-    )
+    try:
+        outgoing = SyncToken.SyncToken.from_headers({
+            SyncToken.SyncToken.SYNC_TOKEN_HEADER: page.outgoing_token,
+        })
+        _log_sync_observability(
+            requesting_device_id,
+            incoming_cursor,
+            _sync_cursor_summary(outgoing),
+            _pending_page_observability(page),
+            response_mode="pending_replay",
+            capture_session=capture_session,
+        )
+    except Exception:
+        log.warning(
+            "Kobo Sync observability failed reason=summary_emission_failed",
+            exc_info=True,
+        )
+
+
+def _serialize_pending_confirmation(confirmation):
+    """Keep optional counters from invalidating an otherwise valid page."""
+    try:
+        return json.dumps(confirmation, separators=(",", ":"))
+    except Exception:
+        log.warning(
+            "Kobo Sync observability failed "
+            "reason=pending_observability_serialization_failed",
+            exc_info=True,
+        )
+        confirmation_without_observability = dict(confirmation)
+        confirmation_without_observability.pop("observability", None)
+        return json.dumps(
+            confirmation_without_observability, separators=(",", ":"),
+        )
 
 
 def _abort_sync_with_observability(
@@ -1293,11 +1437,11 @@ def HandleSyncRequest():
 
             if books_to_delete_ids:
                 log.info(f"Kobo Sync: Found {len(books_to_delete_ids)} books to remove from device for user {current_user.name}")
-                known_removal_fingerprints = (
-                    kobo_sync_status.get_device_entitlement_fingerprints(
-                        requesting_device_id, books_to_delete_ids,
-                    )
-                    if requesting_device_id else {}
+                known_removal_fingerprints = _diagnostic_ledger_lookup(
+                    kobo_sync_status.get_device_entitlement_fingerprints,
+                    requesting_device_id,
+                    books_to_delete_ids,
+                    scope="live_scope_removal",
                 )
 
                 # Go through the “To be deleted” list
@@ -1312,12 +1456,12 @@ def HandleSyncRequest():
                         sync_results.append({"ChangedEntitlement": entitlement})
                         known_record = known_removal_fingerprints.get(book_id)
                         if known_record is not None:
-                            reemit_reasons["live_scope_removal"] += 1
-                            removal_fingerprint = _entitlement_fingerprint(
-                                entitlement,
-                            )
-                            if known_record.fingerprint != removal_fingerprint:
-                                fingerprint_mismatch_reemitted += 1
+                            fingerprint_mismatch_reemitted += \
+                                _observe_live_scope_removal(
+                                    reemit_reasons,
+                                    known_record,
+                                    entitlement,
+                                )
 
         except Exception as e:
             log.error(f"Kobo Sync: Error during deletion logic: {e}")
@@ -1634,13 +1778,19 @@ def HandleSyncRequest():
         reading_state.id for reading_state in reading_state_page
     }
 
-    known_entitlement_fingerprints = (
-        kobo_sync_status.get_device_entitlement_fingerprints(
+    if requesting_device_id and sync_token.is_cwng_token:
+        known_entitlement_fingerprints = \
+            kobo_sync_status.get_device_entitlement_fingerprints(
             requesting_device_id,
             [book.Books.id for book in books_list],
         )
-        if requesting_device_id else {}
-    )
+    else:
+        known_entitlement_fingerprints = _diagnostic_ledger_lookup(
+            kobo_sync_status.get_device_entitlement_fingerprints,
+            requesting_device_id,
+            [book.Books.id for book in books_list],
+            scope="live_non_cwng_reset",
+        )
     prior_entitlement_fingerprints = (
         known_entitlement_fingerprints if sync_token.is_cwng_token else {}
     )
@@ -1723,16 +1873,15 @@ def HandleSyncRequest():
         else:
             known_record = known_entitlement_fingerprints.get(book.Books.id)
             if known_record is not None:
-                reemit_reasons[_entitlement_reemit_reason(
+                fingerprint_mismatch_reemitted += _observe_entitlement_reemit(
+                    reemit_reasons,
                     known_record,
                     entitlement_fingerprint,
                     entitlement_change_basis,
                     eligible=replay_suppression_eligible,
                     is_cwng_token=sync_token.is_cwng_token,
                     prefix="live_",
-                )] += 1
-                if known_record.fingerprint != entitlement_fingerprint:
-                    fingerprint_mismatch_reemitted += 1
+                )
             if book.Books.id not in prior_entitlement_fingerprints:
                 sync_results.append({"NewEntitlement": entitlement})
             else:
@@ -2052,13 +2201,19 @@ def HandleSyncRequest():
         .limit(SYNC_ITEM_LIMIT)
         .all()
     )
-    known_deleted_fingerprints = (
-        kobo_sync_status.get_device_deleted_entitlement_fingerprints(
+    if replay_suppression_eligible:
+        known_deleted_fingerprints = \
+            kobo_sync_status.get_device_deleted_entitlement_fingerprints(
             requesting_device_id,
             [str(tombstone.book_uuid) for tombstone in pending_deletions],
         )
-        if requesting_device_id else {}
-    )
+    else:
+        known_deleted_fingerprints = _diagnostic_ledger_lookup(
+            kobo_sync_status.get_device_deleted_entitlement_fingerprints,
+            requesting_device_id,
+            [str(tombstone.book_uuid) for tombstone in pending_deletions],
+            scope="removed_non_suppressing",
+        )
     prior_deleted_fingerprints = (
         known_deleted_fingerprints if sync_token.is_cwng_token else {}
     )
@@ -2102,16 +2257,15 @@ def HandleSyncRequest():
         else:
             known_record = known_deleted_fingerprints.get(book_uuid)
             if known_record is not None:
-                reemit_reasons[_entitlement_reemit_reason(
+                fingerprint_mismatch_reemitted += _observe_entitlement_reemit(
+                    reemit_reasons,
                     known_record,
                     fingerprint,
                     deleted_change_basis,
                     eligible=replay_suppression_eligible,
                     is_cwng_token=sync_token.is_cwng_token,
                     prefix="removed_",
-                )] += 1
-                if known_record.fingerprint != fingerprint:
-                    fingerprint_mismatch_reemitted += 1
+                )
             sync_results.append({"ChangedEntitlement": entitlement})
             if replay_suppression_enabled and requesting_device_id:
                 deleted_fingerprint_updates[book_uuid] = fingerprint
@@ -2150,7 +2304,7 @@ def HandleSyncRequest():
     sync_token.delivery_epoch = secrets.token_hex(16)
     response = generate_sync_response(sync_token, sync_results)
     sync_cursor_out = _sync_cursor_summary(sync_token)
-    observability = _sync_observability(
+    observability = _sync_observability_fail_open(
         sync_results,
         suppressed_replay=(
             len(suppressed_unchanged_book_ids)
@@ -2216,7 +2370,7 @@ def HandleSyncRequest():
             response.headers[SyncToken.SyncToken.SYNC_TOKEN_HEADER],
             response.get_data(as_text=True),
             json.dumps(stored_headers, separators=(",", ":")),
-            json.dumps(confirmation, separators=(",", ":")),
+            _serialize_pending_confirmation(confirmation),
         )
     else:
         # Authenticated production requests resolve a physical device. Keep the

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -7,6 +7,7 @@
 # See CONTRIBUTORS for full list of authors.
 
 import base64
+from collections import Counter
 import hashlib
 import logging
 from datetime import datetime, timezone
@@ -31,6 +32,7 @@ from flask import (
     send_from_directory,
     g,
     has_request_context,
+    after_this_request,
 )
 from .cw_login import current_user
 from werkzeug.datastructures import Headers
@@ -411,6 +413,315 @@ def _sync_cursor_summary(sync_token):
     )
 
 
+_SYNC_CURSOR_LOG_FIELDS = (
+    "books_modified",
+    "books_id",
+    "books_created",
+    "archive_modified",
+    "reading_state_modified",
+    "tags_modified",
+    "magic_shelf_id",
+    "magic_shelf_membership",
+)
+
+
+def _sync_cursor_log_value(cursor_summary):
+    """Serialize a compact, stable cursor vector for one structured log field."""
+    rendered = {}
+    for field, value in zip(_SYNC_CURSOR_LOG_FIELDS, cursor_summary):
+        if isinstance(value, datetime):
+            rendered[field] = value.isoformat()
+        else:
+            rendered[field] = value
+    return json.dumps(rendered, separators=(",", ":"), ensure_ascii=True)
+
+
+def _sync_device_log_id(device_id):
+    """Return a short hashed label without logging a raw device id."""
+    raw_device_id = None
+    if has_request_context():
+        raw_device_id = request.headers.get("x-kobo-deviceid")
+    if raw_device_id:
+        source = "header:" + raw_device_id
+    elif device_id is not None:
+        source = "internal:" + str(device_id)
+    else:
+        return "unknown"
+    return hashlib.sha256(source.encode("utf-8")).hexdigest()[:12]
+
+
+def _begin_sync_exchange_capture(requesting_device_id, raw_sync_token):
+    """Attach the existing private exchange recorder to one library sync."""
+    try:
+        from .services import kobo_exchange_capture
+
+        device_hash = _sync_device_log_id(requesting_device_id)
+        x_kobo_sync = request.headers.get("x-kobo-sync")
+        selected_headers = [
+            # The generic header renderer redacts token-bearing fields. The
+            # exact opaque cursor is retained in sync_exchange below, inside
+            # the same private, bounded envelope.
+            (SyncToken.SyncToken.SYNC_TOKEN_HEADER, raw_sync_token or ""),
+            ("x-cwng-device-hash", device_hash),
+        ]
+        if x_kobo_sync is not None:
+            selected_headers.append(("x-kobo-sync", x_kobo_sync))
+        capture_session = kobo_exchange_capture.begin_capture(
+            exchange="library_sync",
+            method=request.method,
+            path=request.path,
+            query_string=request.query_string,
+            headers=selected_headers,
+            body=request.get_data(cache=True),
+            authentication="authenticated",
+            user_id=getattr(current_user, "id", None),
+        )
+        if capture_session is None:
+            return None
+        capture_session.record_sync_request(
+            incoming_token=raw_sync_token,
+            x_kobo_sync=x_kobo_sync,
+            device_hash=device_hash,
+        )
+
+        @after_this_request
+        def _finish_sync_capture(response):
+            try:
+                capture_session.record_sync_response(
+                    outgoing_token=response.headers.get(
+                        SyncToken.SyncToken.SYNC_TOKEN_HEADER, "",
+                    ),
+                )
+                capture_session.finish(
+                    status=response.status_code,
+                    headers=response.headers.items(),
+                    body=response.get_data(),
+                )
+            except Exception:
+                # Diagnostics are never part of the sync success contract.
+                log.warning(
+                    "Kobo exchange capture finalizer failed exchange=library_sync",
+                    exc_info=True,
+                )
+            return response
+
+        return capture_session
+    except Exception:
+        log.warning(
+            "Kobo exchange capture could not attach exchange=library_sync",
+            exc_info=True,
+        )
+        return None
+
+
+def _sync_entitlement_counts(sync_results):
+    """Count final wire entitlements, including proxied store additions."""
+    counts = {"new": 0, "changed": 0, "removed": 0}
+    for item in sync_results:
+        if not isinstance(item, dict):
+            continue
+        if "NewEntitlement" in item:
+            counts["new"] += 1
+            entitlement = item.get("NewEntitlement")
+        elif "ChangedEntitlement" in item:
+            counts["changed"] += 1
+            entitlement = item.get("ChangedEntitlement")
+        else:
+            continue
+        if not isinstance(entitlement, dict):
+            continue
+        book_entitlement = entitlement.get("BookEntitlement")
+        if (isinstance(book_entitlement, dict)
+                and book_entitlement.get("IsRemoved") is True):
+            counts["removed"] += 1
+    return counts
+
+
+def _entitlement_reemit_reason(
+    record, fingerprint, change_basis, *, eligible, is_cwng_token, prefix,
+):
+    """Classify why a ledger-known entitlement was not replay-suppressed."""
+    if record.fingerprint != fingerprint:
+        if record.change_basis is None:
+            detail = "fingerprint_mismatch_missing_basis"
+        elif change_basis is not None and record.change_basis == change_basis:
+            detail = "fingerprint_mismatch_same_basis"
+        else:
+            detail = "fingerprint_mismatch_basis_changed"
+    elif not is_cwng_token:
+        detail = "non_cwng_reset"
+    elif not eligible:
+        detail = "replay_suppression_disabled"
+    else:
+        detail = "replay_not_suppressed"
+    return prefix + detail
+
+
+def _sync_observability(
+    sync_results,
+    *,
+    suppressed_replay,
+    suppressed_removed,
+    reseeded_shape_change,
+    fingerprint_mismatch_reemitted,
+    reemit_reasons,
+    replay_suppression_enabled,
+    replay_suppression_eligible,
+):
+    counts = _sync_entitlement_counts(sync_results)
+    return {
+        "new": counts["new"],
+        "changed": counts["changed"],
+        "removed": counts["removed"],
+        "suppressed_replay": int(suppressed_replay),
+        "suppressed_removed": int(suppressed_removed),
+        "reseeded_shape_change": int(reseeded_shape_change),
+        "fingerprint_mismatch_reemitted": int(
+            fingerprint_mismatch_reemitted,
+        ),
+        "reemit_reasons": dict(sorted(reemit_reasons.items())),
+        "replay_suppression_enabled": bool(replay_suppression_enabled),
+        "replay_suppression_eligible": bool(replay_suppression_eligible),
+    }
+
+
+def _empty_sync_observability():
+    """Counters for an error response produced before entitlement rendering."""
+    return {
+        "new": 0,
+        "changed": 0,
+        "removed": 0,
+        "suppressed_replay": 0,
+        "suppressed_removed": 0,
+        "reseeded_shape_change": 0,
+        "fingerprint_mismatch_reemitted": 0,
+        "reemit_reasons": {},
+        "replay_suppression_enabled": False,
+        "replay_suppression_eligible": False,
+    }
+
+
+def _format_reemit_reasons(reasons):
+    if not reasons:
+        return "none"
+    return ",".join(
+        "{}:{}".format(reason, count)
+        for reason, count in sorted(reasons.items())
+    )
+
+
+def _log_sync_observability(
+    requesting_device_id,
+    incoming_cursor,
+    outgoing_cursor,
+    observability,
+    *,
+    response_mode,
+    capture_session=None,
+):
+    """Emit the PII-free one-line incident record for one response attempt."""
+    capture_id = getattr(capture_session, "capture_id", "none")
+    incoming_cursor_log = _sync_cursor_log_value(incoming_cursor)
+    outgoing_cursor_log = _sync_cursor_log_value(outgoing_cursor)
+    log.info(
+        "Kobo Sync summary: device=%s capture_id=%s response_mode=%s "
+        "entitlements new=%d changed=%d removed=%d "
+        "suppressed_replay=%d suppressed_unchanged=%d "
+        "suppressed_removed=%d fingerprint_mismatch_reemitted=%d "
+        "reemit_reasons=%s reseeded_shape_change=%d "
+        "replay_suppression enabled=%s eligible=%s "
+        "cursors in=%s out=%s",
+        _sync_device_log_id(requesting_device_id),
+        capture_id,
+        response_mode,
+        observability.get("new", 0),
+        observability.get("changed", 0),
+        observability.get("removed", 0),
+        observability.get("suppressed_replay", 0),
+        observability.get("suppressed_replay", 0),
+        observability.get("suppressed_removed", 0),
+        observability.get("fingerprint_mismatch_reemitted", 0),
+        _format_reemit_reasons(observability.get("reemit_reasons", {})),
+        observability.get("reseeded_shape_change", 0),
+        observability.get("replay_suppression_enabled", False),
+        observability.get("replay_suppression_eligible", False),
+        incoming_cursor_log,
+        outgoing_cursor_log,
+    )
+    if capture_session is not None:
+        capture_session.record_sync_info_summary(
+            response_mode=response_mode,
+            incoming_cursor=incoming_cursor_log,
+            outgoing_cursor=outgoing_cursor_log,
+            counters=observability,
+        )
+
+
+def _pending_page_observability(page):
+    """Read stored diagnostics, with a response-body fallback for old rows."""
+    try:
+        confirmation = json.loads(page.confirmation_json or "{}")
+        observability = confirmation.get("observability")
+        if isinstance(observability, dict):
+            return observability
+    except (TypeError, ValueError):
+        pass
+
+    try:
+        sync_results = json.loads(page.response_body or "[]")
+    except (TypeError, ValueError):
+        sync_results = []
+    counts = _sync_entitlement_counts(sync_results)
+    return {
+        "new": counts["new"],
+        "changed": counts["changed"],
+        "removed": counts["removed"],
+        "suppressed_replay": 0,
+        "suppressed_removed": 0,
+        "reseeded_shape_change": 0,
+        "fingerprint_mismatch_reemitted": 0,
+        "reemit_reasons": {},
+        "replay_suppression_enabled": False,
+        "replay_suppression_eligible": False,
+    }
+
+
+def _log_pending_page_observability(
+    page, requesting_device_id, incoming_cursor, capture_session=None,
+):
+    outgoing = SyncToken.SyncToken.from_headers({
+        SyncToken.SyncToken.SYNC_TOKEN_HEADER: page.outgoing_token,
+    })
+    _log_sync_observability(
+        requesting_device_id,
+        incoming_cursor,
+        _sync_cursor_summary(outgoing),
+        _pending_page_observability(page),
+        response_mode="pending_replay",
+        capture_session=capture_session,
+    )
+
+
+def _abort_sync_with_observability(
+    status,
+    requesting_device_id,
+    incoming_cursor,
+    *,
+    response_mode,
+    capture_session,
+):
+    """Log and link a sync failure that has no entitlement response body."""
+    _log_sync_observability(
+        requesting_device_id,
+        incoming_cursor,
+        incoming_cursor,
+        _empty_sync_observability(),
+        response_mode=response_mode,
+        capture_session=capture_session,
+    )
+    return abort(status)
+
+
 def normalized_books_last_modified(value):
     """Return a UTC, fixed-width SQL key for calibre's mixed timestamp text.
 
@@ -707,16 +1018,25 @@ def get_magic_shelf_membership_added_at(user_id):
 @requires_kobo_auth
 # @download_required
 def HandleSyncRequest():
-    if not current_user.role_download():
-        log.info("Users need download permissions for syncing library to Kobo reader")
-        return abort(403)
-
     raw_sync_token = request.headers.get(
         SyncToken.SyncToken.SYNC_TOKEN_HEADER, "",
     )
     sync_token = SyncToken.SyncToken.from_headers(request.headers)
     sync_cursor_in = _sync_cursor_summary(sync_token)
     requesting_device_id = getattr(g, "annotation_origin_device_id", None)
+    capture_session = _begin_sync_exchange_capture(
+        requesting_device_id, raw_sync_token,
+    )
+    if not current_user.role_download():
+        log.info("Users need download permissions for syncing library to Kobo reader")
+        return _abort_sync_with_observability(
+            403,
+            requesting_device_id,
+            sync_cursor_in,
+            response_mode="download_forbidden",
+            capture_session=capture_session,
+        )
+
     pending_page = kobo_sync_status.get_pending_sync_page(
         requesting_device_id,
     )
@@ -730,7 +1050,13 @@ def HandleSyncRequest():
         if not _acknowledge_pending_page(
             pending_page, requesting_device_id,
         ):
-            return abort(503)
+            return _abort_sync_with_observability(
+                503,
+                requesting_device_id,
+                sync_cursor_in,
+                response_mode="pending_ack_failed",
+                capture_session=capture_session,
+            )
         acknowledged_pending_page = True
         pending_page = None
 
@@ -742,7 +1068,13 @@ def HandleSyncRequest():
     if (pruned_pending_pages
             and not acknowledged_pending_page
             and ub.session_commit() is False):
-        return abort(503)
+        return _abort_sync_with_observability(
+            503,
+            requesting_device_id,
+            sync_cursor_in,
+            response_mode="pending_prune_commit_failed",
+            capture_session=capture_session,
+        )
     if not acknowledged_pending_page:
         # Pruning may have removed the row loaded for the pre-prune ack lookup.
         pending_page = kobo_sync_status.get_pending_sync_page(
@@ -752,10 +1084,20 @@ def HandleSyncRequest():
         if pending_page.incoming_token_hash == _sync_token_hash(raw_sync_token):
             replay = _pending_response(pending_page)
             if replay is None:
-                return abort(503)
+                return _abort_sync_with_observability(
+                    503,
+                    requesting_device_id,
+                    sync_cursor_in,
+                    response_mode="pending_response_corrupt",
+                    capture_session=capture_session,
+                )
             log.info(
                 "Kobo Sync: replaying unacknowledged page for device %s",
                 requesting_device_id,
+            )
+            _log_pending_page_observability(
+                pending_page, requesting_device_id, sync_cursor_in,
+                capture_session,
             )
             return replay
         if not sync_token.is_cwng_token:
@@ -774,7 +1116,19 @@ def HandleSyncRequest():
                 requesting_device_id,
             )
             replay = _pending_response(pending_page)
-            return replay if replay is not None else abort(503)
+            if replay is None:
+                return _abort_sync_with_observability(
+                    503,
+                    requesting_device_id,
+                    sync_cursor_in,
+                    response_mode="pending_response_corrupt",
+                    capture_session=capture_session,
+                )
+            _log_pending_page_observability(
+                pending_page, requesting_device_id, sync_cursor_in,
+                capture_session,
+            )
+            return replay
     # A server-time fence distinguishes repair work that existed when this
     # request began from work armed by an entitlement/reset in this response.
     # The latter must survive until the next request, after the device has had
@@ -829,24 +1183,44 @@ def HandleSyncRequest():
     sync_results = []
     books_to_delete_ids = set()
     rehydrate_positions_emitted = []
+    fingerprint_mismatch_reemitted = 0
+    reemit_reasons = Counter()
 
     try:
         calibre_db.refresh_for_new_data()
     except Exception:
         log.exception("Kobo Sync: failed to refresh the library database")
-        return abort(503)
+        return _abort_sync_with_observability(
+            503,
+            requesting_device_id,
+            sync_cursor_in,
+            response_mode="library_refresh_failed",
+            capture_session=capture_session,
+        )
 
     # Upgrade bridge: flat delivery markers are user-wide and therefore cannot
     # prove receipt by any physical device. Mark the boundary but leave every
     # uncertain book absent from the confirmed ledger so it is reannounced New.
     if (requesting_device_id
             and not _seed_existing_device_entitlement_ledgers(current_user.id)):
-        return abort(503)
+        return _abort_sync_with_observability(
+            503,
+            requesting_device_id,
+            sync_cursor_in,
+            response_mode="ledger_seed_failed",
+            capture_session=capture_session,
+        )
     # Pre-ack rows prove only a committed server emission. Clear them once
     # before they can hide an uncertain book from the recovery arm below.
     if (requesting_device_id
             and not _migrate_device_entitlement_classification(current_user.id)):
-        return abort(503)
+        return _abort_sync_with_observability(
+            503,
+            requesting_device_id,
+            sync_cursor_in,
+            response_mode="ledger_migration_failed",
+            capture_session=capture_session,
+        )
 
 
     # Magic-shelf book IDs + membership timestamp are computed for BOTH sync
@@ -919,6 +1293,12 @@ def HandleSyncRequest():
 
             if books_to_delete_ids:
                 log.info(f"Kobo Sync: Found {len(books_to_delete_ids)} books to remove from device for user {current_user.name}")
+                known_removal_fingerprints = (
+                    kobo_sync_status.get_device_entitlement_fingerprints(
+                        requesting_device_id, books_to_delete_ids,
+                    )
+                    if requesting_device_id else {}
+                )
 
                 # Go through the “To be deleted” list
                 for book_id in books_to_delete_ids:
@@ -930,6 +1310,14 @@ def HandleSyncRequest():
                             "BookMetadata": get_metadata(book),
                         }
                         sync_results.append({"ChangedEntitlement": entitlement})
+                        known_record = known_removal_fingerprints.get(book_id)
+                        if known_record is not None:
+                            reemit_reasons["live_scope_removal"] += 1
+                            removal_fingerprint = _entitlement_fingerprint(
+                                entitlement,
+                            )
+                            if known_record.fingerprint != removal_fingerprint:
+                                fingerprint_mismatch_reemitted += 1
 
         except Exception as e:
             log.error(f"Kobo Sync: Error during deletion logic: {e}")
@@ -1246,12 +1634,15 @@ def HandleSyncRequest():
         reading_state.id for reading_state in reading_state_page
     }
 
-    prior_entitlement_fingerprints = (
+    known_entitlement_fingerprints = (
         kobo_sync_status.get_device_entitlement_fingerprints(
             requesting_device_id,
             [book.Books.id for book in books_list],
         )
-        if requesting_device_id and sync_token.is_cwng_token else {}
+        if requesting_device_id else {}
+    )
+    prior_entitlement_fingerprints = (
+        known_entitlement_fingerprints if sync_token.is_cwng_token else {}
     )
     entitlement_fingerprint_updates = {}
     entitlement_change_basis_updates = {}
@@ -1330,6 +1721,18 @@ def HandleSyncRequest():
                 entitlement_change_basis_updates[book.Books.id] = \
                     entitlement_change_basis
         else:
+            known_record = known_entitlement_fingerprints.get(book.Books.id)
+            if known_record is not None:
+                reemit_reasons[_entitlement_reemit_reason(
+                    known_record,
+                    entitlement_fingerprint,
+                    entitlement_change_basis,
+                    eligible=replay_suppression_eligible,
+                    is_cwng_token=sync_token.is_cwng_token,
+                    prefix="live_",
+                )] += 1
+                if known_record.fingerprint != entitlement_fingerprint:
+                    fingerprint_mismatch_reemitted += 1
             if book.Books.id not in prior_entitlement_fingerprints:
                 sync_results.append({"NewEntitlement": entitlement})
             else:
@@ -1649,12 +2052,15 @@ def HandleSyncRequest():
         .limit(SYNC_ITEM_LIMIT)
         .all()
     )
-    prior_deleted_fingerprints = (
+    known_deleted_fingerprints = (
         kobo_sync_status.get_device_deleted_entitlement_fingerprints(
             requesting_device_id,
             [str(tombstone.book_uuid) for tombstone in pending_deletions],
         )
-        if replay_suppression_eligible else {}
+        if requesting_device_id else {}
+    )
+    prior_deleted_fingerprints = (
+        known_deleted_fingerprints if sync_token.is_cwng_token else {}
     )
     deleted_fingerprint_updates = {}
     deleted_change_basis_updates = {}
@@ -1667,7 +2073,7 @@ def HandleSyncRequest():
         }
         fingerprint = (
             _entitlement_fingerprint(entitlement)
-            if replay_suppression_enabled and requesting_device_id else None
+            if requesting_device_id else None
         )
         deleted_change_basis = _deleted_entitlement_change_basis(
             tombstone.deleted_at,
@@ -1694,6 +2100,18 @@ def HandleSyncRequest():
                 deleted_fingerprint_updates[book_uuid] = fingerprint
                 deleted_change_basis_updates[book_uuid] = deleted_change_basis
         else:
+            known_record = known_deleted_fingerprints.get(book_uuid)
+            if known_record is not None:
+                reemit_reasons[_entitlement_reemit_reason(
+                    known_record,
+                    fingerprint,
+                    deleted_change_basis,
+                    eligible=replay_suppression_eligible,
+                    is_cwng_token=sync_token.is_cwng_token,
+                    prefix="removed_",
+                )] += 1
+                if known_record.fingerprint != fingerprint:
+                    fingerprint_mismatch_reemitted += 1
             sync_results.append({"ChangedEntitlement": entitlement})
             if replay_suppression_enabled and requesting_device_id:
                 deleted_fingerprint_updates[book_uuid] = fingerprint
@@ -1726,33 +2144,28 @@ def HandleSyncRequest():
     sync_token.archive_last_modified = new_archived_last_modified
     sync_token.reading_state_last_modified = new_reading_state_last_modified
 
-    new_entitlement_count = sum("NewEntitlement" in item for item in sync_results)
-    changed_entitlement_count = sum("ChangedEntitlement" in item for item in sync_results)
-    log.debug(
-        "Kobo Sync summary: device=%s entitlements new=%d changed=%d "
-        "suppressed_unchanged=%d suppressed_removed=%d "
-        "reseeded_shape_change=%d "
-        "replay_suppression enabled=%s eligible=%s "
-        "cursors in=%s out=%s",
-        requesting_device_id,
-        new_entitlement_count,
-        changed_entitlement_count,
-        len(suppressed_unchanged_book_ids)
-        + len(suppressed_deleted_entitlement_uuids),
-        len(suppressed_deleted_entitlement_uuids),
-        len(reseeded_shape_change_book_ids)
-        + len(reseeded_shape_change_deleted_uuids),
-        replay_suppression_enabled,
-        replay_suppression_eligible,
-        sync_cursor_in,
-        _sync_cursor_summary(sync_token),
-    )
-
     # Even a cursor-identical page needs a distinct acknowledgment token (for
     # example, a DeletedTag-only response).  This nonce is tiny and the device
     # treats the token opaquely; the exact serialized token stays server-side.
     sync_token.delivery_epoch = secrets.token_hex(16)
     response = generate_sync_response(sync_token, sync_results)
+    sync_cursor_out = _sync_cursor_summary(sync_token)
+    observability = _sync_observability(
+        sync_results,
+        suppressed_replay=(
+            len(suppressed_unchanged_book_ids)
+            + len(suppressed_deleted_entitlement_uuids)
+        ),
+        suppressed_removed=len(suppressed_deleted_entitlement_uuids),
+        reseeded_shape_change=(
+            len(reseeded_shape_change_book_ids)
+            + len(reseeded_shape_change_deleted_uuids)
+        ),
+        fingerprint_mismatch_reemitted=fingerprint_mismatch_reemitted,
+        reemit_reasons=reemit_reasons,
+        replay_suppression_enabled=replay_suppression_enabled,
+        replay_suppression_eligible=replay_suppression_eligible,
+    )
 
     if requesting_device_id:
         confirmation = {
@@ -1777,6 +2190,7 @@ def HandleSyncRequest():
                 for book_uuid, fingerprint in deleted_fingerprint_updates.items()
             },
             "removed_book_ids": sorted(books_to_delete_ids),
+            "observability": observability,
             "rehydrate_positions": [
                 {
                     "id": position.id,
@@ -1817,7 +2231,23 @@ def HandleSyncRequest():
     # delivery state was promoted at the beginning of this request (when its
     # predecessor token was presented) and lands atomically with this page.
     if ub.session_commit() is False:
+        _log_sync_observability(
+            requesting_device_id,
+            sync_cursor_in,
+            sync_cursor_out,
+            observability,
+            response_mode="commit_failed",
+            capture_session=capture_session,
+        )
         return abort(503)
+    _log_sync_observability(
+        requesting_device_id,
+        sync_cursor_in,
+        sync_cursor_out,
+        observability,
+        response_mode="new_page",
+        capture_session=capture_session,
+    )
     return response
 
 

--- a/cps/kobo_sync_status.py
+++ b/cps/kobo_sync_status.py
@@ -74,11 +74,12 @@ def add_synced_books_batch(book_identities, *, commit=True):
     return ub.session_commit() if commit else True
 
 
-def get_device_entitlement_fingerprints(device_id, book_ids):
+def get_device_entitlement_fingerprints(device_id, book_ids, *, _session=None):
     """Return the last delivered ledger record for each candidate book."""
     if not device_id or not book_ids:
         return {}
-    rows = ub.session.query(
+    query_session = _session or ub.session
+    rows = query_session.query(
             ub.KoboDeviceBookEntitlement.book_id,
             ub.KoboDeviceBookEntitlement.fingerprint,
             ub.KoboDeviceBookEntitlement.payload_schema_version,
@@ -132,11 +133,14 @@ def stage_device_entitlement_fingerprints(
         ub.session.execute(statement)
 
 
-def get_device_deleted_entitlement_fingerprints(device_id, book_uuids):
+def get_device_deleted_entitlement_fingerprints(
+    device_id, book_uuids, *, _session=None,
+):
     """Return delivered hard-delete ledger records for one device."""
     if not device_id or not book_uuids:
         return {}
-    rows = ub.session.query(
+    query_session = _session or ub.session
+    rows = query_session.query(
             ub.KoboDeviceDeletedEntitlement.book_uuid,
             ub.KoboDeviceDeletedEntitlement.fingerprint,
             ub.KoboDeviceDeletedEntitlement.payload_schema_version,

--- a/cps/services/kobo_exchange_capture.py
+++ b/cps/services/kobo_exchange_capture.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # SPDX-License-Identifier: GPL-3.0-or-later
-"""Private, passive capture of Kobo Reading Services exchanges.
+"""Private, passive capture of Kobo device API exchanges.
 
 The observer is deliberately harder to enable than an ordinary boolean flag:
 ``CWNG_KOBO_READING_SERVICES_CAPTURE`` must exactly equal
@@ -9,10 +9,12 @@ application database in a hidden, mode-0700 directory.  They are not included
 in the annotation backup format or any repository artifact.
 
 Each gzip record contains explicit authentication provenance, the device
-request, the exact request body actually sent upstream, Kobo's response, and
-the final response returned to the device. Credential-bearing headers are
-redacted. Annotation text remains only in the private record; ordinary logs
-contain structural counts and capture IDs only.
+request, any exact request body sent upstream, Kobo's response, and the final
+response returned to the device. Library-sync records also retain the opaque
+incoming/outgoing cursors and a structured pointer to the matching INFO
+summary. Credential-bearing generic headers are redacted. Annotation and
+library metadata remain only in the private record; ordinary logs contain
+structural counts and capture IDs only.
 
 Unauthenticated captures are opt-in, carry no user identity, and use a tighter
 independent store so untrusted traffic cannot evict authenticated diagnostics
@@ -283,7 +285,7 @@ class CaptureSession:
             else MAX_BODY_BYTES
         )
         self._record = {
-            "schema_version": 2,
+            "schema_version": 3,
             "capture_id": self.capture_id,
             "captured_at": datetime.now(timezone.utc).isoformat(),
             "exchange": str(exchange)[:64],
@@ -303,6 +305,7 @@ class CaptureSession:
             "upstream_error": None,
             "device_response": None,
             "decisions": [],
+            "sync_exchange": None,
         }
 
     def _mutate(self, callback) -> bool:
@@ -361,6 +364,81 @@ class CaptureSession:
         return self._mutate(lambda: self._record.__setitem__(
             "upstream_error", str(error_kind)[:64],
         ))
+
+    def record_sync_request(
+        self, *, incoming_token, x_kobo_sync, device_hash,
+    ) -> bool:
+        """Record the selected library-sync headers without a raw device id."""
+        value = {
+            "request": {
+                "incoming_token": str(incoming_token or ""),
+                "x_kobo_sync": (
+                    None if x_kobo_sync is None else str(x_kobo_sync)
+                ),
+                "device_hash": str(device_hash),
+            },
+            "response": {"outgoing_token": None},
+            "info_summary": None,
+        }
+        if not _body_is_within_bound(
+            json.dumps(value, separators=(",", ":")).encode("utf-8"),
+            max_bytes=self._max_body_bytes,
+        ):
+            self._invalid = True
+            return False
+        return self._mutate(lambda: self._record.__setitem__(
+            "sync_exchange", value,
+        ))
+
+    def record_sync_response(self, *, outgoing_token) -> bool:
+        """Record the exact opaque token returned to Nickel."""
+        token = str(outgoing_token or "")
+        if not _body_is_within_bound(
+            token.encode("utf-8"), max_bytes=self._max_body_bytes,
+        ):
+            self._invalid = True
+            return False
+
+        def _record():
+            sync_exchange = self._record.get("sync_exchange")
+            if not isinstance(sync_exchange, dict):
+                raise ValueError("sync request context was not recorded")
+            sync_exchange["response"] = {"outgoing_token": token}
+
+        return self._mutate(_record)
+
+    def record_sync_info_summary(
+        self, *, response_mode, incoming_cursor, outgoing_cursor, counters,
+    ) -> bool:
+        """Link the private body to the PII-free INFO summary and its counts."""
+        value = {
+            "log_event": "Kobo Sync summary",
+            "capture_id": self.capture_id,
+            "response_mode": str(response_mode)[:64],
+            "incoming_cursor": str(incoming_cursor),
+            "outgoing_cursor": str(outgoing_cursor),
+            "counters": counters,
+        }
+        try:
+            serialized = json.dumps(
+                value, ensure_ascii=True, separators=(",", ":"),
+            ).encode("utf-8")
+        except (TypeError, ValueError):
+            self._invalid = True
+            return False
+        if not _body_is_within_bound(
+            serialized, max_bytes=self._max_body_bytes,
+        ):
+            self._invalid = True
+            return False
+
+        def _record():
+            sync_exchange = self._record.get("sync_exchange")
+            if not isinstance(sync_exchange, dict):
+                raise ValueError("sync request context was not recorded")
+            sync_exchange["info_summary"] = value
+
+        return self._mutate(_record)
 
     def finish(self, *, status, headers, body) -> bool:
         """Persist the complete envelope; never raise into the observed route."""

--- a/docs/kobo-reading-services-capture.md
+++ b/docs/kobo-reading-services-capture.md
@@ -13,6 +13,15 @@ Unset the variable and restart immediately after the experiment. Values such as
 `1`, `true`, different case, or values with surrounding whitespace do not
 enable capture.
 
+**Captured request and response bodies are raw, not hashed or redacted.** They
+can contain book titles, reading data, endpoint and download paths, and other
+library metadata. Library-sync capture also deliberately stores the exact raw
+incoming and outgoing opaque sync tokens. This is why the gate names private
+reading data and why these records must remain local and short-lived. The
+ordinary `Kobo Sync summary` INFO line is separate: it contains only structural
+counters, cursor values, a capture ID, and a short hash of the device ID; it
+does not log raw titles, paths, user/device identifiers, or opaque sync tokens.
+
 Records are written to:
 
 ```text

--- a/docs/kobo-reading-services-capture.md
+++ b/docs/kobo-reading-services-capture.md
@@ -1,4 +1,4 @@
-# Kobo Reading Services private exchange capture
+# Kobo private exchange capture
 
 This diagnostic is for short, operator-controlled hardware experiments. It is
 off by default and cannot be enabled with an ordinary boolean value.
@@ -26,7 +26,7 @@ a repository, issue attachment, or other shared artifact. External backup jobs
 that archive all of `/config` should explicitly exclude
 `.cwng-private-observability/`.
 
-Each schema-version-2 record contains:
+Each schema-version-3 record contains:
 
 - explicit request provenance (`authenticated`, `unauthenticated`, or
   `not_recorded`) and a local user ID only when one was authenticated;
@@ -37,10 +37,19 @@ Each schema-version-2 record contains:
 - Kobo's raw response body and redacted headers; and
 - the final status, redacted headers, and exact body returned to the device.
 
+Library-sync (`/v1/library/sync`) records use the same directory, file layout,
+size bounds, and retention policy. They contain the exact response body (which
+can include the user's library metadata), the incoming and outgoing opaque sync
+tokens, `x-kobo-sync`, the request's device ID hashed to the same short label as
+the INFO summary, and a structured pointer to that summary's counters. The raw
+device ID is not recorded.
+
 Bodies carry byte length and SHA-256 metadata. UTF-8 bodies are stored directly;
 any non-UTF-8 body is base64 encoded. Credential-like headers—including
 Authorization, cookies, Kobo user keys, API keys, secrets, and tokens—are
-replaced with `***REDACTED***` in every leg.
+replaced with `***REDACTED***` in every generic header leg. Library-sync's
+incoming and outgoing opaque tokens are deliberately retained in its private
+`sync_exchange` section so an interrupted page chain can be reconstructed.
 
 Retention is automatic and cross-process locked: at most 256 records, 64 MiB
 compressed total, seven days, and 16 MiB for any individual body. An exchange

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -297,6 +297,8 @@ CWA_METADATA_LOCK_DIR=${CONFIG_DIR}
 
 # Private Kobo Reading Services diagnostic capture. Default: disabled.
 # Enabling requires this exact acknowledgement and records private reading exchanges for 7 days.
+# Captured bodies are raw: they can contain titles, request/download paths, reading data, and
+# library-sync's exact opaque incoming/outgoing tokens. Keep captures private and short-lived.
 # CWNG_KOBO_READING_SERVICES_CAPTURE=I_UNDERSTAND_THIS_CAPTURES_PRIVATE_READING_DATA
 
 # Override the autopilot tier-policy config path. Default: .github/policy/tier-policy.config.

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -173,7 +173,7 @@ surfaces; reverse dependents cannot be discovered by that traversal and must be 
 prefixes. The whole `cps/api/` blueprint tree is therefore protected explicitly: its registration in
 `cps/main.py` points toward the handlers, opposite to the import direction walked by the classifier. The
 two-level cutoff only bounds each root's dependency fan-out—it is not what excludes reverse dependents.
-At this revision the derived set is 157 of 223 local Python modules (the closure correctly picks
+At this revision the derived set is 158 of 223 local Python modules (the closure correctly picks
 up `cps/services/device_delivery.py` through the book-action request path, and this branch's
 `cps/user_preferences.py` through the account API path). Measured at `origin/main`
 `e6298e0d560b`, the previous and expanded policies each fired on 26 of the latest 100 first-parent commits;

--- a/tests/unit/test_1925_kobo_sync_dedownload.py
+++ b/tests/unit/test_1925_kobo_sync_dedownload.py
@@ -11,6 +11,10 @@ be delivered.
 """
 
 from datetime import datetime, timedelta, timezone
+import gzip
+import hashlib
+import inspect
+import json
 import logging
 from types import SimpleNamespace
 
@@ -36,6 +40,57 @@ def _changed_reading_states(response):
         for item in response.get_json()
         if "ChangedReadingState" in item
     ]
+
+
+def _private_capture_records(root):
+    return [
+        json.loads(gzip.decompress(path.read_bytes()))
+        for path in sorted(root.glob("exchange-*.json.gz"))
+    ]
+
+
+def _enable_private_sync_capture(monkeypatch, tmp_path):
+    from cps.services import kobo_exchange_capture as capture
+
+    root = tmp_path / "private-kobo-exchanges"
+    monkeypatch.setenv(
+        capture.ENABLE_ENV, capture.ENABLE_ACKNOWLEDGEMENT,
+    )
+    monkeypatch.setattr(capture, "_capture_root", lambda: root)
+    monkeypatch.setattr(
+        capture,
+        "_run_off_hub_bounded",
+        lambda _scope, function: function(),
+    )
+    return capture, root
+
+
+def _sync_through_response_pipeline(
+    sync_harness,
+    *,
+    token=None,
+    raw_device_id="b" * 64,
+    x_kobo_sync=None,
+):
+    """Dispatch the real handler and run Flask's after-response observers."""
+    from cps import kobo
+
+    headers = {
+        "x-kobo-deviceid": raw_device_id,
+        "x-kobo-devicemodel": sync_harness.device.model,
+    }
+    if token is not None:
+        headers[kobo.SyncToken.SyncToken.SYNC_TOKEN_HEADER] = token
+    if x_kobo_sync is not None:
+        headers["x-kobo-sync"] = x_kobo_sync
+    with sync_harness.app.test_request_context(
+        "/v1/library/sync", headers=headers,
+    ):
+        g.annotation_origin_device_id = sync_harness.device.id
+        response = sync_harness.app.make_response(
+            kobo.HandleSyncRequest.__wrapped__(),
+        )
+        return sync_harness.app.process_response(response)
 
 
 def _add_kobo_shelf(
@@ -286,6 +341,140 @@ def sync_harness(monkeypatch):
     engine.dispose()
 
 
+def test_library_sync_private_capture_records_exact_response_and_summary_link(
+    sync_harness, monkeypatch, tmp_path, caplog,
+):
+    from cps import kobo
+
+    _capture, root = _enable_private_sync_capture(monkeypatch, tmp_path)
+    caplog.set_level(logging.INFO, logger="cps.kobo")
+    incoming_token = kobo.SyncToken.SyncToken().build_sync_token()
+    raw_device_id = "capture-device-id"
+
+    response = _sync_through_response_pipeline(
+        sync_harness,
+        token=incoming_token,
+        raw_device_id=raw_device_id,
+        x_kobo_sync="continue",
+    )
+
+    assert response.status_code == 200
+    [record] = _private_capture_records(root)
+    assert record["schema_version"] == 3
+    assert record["exchange"] == "library_sync"
+    assert record["device_request"]["path"] == "/v1/library/sync"
+    assert record["device_request"]["body"]["data"] == ""
+    request_headers = dict(record["device_request"]["headers"])
+    expected_device_hash = hashlib.sha256(
+        ("header:" + raw_device_id).encode("utf-8"),
+    ).hexdigest()[:12]
+    assert request_headers == {
+        "x-kobo-synctoken": "***REDACTED***",
+        "x-cwng-device-hash": expected_device_hash,
+        "x-kobo-sync": "continue",
+    }
+    sync_exchange = record["sync_exchange"]
+    assert sync_exchange["request"] == {
+        "incoming_token": incoming_token,
+        "x_kobo_sync": "continue",
+        "device_hash": expected_device_hash,
+    }
+    assert sync_exchange["response"]["outgoing_token"] == response.headers[
+        sync_harness.token_header
+    ]
+    assert record["device_response"]["body"]["data"].encode() \
+        == response.get_data()
+    assert record["upstream_request"] is None
+    assert record["upstream_response"] is None
+    assert raw_device_id not in json.dumps(record)
+    info_summary = sync_exchange["info_summary"]
+    assert info_summary["log_event"] == "Kobo Sync summary"
+    assert info_summary["capture_id"] == record["capture_id"]
+    assert info_summary["response_mode"] == "new_page"
+    assert info_summary["counters"]["new"] == 1
+    assert info_summary["counters"]["changed"] == 0
+    assert info_summary["counters"]["removed"] == 0
+    summaries = [
+        item.getMessage() for item in caplog.records
+        if item.getMessage().startswith("Kobo Sync summary:")
+    ]
+    assert "capture_id={}".format(record["capture_id"]) in summaries[-1]
+    assert "device={}".format(expected_device_hash) in summaries[-1]
+    assert "entitlements new=1 changed=0 removed=0" in summaries[-1]
+
+
+def test_library_sync_private_capture_reuses_authenticated_retention(
+    sync_harness, monkeypatch, tmp_path,
+):
+    capture, root = _enable_private_sync_capture(monkeypatch, tmp_path)
+    monkeypatch.setattr(capture, "MAX_FILES", 2)
+    monkeypatch.setattr(capture, "MAX_TOTAL_BYTES", 1024 * 1024)
+    incoming_token = kobo_token = None
+
+    # Repeating the same unacknowledged request exercises the real pending-page
+    # replay path while producing four distinct exchange records.
+    for _index in range(4):
+        response = _sync_through_response_pipeline(
+            sync_harness,
+            token=incoming_token,
+            raw_device_id="retention-device-id",
+        )
+        assert response.status_code == 200
+        if incoming_token is None:
+            kobo_token = response.headers[sync_harness.token_header]
+
+    records = _private_capture_records(root)
+    assert len(records) == 2
+    assert all(record["exchange"] == "library_sync" for record in records)
+    assert all(
+        record["sync_exchange"]["response"]["outgoing_token"] == kobo_token
+        for record in records
+    )
+    assert sum(
+        path.stat().st_size for path in root.glob("exchange-*.json.gz")
+    ) <= capture.MAX_TOTAL_BYTES
+
+
+def test_library_sync_capture_persistence_failure_never_changes_response(
+    sync_harness, monkeypatch, tmp_path,
+):
+    from cps.services import kobo_exchange_capture as capture
+
+    monkeypatch.delenv(capture.ENABLE_ENV, raising=False)
+    request_token = None
+    baseline = _sync_through_response_pipeline(
+        sync_harness,
+        token=request_token,
+        raw_device_id="failure-device-id",
+    )
+    baseline_wire = (
+        baseline.status_code,
+        baseline.get_data(),
+        baseline.headers[sync_harness.token_header],
+        baseline.headers.get("x-kobo-sync"),
+    )
+
+    _capture, root = _enable_private_sync_capture(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        capture.CaptureSession,
+        "_persist",
+        lambda _self: (_ for _ in ()).throw(OSError("capture unavailable")),
+    )
+    observed = _sync_through_response_pipeline(
+        sync_harness,
+        token=request_token,
+        raw_device_id="failure-device-id",
+    )
+
+    assert (
+        observed.status_code,
+        observed.get_data(),
+        observed.headers[sync_harness.token_header],
+        observed.headers.get("x-kobo-sync"),
+    ) == baseline_wire
+    assert not list(root.glob("exchange-*.json.gz")) if root.exists() else True
+
+
 def test_sync_refresh_preserves_a_concurrent_library_session(
     sync_harness, monkeypatch,
 ):
@@ -388,7 +577,8 @@ def test_interrupted_sync_token_loss_does_not_redeliver_unchanged_entitlement(
         if record.getMessage().startswith("Kobo Sync summary:")
     ]
     assert len(summaries) == 2
-    assert "entitlements new=0 changed=0 suppressed_unchanged=1" in summaries[-1]
+    assert "entitlements new=0 changed=0 removed=0" in summaries[-1]
+    assert "suppressed_replay=1 suppressed_unchanged=1" in summaries[-1]
     assert "replay_suppression enabled=True eligible=True" in summaries[-1]
     assert "cursors in=" in summaries[-1] and " out=" in summaries[-1]
 
@@ -471,6 +661,233 @@ def test_expired_orphan_pending_page_is_pruned_after_device_moves_on(
     assert sync_harness.session.query(ub.KoboDeviceBookEntitlement).count() == 0
 
 
+def test_pending_page_replay_logs_the_stored_response_counts(
+    sync_harness, caplog,
+):
+    """A byte replay gets its own INFO incident line with original counts."""
+    caplog.set_level(logging.INFO, logger="cps.kobo")
+
+    offered = sync_harness.sync(acknowledge=False)
+    replayed = sync_harness.sync(acknowledge=False)
+
+    assert replayed.get_data() == offered.get_data()
+    summaries = [
+        record.getMessage() for record in caplog.records
+        if record.getMessage().startswith("Kobo Sync summary:")
+    ]
+    assert len(summaries) == 2
+    assert "response_mode=pending_replay" in summaries[-1]
+    assert "entitlements new=1 changed=0 removed=0" in summaries[-1]
+    assert "suppressed_replay=0" in summaries[-1]
+    assert "fingerprint_mismatch_reemitted=0" in summaries[-1]
+    assert "reemit_reasons=none" in summaries[-1]
+    assert "cursors in=" in summaries[-1] and " out=" in summaries[-1]
+    assert "a" * 64 not in summaries[-1]
+
+
+def test_upgrade_reading_state_frontier_keeps_base_fingerprint_stable(
+    sync_harness, monkeypatch,
+):
+    """#2107 may move state between envelopes, never re-emit the base book."""
+    from cps import kobo, ub
+
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+    first = sync_harness.sync()
+    assert len(_entitlements(first)) == 1
+    ledger = sync_harness.session.query(
+        ub.KoboDeviceBookEntitlement,
+    ).one()
+    original_fingerprint = ledger.fingerprint
+    sync_harness.session.query(ub.DeviceReadingPosition).update({
+        ub.DeviceReadingPosition.rehydrate_needed: False,
+    })
+    sync_harness.session.commit()
+
+    modified = datetime(2026, 8, 28, 12, 30, 0)
+    state = _add_reading_state(sync_harness, modified, progress=42.0)
+    with sync_harness.app.test_request_context("/v1/library/sync"):
+        base_entitlement = {
+            "BookEntitlement": kobo.create_book_entitlement(
+                sync_harness.book, archived=False,
+            ),
+            "BookMetadata": kobo.get_metadata(sync_harness.book),
+        }
+        state_bearing_entitlement = dict(base_entitlement)
+        state_bearing_entitlement["ReadingState"] = (
+            kobo.get_kobo_reading_state_response(sync_harness.book, state)
+        )
+
+    assert kobo._entitlement_fingerprint(base_entitlement) == original_fingerprint
+    assert (
+        kobo._entitlement_fingerprint(state_bearing_entitlement)
+        != original_fingerprint
+    ), "the wire envelope changes when ReadingState moves, by design"
+
+    stale_token = kobo.SyncToken.SyncToken().build_sync_token()
+    upgraded = sync_harness.sync(stale_token)
+
+    assert _entitlements(upgraded) == [], (
+        "a reading-state placement change must not re-offer an already-held book"
+    )
+    states = _changed_reading_states(upgraded)
+    assert len(states) == 1
+    assert states[0]["EntitlementId"] == sync_harness.book.uuid
+    sync_harness.session.expire_all()
+    assert sync_harness.session.query(
+        ub.KoboDeviceBookEntitlement.fingerprint,
+    ).scalar() == original_fingerprint
+
+
+def test_failed_book_delete_rolls_back_archive_and_preserves_device_ledger(
+    sync_harness, monkeypatch,
+):
+    """#2102 cannot leak a staged removal into the following library sync."""
+    from werkzeug.exceptions import ServiceUnavailable
+    from cps import kobo, ub
+
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+    first = sync_harness.sync()
+    ledger = sync_harness.session.query(
+        ub.KoboDeviceBookEntitlement,
+    ).one()
+    original_fingerprint = ledger.fingerprint
+    sync_harness.user.check_visibility = lambda _permission: True
+
+    def reject_commit(*_args, **_kwargs):
+        sync_harness.session.rollback()
+        return False
+
+    monkeypatch.setattr(ub, "session_commit", reject_commit)
+    with sync_harness.app.test_request_context(
+        "/v1/library/{}".format(sync_harness.book.uuid), method="DELETE",
+    ):
+        g.annotation_origin_device_id = sync_harness.device.id
+        with pytest.raises(ServiceUnavailable) as raised:
+            inspect.unwrap(kobo.HandleBookDeletionRequest)(
+                sync_harness.book.uuid,
+            )
+    assert raised.value.code == 503
+
+    sync_harness.session.expire_all()
+    assert sync_harness.session.query(ub.ArchivedBook).count() == 0
+    assert sync_harness.session.query(ub.KoboSyncedBooks).count() == 1
+    assert sync_harness.session.query(
+        ub.KoboDeviceBookEntitlement.fingerprint,
+    ).scalar() == original_fingerprint
+
+    monkeypatch.setattr(
+        ub, "session_commit",
+        lambda *_args, **_kwargs: sync_harness.session.commit() or True,
+    )
+    following = sync_harness.sync(first.headers[sync_harness.token_header])
+    assert _entitlements(following) == []
+
+
+def test_annotation_get_503_does_not_mutate_book_delivery_state(
+    sync_harness, monkeypatch,
+):
+    """#2108's annotation-only 503 cannot queue a library removal response."""
+    from cps import kobo, readingservices, ub
+
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+    first = sync_harness.sync()
+    ledger = sync_harness.session.query(
+        ub.KoboDeviceBookEntitlement,
+    ).one()
+    original_fingerprint = ledger.fingerprint
+
+    monkeypatch.setattr(
+        readingservices,
+        "current_user",
+        SimpleNamespace(id=sync_harness.user.id, is_authenticated=True),
+    )
+    monkeypatch.setattr(
+        readingservices.config, "config_kobo_sync", True, raising=False,
+    )
+    monkeypatch.setattr(
+        readingservices, "_begin_exchange_capture", lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        readingservices,
+        "resolve_entitlement_ownership",
+        lambda _entitlement_id: readingservices.OWNERSHIP_UNKNOWN,
+    )
+    monkeypatch.setattr(
+        readingservices,
+        "_possible_annotation_ownership",
+        lambda *_a, **_k: readingservices.POSSIBLE_OWNERSHIP_LOOKUP_FAILED,
+    )
+    with sync_harness.app.test_request_context(
+        "/api/v3/content/{}/annotations".format(sync_harness.book.uuid),
+        method="GET",
+    ):
+        response = inspect.unwrap(readingservices.handle_annotations)(
+            sync_harness.book.uuid,
+        )
+
+    assert response.status_code == 503
+    sync_harness.session.expire_all()
+    assert sync_harness.session.query(ub.ArchivedBook).count() == 0
+    assert sync_harness.session.query(ub.KoboDeletedBook).count() == 0
+    assert sync_harness.session.query(ub.KoboSyncedBooks).count() == 1
+    assert sync_harness.session.query(
+        ub.KoboDeviceBookEntitlement.fingerprint,
+    ).scalar() == original_fingerprint
+
+    following = sync_harness.sync(first.headers[sync_harness.token_header])
+    assert _entitlements(following) == []
+
+
+def test_furthest_wins_parent_clock_emits_state_without_entitlement(
+    sync_harness, monkeypatch,
+):
+    """#2118 may advance KoboReadingState, never Books or its fingerprint."""
+    from cps import kobo, ub
+
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+    first = sync_harness.sync()
+    ledger = sync_harness.session.query(
+        ub.KoboDeviceBookEntitlement,
+    ).one()
+    original_fingerprint = ledger.fingerprint
+    original_book_clock = sync_harness.book.last_modified
+    sync_harness.session.query(ub.DeviceReadingPosition).update({
+        ub.DeviceReadingPosition.rehydrate_needed: False,
+    })
+    sync_harness.session.commit()
+
+    written = sync_harness.put_position(
+        45.0, clock="2026-09-03T15:00:00Z",
+    )
+    assert written.status_code == 200
+    sync_harness.session.expire_all()
+    state = sync_harness.session.query(ub.KoboReadingState).one()
+    assert state.last_modified == datetime(2026, 9, 3, 15, 0, 0)
+    assert sync_harness.session.get(
+        type(sync_harness.book), sync_harness.book.id,
+    ).last_modified == original_book_clock
+
+    stale_token = kobo.SyncToken.SyncToken().build_sync_token()
+    following = sync_harness.sync(stale_token)
+
+    assert _entitlements(following) == []
+    states = _changed_reading_states(following)
+    assert len(states) == 1
+    assert states[0]["CurrentBookmark"]["ProgressPercent"] == 45
+    sync_harness.session.expire_all()
+    assert sync_harness.session.query(
+        ub.KoboDeviceBookEntitlement.fingerprint,
+    ).scalar() == original_fingerprint
+
+
 def test_same_version_payload_mismatch_delivers_and_restamps(
     sync_harness, caplog, monkeypatch,
 ):
@@ -513,6 +930,17 @@ def test_same_version_payload_mismatch_delivers_and_restamps(
         record.getMessage() for record in caplog.records
         if record.getMessage().startswith("Kobo Sync summary:")
     ]
+    mismatch_summaries = [
+        summary for summary in summaries
+        if "fingerprint_mismatch_reemitted=1" in summary
+    ]
+    assert len(mismatch_summaries) == 1
+    assert "entitlements new=0 changed=1 removed=0" in mismatch_summaries[0]
+    assert "suppressed_replay=0" in mismatch_summaries[0]
+    assert (
+        "reemit_reasons=live_fingerprint_mismatch_same_basis:1"
+        in mismatch_summaries[0]
+    )
     assert "reseeded_shape_change=0" in summaries[-1]
 
 
@@ -1664,7 +2092,7 @@ def test_shelf_only_membership_addition_emits_once(sync_harness):
 
 
 def test_shelf_only_removal_command_and_ledger_cleanup_are_unchanged(
-    sync_harness, monkeypatch,
+    sync_harness, monkeypatch, caplog,
 ):
     """Removing a shelf member still emits IsRemoved and clears both markers."""
     from cps import kobo, ub
@@ -1673,6 +2101,7 @@ def test_shelf_only_removal_command_and_ledger_cleanup_are_unchanged(
     monkeypatch.setattr(
         kobo.config, "config_kobo_suppress_replayed_entitlements", True,
     )
+    caplog.set_level(logging.INFO, logger="cps.kobo")
     _shelf, link = _add_kobo_shelf(
         sync_harness,
         date_added=datetime(2026, 8, 28, 12, 5, 0),
@@ -1691,6 +2120,13 @@ def test_shelf_only_removal_command_and_ledger_cleanup_are_unchanged(
     assert envelopes[0]["ChangedEntitlement"]["BookEntitlement"]["IsRemoved"] is True
     assert sync_harness.session.query(ub.KoboSyncedBooks).count() == 0
     assert sync_harness.session.query(ub.KoboDeviceBookEntitlement).count() == 0
+    summaries = [
+        record.getMessage() for record in caplog.records
+        if record.getMessage().startswith("Kobo Sync summary:")
+    ]
+    assert "entitlements new=0 changed=1 removed=1" in summaries[-1]
+    assert "fingerprint_mismatch_reemitted=1" in summaries[-1]
+    assert "reemit_reasons=live_scope_removal:1" in summaries[-1]
 
 
 @pytest.mark.parametrize("removed_book_was_sole_marker", [False, True])
@@ -3255,10 +3691,10 @@ def test_partial_legacy_and_store_tokens_degrade_without_exception():
 def test_sync_summary_handles_store_min_and_nullable_cursor_shapes(
     sync_harness, caplog,
 ):
-    """The permanent DEBUG diagnostic must never become a sync failure."""
+    """The permanent INFO diagnostic must never become a sync failure."""
     from cps import kobo
 
-    caplog.set_level(logging.DEBUG, logger="cps.kobo")
+    caplog.set_level(logging.INFO, logger="cps.kobo")
     response = sync_harness.sync("official.store-token")
     assert response.status_code == 200
     summaries = [
@@ -3266,7 +3702,10 @@ def test_sync_summary_handles_store_min_and_nullable_cursor_shapes(
         if record.getMessage().startswith("Kobo Sync summary:")
     ]
     assert len(summaries) == 1
-    assert "entitlements new=1 changed=0" in summaries[0]
+    assert "entitlements new=1 changed=0 removed=0" in summaries[0]
+    assert "suppressed_replay=0" in summaries[0]
+    assert "fingerprint_mismatch_reemitted=0" in summaries[0]
+    assert "reemit_reasons=none" in summaries[0]
     assert "cursors in=" in summaries[0] and " out=" in summaries[0]
 
     nullable = SimpleNamespace(

--- a/tests/unit/test_1925_kobo_sync_dedownload.py
+++ b/tests/unit/test_1925_kobo_sync_dedownload.py
@@ -42,6 +42,18 @@ def _changed_reading_states(response):
     ]
 
 
+def _response_wire(response):
+    """The review contract is status plus exact response bytes."""
+    return response.status_code, response.get_data()
+
+
+def _discard_pending_page(sync_harness):
+    from cps import kobo_sync_status
+
+    kobo_sync_status.delete_pending_sync_page(sync_harness.device.id)
+    sync_harness.session.commit()
+
+
 def _private_capture_records(root):
     return [
         json.loads(gzip.decompress(path.read_bytes()))
@@ -387,6 +399,12 @@ def test_library_sync_private_capture_records_exact_response_and_summary_link(
     assert record["upstream_request"] is None
     assert record["upstream_response"] is None
     assert raw_device_id not in json.dumps(record)
+    raw_capture = json.dumps(record)
+    assert sync_harness.book.title in raw_capture
+    assert "/v1/library/sync" in raw_capture
+    assert "/download/" in raw_capture
+    assert incoming_token in raw_capture
+    assert response.headers[sync_harness.token_header] in raw_capture
     info_summary = sync_exchange["info_summary"]
     assert info_summary["log_event"] == "Kobo Sync summary"
     assert info_summary["capture_id"] == record["capture_id"]
@@ -401,6 +419,16 @@ def test_library_sync_private_capture_records_exact_response_and_summary_link(
     assert "capture_id={}".format(record["capture_id"]) in summaries[-1]
     assert "device={}".format(expected_device_hash) in summaries[-1]
     assert "entitlements new=1 changed=0 removed=0" in summaries[-1]
+    for raw_value in (
+        raw_device_id,
+        sync_harness.user.name,
+        sync_harness.book.title,
+        "/v1/library/sync",
+        "/download/",
+        incoming_token,
+        response.headers[sync_harness.token_header],
+    ):
+        assert raw_value not in summaries[-1]
 
 
 def test_library_sync_private_capture_reuses_authenticated_retention(
@@ -473,6 +501,205 @@ def test_library_sync_capture_persistence_failure_never_changes_response(
         observed.headers.get("x-kobo-sync"),
     ) == baseline_wire
     assert not list(root.glob("exchange-*.json.gz")) if root.exists() else True
+
+
+def test_sync_summary_emission_failure_preserves_pending_replay_bytes(
+    sync_harness, monkeypatch, caplog,
+):
+    from cps import kobo
+
+    caplog.set_level(logging.WARNING, logger="cps.kobo")
+    sync_harness.sync(acknowledge=False)
+    baseline = sync_harness.sync(acknowledge=False)
+
+    def fail_cursor_format(_cursor):
+        raise RuntimeError("injected summary formatter failure")
+
+    monkeypatch.setattr(kobo, "_sync_cursor_log_value", fail_cursor_format)
+    observed = sync_harness.sync(acknowledge=False)
+
+    assert _response_wire(observed) == _response_wire(baseline)
+    assert any(
+        "reason=summary_emission_failed" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_sync_capture_summary_failure_preserves_pending_replay_bytes(
+    sync_harness, monkeypatch, caplog,
+):
+    from cps.services import kobo_exchange_capture as capture
+
+    class CaptureProbe:
+        capture_id = "capture-probe"
+
+        def __init__(self, fail):
+            self.fail = fail
+
+        def record_sync_request(self, **_kwargs):
+            return None
+
+        def record_sync_info_summary(self, **_kwargs):
+            if self.fail:
+                raise RuntimeError("injected capture summary failure")
+
+        def record_sync_response(self, **_kwargs):
+            return None
+
+        def finish(self, **_kwargs):
+            return True
+
+    caplog.set_level(logging.WARNING, logger="cps.kobo")
+    sync_harness.sync(acknowledge=False)
+    should_fail = {"value": False}
+    monkeypatch.setattr(
+        capture,
+        "begin_capture",
+        lambda **_kwargs: CaptureProbe(should_fail["value"]),
+    )
+    baseline = sync_harness.sync(acknowledge=False)
+    should_fail["value"] = True
+    observed = sync_harness.sync(acknowledge=False)
+
+    assert _response_wire(observed) == _response_wire(baseline)
+    assert any(
+        "reason=capture_summary_record_failed" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_reemit_reason_failure_preserves_non_cwng_reset_bytes(
+    sync_harness, monkeypatch, caplog,
+):
+    from cps import kobo
+
+    caplog.set_level(logging.WARNING, logger="cps.kobo")
+    sync_harness.sync()
+    monkeypatch.setattr(kobo.secrets, "token_hex", lambda _size: "a" * 32)
+    baseline = sync_harness.sync("official.store-token", acknowledge=False)
+    _discard_pending_page(sync_harness)
+
+    def fail_reason(*_args, **_kwargs):
+        raise RuntimeError("injected reason classification failure")
+
+    monkeypatch.setattr(kobo, "_entitlement_reemit_reason", fail_reason)
+    observed = sync_harness.sync("official.store-token", acknowledge=False)
+
+    assert _response_wire(observed) == _response_wire(baseline)
+    assert any(
+        "reason=reason_classification_failed" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_pending_observability_serialization_failure_preserves_response_bytes(
+    sync_harness, monkeypatch, caplog,
+):
+    from cps import kobo
+
+    caplog.set_level(logging.WARNING, logger="cps.kobo")
+    sync_harness.sync()
+    monkeypatch.setattr(kobo.secrets, "token_hex", lambda _size: "b" * 32)
+    baseline = sync_harness.sync("official.store-token", acknowledge=False)
+    _discard_pending_page(sync_harness)
+    real_observability = kobo._sync_observability
+
+    def unserializable_observability(*args, **kwargs):
+        counters = real_observability(*args, **kwargs)
+        counters["injected_unserializable"] = {"not-json"}
+        return counters
+
+    monkeypatch.setattr(
+        kobo, "_sync_observability", unserializable_observability,
+    )
+    observed = sync_harness.sync("official.store-token", acknowledge=False)
+
+    assert _response_wire(observed) == _response_wire(baseline)
+    assert any(
+        "reason=pending_observability_serialization_failed"
+        in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_diagnostic_reset_ledger_failure_preserves_response_bytes(
+    sync_harness, monkeypatch, caplog,
+):
+    from cps import kobo, kobo_sync_status
+
+    caplog.set_level(logging.WARNING, logger="cps.kobo")
+    sync_harness.sync()
+    monkeypatch.setattr(kobo.secrets, "token_hex", lambda _size: "c" * 32)
+    baseline = sync_harness.sync("official.store-token", acknowledge=False)
+    _discard_pending_page(sync_harness)
+
+    def fail_diagnostic_read(_device_id, _book_ids, *, _session=None):
+        assert _session is not None
+        raise RuntimeError("injected diagnostic ledger failure")
+
+    monkeypatch.setattr(
+        kobo_sync_status,
+        "get_device_entitlement_fingerprints",
+        fail_diagnostic_read,
+    )
+    observed = sync_harness.sync("official.store-token", acknowledge=False)
+
+    assert _response_wire(observed) == _response_wire(baseline)
+    assert any(
+        "reason=diagnostic_ledger_read_failed "
+        "scope=live_non_cwng_reset" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_live_removal_diagnostic_failure_preserves_staged_acknowledgement(
+    sync_harness, monkeypatch, caplog,
+):
+    from cps import kobo_sync_status, ub
+
+    caplog.set_level(logging.WARNING, logger="cps.kobo")
+    sync_harness.user.kobo_only_shelves_sync = True
+    _shelf, link = _add_kobo_shelf(sync_harness)
+    offered = sync_harness.sync(acknowledge=False)
+    offered_token = offered.headers[sync_harness.token_header]
+    sync_harness.session.delete(link)
+    sync_harness.session.commit()
+
+    real_lookup = kobo_sync_status.get_device_entitlement_fingerprints
+
+    def fail_diagnostic_read(device_id, book_ids, *, _session=None):
+        if _session is not None:
+            raise RuntimeError("injected live-removal ledger failure")
+        return real_lookup(device_id, book_ids)
+
+    monkeypatch.setattr(
+        kobo_sync_status,
+        "get_device_entitlement_fingerprints",
+        fail_diagnostic_read,
+    )
+    observed = sync_harness.sync(offered_token, acknowledge=False)
+
+    assert observed.status_code == 200
+    assert sync_harness.session.query(ub.KoboSyncedBooks).count() == 1
+    assert sync_harness.session.query(
+        ub.KoboDeviceBookEntitlement,
+    ).count() == 1
+    pending = kobo_sync_status.get_pending_sync_page(sync_harness.device.id)
+    assert pending is not None
+    assert pending.response_body.encode() == observed.get_data()
+    assert any(
+        "reason=diagnostic_ledger_read_failed "
+        "scope=live_scope_removal" in record.getMessage()
+        for record in caplog.records
+    )
+
+    monkeypatch.setattr(
+        kobo_sync_status,
+        "get_device_entitlement_fingerprints",
+        real_lookup,
+    )
+    no_fault_replay = sync_harness.sync(offered_token, acknowledge=False)
+    assert _response_wire(observed) == _response_wire(no_fault_replay)
 
 
 def test_sync_refresh_preserves_a_concurrent_library_session(

--- a/tests/unit/test_kobo_reading_services_exchange_capture.py
+++ b/tests/unit/test_kobo_reading_services_exchange_capture.py
@@ -338,7 +338,7 @@ def test_unauthenticated_patch_401_captures_body_with_explicit_provenance_outsid
 
     assert response.status_code == 401
     [record] = _records(unauthenticated_root)
-    assert record["schema_version"] == 2
+    assert record["schema_version"] == 3
     assert record["exchange"] == "annotations_patch_unauthenticated"
     assert record["request_provenance"] == {
         "authentication": "unauthenticated",


### PR DESCRIPTION
Forensics and observability for the reported Kobo "books removed from the device after a sync" regression (a household Libra Colour 2, twice).

## What was established first (state/kobo-dedownload report, OBSERVED on the live instance)
- The device's last sync predates every merge from that day, so the merges did not cause the incident.
- Instance logs show 13 kepub re-downloads and **no removal signal** in the window; the exact sync bodies were not recorded, so the trigger could not be proven from logs alone.
- Five code-level suspects (byte-identical re-emitted entitlements, fingerprint scope, pending-page replay, annotation 503 wipe, expired-page prune) were each checked against the current code with firmware-shaped guards in `tests/unit/test_1925_kobo_sync_dedownload.py`; none reproduces a removal.

## What this PR adds
- **Structured per-sync INFO summary** (PII-free): response mode, incoming/outgoing cursor vectors, counters and every re-emission reason, plus a 12-char device hash instead of the raw device id.
- **`/v1/library/sync` joins the existing opt-in private exchange capture** (same gate `CWNG_KOBO_READING_SERVICES_CAPTURE=I_UNDERSTAND_THIS_CAPTURES_PRIVATE_READING_DATA`, same directory, 0700/0600, atomic gzip, 16 MiB body bound, 256 files / 64 MiB / 7-day retention, cross-process lock). A record holds the exact opaque sync tokens, the finalized response body Nickel receives (bytes + sha256), the response headers, and the matching INFO summary; the INFO line carries `capture_id=` for correlation. Schema bumped to v3; annotation/checkforchanges records unchanged apart from a null `sync_exchange`.
- Capture failure of any kind (attach, observe, lock, persist) cannot alter the sync response — proven by a baseline-equality test.
- Docs disclose that enabling capture stores complete library-sync metadata and tokens.

## Verification (OBSERVED)
- `test_1925_kobo_sync_dedownload.py` 78 passed; exchange-capture suite 15 passed; full `tests/unit` 8,203 passed, 111 skipped on top of `27eda19d20`.

## Not settled (ASSUMED / needs the device)
- Whether the original removal came from server sync, Calibre's Kobo driver over USB, or Nickel's post-USB rescan: the incident predates body capture. The reporter noted it "seemed to happen when connected to the computer", which points at the USB path; on-device replication is queued for when the test Kobo is reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016HTQrgFiyGnVJU2MxXTkJ2
