### PR TITLE
fix(spa): keep ingest retry markers internal

### DIFF
--- a/changelog.d/2133.md
+++ b/changelog.d/2133.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- **Book pages no longer scroll sideways after books are imported.** Internal
+  retry-safety data stays out of displayed and editable book identifiers, while
+  legitimate long custom identifiers wrap within the page on phones and other
+  narrow screens.

--- a/cps/api/serializers.py
+++ b/cps/api/serializers.py
@@ -4,7 +4,7 @@
 
 from datetime import date, datetime
 
-from .. import constants
+from .. import constants, db
 from ..clean_html import clean_string
 from ..cover_version import COVER_VERSION_ARG, cover_version_token
 from ..ui_themes import theme_slug

--- a/cps/db.py
+++ b/cps/db.py
@@ -366,6 +366,20 @@ books_publishers_link = Table('books_publishers_link', Base.metadata,
                               )
 
 
+# Calibre has no separate transactional sidecar table for per-source ingest
+# commits. The ingest helper therefore records its retry marker alongside book
+# identifiers so the book write and marker share one database transaction.
+# These rows are application state, not bibliographic identifiers. Keep the
+# default Books.identifiers relationship public-only so every ORM consumer gets
+# the safe view without remembering its own filter. Code that genuinely needs
+# ingest state must opt into Books.internal_identifiers by name.
+INTERNAL_IDENTIFIER_PREFIX = "cwng_ingest_sha256_"
+
+
+def is_internal_identifier_type(identifier_type):
+    return str(identifier_type or "").lower().startswith(INTERNAL_IDENTIFIER_PREFIX)
+
+
 class Library_Id(Base):
     __tablename__ = 'library_id'
     id = Column(Integer, primary_key=True)
@@ -711,7 +725,28 @@ class Books(Base):
     ratings = relationship(Ratings, secondary=books_ratings_link, backref='books', lazy='selectin')
     languages = relationship(Languages, secondary=books_languages_link, backref='books', lazy='selectin')
     publishers = relationship(Publishers, secondary=books_publishers_link, backref='books', lazy='selectin')
-    identifiers = relationship(Identifiers, backref='books', lazy='selectin')
+    identifiers = relationship(
+        Identifiers,
+        primaryjoin=lambda: and_(
+            Books.id == Identifiers.book,
+            func.substr(
+                func.lower(Identifiers.type), 1, len(INTERNAL_IDENTIFIER_PREFIX)
+            ) != INTERNAL_IDENTIFIER_PREFIX,
+        ),
+        backref='books',
+        lazy='selectin',
+    )
+    internal_identifiers = relationship(
+        Identifiers,
+        primaryjoin=lambda: and_(
+            Books.id == Identifiers.book,
+            func.substr(
+                func.lower(Identifiers.type), 1, len(INTERNAL_IDENTIFIER_PREFIX)
+            ) == INTERNAL_IDENTIFIER_PREFIX,
+        ),
+        viewonly=True,
+        lazy='select',
+    )
 
     def __init__(self, title, sort, author_sort, timestamp, pubdate, series_index, last_modified, path, has_cover,
                  authors, tags, languages=None):

--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -2617,13 +2617,17 @@ def modify_database_object(input_elements, db_book_object, db_object, db_session
 def modify_identifiers(input_identifiers, db_identifiers, db_session):
     """Modify Identifiers to match input information.
        input_identifiers is a list of read-to-persist Identifiers objects.
-       db_identifiers is a list of already persisted list of Identifiers objects."""
+       db_identifiers is a list of already persisted list of Identifiers objects.
+
+       Books.identifiers excludes reserved ingest state at the ORM boundary.
+       Still reject reserved input here so a crafted form/API payload cannot
+       create or replace an internal row."""
     changed = False
     error = False
     input_dict = {}
     for identifier in input_identifiers:
         identifier_type = (identifier.type or "").strip().lower()
-        if not identifier_type:
+        if not identifier_type or db.is_internal_identifier_type(identifier_type):
             continue
         if identifier_type in input_dict:
             error = True

--- a/cps/progress_syncing/protocols/kosync.py
+++ b/cps/progress_syncing/protocols/kosync.py
@@ -1833,7 +1833,10 @@ def export_progress():
             # Chunk the id lookup so a user with a very large library (or one who
             # has seeded many numeric progress rows) can't blow past the SQLite
             # host's bound-parameter limit and 500 the export.
-            _CHUNK = 500
+            # Books.identifiers contributes three bound values for its reserved
+            # prefix predicate; leave room for them under this lane's 500-bind
+            # ceiling while retaining the same bounded-query behaviour.
+            _CHUNK = 497
             for start in range(0, len(book_ids), _CHUNK):
                 chunk = book_ids[start:start + _CHUNK]
                 calibre_query = (
@@ -1864,7 +1867,9 @@ def export_progress():
                         calibre_db.session.query(
                             Identifiers.book, Identifiers.type, Identifiers.val
                         )
-                        .filter(Identifiers.book.in_(matched_ids))
+                        .select_from(Books)
+                        .join(Books.identifiers)
+                        .filter(Books.id.in_(matched_ids))
                         .all()
                     )
                     for book_id, identifier_type, identifier_value in identifier_rows:

--- a/frontend/e2e/book-detail.spec.ts
+++ b/frontend/e2e/book-detail.spec.ts
@@ -190,6 +190,29 @@ test('book detail with a "More by" strip has no horizontal overflow on mobile', 
   await assertNoHorizontalOverflow(page);
 });
 
+test('long custom identifier types and values stay within the metadata grid', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/app');
+  const bookId = await firstBookId(page);
+  test.skip(bookId == null, 'seed has no books');
+
+  const longType = `external-catalog-${'x'.repeat(64)}`;
+  const longValue = `record-${'y'.repeat(96)}`;
+  await page.route(`**/api/v1/books/${bookId}`, async (route) => {
+    const res = await route.fetch();
+    const book = await res.json();
+    book.identifiers = [
+      ...(book.identifiers ?? []),
+      { type: longType, label: longType, val: longValue, url: null },
+    ];
+    await route.fulfill({ response: res, json: book });
+  });
+
+  await page.goto(`/app/book/${bookId}`, { waitUntil: 'domcontentloaded' });
+  await expect(page.locator('main dl')).toContainText(longType, { timeout: 10_000 });
+  await assertNoHorizontalOverflow(page);
+});
+
 // A reader without the edit role sees the read-only tag pills, and those pills
 // were `white-space: nowrap` with no max-width. Real libraries carry
 // Library-of-Congress subject headings ("France -- History -- Revolution,

--- a/frontend/src/pages/BookDetail.module.css
+++ b/frontend/src/pages/BookDetail.module.css
@@ -583,9 +583,13 @@
 /* Metadata definition list */
 .meta {
   display: grid;
-  grid-template-columns: auto 1fr;
+  /* Identifier types and values are user metadata and may be long unbroken
+     tokens. Keep the label content-sized only up to 40% of the row, then let
+     both tracks wrap instead of widening the document. */
+  grid-template-columns: fit-content(40%) minmax(0, 1fr);
   gap: var(--sp-1) var(--sp-4);
   margin: 0;
+  min-width: 0;
 }
 
 .metaLabel {
@@ -595,12 +599,16 @@
   letter-spacing: 0.05em;
   font-weight: var(--fw-medium);
   padding-top: 2px; /* align with value baseline */
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .metaValue {
   font-size: var(--fs-sm);
   color: var(--text);
   margin: 0;
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 /* Description prose. Since #1828 this sits directly under the title/author

--- a/tests/unit/test_580_edit_identifiers.py
+++ b/tests/unit/test_580_edit_identifiers.py
@@ -52,6 +52,23 @@ def test_editable_metadata_includes_identifiers():
     ]
 
 
+def test_shared_identifier_reconciler_ignores_submitted_internal_marker():
+    from cps import editbooks
+    session = MagicMock()
+    digest = "c" * 64
+    submitted_marker = SimpleNamespace(
+        type=f"cwng_ingest_sha256_{digest}", val="forged",
+    )
+
+    changed, duplicate = editbooks.modify_identifiers(
+        [submitted_marker], [], session,
+    )
+
+    assert changed is False
+    assert duplicate is False
+    session.add.assert_not_called()
+
+
 def test_update_metadata_persists_identifiers_lowercased_and_skips_blank_rows():
     from cps.api import edit as mod
     session = MagicMock()

--- a/tests/unit/test_internal_identifier_visibility.py
+++ b/tests/unit/test_internal_identifier_visibility.py
@@ -1,0 +1,217 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Internal ingest identifiers stay outside every public ORM consumer."""
+
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+from jinja2 import Environment, FileSystemLoader
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from cps import db, epub_helper, helper
+from cps.duplicates import select_book_to_keep
+from cps.services import parallel
+from tests.fixtures.kepub_fixture import build_calibre_epub3_series_kepub
+
+
+pytestmark = pytest.mark.unit
+
+_DIGEST = "d" * 64
+_MARKER_TYPE = f"cwng_ingest_sha256_{_DIGEST}"
+
+
+@pytest.fixture
+def calibre_session():
+    def creator():
+        connection = sqlite3.connect(":memory:", check_same_thread=False)
+        connection.execute("ATTACH DATABASE ':memory:' AS calibre")
+        return connection
+
+    engine = create_engine(
+        "sqlite+pysqlite://", creator=creator, poolclass=StaticPool,
+    )
+    db.Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    try:
+        yield session
+    finally:
+        session.close()
+        engine.dispose()
+
+
+def _seed_book(session, title, *, timestamp=None, identifiers=()):
+    now = timestamp or datetime(2026, 1, 2, tzinfo=timezone.utc)
+    author = session.query(db.Authors).filter(db.Authors.name == "Test Author").first()
+    if author is None:
+        author = db.Authors("Test Author", "Author, Test")
+    book = db.Books(
+        title, title, "Author, Test", now, now, "1.0", now,
+        f"test/{title.lower().replace(' ', '-')}", False, [], [],
+    )
+    book.uuid = f"uuid-{title.lower().replace(' ', '-')}"
+    book.authors = [author]
+    session.add(book)
+    session.commit()
+    session.add_all([
+        db.Identifiers(value, identifier_type, book.id)
+        for identifier_type, value in identifiers
+    ])
+    session.commit()
+    session.expire_all()
+    return session.query(db.Books).filter(db.Books.id == book.id).one()
+
+
+def test_book_identifier_relationship_is_the_visibility_choke_point(calibre_session):
+    """Raw reserved rows are hidden normally and available only by explicit access."""
+    book = _seed_book(
+        calibre_session,
+        "Relationship Probe",
+        identifiers=(
+            ("isbn", "9780000000001"),
+            (_MARKER_TYPE.upper(), _DIGEST),
+            ("x-cwng_ingest_sha256_public", "near-prefix"),
+        ),
+    )
+
+    assert {(row.type, row.val) for row in book.identifiers} == {
+        ("isbn", "9780000000001"),
+        ("x-cwng_ingest_sha256_public", "near-prefix"),
+    }
+    assert [(row.type.lower(), row.val) for row in book.internal_identifiers] == [
+        (_MARKER_TYPE, _DIGEST),
+    ]
+    assert calibre_session.query(db.Identifiers).filter(
+        db.Identifiers.book == book.id,
+    ).count() == 3
+    assert calibre_session.query(db.Books).filter(
+        db.Books.id == book.id,
+        db.Books.identifiers.any(db.Identifiers.type == _MARKER_TYPE),
+    ).count() == 0
+    assert calibre_session.query(db.Books).filter(
+        db.Books.id == book.id,
+        db.Books.internal_identifiers.any(db.Identifiers.type == _MARKER_TYPE),
+    ).count() == 1
+
+    from cps.editbooks import modify_identifiers
+    _changed, duplicate = modify_identifiers(
+        [
+            db.Identifiers("9780000000005", "isbn", book.id),
+            db.Identifiers("near-prefix", "x-cwng_ingest_sha256_public", book.id),
+        ],
+        book.identifiers,
+        calibre_session,
+    )
+    assert duplicate is False
+    calibre_session.commit()
+    calibre_session.expire_all()
+    reloaded = calibre_session.query(db.Books).filter(db.Books.id == book.id).one()
+    assert [(row.type.lower(), row.val) for row in reloaded.internal_identifiers] == [
+        (_MARKER_TYPE, _DIGEST),
+    ]
+    assert {row.type: row.val for row in reloaded.identifiers}["isbn"] == (
+        "9780000000005"
+    )
+
+
+def test_listenmp3_does_not_render_internal_identifier(calibre_session):
+    book = _seed_book(
+        calibre_session,
+        "Audio Surface",
+        identifiers=(("isbn", "9780000000002"), (_MARKER_TYPE, _DIGEST)),
+    )
+    environment = Environment(
+        loader=FileSystemLoader("cps/templates"), autoescape=True,
+    )
+    environment.filters.update({
+        "clean_string": lambda value: value,
+        "escapedlink": lambda value: value,
+        "formatdate": lambda value, *_args: value,
+        "formatfloat": lambda value, *_args: value,
+        "last_modified": lambda _value: "",
+    })
+
+    def gettext(message, **values):
+        return message % values if values else message
+
+    rendered = environment.get_template("listenmp3.html").render(
+        entry=book,
+        mp3file=book.id,
+        audioformat="mp3",
+        bookmark=None,
+        books_shelfs=[],
+        current_user=SimpleNamespace(is_anonymous=True, is_authenticated=False),
+        g=SimpleNamespace(google_site_verification="", shelves_access=[]),
+        _=gettext,
+        csrf_token=lambda: "test-csrf",
+        url_for=lambda endpoint, **_values: f"/{endpoint}",
+    )
+
+    assert "ISBN" in rendered
+    assert "9780000000002" in rendered
+    assert _MARKER_TYPE not in rendered.lower()
+    assert _DIGEST not in rendered
+
+
+def test_downloaded_kepub_opf_does_not_contain_internal_identifier(
+    calibre_session, monkeypatch, tmp_path,
+):
+    book = _seed_book(
+        calibre_session,
+        "Kepub Surface",
+        identifiers=(("isbn", "9780000000003"), (_MARKER_TYPE, _DIGEST)),
+    )
+    source = build_calibre_epub3_series_kepub(tmp_path / "source.kepub")
+
+    class Query:
+        def filter(self, *_args):
+            return self
+
+        def order_by(self, *_args):
+            return self
+
+        def all(self):
+            return []
+
+    monkeypatch.setattr(
+        helper.calibre_db,
+        "session",
+        SimpleNamespace(query=lambda *_args: Query()),
+    )
+    monkeypatch.setattr(helper, "current_user", SimpleNamespace(locale="en"))
+    monkeypatch.setattr(helper, "_", lambda value: value)
+    monkeypatch.setattr(helper, "get_temp_dir", lambda: str(tmp_path))
+    monkeypatch.setattr(helper, "uuid4", lambda: "served-copy")
+    monkeypatch.setattr(parallel, "run_blocking", lambda job: job())
+
+    output_dir, output_name = helper.do_kepubify_metadata_replace(book, str(source))
+    served = f"{output_dir}/{output_name}.kepub"
+    package, _package_name = epub_helper.get_content_opf(served)
+    merged = epub_helper.etree.tostring(package, encoding="unicode")
+
+    assert "9780000000003" in merged
+    assert _MARKER_TYPE not in merged.lower()
+    assert _DIGEST not in merged
+
+
+def test_most_metadata_duplicate_resolution_ignores_internal_identifier(calibre_session):
+    newer_time = datetime(2026, 1, 2, tzinfo=timezone.utc)
+    older = _seed_book(
+        calibre_session,
+        "Older Duplicate",
+        timestamp=newer_time - timedelta(days=1),
+        identifiers=((_MARKER_TYPE, _DIGEST),),
+    )
+    newer = _seed_book(
+        calibre_session,
+        "Newer Duplicate",
+        timestamp=newer_time,
+    )
+
+    kept = select_book_to_keep([older, newer], "most_metadata")
+
+    assert kept.id == newer.id
+    assert older.internal_identifiers[0].type == _MARKER_TYPE

--- a/tests/unit/test_kosync_progress_export.py
+++ b/tests/unit/test_kosync_progress_export.py
@@ -303,6 +303,24 @@ def test_identifier_types_differing_only_beyond_ascii_case_both_survive(env):
     assert identifiers == {kelvin: "kelvin-id", "k": "ascii-k-id"}
 
 
+def test_internal_ingest_identifier_is_not_exported(env):
+    digest = "d" * 64
+    book = _seed_book(
+        env.calibre_session,
+        title="Internal Identifier",
+        authors=["A"],
+        identifiers={
+            "isbn": "9780000000004",
+            f"cwng_ingest_sha256_{digest}": digest,
+        },
+    )
+    _seed_progress(env.app_session, document=str(book.id))
+
+    identifiers = env.client.get("/kosync/export").get_json()[0]["identifiers"]
+
+    assert identifiers == {"isbn": "9780000000004"}
+
+
 def test_author_name_comma_is_unescaped(env):
     # Calibre escapes a comma inside a single author name as "|", so
     # "William H. Keith, Jr." is stored as "William H. Keith| Jr.". #730/#732


### PR DESCRIPTION
## Summary

- reserve `cwng_ingest_sha256_*` rows as internal ingest state at the `Books.identifiers` ORM relationship boundary
- expose those rows only through the explicit, read-only `Books.internal_identifiers` accessor
- route the KOReader export identifier query through the filtered relationship instead of querying around the boundary
- reject forged reserved-prefix identifier submissions while leaving legitimate near-prefix and custom identifiers unchanged
- retain bounded/wrapping metadata-grid tracks so arbitrary legitimate identifiers cannot create horizontal page overflow
- cover the ORM choke point plus the audio UI, KOReader export, downloaded KEPUB OPF, and destructive duplicate-selection surfaces

## Root cause and causal chain

1. **OBSERVED:** #2129 stores a transactional retry digest as a Calibre identifier whose type is `cwng_ingest_sha256_<digest>`.
2. **OBSERVED:** `Books.identifiers` previously loaded that application-state row as ordinary bibliographic metadata.
3. **OBSERVED:** every ORM consumer therefore received the marker unless it remembered a private filtering rule; the first implementation covered the SPA/classic editors and detail serializer but missed audio rendering, KOReader export, KEPUB metadata generation, and duplicate scoring.
4. **OBSERVED:** the long unbroken type/value expanded the SPA metadata grid beyond narrow viewports, producing the existing E2E failures.
5. **OBSERVED:** the same leak exposed the marker to other clients and allowed it to add duplicate-resolution metadata weight.
6. **OBSERVED:** filtering the relationship now makes the reserved row absent from normal collection loads, relationship predicates, templates, serializers, generated metadata, and duplicate scoring, while `internal_identifiers` and raw Calibre/SQLite ingest reads retain access to it.

No link in this chain is assumed.

## Verification

- reproduced all five new regressions against reviewed head `0b226cf348`: ORM choke point, audio template, KOReader export, final downloaded KEPUB OPF, and most-metadata duplicate selection
- new five-surface runtime regressions pass on this head
- `pytest -q tests/unit -k "identifier or ingest or edit or kosync or duplicate or epub"`: 1,283 passed, 30 skipped
- focused identifier/ingest/KOReader/KEPUB/duplicate corpus: 70 passed
- fresh production image real-Calibre transaction probe: 1 passed, including marker creation/read, overwrite, rollback, restoration, and digest assertions
- SPA E2E/typecheck compilation and unit corpus: 52 passed
- SQLAlchemy mapper configuration completed with `SAWarning` promoted to errors
- changelog integrity guard and `git diff --check` passed

## Scope

The Calibre ingest transaction and marker storage format are intentionally unchanged: the helper still writes through Calibre's API inside the metadata transaction, and crash/retry checks still read the raw table directly. The public relationship is the single visibility choke point. Consumer-specific serializer/template filters that became dead were removed; the write-side forged-prefix rejection remains. The absolute horizontal-overflow assertion is unchanged, with no skips or tolerances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Claude-Session: https://claude.ai/code/session_016HTQrgFiyGnVJU2MxXTkJ2