### PR TITLE
fix(spa): keep ingest retry markers internal

### DIFF
--- a/changelog.d/2134-ingest-marker-leak.md
+++ b/changelog.d/2134-ingest-marker-leak.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **A book's detail page no longer shows an internal ingest bookkeeping value as if it were book metadata.** Books imported since the ingest retry work landed carried a private `cwng_ingest_sha256_…` entry in Calibre's identifiers table, and the detail page and metadata editor listed it alongside real identifiers like ISBN. On a phone the 83-character value could not wrap, so it pushed the page sideways and left the buttons off screen. The value is still recorded and still used by ingest — it is simply no longer treated as something you wrote. Editing a book's identifiers now preserves it rather than deleting it, and the reserved name cannot be submitted by hand.

--- a/cps/api/edit.py
+++ b/cps/api/edit.py
@@ -15,7 +15,11 @@ from flask import jsonify, request, Response
 from flask_babel import get_locale
 
 from . import api_v1
-from .serializers import serialize_book_detail, cover_url_for
+from .serializers import (
+    cover_url_for,
+    is_internal_identifier_type,
+    serialize_book_detail,
+)
 from .. import calibre_db, config, db, ub, isoLanguages, logger
 from ..cw_login import current_user
 from ..usermanagement import login_required_if_no_ano
@@ -362,6 +366,7 @@ def _editable_metadata(book):
         "identifiers": [
             {"type": i.type, "val": i.val}
             for i in (getattr(book, "identifiers", None) or [])
+            if not is_internal_identifier_type(getattr(i, "type", None))
         ],
         # User-defined calibre columns (#pages, #status, …). The SPA has shown
         # these on the book page since v4.1.11 but had no way to change one, so
@@ -499,6 +504,7 @@ def update_metadata(book_id):
     if "identifiers" in data:
         raw_ids = data.get("identifiers") or []
         input_identifiers = []
+        reserved_identifier_submitted = False
         for entry in raw_ids if isinstance(raw_ids, list) else []:
             if not isinstance(entry, dict):
                 continue
@@ -506,14 +512,26 @@ def update_metadata(book_id):
             id_val = str(entry.get("val") or "").strip()
             if not id_type or not id_val:
                 continue  # skip blank rows (a half-filled row isn't an error)
+            if is_internal_identifier_type(id_type):
+                reserved_identifier_submitted = True
+                continue
             input_identifiers.append(db.Identifiers(id_val, id_type, book_id))
-        changed, id_error = modify_identifiers(
-            input_identifiers, book.identifiers, calibre_db.session)
+        editable_db_identifiers = [
+            identifier for identifier in book.identifiers
+            if not is_internal_identifier_type(getattr(identifier, "type", None))
+        ]
+        if reserved_identifier_submitted:
+            changed, id_error = False, True
+            identifier_error = "Reserved identifier type."
+        else:
+            changed, id_error = modify_identifiers(
+                input_identifiers, editable_db_identifiers, calibre_db.session)
+            identifier_error = "Duplicate identifier type — each type may appear once."
         if id_error:
             # A duplicate type may have already queued partial add/deletes on the
             # session — discard them so a rejected payload never persists partially.
             calibre_db.session.rollback()
-            errors["identifiers"] = "Duplicate identifier type — each type may appear once."
+            errors["identifiers"] = identifier_error
         elif changed:
             try:
                 calibre_db.session.commit()

--- a/cps/api/serializers.py
+++ b/cps/api/serializers.py
@@ -47,6 +47,18 @@ ORDERABLE_SIDEBAR_KEYS = [
     "shelves",
 ]
 
+# Calibre's identifiers table also carries CWNG-private bookkeeping. These
+# values must remain available to backend jobs, but they are not book metadata:
+# exposing them through detail/edit APIs renders a 64-byte digest as a user
+# identifier and lets an ordinary metadata edit delete the retry marker.
+INTERNAL_IDENTIFIER_PREFIXES = ("cwng_ingest_sha256_",)
+
+
+def is_internal_identifier_type(identifier_type):
+    """Return whether an identifier type is reserved for CWNG bookkeeping."""
+    normalized = str(identifier_type or "").strip().lower()
+    return normalized.startswith(INTERNAL_IDENTIFIER_PREFIXES)
+
 
 def serialize_sidebar_visibility(user):
     """Return {key: bool} for each configurable sidebar entry, using the same
@@ -324,6 +336,8 @@ def serialize_book_detail(book, read=False, archived=False, favorited=False, hid
     # plain text (url=None).
     identifiers = []
     for i in (getattr(book, "identifiers", None) or []):
+        if is_internal_identifier_type(getattr(i, "type", None)):
+            continue
         try:
             link = repr(i)
         except Exception:

--- a/tests/unit/test_580_edit_identifiers.py
+++ b/tests/unit/test_580_edit_identifiers.py
@@ -52,6 +52,68 @@ def test_editable_metadata_includes_identifiers():
     ]
 
 
+def test_editable_metadata_hides_internal_ingest_retry_marker():
+    from cps.api import edit as mod
+    marker = SimpleNamespace(type="cwng_ingest_sha256_" + "a" * 64, val="a" * 64)
+    book = _fake_book([SimpleNamespace(type="isbn", val="123"), marker])
+
+    assert mod._editable_metadata(book)["identifiers"] == [
+        {"type": "isbn", "val": "123"},
+    ]
+
+
+def test_update_metadata_preserves_internal_ingest_retry_marker():
+    from cps.api import edit as mod
+    session = MagicMock()
+    marker = SimpleNamespace(type="cwng_ingest_sha256_" + "a" * 64, val="a" * 64)
+    isbn = SimpleNamespace(type="isbn", val="old")
+    book = _fake_book([isbn, marker])
+    captured = {}
+
+    def fake_modify(inp, dbids, sess):
+        captured["dbids"] = dbids
+        return False, False
+
+    with _ctx("/api/v1/books/5/metadata", body={
+        "identifiers": [{"type": "isbn", "val": "old"}],
+    }):
+        with patch.object(mod, "current_user", _editor()), \
+             patch.object(mod, "calibre_db",
+                          SimpleNamespace(get_filtered_book=lambda *a, **k: book, session=session,
+                                          get_cc_columns=lambda *a, **k: [])), \
+             patch.object(mod, "modify_identifiers", side_effect=fake_modify), \
+             patch.object(mod, "get_locale", return_value="en"):
+            resp = inspect.unwrap(mod.update_metadata)(5)
+
+    assert captured["dbids"] == [isbn]
+    session.delete.assert_not_called()
+    assert resp.status_code == 200
+
+
+def test_update_metadata_rejects_internal_ingest_retry_marker():
+    from cps.api import edit as mod
+    session = MagicMock()
+    marker_type = "cwng_ingest_sha256_" + "a" * 64
+    book = _fake_book([])
+
+    with _ctx("/api/v1/books/5/metadata", body={
+        "identifiers": [{"type": marker_type, "val": "a" * 64}],
+    }):
+        with patch.object(mod, "current_user", _editor()), \
+             patch.object(mod, "calibre_db",
+                          SimpleNamespace(get_filtered_book=lambda *a, **k: book, session=session,
+                                          get_cc_columns=lambda *a, **k: [])), \
+             patch.object(mod, "modify_identifiers",
+                          side_effect=AssertionError("reserved marker must not be editable")), \
+             patch.object(mod, "get_locale", return_value="en"):
+            resp = inspect.unwrap(mod.update_metadata)(5)
+
+    payload = json.loads(resp.get_data())
+    assert payload["errors"]["identifiers"] == "Reserved identifier type."
+    session.rollback.assert_called_once()
+    session.commit.assert_not_called()
+
+
 def test_update_metadata_persists_identifiers_lowercased_and_skips_blank_rows():
     from cps.api import edit as mod
     session = MagicMock()

--- a/tests/unit/test_api_v1_detail.py
+++ b/tests/unit/test_api_v1_detail.py
@@ -79,6 +79,23 @@ def test_serialize_book_detail_full():
 
 
 @pytest.mark.unit
+def test_serialize_book_detail_hides_internal_ingest_retry_marker():
+    """The retry digest is backend state, not user-visible book metadata."""
+    from cps.api.serializers import serialize_book_detail
+
+    marker = "cwng_ingest_sha256_" + "a" * 64
+    book = _make_book(identifiers=[
+        Identifiers("9780441013593", "isbn", 1),
+        Identifiers("a" * 64, marker, 1),
+    ])
+
+    assert serialize_book_detail(book)["identifiers"] == [{
+        "type": "isbn", "val": "9780441013593",
+        "url": "https://www.worldcat.org/isbn/9780441013593", "label": "ISBN",
+    }]
+
+
+@pytest.mark.unit
 def test_serialize_book_detail_empty():
     from cps.api.serializers import serialize_book_detail
     book = SimpleNamespace(


### PR DESCRIPTION
Unblocks `main`, whose SPA E2E lane has been red since `e4d3dfecff`.

## What was wrong

The ingest retry work in #2129 stores its private digest in Calibre's ordinary `identifiers` table,
as an identifier whose type is `cwng_ingest_sha256_<64 hex>`. Nothing filtered it on the way out, so
`/api/v1/books/<id>` returned it as book metadata and `BookDetail` rendered the 83-character type and
its 64-character value as a `<dt>/<dd>` pair. `BookDetail.module.css` lays that grid out as
`auto 1fr` with no break rule, so on a 390 px viewport the unbreakable string forced the document to
roughly 1,128–1,226 px. Every nearby element ended up outside the viewport, which is why 16 specs
failed on horizontal overflow and why clicks timed out — pointer interception on a page that had been
widened, not a broken route.

**This is not only a CI problem.** Every real library ingested since `e4d3dfecff` shows the marker on
the book detail page and in the metadata editor.

## What this does

`cps/api/serializers.py` gains a named private-identifier boundary and skips those rows in public
detail serialization; ISBN, URI, Goodreads, Amazon and every other user identifier are untouched.
`cps/api/edit.py` hides them from the SPA editor, **preserves** them when reconciling user-visible
identifiers, and rejects an attempt to submit a reserved type — without that half, hiding the marker
would let the next metadata edit silently delete it and destroy retry idempotency.

The marker stays stored and queryable by ingest. No migration, no marker-format change, no dependency,
no CSS workaround, and no cleanup of existing rows is needed.

## Evidence

Container-level, on the exact immutable first-red image
`sha256:7b14acfce6d6bcb79bfb2450757c2be0081c82e28040b9a153121c16ae80c279`: the same five fixtures
ingest, five `cwng_ingest_sha256_*` rows are present, and the four named specs across desktop and
mobile fail with 738–753 px of overflow. A locally built patched image stores the same five markers,
omits them from the API, and passes all nine of that selection plus the three further mobile specs
the raw log named. The intervention changes marker visibility only — same seed, browser, database
rows, route and viewport — which is what separates this from harness drift or a thin fixture.

Manager-run red/green: 24 passed on the branch; removing the two-line serializer skip fails exactly
`test_serialize_book_detail_hides_internal_ingest_retry_marker` and nothing else.

Alternatives eliminated with evidence before this was accepted: image/version skew (the job resolved
`sha-e4d3dfecff` exactly), a thin fixture (seed reached 5/5), progressive resource starvation
(failures are spread 04:06–04:16, not clustered late), a layout-code change (the commit touches no
frontend file), and an invalid baseline (E2E ran and passed at both `074350c6b3` and `7e9221f455`).

## Before merging

`cps/api/edit.py` now validates a user-submitted identifier type against a reserved prefix. That
round-trip — hide, preserve, reject — is the part worth a second pair of eyes; the display half is
straightforward.
