### PR TITLE
ci: a cancelled image build no longer blocks the next commit's immutable tag

### DIFF
--- a/.github/workflows/docker-image-build-dev.yml
+++ b/.github/workflows/docker-image-build-dev.yml
@@ -34,8 +34,10 @@ on:
 concurrency:
   group: dev-image-${{ github.event.pull_request.number || github.ref }}
   # Superseded PR heads may cancel their own unpublished verification build.
-  # Main/manual runs publish load-bearing artifacts and must serialize: a
-  # later neutral commit cannot cancel the relevant build it needs to alias.
+  # Main/manual runs publish load-bearing artifacts and must serialize so an
+  # older build can never finish after a newer one and move :dev backwards.
+  # GitHub may still cancel an older pending main run when another one queues;
+  # the alias gate below recovers by building its exact subject in that case.
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # GITHUB_TOKEN is read-only on packages by default. Builds push to
@@ -148,8 +150,8 @@ jobs:
   ensure-mirror:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: classify
-    if: needs.classify.outputs.full_build == 'true'
+    needs: [classify, alias-image-neutral-commit]
+    if: needs.alias-image-neutral-commit.outputs.build_required == 'true'
     steps:
       - name: Checkout (read Python pin from Dockerfile)
         uses: actions/checkout@v7
@@ -166,8 +168,8 @@ jobs:
   build-amd64:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: [classify, ensure-mirror]
-    if: needs.classify.outputs.full_build == 'true'
+    needs: [classify, alias-image-neutral-commit, ensure-mirror]
+    if: needs.alias-image-neutral-commit.outputs.build_required == 'true'
     steps:
       - name: Set build ref
         env:
@@ -283,13 +285,14 @@ jobs:
           # "Compose docker outputs" step above, which conditionally
           # includes the DockerHub image name when DOCKERHUB_PUSH_ENABLED.
           outputs: ${{ env.DOCKER_BUILD_OUTPUTS }}
-          # PBS_SOURCE=ghcr pulls Python/kepubify from our GHCR mirror rather
-          # than the release CDN, which intermittently 404s the Actions egress.
-          # Contributors build without it and fall back to the CDN (see Dockerfile).
+          # Same-repository/main builds use the GHCR mirror rather than the
+          # flaky release CDN. Keep the selector fork-aware even though the
+          # build gate already excludes forks: the recovery gate must never
+          # make the private mirror reachable if its classification regresses.
           build-args: |
             BUILD_DATE=${{ github.event.repository.updated_at }}
             VERSION=DEV_BUILD-${{ env.IMAGE_TAG }}-${{ vars.CURRENT_DEV_BUILD_NUM }}
-            PBS_SOURCE=ghcr
+            PBS_SOURCE=${{ github.event.pull_request.head.repo.fork == true && 'upstream' || 'ghcr' }}
 
       # --- 4. Export Digest for Merge Job ---
       - name: Export digest
@@ -318,8 +321,8 @@ jobs:
     # operator hardware), so GitHub-hosted is the safer default.
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 60
-    needs: [classify, ensure-mirror]
-    if: needs.classify.outputs.full_build == 'true'
+    needs: [classify, alias-image-neutral-commit, ensure-mirror]
+    if: needs.alias-image-neutral-commit.outputs.build_required == 'true'
     steps:
       - name: Set build ref
         env:
@@ -436,13 +439,14 @@ jobs:
           # "Compose docker outputs" step below, which conditionally
           # includes the DockerHub image name when DOCKERHUB_PUSH_ENABLED.
           outputs: ${{ env.DOCKER_BUILD_OUTPUTS }}
-          # PBS_SOURCE=ghcr pulls Python/kepubify from our GHCR mirror rather
-          # than the release CDN, which intermittently 404s the Actions egress.
-          # Contributors build without it and fall back to the CDN (see Dockerfile).
+          # Same-repository/main builds use the GHCR mirror rather than the
+          # flaky release CDN. Keep the selector fork-aware even though the
+          # build gate already excludes forks: the recovery gate must never
+          # make the private mirror reachable if its classification regresses.
           build-args: |
             BUILD_DATE=${{ github.event.repository.updated_at }}
             VERSION=DEV_BUILD-${{ env.IMAGE_TAG }}-${{ vars.CURRENT_DEV_BUILD_NUM }}
-            PBS_SOURCE=ghcr
+            PBS_SOURCE=${{ github.event.pull_request.head.repo.fork == true && 'upstream' || 'ghcr' }}
 
       # --- 4. Rotate Cache (Prevent Infinite Growth) ---
       - name: Move cache
@@ -481,8 +485,8 @@ jobs:
   merge:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [classify, build-amd64, build-arm]
-    if: needs.classify.outputs.full_build == 'true'
+    needs: [classify, alias-image-neutral-commit, build-amd64, build-arm]
+    if: needs.alias-image-neutral-commit.outputs.build_required == 'true'
     steps:
       # --- 1. Calculate Variables ---
       - name: Set build ref
@@ -615,27 +619,33 @@ jobs:
           name: 'CURRENT_DEV_BUILD_NUM'
           token: ${{ secrets.GH_PAT || secrets.DEV_BUILD_NUM_INCREMENTOR_TOKEN }}
 
-  # Image-neutral main commits (docs/tests/workflow policy) deliberately do not
-  # rebuild or advance :dev. They still need an immutable subject identifier so
-  # Test Suite can prove which backend it exercised. Copying the existing
-  # manifest to sha-<commit> is registry-only and does not restart the canary.
+  # Image-neutral main commits normally do not rebuild or advance :dev. They
+  # still need an immutable subject identifier so Test Suite can prove which
+  # backend it exercised. Copying the existing manifest to sha-<commit> is
+  # registry-only and does not restart the canary. If the exact source producer
+  # was cancelled or failed, this gate promotes the subject into the ordinary
+  # serialized build path: rebuilding the subject is always byte-correct, while
+  # copying any older available image would not be.
   alias-image-neutral-commit:
-    name: Alias unchanged image to commit
+    name: Prepare immutable subject image
     runs-on: ubuntu-latest
     # The source producer may legitimately consume its full 95-minute
     # classify+mirror+architecture+merge budget. The script stops sooner when
     # that exact run/job fails and never substitutes the floating :dev tag.
     timeout-minutes: 100
     needs: classify
-    if: needs.classify.outputs.alias_image == 'true'
+    outputs:
+      build_required: ${{ steps.route.outputs.build_required }}
     steps:
       - name: Checkout exact subject
+        if: needs.classify.outputs.alias_image == 'true'
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ github.sha }}
 
       - name: Log in to GHCR
+        if: needs.classify.outputs.alias_image == 'true'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -643,11 +653,14 @@ jobs:
           password: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx (registry-only)
+        if: needs.classify.outputs.alias_image == 'true'
         uses: docker/setup-buildx-action@v4
         with:
           driver: docker
 
       - name: Publish immutable commit alias
+        id: publish
+        if: needs.classify.outputs.alias_image == 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
           IMAGE_SOURCE: ${{ needs.classify.outputs.image_source }}
@@ -656,4 +669,17 @@ jobs:
           base="ghcr.io/${{ github.repository_owner }}/$(echo '${{ github.event.repository.name }}' | tr '[:upper:]' '[:lower:]')"
           bash scripts/alias-e2e-image.sh \
             "$base" "$IMAGE_SOURCE" "$SUBJECT_SHA" 191 30 \
-            "${{ github.repository }}" push "${{ github.api_url }}"
+            "${{ github.repository }}" push "${{ github.api_url }}" \
+            "$GITHUB_OUTPUT"
+
+      - name: Route unavailable alias to exact-subject build
+        id: route
+        env:
+          CLASSIFIED_FULL_BUILD: ${{ needs.classify.outputs.full_build }}
+          RECOVERY_BUILD: ${{ steps.publish.outputs.recovery_build }}
+        run: |
+          if [[ "$CLASSIFIED_FULL_BUILD" == "true" || "$RECOVERY_BUILD" == "true" ]]; then
+            echo "build_required=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "build_required=false" >> "$GITHUB_OUTPUT"
+          fi

--- a/.github/workflows/docker-image-build-dev.yml
+++ b/.github/workflows/docker-image-build-dev.yml
@@ -17,7 +17,11 @@ on:
     branches: [main]
   # A cheap classifier runs on every PR, but only same-repository PRs whose
   # architectural concurrency closure changed build. Forks never receive a
-  # package-write job, and ordinary PRs pay only for checkout + classification.
+  # package-write job. An ordinary PR pays for checkout + classification plus
+  # one short routing job: the build gate below reads a single build_required
+  # decision, so that job has to reach a verdict on every event rather than
+  # being skipped. Its checkout, GHCR login and publish steps stay individually
+  # gated on alias_image, which no pull_request event can set.
   pull_request:
     branches: [main, dev]
   workflow_dispatch:

--- a/changelog.d/ci-alias-recovers-from-cancelled-producer.md
+++ b/changelog.d/ci-alias-recovers-from-cancelled-producer.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- **Back-to-back main updates no longer leave the release train blocked by a
+  cancelled image build.** When an unchanged commit cannot alias its required
+  ancestor image because that producer was cancelled or failed, CI now builds
+  the exact commit and publishes its immutable image tag automatically.

--- a/changelog.d/ci-alias-recovers-from-cancelled-producer.md
+++ b/changelog.d/ci-alias-recovers-from-cancelled-producer.md
@@ -3,4 +3,8 @@
 - **Back-to-back main updates no longer leave the release train blocked by a
   cancelled image build.** When an unchanged commit cannot alias its required
   ancestor image because that producer was cancelled or failed, CI now builds
-  the exact commit and publishes its immutable image tag automatically.
+  the exact commit and publishes its immutable image tag automatically. Because
+  that is a real build rather than a tag copy, it also advances `:dev`, so a
+  dev-channel deployment restarts on a commit that would previously have been
+  skipped. The image content is unchanged — such a commit touches nothing the
+  image is built from.

--- a/scripts/alias-e2e-image.sh
+++ b/scripts/alias-e2e-image.sh
@@ -6,7 +6,7 @@
 # backend bytes that the subject commit does not contain.
 set -euo pipefail
 
-usage="usage: alias-e2e-image.sh IMAGE SOURCE_SHA SUBJECT_SHA [ATTEMPTS] [DELAY_SECONDS] [PRODUCER_REPOSITORY PRODUCER_EVENT API_URL]"
+usage="usage: alias-e2e-image.sh IMAGE SOURCE_SHA SUBJECT_SHA [ATTEMPTS] [DELAY_SECONDS] [PRODUCER_REPOSITORY PRODUCER_EVENT API_URL [RECOVERY_OUTPUT]]"
 image="${1:?$usage}"
 source_sha="${2:?$usage}"
 subject_sha="${3:?$usage}"
@@ -15,6 +15,7 @@ delay_seconds="${5:-30}"
 producer_repository="${6:-}"
 producer_event="${7:-}"
 api_url="${8:-}"
+recovery_output="${9:-}"
 repo_root="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel)}"
 classifier="${CLASSIFIER_PATH:-$repo_root/scripts/ci_path_classification.py}"
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
@@ -29,6 +30,10 @@ if ! [[ "$attempts" =~ ^[1-9][0-9]*$ && "$delay_seconds" =~ ^[0-9]+$ ]]; then
   exit 2
 fi
 if [[ -n "$producer_repository" ]] && [[ -z "$producer_event" || -z "$api_url" ]]; then
+  echo "$usage" >&2
+  exit 2
+fi
+if [[ -n "$recovery_output" && -z "$producer_repository" ]]; then
   echo "$usage" >&2
   exit 2
 fi
@@ -58,11 +63,20 @@ for ((attempt = 1; attempt <= attempts; attempt++)); do
     break
   fi
   if [[ -n "$producer_repository" ]]; then
-    if python3 "$producer_check" \
+    if python3 "$producer_check" --terminal-exit-code 75 \
       "$producer_repository" "$source_sha" "$producer_event" "$api_url"; then
       :
     else
-      exit $?
+      producer_status=$?
+      if [[ "$producer_status" == 75 && -n "$recovery_output" ]]; then
+        printf 'recovery_build=true\n' >> "$recovery_output"
+        echo "Source image is terminally unavailable; building exact subject $subject_sha instead." >&2
+        exit 0
+      fi
+      # Preserve the aliaser's ordinary one-bit failure contract outside the
+      # workflow recovery mode. Unknown API state must never authorize a copy
+      # or be mistaken for a known terminal producer.
+      exit 1
     fi
   fi
   if (( attempt < attempts )); then

--- a/scripts/check-e2e-image-producer.py
+++ b/scripts/check-e2e-image-producer.py
@@ -5,6 +5,8 @@
 Exit 0 only while the matching Build & Push run is queued or in progress.  A
 terminal producer, a failed producer job, an absent run, or an unreadable API
 all exit non-zero so callers never turn an unknown producer into a blind poll.
+Callers that can safely rebuild the exact subject may request a distinct exit
+code for terminal producers; unknown/absent API state still exits 1.
 """
 
 from __future__ import annotations
@@ -29,6 +31,12 @@ FAILED_CONCLUSIONS = frozenset(
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--terminal-exit-code",
+        type=int,
+        default=1,
+        help="exit code for a terminal run/job (default: 1)",
+    )
     parser.add_argument("repository", help="GitHub owner/repository")
     parser.add_argument("sha", help="full producer commit SHA")
     parser.add_argument("event", choices=("push", "pull_request"))
@@ -63,6 +71,8 @@ def _error(message: str) -> int:
 
 def main() -> int:
     args = _parser().parse_args()
+    if not 1 <= args.terminal_exit_code <= 125:
+        return _error("terminal exit code must be between 1 and 125")
     if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", args.repository):
         return _error(f"invalid GitHub repository {args.repository!r}")
     if not re.fullmatch(r"[0-9a-fA-F]{40,64}", args.sha):
@@ -98,10 +108,11 @@ def main() -> int:
         conclusion = run.get("conclusion")
 
         if status == "completed":
-            return _error(
+            _error(
                 f"Build & Push producer run {run_id} concluded {conclusion or 'without a verdict'} "
                 f"but did not publish the required image: {run_url}"
             )
+            return args.terminal_exit_code
         if status not in LIVE_STATUSES:
             return _error(
                 f"Build & Push producer run {run_id} has unexpected status {status!r}: {run_url}"
@@ -122,10 +133,11 @@ def main() -> int:
             if job.get("status") == "completed" and job_conclusion in FAILED_CONCLUSIONS:
                 job_name = job.get("name") or job.get("id") or "unknown job"
                 job_url = job.get("html_url") or run_url
-                return _error(
+                _error(
                     f"Build & Push producer job {job_name!r} concluded {job_conclusion} "
                     f"in run {run_id}: {job_url} (run: {run_url})"
                 )
+                return args.terminal_exit_code
     except RuntimeError as exc:
         return _error(str(exc))
 

--- a/tests/unit/test_ci_e2e_commit_gate.py
+++ b/tests/unit/test_ci_e2e_commit_gate.py
@@ -296,6 +296,7 @@ def _run_alias(
     dev_matches: bool = True,
     source_succeeds_on: int = 1,
     api_url: str | None = None,
+    recovery_output: Path | None = None,
 ):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir(exist_ok=True)
@@ -333,6 +334,8 @@ def _run_alias(
     command = ["bash", str(ALIASER), "registry.example/project/app", source, subject]
     if api_url:
         command.extend(["4", "0", "example/project", "push", api_url])
+        if recovery_output is not None:
+            command.append(str(recovery_output))
     proc = subprocess.run(
         command,
         cwd=tmp_path,
@@ -513,12 +516,15 @@ def test_alias_waits_for_live_source_producer_then_preserves_digest_invariants(t
     assert f"-t registry.example/project/app:sha-{subject}" in log
 
 
-def test_alias_stops_when_source_producer_has_failed(tmp_path):
+@pytest.mark.parametrize("conclusion", ["cancelled", "failure"])
+def test_alias_routes_terminal_source_producer_to_subject_rebuild(tmp_path, conclusion):
+    """Observed terminal producers recover without manufacturing an alias."""
     _git(tmp_path, "init", "-q")
     _stage_alias_test_dockerignore(tmp_path)
     source = _commit(tmp_path, "backend", "cps/web.py", "WRITE = 1\n")
     subject = _commit(tmp_path, "docs", "docs/usage.md", "docs\n")
-    responses = [{"status": "completed", "conclusion": "failure"}]
+    recovery_output = tmp_path / "github-output"
+    responses = [{"status": "completed", "conclusion": conclusion}]
     with _ActionsApi(responses) as api:
         proc, log = _run_alias(
             tmp_path,
@@ -526,12 +532,14 @@ def test_alias_stops_when_source_producer_has_failed(tmp_path):
             subject,
             source_succeeds_on=99,
             api_url=api.url,
+            recovery_output=recovery_output,
         )
 
-    assert proc.returncode == 1
+    assert proc.returncode == 0, proc.stderr
     assert api.run_requests == 1
     assert "https://github.example/runs/77" in proc.stderr
-    assert "concluded failure" in proc.stderr
+    assert f"concluded {conclusion}" in proc.stderr
+    assert recovery_output.read_text(encoding="utf-8") == "recovery_build=true\n"
     assert log == ""
 
 

--- a/tests/unit/test_ci_e2e_commit_gate.py
+++ b/tests/unit/test_ci_e2e_commit_gate.py
@@ -23,6 +23,7 @@ TESTS_WORKFLOW = REPO / ".github" / "workflows" / "tests.yml"
 DEV_WORKFLOW = REPO / ".github" / "workflows" / "docker-image-build-dev.yml"
 RESOLVER = REPO / "scripts" / "resolve-e2e-image.sh"
 ALIASER = REPO / "scripts" / "alias-e2e-image.sh"
+PRODUCER_CHECKER = REPO / "scripts" / "check-e2e-image-producer.py"
 
 
 @pytest.mark.parametrize(
@@ -246,6 +247,9 @@ class _ActionsApi:
                     index = min(api.run_requests, len(api.responses) - 1)
                     response = dict(api.responses[index])
                     api.run_requests += 1
+                    if response.pop("malformed", False):
+                        self._send_body(b'{"workflow_runs":')
+                        return
                     if response.pop("absent", False):
                         payload = {"workflow_runs": []}
                         self._send_json(payload)
@@ -264,7 +268,9 @@ class _ActionsApi:
                 self._send_json(payload)
 
             def _send_json(self, payload):
-                body = json.dumps(payload).encode()
+                self._send_body(json.dumps(payload).encode())
+
+            def _send_body(self, body):
                 self.send_response(200)
                 self.send_header("Content-Type", "application/json")
                 self.send_header("Content-Length", str(len(body)))
@@ -371,11 +377,23 @@ def test_neutral_alias_rejects_an_intervening_image_relevant_commit(tmp_path):
     _commit(tmp_path, "middle docs", "docs/one.md", "one\n")
     new_source = _commit(tmp_path, "new backend", "cps/kobo.py", "WRITE = 2\n")
     subject = _commit(tmp_path, "new docs", "docs/two.md", "two\n")
+    recovery_output = tmp_path / "github-output"
+    recovery_output.write_text("sentinel=preserved\n", encoding="utf-8")
 
-    proc, log = _run_alias(tmp_path, old_source, subject)
+    with _ActionsApi([{"status": "completed", "conclusion": "failure"}]) as api:
+        proc, log = _run_alias(
+            tmp_path,
+            old_source,
+            subject,
+            api_url=api.url,
+            recovery_output=recovery_output,
+        )
+
     assert proc.returncode == 1
     assert "is not the newest image-relevant ancestor" in proc.stderr
     assert f"Expected source: {new_source}" in proc.stderr
+    assert api.run_requests == 0
+    assert recovery_output.read_text(encoding="utf-8") == "sentinel=preserved\n"
     assert log == ""
 
 
@@ -541,6 +559,99 @@ def test_alias_routes_terminal_source_producer_to_subject_rebuild(tmp_path, conc
     assert f"concluded {conclusion}" in proc.stderr
     assert recovery_output.read_text(encoding="utf-8") == "recovery_build=true\n"
     assert log == ""
+
+
+@pytest.mark.parametrize(
+    ("response", "error_fragment"),
+    [
+        ({"absent": True}, "no Build & Push producer run exists"),
+        ({"malformed": True}, "GitHub Actions API request failed"),
+    ],
+    ids=("absent-run", "malformed-api-response"),
+)
+def test_alias_recovery_refuses_unknown_producer_state(
+    tmp_path, response, error_fragment
+):
+    """Unknown producer state cannot authorize an exact-subject recovery build."""
+    _git(tmp_path, "init", "-q")
+    _stage_alias_test_dockerignore(tmp_path)
+    source = _commit(tmp_path, "backend", "cps/web.py", "WRITE = 1\n")
+    subject = _commit(tmp_path, "docs", "docs/usage.md", "docs\n")
+    recovery_output = tmp_path / "github-output"
+    recovery_output.write_text("sentinel=preserved\n", encoding="utf-8")
+
+    with _ActionsApi([response]) as api:
+        proc, log = _run_alias(
+            tmp_path,
+            source,
+            subject,
+            source_succeeds_on=99,
+            api_url=api.url,
+            recovery_output=recovery_output,
+        )
+
+    output = recovery_output.read_text(encoding="utf-8")
+    assert proc.returncode == 1
+    assert api.run_requests == 1
+    assert error_fragment in proc.stderr
+    assert "recovery_build=" not in output
+    assert output == "sentinel=preserved\n"
+    assert log == ""
+
+
+@pytest.mark.parametrize(
+    ("response", "expected_exit", "error_fragment"),
+    [
+        (
+            {"status": "completed", "conclusion": "cancelled"},
+            75,
+            "concluded cancelled",
+        ),
+        (
+            {
+                "status": "in_progress",
+                "conclusion": None,
+                "jobs": [
+                    {
+                        "name": "Build and push",
+                        "status": "completed",
+                        "conclusion": "failure",
+                    }
+                ],
+            },
+            75,
+            "job 'Build and push' concluded failure",
+        ),
+        ({"absent": True}, 1, "no Build & Push producer run exists"),
+        ({"malformed": True}, 1, "GitHub Actions API request failed"),
+    ],
+    ids=("terminal-run", "terminal-job", "absent-run", "malformed-api-response"),
+)
+def test_producer_checker_reserves_terminal_exit_code_for_known_terminal_state(
+    response, expected_exit, error_fragment
+):
+    """The recovery-specific code distinguishes terminal facts from API unknowns."""
+    with _ActionsApi([response]) as api:
+        proc = subprocess.run(
+            [
+                "python3",
+                str(PRODUCER_CHECKER),
+                "--terminal-exit-code",
+                "75",
+                "example/project",
+                "a" * 40,
+                "push",
+                api.url,
+            ],
+            cwd=REPO,
+            env={**os.environ, "GITHUB_TOKEN": "test-token"},
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+    assert proc.returncode == expected_exit
+    assert error_fragment in proc.stderr
 
 
 def test_resolver_stops_on_failed_job_before_live_run_concludes(tmp_path):

--- a/tests/unit/test_dev_image_build_once_when_image_relevant_never_when_ignored.py
+++ b/tests/unit/test_dev_image_build_once_when_image_relevant_never_when_ignored.py
@@ -376,7 +376,7 @@ def test_translation_commit_push_self_triggers_ci_premise():
 
 
 def test_dev_workflow_keeps_push_trigger_and_aliases_image_neutral_commits():
-    """Neutral commits alias only from the classifier-proven source commit."""
+    """Neutral commits alias or rebuild from the exact subject, never stale bytes."""
     _dev_push_trigger()
     wf = _load(DEV_WF)
     jobs = wf.get("jobs") or {}
@@ -384,7 +384,10 @@ def test_dev_workflow_keeps_push_trigger_and_aliases_image_neutral_commits():
     alias = jobs.get("alias-image-neutral-commit") or {}
     assert classifier, "dev workflow lost its path-classification job"
     assert alias, "image-neutral commits no longer get an immutable sha alias"
-    assert "alias_image" in str(alias.get("if") or "")
+    assert not alias.get("if"), (
+        "the alias/rebuild gate must finish on full builds too, so downstream "
+        "jobs have one build_required decision"
+    )
     outputs = classifier.get("outputs") or {}
     assert "image_source" in outputs
     publish = next(
@@ -392,6 +395,15 @@ def test_dev_workflow_keeps_push_trigger_and_aliases_image_neutral_commits():
     )
     assert "needs.classify.outputs.image_source" in str((publish.get("env") or {}).get("IMAGE_SOURCE"))
     assert "alias-e2e-image.sh" in str(publish.get("run") or "")
+    assert '"$GITHUB_OUTPUT"' in str(publish.get("run") or "")
+    assert "build_required" in (alias.get("outputs") or {})
+    for job_name in ("ensure-mirror", "build-amd64", "build-arm", "merge"):
+        job = jobs[job_name]
+        needs = job.get("needs") or []
+        if isinstance(needs, str):
+            needs = [needs]
+        assert "alias-image-neutral-commit" in needs, job_name
+        assert "build_required" in str(job.get("if") or ""), job_name
     assert classify_paths(["docs/usage.md"], REPO_ROOT)["image"] is False
     assert classify_paths(["tests/unit/test_example.py"], REPO_ROOT)["image"] is False
     assert classify_paths(["cps/web.py"], REPO_ROOT)["image"] is True


### PR DESCRIPTION
`main` has gone red twice in two days with no code defect, because a commit whose image is
identical to its parent's could not be given an immutable tag.

## What was wrong

The dev-image workflow gives an image-neutral commit its `sha-<commit>` tag by aliasing the tag of
its newest image-relevant ancestor. That only works if the ancestor's build actually published.

On 2026-09-02, `ebb033045b` (push to main, 07:52:18Z) and `2fc639d024` (07:52:52Z) landed 34
seconds apart. `ebb033045b`'s Build & Push run `33605757582` concluded **cancelled**, so
`sha-ebb033045b` was never published. `2fc639d024` is image-neutral relative to it, so its alias
job resolved `IMAGE_SOURCE=ebb033045b`, could not find the tag, and failed:

```
ERROR: Build & Push producer run 33605757582 concluded cancelled but did not publish the required image
```

`Test Suite` run `33605802971` then failed at "Resolve image to test" and the SPA E2E lane never
executed — so `main` read red while Fast Tests, Frontend Build and Integration Tests were all green.
The same shape hit `d8ca3fbd84` on 2026-09-01. Confirmed against the registry: `sha-ebb033045b…`,
`sha-2fc639d024…` and `sha-4d23102bb2…` are all absent from GHCR, and stay absent — this does not
heal on its own, so the documented two-dispatch manual-E2E escape hatch cannot be used for those
commits either.

`cancel-in-progress: ${{ github.event_name == 'pull_request' }}` has been set since #1941
(2026-08-28) and did not prevent this: it protects a run that is already *in progress*, while the
runs being lost are *pending* ones displaced when a newer commit queues into the same group. The
comment above that setting claimed the opposite, so the workflow documented a guarantee it did not
have.

**Not the same bug as #2104.** That one was a race — for `4d23102bb2` the alias job gave up at
17:01:22Z while producer run `33535095580` was still building; it succeeded at 17:07:30Z and
`sha-87036d2a659b…` exists today. #2104 coupled the wait to the producer's verdict and fixed it.
The case here is the one where waiting can never help, because the producer is already dead.

## What this does

The alias job now always runs and always emits one `build_required` decision, which every build job
gates on instead of reading `classify.outputs.full_build` directly:

- an image-relevant commit builds exactly as before (`full_build=true` → `build_required=true`);
- an image-neutral commit whose source image exists aliases exactly as before (`build_required=false`);
- an image-neutral commit whose **exact** source producer is known terminal (`cancelled` or
  `failure`) sets `recovery_build=true`, and the subject is built through the ordinary
  two-architecture + manifest-merge path.

Recovery builds the subject SHA itself. It never copies some other available tag — an older
image-relevant tag is by definition the wrong tree, and manufacturing `sha-<subject>` from it would
be a false verdict for `Test Suite`. No existing guard was relaxed. Precisely: the
newest-image-relevant-ancestor check and the ancestry check both run *before* the wait loop, so
recovery is unreachable until they pass. The `:dev`-digest check sits *after* the loop and is
deliberately not on the recovery path — it exists to guard the **copy**, and in the recovery case
there is no copy to guard, only a build from the subject's own tree. (It could not pass there
anyway: recovery is entered exactly when the source image is absent, so there is no source digest
for `:dev` to match.) Unknown or unreadable producer state is still a hard failure, and is now
pinned by tests as well as by the code.

**The trigger is wider than "cancelled or failed", and worth stating.** `check-e2e-image-producer.py`
treats *any* completed producer run whose image is not visible as terminal — including one that
concluded `success`. So a transient GHCR `imagetools inspect` failure against a healthy, published
source can also route to a recovery build. That is a deliberate trade rather than an oversight:
before this change the same situation failed the workflow and turned `main` red, and a recovery
build still produces a byte-correct `sha-<subject>`. The cost is a wasted build and a canary
restart on a registry hiccup. Recorded as a pending finding rather than narrowed here, because
narrowing it would reintroduce the red-`main` case this PR exists to remove.

`--terminal-exit-code` is the seam: `check-e2e-image-producer.py` keeps exit 1 for absent/malformed/
unreadable API responses and lets a caller that can safely rebuild ask for a distinct code (75) for a
*known terminal* producer. Only `alias-e2e-image.sh`, and only when the workflow passes it a
recovery-output path, turns that code into a rebuild.

**One consequence worth stating plainly:** a recovery build advances `:dev` and `:dev-<n>` for a
commit that would otherwise not have touched them, so a watchtower-tracking instance restarts on it.
The image content is byte-equivalent — the commit is image-neutral by construction — so the cost is
a restart and a build-number bump, against the alternative of `main` staying red and the release
train staying blocked.

Two `PBS_SOURCE=ghcr` literals became fork-aware (`upstream` on a fork PR). That is a no-op today —
`classify` already sets `full_build=false` for fork PRs, so the build jobs never run there — but the
build gate now derives from the alias job, and this keeps the private GHCR mirror unreachable from a
fork even if that classification ever regresses.

## Evidence

**Red/green, re-run independently by the manager on a clean worktree at `dd21929133`** (not taken
from the worker's report):

| run | command | result |
|---|---|---|
| green | `pytest -q tests/unit/test_ci_e2e_commit_gate.py tests/unit/test_dev_image_build_once_when_image_relevant_never_when_ignored.py` | **77 passed** in 155.79s |
| red | same suites, with `docker-image-build-dev.yml`, `alias-e2e-image.sh` and `check-e2e-image-producer.py` reverted to `origin/main` | **3 failed** in 10.45s |

The three that fail without the fix are exactly the contract: the parametrized
`test_alias_routes_terminal_source_producer_to_subject_rebuild[cancelled]` and `[failure]`, and
`test_dev_workflow_keeps_push_trigger_and_aliases_image_neutral_commits`, which pins that the alias
job carries no job-level `if`, exposes `build_required`, and that all four of `ensure-mirror`,
`build-amd64`, `build-arm` and `merge` both need it and gate on it.

Full `-m "smoke or unit"` suite, worker-run on native Linux in a capped 2-CPU/4-GiB container:
**8462 passed, 77 skipped** in 225.56s. `actionlint` on the changed workflow: exit 0, no output.

**The new job graph was executed on real GitHub, not only parsed.** This PR's own
`Build & Push - Dev - Split Strategy` run
([33622400171](https://github.com/new-usemame/Calibre-Web-NextGen/actions/runs/33622400171),
conclusion `success`) shows the intended shape end to end:

- `Prepare immutable subject image` — **ran**, with no job-level `if:`, exactly as the change intends;
- its `Route unavailable alias to exact-subject build` step ran with `CLASSIFIED_FULL_BUILD: false`
  and an **empty** `RECOVERY_BUILD` (the skipped publish step's output resolving to `''`, as modelled)
  and emitted `build_required=false`;
- `Checkout exact subject`, `Log in to GHCR` and `Publish immutable commit alias` produced no log
  output at all — skipped, so the `alias_image == 'true'` per-step gate holds on a `pull_request`
  and no credential path opened;
- `ensure-mirror`, `build-amd64`, `build-arm` and `merge` were all **skipped**.

**Limits, stated rather than hidden.** What remains unobserved is the recovery branch itself
(`build_required=true` from a terminal producer): it can only fire on a real push to `main` behind a
cancelled or failed image build, so proving it would mean merging or pushing a synthetic commit to
`main`. That one link is **ASSUMED**, resting on the unit tests plus the run above; everything else
in this section is **OBSERVED**. The first real proof will be the next image-neutral commit that
lands behind a cancelled producer.

No dependency, licence or external-service-URL changes. Nothing under `cps/` or `frontend/` is
touched, so there is no user-facing runtime surface to drive.

Resolves pending finding `PF-2026-09-01T22-00-04Z-25390`, and corrects it: the remedy it proposed
(give Build & Push the main-branch no-cancel rule Test Suite already has) was already implemented
and is a no-op against this failure.
