### PR TITLE
test(kobo): the sync suite's device clocks stop being wall-clock literals

### DIFF
--- a/tests/unit/test_1925_kobo_sync_dedownload.py
+++ b/tests/unit/test_1925_kobo_sync_dedownload.py
@@ -1483,18 +1483,25 @@ def test_furthest_wins_parent_clock_emits_state_without_entitlement(
     ).one()
     original_fingerprint = ledger.fingerprint
     original_book_clock = sync_harness.book.last_modified
+    original_state_clock = kobo.get_or_create_reading_state(
+        sync_harness.book.id,
+    ).last_modified
+    device_clock = (
+        original_state_clock + timedelta(seconds=1)
+    ).replace(microsecond=0)
+    assert device_clock > original_state_clock
     sync_harness.session.query(ub.DeviceReadingPosition).update({
         ub.DeviceReadingPosition.rehydrate_needed: False,
     })
     sync_harness.session.commit()
 
     written = sync_harness.put_position(
-        45.0, clock="2026-09-03T15:00:00Z",
+        45.0, clock=device_clock.strftime("%Y-%m-%dT%H:%M:%SZ"),
     )
     assert written.status_code == 200
     sync_harness.session.expire_all()
     state = sync_harness.session.query(ub.KoboReadingState).one()
-    assert state.last_modified == datetime(2026, 9, 3, 15, 0, 0)
+    assert state.last_modified == device_clock
     assert sync_harness.session.get(
         type(sync_harness.book), sync_harness.book.id,
     ).last_modified == original_book_clock

--- a/tests/unit/test_annotations_import_endpoint.py
+++ b/tests/unit/test_annotations_import_endpoint.py
@@ -27,7 +27,7 @@ Coverage:
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 import sqlite3
 from types import SimpleNamespace
@@ -597,8 +597,19 @@ class TestNewerDeviceMerge:
         )
         before = session.query(ub.Annotation).filter_by(annotation_id="bm-002").one()
         before_revision = before.content_revision
+        observed_watermark = max(filter(None, (
+            before.client_modified_at,
+            before.server_modified_at,
+            before.last_synced,
+            before.created_at,
+        )))
+        device_clock = (
+            observed_watermark + timedelta(seconds=1)
+        ).replace(microsecond=0)
+        assert device_clock > observed_watermark
         self._edit_fixture(
-            synthetic_db, modified="2099-01-01T00:00:00Z",
+            synthetic_db,
+            modified=device_clock.strftime("%Y-%m-%dT%H:%M:%SZ"),
             text="edited passage", note="edited note", color=3,
         )
 
@@ -623,7 +634,7 @@ class TestNewerDeviceMerge:
         assert row.end_offset == 17
         assert row.context_string == "replacement context"
         assert row.chapter_progress == 0.91
-        assert row.client_modified_at == datetime(2099, 1, 1)
+        assert row.client_modified_at == device_clock
         assert row.content_revision == before_revision + 1
 
     def test_older_device_copy_reports_conflict_without_overwriting_server(


### PR DESCRIPTION
## The failure

At **2026-09-03T15:00:00Z** every branch in this repository started failing `Fast Tests (Smoke + Unit)`
on one test, with no code change to cause it:

```
tests/unit/test_1925_kobo_sync_dedownload.py:1497:
    assert state.last_modified == datetime(2026, 9, 3, 15, 0, 0)
E   assert datetime.datetime(2026, 9, 3, 15, 7, 36, 971019) == datetime.datetime(2026, 9, 3, 15, 0)
```

OBSERVED on PR #2149, run
[33770638106](https://github.com/new-usemame/Calibre-Web-NextGen/actions/runs/33770638106), job
started 15:07:36Z — one FAILED in the whole lane. The test body is byte-identical on `main` and on
that PR's branch (`diff` of the two blobs is empty), so it was never that PR's change. `main`'s own
newest run predates 15:00Z, which is why `main` still reads green.

## Root cause

`test_furthest_wins_parent_clock_emits_state_without_entitlement` (added in 7e9221f455, #2128) sent
the device clock as an **absolute literal**, `clock="2026-09-03T15:00:00Z"`, and asserted it came
back. `HandleStateRequest` accepts a device `LastModified` only when it is strictly newer than the
reading-state row's stored clock (`cps/kobo.py:3610`, `device_positions.timestamp_is_newer`); the row
is stamped with server time by the harness's first `sync()`. The literal was two days in the future
when it was written, so it was accepted. At 15:00:00Z it became the past, the product correctly
**rejected** it, `_apply_kobo_last_modified` correctly retained the stored clock — and the assertion
blew up. The product code was right the entire time; the test had encoded its own precondition as a
wall-clock date.

## The fix

Derive the device clock at run time from state the test observes, so the precondition
("strictly newer than what is stored") holds whenever the suite runs. The invariant under test is
unchanged and no assertion is weakened: an accepted, newer device clock advances
`KoboReadingState.last_modified` and must **not** advance `Books.last_modified` or the entitlement
fingerprint, so the following sync emits no entitlement.

Bumping the literal to a later date was rejected: that is the same bomb with a longer fuse.

## Evidence

**RED** — the pre-fix test body, two independent instruments:

| Instrument | When | Result |
|---|---|---|
| GitHub Actions, PR #2149 run 33770638106 | 2026-09-03T15:07:36Z | `assert datetime(2026,9,3,15,7,36,971019) == datetime(2026,9,3,15,0)` — 1 FAILED in the lane |
| Local, `pytest tests/unit/test_1925_kobo_sync_dedownload.py::test_furthest_wins_parent_clock_emits_state_without_entitlement` | 2026-09-03T16:55:22Z | `assert datetime(2026,9,3,16,55,22,852533) == datetime(2026,9,3,15,0)` — `1 failed in 2.55s` |

The two failures differ only in the "now" they captured, which is the signature of a wall-clock
dependency rather than a code defect.

**GREEN** — after the fix, manager-run independently of the author:

```
pytest tests/unit/test_1925_kobo_sync_dedownload.py::test_furthest_wins_parent_clock_emits_state_without_entitlement \
       tests/unit/test_annotations_import_endpoint.py
31 passed, 90 warnings in 6.25s
```

Whole affected files: `test_1925_kobo_sync_dedownload.py` **94 passed**,
`test_annotations_import_endpoint.py` **30 passed**.

## Sweep

The whole `tests/` tree was swept for the same defect class — an absolute date literal that must
outrun a value the system derives from the current clock. **One other real bomb**, fixed here:
`test_annotations_import_endpoint.py` sent a `2099-01-01` device clock that had to beat server-now
`server_modified_at`/`last_synced`; it now derives its clock from the maximum watermark observed on
the imported row, which also tightens the test from a 73-year margin to the one-second boundary the
comparison actually implements. Twenty-one other absolute-date sites were examined and classified
harmless (fixed fixtures compared against other fixed fixtures, injected `now`, or generated clocks
that need only exceed a *historical* lower bound — those get safer as time passes, not riskier).

Product code was scanned too (`cps/`, `scripts/`, `frontend/src/`): no absolute date literal is
compared against the current clock. No product code changed.

No changelog fragment: `changelog.d/README.md` exempts changes confined to `tests/`.

## Trail

`state/completed.log` (tick 2026-09-03T16:00:01Z); findings recorded in `state/findings-pending.jsonl`.
