### PR TITLE
fix(hardcover): one pending review row per book, and a rejection that sticks

### DIFF
--- a/changelog.d/2103-hardcover-match-queue-dedup.md
+++ b/changelog.d/2103-hardcover-match-queue-dedup.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- **Hardcover auto-fetch no longer repeats ambiguous work indefinitely.** Each book now has at
+  most one pending match-review item, refreshed with the newest candidates instead of duplicated.
+  Books whose match was rejected are excluded before Hardcover is searched again, and upgrades
+  collapse existing duplicate pending items while preserving reviewed history. Reported by
+  @magdalar in #2103.

--- a/cps/tasks/auto_hardcover_id.py
+++ b/cps/tasks/auto_hardcover_id.py
@@ -14,6 +14,7 @@ from typing import List, Optional
 from cps import config, db, logger, ub
 from cps.services.worker import CalibreTask, STAT_FAIL, STAT_FINISH_SUCCESS, STAT_CANCELLED, STAT_ENDED
 from flask_babel import lazy_gettext as N_
+from sqlalchemy import exc as sa_exc
 from sqlalchemy.orm import selectinload
 
 # Import the Hardcover provider
@@ -102,11 +103,14 @@ class TaskAutoHardcoverID(CalibreTask):
             total_books = len(book_ids)
             
             if total_books == 0:
-                self.log.info("No books found without Hardcover IDs")
+                self.log.info("No books eligible for Hardcover ID auto-fetch")
                 self._handleSuccess()
                 return
             
-            self.log.info(f"Found {total_books} books without Hardcover IDs. Processing in batches of {self.batch_size}...")
+            self.log.info(
+                f"Found {total_books} eligible books without Hardcover IDs. "
+                f"Processing in batches of {self.batch_size}..."
+            )
             
             # Process books in batches
             batch_count = (total_books + self.batch_size - 1) // self.batch_size
@@ -195,16 +199,62 @@ class TaskAutoHardcoverID(CalibreTask):
 
     def _get_books_without_hardcover_id(self) -> List[int]:
         """
-        Query book IDs that don't have any Hardcover identifiers.
-        Excludes books with hardcover-id, hardcover-slug, or hardcover-edition.
+        Query eligible book IDs that don't have any Hardcover identifiers.
+
+        Books with a pending review or a durable rejection are removed before
+        the caller performs any Hardcover API search. Calibre and app data use
+        separate SQLite databases, so page through Calibre IDs and filter via
+        one thread-local app.db review-state snapshot.
         """
-        rows = self.calibre_db.session.query(db.Books.id).filter(
+        excluded_book_ids = self._get_review_excluded_book_ids()
+        query = self.calibre_db.session.query(db.Books.id).filter(
             ~db.Books.identifiers.any(
                 db.Identifiers.type.in_(['hardcover-id', 'hardcover-slug', 'hardcover-edition'])
             )
-        ).limit(10000).all()  # Safety limit
+        )
 
-        return [row[0] for row in rows if row[0] is not None]
+        eligible_book_ids = []
+        last_book_id = 0
+        page_size = 1000
+        while len(eligible_book_ids) < 10000:  # Safety limit
+            rows = (
+                query.filter(db.Books.id > last_book_id)
+                .order_by(db.Books.id)
+                .limit(page_size)
+                .all()
+            )
+            if not rows:
+                break
+            last_book_id = rows[-1][0]
+            eligible_book_ids.extend(
+                row[0]
+                for row in rows
+                if row[0] is not None and row[0] not in excluded_book_ids
+            )
+
+        return eligible_book_ids[:10000]
+
+    def _get_review_excluded_book_ids(self) -> set[int]:
+        """Load pending and durably rejected book IDs from thread-local app.db."""
+        ub_session = None
+        try:
+            ub_session = ub.init_db_thread()
+            rows = (
+                ub_session.query(ub.HardcoverMatchQueue.book_id)
+                .filter(
+                    (ub.HardcoverMatchQueue.reviewed == 0)
+                    | (
+                        (ub.HardcoverMatchQueue.reviewed == 1)
+                        & (ub.HardcoverMatchQueue.review_action == 'reject')
+                    )
+                )
+                .distinct()
+                .all()
+            )
+            return {row[0] for row in rows if row[0] is not None}
+        finally:
+            if ub_session is not None:
+                ub_session.close()
 
     def _get_books_for_batch(self, book_ids: List[int]) -> List[db.Books]:
         """
@@ -323,9 +373,17 @@ class TaskAutoHardcoverID(CalibreTask):
             self.log.info(f"Auto-matched book {book_id} '{title}' to Hardcover ID {best_result.id} (confidence: {best_score:.3f})")
         else:
             # Queue for manual review
-            self._queue_for_review(book_id, title, authors_csv, search_query, scored_results)
-            self.queued_for_review += 1
-            self.log.debug(f"Queued book {book_id} '{title}' for manual review (confidence: {best_score:.3f})")
+            queued = self._queue_for_review(
+                book_id, title, authors_csv, search_query, scored_results
+            )
+            if queued:
+                self.queued_for_review += 1
+                self.log.debug(f"Queued book {book_id} '{title}' for manual review (confidence: {best_score:.3f})")
+            else:
+                self.log.info(
+                    f"Skipped review queue for book {book_id} '{title}' "
+                    "because it was rejected while auto-fetch was running"
+                )
 
     def _apply_hardcover_id(self, book_id: int, result):
         """Apply Hardcover identifiers to a book"""
@@ -355,8 +413,15 @@ class TaskAutoHardcoverID(CalibreTask):
             self.calibre_db.session.rollback()
             raise
 
-    def _queue_for_review(self, book_id: int, book_title: str, book_authors: str, search_query: str, scored_results: List[dict]):
-        """Queue ambiguous match for manual review"""
+    def _queue_for_review(
+        self,
+        book_id: int,
+        book_title: str,
+        book_authors: str,
+        search_query: str,
+        scored_results: List[dict],
+    ):
+        """Create or refresh one pending review row; return False after rejection."""
         ub_session = None
         try:
             # Background tasks must not touch the global web-request ub.session.
@@ -385,20 +450,60 @@ class TaskAutoHardcoverID(CalibreTask):
                 })
                 scores_json.append([item['score'], item['reason']])
             
-            # Create queue entry
-            queue_entry = ub.HardcoverMatchQueue(
-                book_id=book_id,
-                book_title=book_title,
-                book_authors=book_authors,
-                search_query=search_query,
-                hardcover_results=json.dumps(results_json),
-                confidence_scores=json.dumps(scores_json),
-                created_at=datetime.utcnow().isoformat(),
-                reviewed=0
+            rejected = ub_session.query(ub.HardcoverMatchQueue.id).filter(
+                ub.HardcoverMatchQueue.book_id == book_id,
+                ub.HardcoverMatchQueue.reviewed == 1,
+                ub.HardcoverMatchQueue.review_action == 'reject',
+            ).first()
+            if rejected is not None:
+                return False
+
+            queue_values = {
+                'book_title': book_title,
+                'book_authors': book_authors,
+                'search_query': search_query,
+                'hardcover_results': json.dumps(results_json),
+                'confidence_scores': json.dumps(scores_json),
+                'created_at': datetime.utcnow().isoformat(),
+            }
+            queue_entry = (
+                ub_session.query(ub.HardcoverMatchQueue)
+                .filter(
+                    ub.HardcoverMatchQueue.book_id == book_id,
+                    ub.HardcoverMatchQueue.reviewed == 0,
+                )
+                .order_by(ub.HardcoverMatchQueue.created_at.desc(),
+                          ub.HardcoverMatchQueue.id.desc())
+                .first()
             )
-            
-            ub_session.add(queue_entry)
-            ub_session.commit()
+            if queue_entry is None:
+                queue_entry = ub.HardcoverMatchQueue(
+                    book_id=book_id,
+                    reviewed=0,
+                    **queue_values,
+                )
+                ub_session.add(queue_entry)
+            else:
+                for field, value in queue_values.items():
+                    setattr(queue_entry, field, value)
+
+            try:
+                ub_session.commit()
+            except sa_exc.IntegrityError:
+                # A concurrent crawler may have inserted the unique pending
+                # row after our lookup. Refresh that row rather than surfacing
+                # a harmless race as a task failure.
+                ub_session.rollback()
+                queue_entry = ub_session.query(ub.HardcoverMatchQueue).filter(
+                    ub.HardcoverMatchQueue.book_id == book_id,
+                    ub.HardcoverMatchQueue.reviewed == 0,
+                ).first()
+                if queue_entry is None:
+                    raise
+                for field, value in queue_values.items():
+                    setattr(queue_entry, field, value)
+                ub_session.commit()
+            return True
             
         except Exception as e:
             self.log.error(f"Error queuing book {book_id} for review: {e}")

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -2105,6 +2105,12 @@ class HardcoverBookBlacklist(Base):
 class HardcoverMatchQueue(Base):
     """Queue for ambiguous Hardcover metadata matches requiring manual review."""
     __tablename__ = 'hardcover_match_queue'
+    __table_args__ = (
+        Index(
+            'ix_hardcover_match_queue_review_state_book',
+            'reviewed', 'review_action', 'book_id',
+        ),
+    )
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     book_id = Column(Integer, nullable=False)
@@ -3482,6 +3488,55 @@ def migrate_dismissed_duplicate_groups_table(engine, _session):
         print(f"[dup-dismiss-migration] Failed to add duplicate_key column: {e}", flush=True)
 
 
+def migrate_hardcover_match_queue_dedup(engine, _session):
+    """Keep only the newest pending Hardcover review row for each book.
+
+    Reviewed history is never selected by the DELETE. The set-based aggregate
+    is bounded by the queue table rather than issuing one query per book, and
+    the indexes make both runtime exclusion and pending-row upserts efficient.
+    Re-running performs no deletes and both index statements are no-ops.
+    """
+    with engine.begin() as connection:
+        table_exists = connection.execute(text(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' "
+            "AND name = 'hardcover_match_queue'"
+        )).first()
+        if not table_exists:
+            return
+        deleted = connection.execute(text("""
+            DELETE FROM hardcover_match_queue
+            WHERE reviewed = 0
+              AND id NOT IN (
+                  SELECT MAX(queue.id)
+                  FROM hardcover_match_queue AS queue
+                  JOIN (
+                      SELECT book_id, MAX(created_at) AS newest_created_at
+                      FROM hardcover_match_queue
+                      WHERE reviewed = 0
+                      GROUP BY book_id
+                  ) AS newest
+                    ON newest.book_id = queue.book_id
+                   AND newest.newest_created_at = queue.created_at
+                  WHERE queue.reviewed = 0
+                  GROUP BY queue.book_id
+              )
+        """)).rowcount
+
+    _run_ddl_with_retry(engine, (
+        "CREATE INDEX IF NOT EXISTS "
+        "ix_hardcover_match_queue_review_state_book "
+        "ON hardcover_match_queue(reviewed, review_action, book_id)",
+        "CREATE UNIQUE INDEX IF NOT EXISTS "
+        "uq_hardcover_match_queue_pending_book "
+        "ON hardcover_match_queue(book_id) WHERE reviewed = 0",
+    ))
+    if deleted:
+        log.info(
+            "[hardcover-match-queue-migration] removed %d duplicate pending row(s)",
+            deleted,
+        )
+
+
 def migrate_my_library_admin_intro_table(engine, _session):
     """Create the single-row my_library_admin_intro table idempotently.
 
@@ -4840,6 +4895,7 @@ def migrate_Database(_session):
     add_missing_tables(engine, _session)
     migrate_kobo_entitlement_ledger_columns(engine, _session)
     migrate_thumbnail_lookup_index(engine, _session)
+    migrate_hardcover_match_queue_dedup(engine, _session)
     migrate_registration_table(engine, _session)
     migrate_user_session_table(engine, _session)
     migrate_user_table(engine, _session)
@@ -5171,6 +5227,7 @@ def init_db(app_db_path):
         clean_database(session)
     else:
         Base.metadata.create_all(engine)
+        migrate_hardcover_match_queue_dedup(engine, session)
         _ensure_kobo_opaque_present_guards(engine)
         create_admin_user(session)
         create_anonymous_user(session)

--- a/tests/unit/test_729_hardcover_scoring_pool.py
+++ b/tests/unit/test_729_hardcover_scoring_pool.py
@@ -100,7 +100,13 @@ def test_queue_for_review_caps_stored_candidates_at_three(monkeypatch):
     so the review template's derived "Top N" label matches the 3 rendered cards."""
     captured = {}
 
+    class FakeQuery:
+        def filter(self, *args): return self
+        def order_by(self, *args): return self
+        def first(self): return None
+
     class FakeSession:
+        def query(self, *args): return FakeQuery()
         def add(self, entry): captured["entry"] = entry
         def commit(self): pass
         def rollback(self): pass

--- a/tests/unit/test_auto_hardcover_id_thread_session.py
+++ b/tests/unit/test_auto_hardcover_id_thread_session.py
@@ -69,6 +69,16 @@ def test_auto_hardcover_id_loads_books_with_a_worker_local_calibre_session(monke
     factory.  The provider is mocked only to avoid external HTTP.
     """
     engine, factory = _worker_local_calibre_db(monkeypatch)
+    from cps import ub
+
+    app_engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    ub.HardcoverMatchQueue.__table__.create(app_engine)
+    app_factory = scoped_session(sessionmaker(bind=app_engine, future=True))
+    monkeypatch.setattr(module.ub, "init_db_thread", app_factory)
     monkeypatch.setattr(module.config, "hardcover_sync_enabled", lambda: True)
     monkeypatch.setattr(module.config, "resolved_hardcover_token", lambda: "token")
     monkeypatch.setattr(module, "Hardcover", _NoResultsHardcover)
@@ -112,6 +122,8 @@ def test_auto_hardcover_id_loads_books_with_a_worker_local_calibre_session(monke
         assert observed["book_session"] is observed["task_session"]
         assert task.books_processed == 1
     finally:
+        app_factory.remove()
+        app_engine.dispose()
         factory.remove()
         engine.dispose()
 

--- a/tests/unit/test_hardcover_configuration_cluster.py
+++ b/tests/unit/test_hardcover_configuration_cluster.py
@@ -920,3 +920,313 @@ def test_auto_fetch_ui_has_first_off_option_and_truthful_status_combinations():
             cwa_settings={"hardcover_auto_fetch_schedule": schedule_value},
         )
         assert message in rendered
+
+
+def _ambiguous_hardcover_result(result_id):
+    return SimpleNamespace(
+        id=result_id,
+        title=f"Candidate {result_id}",
+        authors=["Author"],
+        url="",
+        cover="",
+        description="",
+        series="",
+        series_index=None,
+        publisher="",
+        publishedDate="",
+        identifiers={"hardcover-id": result_id},
+    )
+
+
+def _ambiguous_scored_results(result_id):
+    return [{
+        "result": _ambiguous_hardcover_result(result_id),
+        "score": 0.5,
+        "reason": f"ambiguous-{result_id}",
+    }]
+
+
+@pytest.fixture
+def hardcover_queue_runtime(monkeypatch):
+    from datetime import datetime, timezone
+
+    from sqlalchemy import create_engine, event
+    from sqlalchemy.orm import sessionmaker
+    from sqlalchemy.pool import StaticPool
+
+    from cps import db, ub
+    from cps.tasks import auto_hardcover_id as module
+    from cps.tasks.auto_hardcover_id import TaskAutoHardcoverID
+
+    app_engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    ub.HardcoverMatchQueue.__table__.create(app_engine)
+    AppSession = sessionmaker(bind=app_engine)
+    monkeypatch.setattr(module.ub, "init_db_thread", AppSession)
+
+    calibre_engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    event.listen(
+        calibre_engine,
+        "connect",
+        lambda connection, _record: connection.execute(
+            "ATTACH DATABASE ':memory:' AS calibre"
+        ),
+    )
+    db.Base.metadata.create_all(calibre_engine)
+    CalibreSession = sessionmaker(bind=calibre_engine)
+    calibre_session = CalibreSession()
+    book = db.Books(
+        "Ambiguous Book",
+        "Ambiguous Book",
+        "Author",
+        datetime.now(timezone.utc),
+        datetime.now(timezone.utc),
+        "1.0",
+        datetime.now(timezone.utc),
+        "ambiguous-book",
+        False,
+        [],
+        [],
+    )
+    calibre_session.add(book)
+    calibre_session.commit()
+    book_id = book.id
+    calibre_session.close()
+
+    monkeypatch.setattr(
+        module.db,
+        "CalibreDB",
+        lambda **_kwargs: SimpleNamespace(session=CalibreSession()),
+    )
+    monkeypatch.setattr(module.config, "hardcover_sync_enabled", lambda: True)
+    monkeypatch.setattr(module.config, "resolved_hardcover_token", lambda: "token")
+    monkeypatch.setattr(TaskAutoHardcoverID, "_save_stats", lambda self: None)
+
+    searches = []
+
+    class AmbiguousProvider:
+        def search(self, query):
+            searches.append(query)
+            return [_ambiguous_hardcover_result("candidate-1")]
+
+        @staticmethod
+        def calculate_confidence_score(**_kwargs):
+            return 0.5, "ambiguous"
+
+    monkeypatch.setattr(module, "Hardcover", AmbiguousProvider)
+
+    runtime = SimpleNamespace(
+        AppSession=AppSession,
+        book_id=book_id,
+        searches=searches,
+    )
+    try:
+        yield runtime
+    finally:
+        app_engine.dispose()
+        calibre_engine.dispose()
+
+
+def test_two_ambiguous_crawls_leave_one_pending_row(
+    hardcover_queue_runtime, caplog
+):
+    from cps import ub
+    from cps.tasks.auto_hardcover_id import TaskAutoHardcoverID
+
+    first = TaskAutoHardcoverID(batch_size=10, rate_limit_delay=0)
+    second = TaskAutoHardcoverID(batch_size=10, rate_limit_delay=0)
+
+    first.run(None)
+    second.run(None)
+
+    session = hardcover_queue_runtime.AppSession()
+    try:
+        pending = session.query(ub.HardcoverMatchQueue).filter_by(
+            book_id=hardcover_queue_runtime.book_id,
+            reviewed=0,
+        ).all()
+    finally:
+        session.close()
+
+    assert len(hardcover_queue_runtime.searches) == 1
+    assert len(pending) == 1
+    assert first.books_processed == 1
+    assert second.books_processed == 0
+    assert caplog.text.count(
+        "Found 1 eligible books without Hardcover IDs"
+    ) == 1
+    assert "No books eligible for Hardcover ID auto-fetch" in caplog.text
+
+
+def test_queue_for_review_refreshes_existing_pending_row(
+    monkeypatch, hardcover_queue_runtime
+):
+    from cps import ub
+    from cps.tasks import auto_hardcover_id as module
+    from cps.tasks.auto_hardcover_id import TaskAutoHardcoverID
+
+    timestamps = iter(("2026-08-01T00:00:00", "2026-09-01T00:00:00"))
+    monkeypatch.setattr(
+        module,
+        "datetime",
+        SimpleNamespace(
+            utcnow=lambda: SimpleNamespace(isoformat=lambda: next(timestamps))
+        ),
+    )
+    task = TaskAutoHardcoverID()
+
+    task._queue_for_review(
+        hardcover_queue_runtime.book_id,
+        "Original title",
+        "Original author",
+        "original query",
+        _ambiguous_scored_results("old-result"),
+    )
+    task._queue_for_review(
+        hardcover_queue_runtime.book_id,
+        "Updated title",
+        "Updated author",
+        "updated query",
+        _ambiguous_scored_results("new-result"),
+    )
+
+    session = hardcover_queue_runtime.AppSession()
+    try:
+        rows = session.query(ub.HardcoverMatchQueue).filter_by(
+            book_id=hardcover_queue_runtime.book_id,
+            reviewed=0,
+        ).all()
+        assert len(rows) == 1
+        assert rows[0].book_title == "Updated title"
+        assert rows[0].search_query == "updated query"
+        assert rows[0].created_at == "2026-09-01T00:00:00"
+        assert "new-result" in rows[0].hardcover_results
+        assert "ambiguous-new-result" in rows[0].confidence_scores
+    finally:
+        session.close()
+
+
+def test_rejected_book_is_not_researched_or_requeued(hardcover_queue_runtime):
+    from cps import ub
+    from cps.tasks.auto_hardcover_id import TaskAutoHardcoverID
+
+    session = hardcover_queue_runtime.AppSession()
+    session.add(ub.HardcoverMatchQueue(
+        book_id=hardcover_queue_runtime.book_id,
+        book_title="Ambiguous Book",
+        book_authors="Author",
+        search_query="Ambiguous Book Author",
+        hardcover_results="[]",
+        confidence_scores="[]",
+        created_at="2026-08-01T00:00:00",
+        reviewed=1,
+        review_action="reject",
+        reviewed_at="2026-08-02T00:00:00",
+    ))
+    session.commit()
+    session.close()
+
+    task = TaskAutoHardcoverID(batch_size=10, rate_limit_delay=0)
+    task.run(None)
+
+    session = hardcover_queue_runtime.AppSession()
+    try:
+        rows = session.query(ub.HardcoverMatchQueue).filter_by(
+            book_id=hardcover_queue_runtime.book_id,
+        ).all()
+    finally:
+        session.close()
+
+    assert hardcover_queue_runtime.searches == []
+    assert len(rows) == 1
+    assert rows[0].reviewed == 1
+    assert rows[0].review_action == "reject"
+
+
+def test_pending_queue_cleanup_keeps_newest_and_all_reviewed_rows(tmp_path):
+    from sqlalchemy import create_engine, text
+    from sqlalchemy.orm import sessionmaker
+
+    from cps import ub
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'app.db'}")
+    with engine.begin() as connection:
+        connection.execute(text("""
+            CREATE TABLE hardcover_match_queue (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                book_id INTEGER NOT NULL,
+                created_at VARCHAR NOT NULL,
+                reviewed INTEGER NOT NULL,
+                review_action VARCHAR
+            )
+        """))
+        connection.execute(text("""
+            INSERT INTO hardcover_match_queue
+                (book_id, created_at, reviewed, review_action)
+            VALUES
+                (1, '2026-07-01T00:00:00', 0, NULL),
+                (1, '2026-08-01T00:00:00', 0, NULL),
+                (1, '2026-06-01T00:00:00', 1, 'reject'),
+                (2, '2026-07-15T00:00:00', 0, NULL),
+                (2, '2026-07-15T00:00:00', 0, NULL),
+                (2, '2026-05-01T00:00:00', 1, 'skip')
+        """))
+        connection.execute(
+            text(
+                "INSERT INTO hardcover_match_queue "
+                "(book_id, created_at, reviewed, review_action) "
+                "VALUES (:book_id, :created_at, 0, NULL)"
+            ),
+            [
+                {
+                    "book_id": 100 + (index % 274),
+                    "created_at": f"2026-08-01T00:00:00.{index:06d}",
+                }
+                for index in range(30000)
+            ],
+        )
+    session = sessionmaker(bind=engine)()
+    try:
+        ub.migrate_hardcover_match_queue_dedup(engine, session)
+        ub.migrate_hardcover_match_queue_dedup(engine, session)
+    finally:
+        session.close()
+
+    with engine.connect() as connection:
+        pending = connection.execute(text(
+            "SELECT id, book_id, created_at FROM hardcover_match_queue "
+            "WHERE reviewed = 0 AND book_id IN (1, 2) ORDER BY book_id"
+        )).fetchall()
+        pending_count = connection.execute(text(
+            "SELECT COUNT(*) FROM hardcover_match_queue WHERE reviewed = 0"
+        )).scalar()
+        reviewed = connection.execute(text(
+            "SELECT id, book_id, review_action FROM hardcover_match_queue "
+            "WHERE reviewed = 1 ORDER BY id"
+        )).fetchall()
+        indexes = {
+            row[1]: row[2]
+            for row in connection.execute(text(
+                "PRAGMA index_list(hardcover_match_queue)"
+            )).fetchall()
+        }
+
+    assert [tuple(row) for row in pending] == [
+        (2, 1, "2026-08-01T00:00:00"),
+        (5, 2, "2026-07-15T00:00:00"),
+    ]
+    assert pending_count == 276
+    assert [tuple(row) for row in reviewed] == [
+        (3, 1, "reject"),
+        (6, 2, "skip"),
+    ]
+    assert indexes["uq_hardcover_match_queue_pending_book"] == 1
+    assert "ix_hardcover_match_queue_review_state_book" in indexes
+    engine.dispose()


### PR DESCRIPTION
Fixes #2103 (the queue-growth half). Reported by @magdalar.

## What was wrong

The Hardcover auto-fetch task appended a **new** `hardcover_match_queue` row every time it ran
over the same ambiguous book, and it never looked at what a human had already decided. On
@magdalar's instance that produced ~28.9k pending review rows for a few hundred books: the
scheduled crawl kept spending Hardcover API quota re-searching titles that were already sitting
in the review queue, or that the admin had explicitly **rejected**, and the review page filled
with thousands of duplicates of the same handful of books.

## What changes

- **One pending row per book.** `_queue_for_review()` now refreshes the existing pending row in
  place (title, authors, query, candidates, scores, `created_at`) instead of inserting a new one.
  The row **id is deliberately stable** so an admin who already has the row rendered can still act
  on it. A partial unique index `uq_hardcover_match_queue_pending_book (book_id) WHERE reviewed=0`
  enforces the invariant against concurrent writers; the `IntegrityError` path refreshes the row
  that won the race rather than failing the task.
- **A rejection sticks.** Books with a pending row, or with a reviewed row whose
  `review_action='reject'`, are excluded *before* any Hardcover search — so a rejected book stops
  consuming API quota. `_queue_for_review()` re-checks rejection as a race guard in case the human
  rejects between candidate selection and enqueue, and returns `False` (logged, not counted).
- **Upgrades clean up.** `migrate_hardcover_match_queue_dedup()` collapses existing duplicate
  pending rows to the newest per book (max `created_at`, max `id` as the deterministic
  tie-breaker). `WHERE reviewed = 0` keeps every reviewed row — the human decision history is
  never touched. Set-based, idempotent, and the unique index is only created after the collapse.
- **Honest logging.** `Found N eligible books without Hardcover IDs` now reports the count that
  will actually be processed, and the 10,000-book safety cap applies *after* review-state
  exclusion instead of before it, so a large already-queued library can still reach fresh books.

## Evidence

Red/green, independently re-run by the manager on this exact head (`df2177ab17`), reverting only
the two production files to `origin/main` and leaving the new tests in place:

| Run | Result |
|---|---|
| 4 new regressions, production files reverted to `origin/main` | **4 failed** |
| 4 new regressions, this head | 4 passed |
| `test_hardcover_configuration_cluster` + `test_729_hardcover_scoring_pool` + `test_auto_hardcover_id_thread_session` | 47 passed |
| `tests/unit -k hardcover` | 168 passed, 8313 deselected |
| `test_populated_database_boot_gate` + `test_ingest_config_full_load` + `test_1873_app_db_savepoint_containment` | 24 passed |

The migration regression builds **30,000 duplicate pending rows across 274 books in real SQLite**,
runs the migration **twice**, and asserts one pending row survives per book, that the reviewed
`reject`/`skip` rows are all still present, and that both indexes exist.

`tests/unit/test_auto_hardcover_id_thread_session.py` was corrected — not the production
behaviour — because the pre-existing worker-local-session regression had no app-db session for the
new pre-search review lookup.

## Known limitation

`/admin/hardcover/review-matches` was verified by route inspection plus the real-SQLite row-shape
and migration tests, not by a browser drive: the change alters no route, template, or action
handler, only the rows they read. Stated so the gap is on the record rather than implied away.

No new dependencies, no license changes, no new external service URLs.

The second half of #2103 — an off switch for Hardcover auto-fetch on `/cwa-settings` — is not in
this PR.

---

**Rebased note (head `3313e442ab`).** `main` advanced to `f65ed3a731` (#2152, the application-factory
slice) while this was in flight, so `origin/main` was merged in — forward only, no force-push. The
two diffs do not overlap a single file. All evidence above was re-run on the merged head, plus the
37 tests #2152 added or changed (`test_application_factory`, `test_1882_bare_metal_hardening`,
`test_1931_spa_reverse_proxy_auth`) to prove the merge left the new bootstrap intact.
