### PR TITLE
test: place pytest scratch on the external volume when mounted

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -420,6 +420,14 @@ def mock_calibre_tools(mocker):
 # Skip Markers for Conditional Tests
 # ============================================================================
 
+_PYTEST_EXTERNAL_VOLUME_ROOT = "/Volumes/Crucial X8"
+
+
+def _pytest_external_volume_is_mounted(volume_root):
+    """Return whether ``volume_root`` is an available mounted directory."""
+    return os.path.isdir(volume_root) and os.path.ismount(volume_root)
+
+
 def _isolate_pytest_tempdir():
     """Give every pytest process its own tempdir.
 
@@ -463,8 +471,42 @@ def _isolate_pytest_tempdir():
     to a private directory so `cover_enforcer`'s module-scope lock cannot race
     `test_802`'s. This promotes that workaround to the harness, and the local one
     can go once this has settled.
+
+    Scratch lives on the external volume when it is mounted and writable, with
+    ``CWNG_PYTEST_TMP_BASE`` as an explicit override. Otherwise it remains under
+    the system tempdir, and the selected location and reason are reported.
     """
-    base = os.path.join(tempfile.gettempdir(), "cwng-pytest")
+    fallback_base = os.path.join(tempfile.gettempdir(), "cwng-pytest")
+    override_base = os.environ.get("CWNG_PYTEST_TMP_BASE")
+    if override_base is not None:
+        base = override_base
+        reason = "CWNG_PYTEST_TMP_BASE is set"
+    else:
+        volume_root = _PYTEST_EXTERNAL_VOLUME_ROOT
+        external_base = os.path.join(volume_root, "agent-scratch", "cwng-pytest")
+        if _pytest_external_volume_is_mounted(volume_root):
+            try:
+                os.makedirs(external_base, exist_ok=True)
+            except OSError as error:
+                base = fallback_base
+                reason = (
+                    f"{volume_root} is mounted but the external base could not "
+                    f"be created: {error}"
+                )
+            else:
+                if os.access(external_base, os.W_OK):
+                    base = external_base
+                    reason = f"{volume_root} is mounted and writable"
+                else:
+                    base = fallback_base
+                    reason = (
+                        f"{volume_root} is mounted but {external_base} is not writable"
+                    )
+        else:
+            base = fallback_base
+            reason = f"{volume_root} is not mounted"
+
+    print(f"pytest temp base: {base} ({reason})", file=sys.stderr)
     _reap_stale_pytest_tempdirs(base)
     root = os.path.join(base, str(os.getpid()))
     os.makedirs(root, exist_ok=True)

--- a/tests/unit/test_pytest_tempdir_isolation.py
+++ b/tests/unit/test_pytest_tempdir_isolation.py
@@ -11,9 +11,22 @@ from pathlib import Path
 
 import pytest
 
-from tests.conftest import _isolate_pytest_tempdir
+from tests import conftest as pytest_conftest
+
+_isolate_pytest_tempdir = pytest_conftest._isolate_pytest_tempdir
 
 REPO = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture(autouse=True)
+def no_real_external_volume(monkeypatch):
+    """Keep these unit tests independent of the host's actual mounted volumes."""
+    monkeypatch.delenv("CWNG_PYTEST_TMP_BASE", raising=False)
+    monkeypatch.setattr(
+        pytest_conftest,
+        "_pytest_external_volume_is_mounted",
+        lambda _volume_root: False,
+    )
 
 
 @pytest.mark.unit
@@ -65,6 +78,103 @@ def test_the_key_is_the_process_not_the_worker_id(monkeypatch, tmp_path):
         "keying on the worker id makes two concurrent sessions collide on gw0"
     )
     assert Path(root).name == str(os.getpid())
+
+
+@pytest.mark.unit
+def test_explicit_base_override_wins(monkeypatch, tmp_path, capsys):
+    override_base = tmp_path / "override"
+    monkeypatch.setenv("CWNG_PYTEST_TMP_BASE", str(override_base))
+    monkeypatch.setattr(
+        pytest_conftest,
+        "_pytest_external_volume_is_mounted",
+        lambda _volume_root: pytest.fail(
+            "the volume must not be probed with an override"
+        ),
+    )
+
+    root = Path(_isolate_pytest_tempdir())
+
+    assert root.parent == override_base
+    assert capsys.readouterr().err == (
+        f"pytest temp base: {override_base} (CWNG_PYTEST_TMP_BASE is set)\n"
+    )
+
+
+@pytest.mark.unit
+def test_mounted_writable_volume_uses_external_base(monkeypatch, tmp_path, capsys):
+    system_tmp = tmp_path / "system"
+    volume_root = tmp_path / "mounted-volume"
+    monkeypatch.setattr(tempfile, "tempdir", str(system_tmp))
+    monkeypatch.setattr(
+        pytest_conftest, "_PYTEST_EXTERNAL_VOLUME_ROOT", str(volume_root)
+    )
+    monkeypatch.setattr(
+        pytest_conftest,
+        "_pytest_external_volume_is_mounted",
+        lambda candidate: candidate == str(volume_root),
+    )
+
+    root = Path(_isolate_pytest_tempdir())
+    expected_base = volume_root / "agent-scratch" / "cwng-pytest"
+
+    assert root.parent == expected_base
+    assert expected_base.is_dir()
+    assert capsys.readouterr().err == (
+        f"pytest temp base: {expected_base} "
+        f"({volume_root} is mounted and writable)\n"
+    )
+
+
+@pytest.mark.unit
+def test_mounted_unwritable_volume_falls_back_and_reports_why(
+    monkeypatch, tmp_path, capsys
+):
+    system_tmp = tmp_path / "system"
+    volume_root = tmp_path / "mounted-volume"
+    external_base = volume_root / "agent-scratch" / "cwng-pytest"
+    monkeypatch.setattr(tempfile, "tempdir", str(system_tmp))
+    monkeypatch.setattr(
+        pytest_conftest, "_PYTEST_EXTERNAL_VOLUME_ROOT", str(volume_root)
+    )
+    monkeypatch.setattr(
+        pytest_conftest,
+        "_pytest_external_volume_is_mounted",
+        lambda candidate: candidate == str(volume_root),
+    )
+
+    def deny_external_write(candidate, mode):
+        assert candidate == str(external_base)
+        assert mode == os.W_OK
+        return False
+
+    monkeypatch.setattr(os, "access", deny_external_write)
+
+    root = Path(_isolate_pytest_tempdir())
+    fallback_base = system_tmp / "cwng-pytest"
+
+    assert root.parent == fallback_base
+    assert capsys.readouterr().err == (
+        f"pytest temp base: {fallback_base} ({volume_root} is mounted but "
+        f"{external_base} is not writable)\n"
+    )
+
+
+@pytest.mark.unit
+def test_missing_external_volume_uses_system_tempdir(monkeypatch, tmp_path, capsys):
+    system_tmp = tmp_path / "system"
+    volume_root = tmp_path / "missing-volume"
+    monkeypatch.setattr(tempfile, "tempdir", str(system_tmp))
+    monkeypatch.setattr(
+        pytest_conftest, "_PYTEST_EXTERNAL_VOLUME_ROOT", str(volume_root)
+    )
+
+    root = Path(_isolate_pytest_tempdir())
+    fallback_base = system_tmp / "cwng-pytest"
+
+    assert root.parent == fallback_base
+    assert capsys.readouterr().err == (
+        f"pytest temp base: {fallback_base} ({volume_root} is not mounted)\n"
+    )
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Why
`$TMPDIR/cwng-pytest/<pid>/` accumulates on the boot volume: 431 pid dirs = 4.8 GB measured on 2026-09-03 (8.4 GB earlier). Every pytest process gets a private tempdir so the module-level singleton locks in `scripts/` don't collide across processes; that mechanism stays.

## What
`tests/conftest.py::_isolate_pytest_tempdir()` now picks the base in order:
1. `$CWNG_PYTEST_TMP_BASE` (exact path) when set;
2. `/Volumes/Crucial X8/agent-scratch/cwng-pytest` when that volume is a mounted directory and the scratch dir can be created and is writable;
3. `tempfile.gettempdir()/cwng-pytest` otherwise.
One stderr line always names the chosen base and the reason (a mounted-but-unwritable volume says so instead of falling back silently). Per-pid subdir, both `TMPDIR` assignments and `_reap_stale_pytest_tempdirs` are unchanged.

## Tests
Four `@pytest.mark.unit` cases in `tests/unit/test_pytest_tempdir_isolation.py` (env override wins and never probes the mount; fake mounted+writable volume is used; mounted-but-unwritable falls back with the exact stderr line; no mount → system tempdir). The mount probe and volume constant are monkeypatched; nothing touches the real `/Volumes`. 8 passed on two runs; mutants (drop the writability check, drop the env override) each go red.

No changelog fragment: every changed path is under `tests/` (exempt per `changelog.d/README.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ewLYe6jFN1ahDdPDsUkoN
