### PR TITLE
ci(e2e): the SPA install lane survives a warm-cache npm stall

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Install frontend dependencies (npm ci)
         working-directory: frontend
-        run: npm ci
+        run: npm ci --prefer-offline --no-audit --no-fund --loglevel=error
 
       - name: Install system dependencies
         run: |
@@ -218,7 +218,7 @@ jobs:
 
       - name: Install dependencies (npm ci)
         working-directory: frontend
-        run: npm ci
+        run: npm ci --prefer-offline --no-audit --no-fund --loglevel=error
 
       - name: Build SPA (tsc -b && vite build)
         working-directory: frontend
@@ -925,12 +925,20 @@ jobs:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-${{ runner.arch }}-playwright-${{ steps.playwright-version.outputs.version }}
 
-      - name: Install Playwright
-        timeout-minutes: 3
+      # Same-lockfile green run 33833541562 measured 56s total: the npm/browser
+      # medians were 35s/21s. Run 33848680049 twice saw npm ci alone stall for
+      # 193s (>3m) with both caches warm. Ten minutes per step gives >17x/28x
+      # median headroom and >3x that observed stall floor, while still failing
+      # a real setup hang far before the job's 180m guard.
+      - name: Install frontend dependencies (npm ci)
+        timeout-minutes: 10
         working-directory: frontend
-        run: |
-          npm ci
-          npx playwright install --with-deps chromium webkit
+        run: npm ci --prefer-offline --no-audit --no-fund --loglevel=error
+
+      - name: Install Playwright browsers
+        timeout-minutes: 10
+        working-directory: frontend
+        run: npx playwright install --with-deps chromium webkit
 
       # Frontend-only PRs intentionally reuse a digest-pinned :dev backend to
       # avoid a full multi-arch build for a static-bundle change. Overlay their
@@ -944,7 +952,6 @@ jobs:
           needs.changed_paths.outputs.concurrency != 'true'
         working-directory: frontend
         run: |
-          npm ci
           npm run build          # writes ../cps/static/app
           docker cp ../cps/static/app/. cwn-e2e:/app/calibre-web-automated/cps/static/app/
           # Jinja templates too. Not every user-facing surface is React: the PDF

--- a/changelog.d/e2e-install-resiliency.md
+++ b/changelog.d/e2e-install-resiliency.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- **Fully verified pull requests no longer get blocked by a short SPA test
+  dependency-install timeout.** The E2E lane now gives cached frontend and
+  Playwright setup enough time to survive registry stalls, avoids optional npm
+  network passes, and reuses its installed dependency tree for the SPA overlay.

--- a/tests/unit/test_ci_e2e_install_resiliency.py
+++ b/tests/unit/test_ci_e2e_install_resiliency.py
@@ -1,0 +1,227 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Keep the mitigations for the observed SPA E2E install timeout.
+
+OBSERVED on PR #2157, run 33848680049 at head 73b5fdc3c3: both the original
+attempt and rerun restored the npm and 364 MB Playwright caches, entered
+``npm ci`` at 07:45:08, printed only two deprecation warnings by 07:45:10,
+and were killed at 07:48:21 by the ``Install Playwright`` step's three-minute
+cap. The orphaned process was ``npm ci``; Playwright installation never began.
+With the same branch and lockfile, run 33833541562 completed the combined step
+from 04:41:44 to 04:42:40 (56 seconds). The three-minute cap therefore sat too
+close to a high-variance networked install despite warm caches.
+
+The lasting invariants are behavioral rather than step-name pins: every npm CI
+install prefers its restored cache and disables avoidable audit/funding calls;
+each separately diagnosable dependency/browser install in the E2E job has an
+explicit budget well beyond the observed stall but below the job guard; and the
+conditional SPA overlay reuses the unconditional dependency tree installed
+earlier in the same working directory.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "tests.yml"
+
+OBSERVED_STALL_SECONDS = 3 * 60 + 13
+MINIMUM_INSTALL_BUDGET_SECONDS = OBSERVED_STALL_SECONDS * 3
+
+
+def _yaml() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def _e2e_job(src: str) -> str:
+    """Return the job whose displayed name is ``E2E Tests (SPA)``."""
+    match = re.search(
+        r"(?ms)^  ([A-Za-z0-9_-]+):\n"
+        r"(?:(?!^  [A-Za-z0-9_-]+:).)*?"
+        r"^    name:\s*E2E Tests \(SPA\)\s*$"
+        r"(?P<rest>(?:(?!^  [A-Za-z0-9_-]+:).)*)",
+        src,
+    )
+    assert match, "could not locate the E2E Tests (SPA) job"
+    return match.group(0)
+
+
+def _step_blocks(job: str) -> list[str]:
+    """Split one job into step mappings without requiring a YAML package."""
+    starts = [m.start() for m in re.finditer(r"(?m)^      - name:\s*", job)]
+    assert starts, "E2E Tests (SPA) has no named steps"
+    return [
+        job[start : starts[index + 1] if index + 1 < len(starts) else len(job)]
+        for index, start in enumerate(starts)
+    ]
+
+
+def _run_scripts(src: str) -> list[str]:
+    """Extract scalar and block ``run`` scripts from a workflow/job/step."""
+    lines = src.splitlines()
+    scripts: list[str] = []
+    index = 0
+    while index < len(lines):
+        match = re.match(r"^(?P<indent>\s*)run:\s*(?P<value>.*)$", lines[index])
+        if not match:
+            index += 1
+            continue
+        value = match.group("value").strip()
+        if value not in {"|", ">", "|-", ">-"}:
+            scripts.append(value)
+            index += 1
+            continue
+        indent = len(match.group("indent"))
+        index += 1
+        body: list[str] = []
+        while index < len(lines):
+            line = lines[index]
+            if line.strip() and len(line) - len(line.lstrip()) <= indent:
+                break
+            body.append(line.strip())
+            index += 1
+        scripts.append("\n".join(body))
+    return scripts
+
+
+def _npm_ci_commands(src: str) -> list[list[str]]:
+    commands: list[list[str]] = []
+    for script in _run_scripts(src):
+        for line in script.splitlines():
+            for segment in re.split(r"(?:&&|\|\||;)", line):
+                segment = segment.strip()
+                if re.match(r"^npm\s+ci(?:\s|$)", segment):
+                    commands.append(shlex.split(segment))
+    return commands
+
+
+def _step_run(step: str) -> str:
+    scripts = _run_scripts(step)
+    return "\n".join(scripts)
+
+
+def _step_timeout_minutes(step: str) -> int | None:
+    match = re.search(r"(?m)^        timeout-minutes:\s*(\d+)\s*(?:#.*)?$", step)
+    return int(match.group(1)) if match else None
+
+
+def _job_timeout_minutes(job: str) -> int:
+    match = re.search(r"(?m)^    timeout-minutes:\s*(\d+)\s*(?:#.*)?$", job)
+    assert match, "E2E Tests (SPA) must retain a job-level hang guard"
+    return int(match.group(1))
+
+
+def _working_directory(step: str) -> str | None:
+    match = re.search(r"(?m)^        working-directory:\s*([^#\n]+)", step)
+    return match.group(1).strip() if match else None
+
+
+def test_e2e_install_steps_have_budget_far_beyond_observed_stall():
+    """Explicit setup caps must outlive the measured stall yet fail fast."""
+    job = _e2e_job(_yaml())
+    job_timeout = _job_timeout_minutes(job)
+    dependency_steps = [
+        step
+        for step in _step_blocks(job)
+        if re.search(r"\bnpm\s+ci\b", _step_run(step))
+    ]
+    browser_steps = [
+        step
+        for step in _step_blocks(job)
+        if re.search(r"\bplaywright\s+install\b", _step_run(step))
+    ]
+    assert len(dependency_steps) == 1, (
+        "E2E Tests (SPA) needs one dependency-install step"
+    )
+    assert len(browser_steps) == 1, (
+        "E2E browser setup must be separate so the next stall is diagnosable"
+    )
+
+    for step in (*dependency_steps, *browser_steps):
+        step_timeout = _step_timeout_minutes(step)
+        assert step_timeout is not None, (
+            "each E2E dependency/browser install needs its own timeout; the "
+            f"{job_timeout}-minute job guard is not a fail-fast step bound:\n{step}"
+        )
+        step_seconds = step_timeout * 60
+        assert step_seconds >= MINIMUM_INSTALL_BUDGET_SECONDS, (
+            "E2E dependency/browser installs need at least three times the "
+            f"observed {OBSERVED_STALL_SECONDS}s stall, but this step gets "
+            f"only {step_seconds}s:\n{step}"
+        )
+        assert step_timeout < job_timeout, (
+            "an install timeout must fail fast before the job-level guard: "
+            f"step={step_timeout}m, job={job_timeout}m"
+        )
+
+
+def test_every_npm_ci_is_cache_first_non_auditing_and_quiet():
+    """All CI installs avoid optional network calls and routine log noise."""
+    commands = _npm_ci_commands(_yaml())
+    assert commands, "tests.yml must contain at least one npm ci install"
+
+    for command in commands:
+        args = set(command[2:])
+        joined = " ".join(command)
+        assert "--prefer-offline" in args, f"npm ci must prefer its cache: {joined}"
+        assert {"--no-audit", "--audit=false"} & args, (
+            f"npm ci must disable the registry audit call: {joined}"
+        )
+        assert {"--no-fund", "--fund=false"} & args, (
+            f"npm ci must disable the funding pass: {joined}"
+        )
+        quiet = (
+            {"--silent", "--quiet", "--loglevel=error"} & args
+            or "--loglevel" in args and "error" in args
+        )
+        assert quiet, f"npm ci must suppress routine CI noise: {joined}"
+
+
+def test_overlay_reuses_unconditional_dependency_tree_from_earlier_step():
+    """The conditional overlay must not reinstall the identical lockfile."""
+    job = _e2e_job(_yaml())
+    steps = _step_blocks(job)
+    overlay_index, overlay = next(
+        (index, step)
+        for index, step in enumerate(steps)
+        if "docker cp" in _step_run(step) and "npm run build" in _step_run(step)
+    )
+    assert not _npm_ci_commands(overlay), (
+        "the SPA overlay must reuse node_modules instead of running npm ci again"
+    )
+
+    prior_installs = [
+        step for step in steps[:overlay_index] if _npm_ci_commands(step)
+    ]
+    assert len(prior_installs) == 1, (
+        "the overlay needs exactly one earlier dependency install in this job"
+    )
+    install = prior_installs[0]
+    assert _working_directory(install) == _working_directory(overlay) == "frontend", (
+        "the earlier npm ci and overlay build must share frontend/ so node_modules "
+        "is the same installed tree"
+    )
+    assert not re.search(r"(?m)^        if:\s*", install), (
+        "the earlier npm ci must be unconditional so every reachable overlay has "
+        "the installed dependency tree"
+    )
+    assert not re.search(r"(?m)^        continue-on-error:\s*true\s*$", install), (
+        "a failed earlier npm ci must stop the job before the overlay uses its tree"
+    )
+    overlay_if = re.search(
+        r"(?ms)^        if:\s*(?:[>|]-?\s*)?(.*?)(?=^        [A-Za-z_-]+:)",
+        overlay,
+    )
+    assert overlay_if and not re.search(r"\b(?:always|failure)\s*\(", overlay_if.group(1)), (
+        "the overlay must retain GitHub's default success gating so it cannot "
+        "run after the earlier npm ci fails"
+    )

--- a/tests/unit/test_workflow_safety_invariants.py
+++ b/tests/unit/test_workflow_safety_invariants.py
@@ -626,15 +626,30 @@ def _e2e_steps() -> list[dict]:
 
 
 def test_e2e_playwright_install_is_version_cached_and_bounded():
-    """A browser-download stall must fail fast without wasting warm binaries."""
-    steps = _e2e_steps()
+    """Warm dependency/browser setup must still fail fast on real hangs."""
+    wf = _load(WF_DIR / "tests.yml")
+    job = (wf.get("jobs") or {}).get("e2e-tests") or {}
+    steps = [s for s in (job.get("steps") or []) if isinstance(s, dict)]
     version = next(
         s for s in steps if s.get("name") == "Resolve Playwright browser version"
     )
     cache = next(
         s for s in steps if s.get("name") == "Cache Playwright browsers"
     )
-    install = next(s for s in steps if s.get("name") == "Install Playwright")
+    dependency_installs = [
+        s for s in steps if re.search(r"\bnpm\s+ci\b", str(s.get("run") or ""))
+    ]
+    browser_installs = [
+        s for s in steps if "playwright install" in str(s.get("run") or "")
+    ]
+    assert len(dependency_installs) == 1, (
+        "E2E must install its frontend dependency tree exactly once"
+    )
+    assert len(browser_installs) == 1, (
+        "E2E must keep browser setup separate so a future stall is diagnosable"
+    )
+    dependency_install = dependency_installs[0]
+    browser_install = browser_installs[0]
 
     assert version.get("id") == "playwright-version"
     assert "node_modules/playwright-core" in str(version.get("run") or "")
@@ -644,8 +659,26 @@ def test_e2e_playwright_install_is_version_cached_and_bounded():
     assert "steps.playwright-version.outputs.version" in str(
         cache_with.get("key") or ""
     )
-    assert install.get("timeout-minutes") == 3
-    assert steps.index(version) < steps.index(cache) < steps.index(install)
+    job_timeout = job.get("timeout-minutes")
+    assert isinstance(job_timeout, int) and job_timeout > 0, (
+        "E2E browser setup must retain a job-level hang guard"
+    )
+    for install in (dependency_install, browser_install):
+        step_timeout = install.get("timeout-minutes")
+        assert isinstance(step_timeout, int), (
+            "each E2E dependency/browser install needs an explicit hang guard"
+        )
+        assert 5 <= step_timeout <= 15, (
+            "each install cap must reject the former three-minute false-red "
+            "budget but still fail fast instead of consuming the 180-minute job"
+        )
+        assert step_timeout < job_timeout
+    assert (
+        steps.index(version)
+        < steps.index(cache)
+        < steps.index(dependency_install)
+        < steps.index(browser_install)
+    )
 
 
 def test_e2e_uses_head_backend_only_for_backend_prs():


### PR DESCRIPTION
## What this fixes

`E2E Tests (SPA)` has killed three consecutive runs on PR #2157 at the same step. It is not
variance: green run `33833541562` and red run `33848680049` restored a **byte-identical** npm cache
key and the same 364 MB Playwright cache from the same lockfile. `npm ci` took **35s** in the green
run and stalled past **193s** in the red one, at which point the step's `timeout-minutes: 3` cap
killed it with Playwright installation never started.

Three changes, each with its own regression test:

1. **Every `npm ci` in `tests.yml`** gains `--prefer-offline --no-audit --no-fund --loglevel=error`.
   The audit and funding passes are the network work in that span that the cache does not cover.
2. **`Install Playwright` is split** into `Install frontend dependencies (npm ci)` and
   `Install Playwright browsers`, each with `timeout-minutes: 10`. A future stall now names which
   phase stalled instead of hiding both behind one step. Ten minutes is >17x the 35s npm median,
   >28x the 21s browser median and >3x the observed 193s stall floor, and still fails far short of
   the job's 180-minute guard.
3. **The SPA overlay's second `npm ci` is removed.** The unconditional install step above it runs in
   the same job with the same `working-directory: frontend`, so the tree is already present; the
   overlay was re-installing it on every frontend-only PR.

## Why the timeout went up rather than away

An earlier revision of this branch dropped both step caps and relaxed
`test_e2e_playwright_install_is_version_cached_and_bounded` to accept a missing timeout. That was
held and corrected: a test whose name ends `_and_bounded` must require a bound. The restored
assertion demands an explicit integer cap on both install steps, in the range 5-15 minutes, strictly
below the job timeout - which rejects the old 3-minute false-red budget *and* rejects no cap at all,
without pinning to the 10 chosen here.

## Evidence

- **Red/green, manager-run at `3d094badca`:** `tests/unit/test_ci_e2e_install_resiliency.py` is
  3 passed at this head and 3 failed against `origin/main`'s `tests.yml`.
- **Mutation:** removing `timeout-minutes` from an E2E install step at this head makes
  `test_e2e_install_steps_have_budget_far_beyond_observed_stall` fail with
  *"the 180-minute job guard is not a fail-fast step bound"*. The weakening that was held is now
  caught by a test.
- **`actionlint`** on the modified `tests.yml`: zero findings, identical to `origin/main`'s.
- **Not merged on this tick.** The one thing this change is about - the lane running green with the
  new step boundaries - can only be observed in the CI run this push starts. Gate
  `state/gates/pr-ci-e2e-install.json` records `practical_verification: false` and
  `authorize_merge: false` for that reason.

Unblocks #2157, which is otherwise fully gated at `73b5fdc3c3`.

