### PR TITLE
test: bound the external-volume probe so a wedged drive cannot hang pytest startup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,14 +14,18 @@ Environment Variables:
     USE_DOCKER_VOLUMES: Set to 'true' to use Docker volumes instead of bind mounts.
                        Required for Docker-in-Docker test environments.
                        Example: USE_DOCKER_VOLUMES=true pytest tests/integration/
+    CWNG_PYTEST_TMP_BASE: Explicit base for per-process pytest temp directories.
+    CWNG_PYTEST_TMP_PROBE_SECONDS: External-volume probe timeout (default: 5).
 """
 
+import math
 import os
 import re
 import sys
 import pytest
 import tempfile
 import shutil
+import threading
 import time
 import requests
 import subprocess
@@ -421,11 +425,109 @@ def mock_calibre_tools(mocker):
 # ============================================================================
 
 _PYTEST_EXTERNAL_VOLUME_ROOT = "/Volumes/Crucial X8"
+_PYTEST_EXTERNAL_VOLUME_PROBE_SECONDS = 5.0
+_PYTEST_EXTERNAL_VOLUME_PROBE_CODE = r"""
+import os
+import sys
+
+volume_root, external_base = sys.argv[1:3]
+if not (os.path.isdir(volume_root) and os.path.ismount(volume_root)):
+    raise SystemExit(3)
+
+os.makedirs(external_base, exist_ok=True)
+probe_path = os.path.join(external_base, f".cwng-pytest-probe-{os.getpid()}")
+try:
+    descriptor = os.open(
+        probe_path,
+        os.O_CREAT | os.O_EXCL | os.O_WRONLY,
+        0o600,
+    )
+    try:
+        os.write(descriptor, b"probe")
+    finally:
+        os.close(descriptor)
+finally:
+    try:
+        os.unlink(probe_path)
+    except FileNotFoundError:
+        pass
+"""
 
 
-def _pytest_external_volume_is_mounted(volume_root):
-    """Return whether ``volume_root`` is an available mounted directory."""
-    return os.path.isdir(volume_root) and os.path.ismount(volume_root)
+def _pytest_external_volume_probe_runner(command, timeout_seconds):
+    """Run the volume probe without ever waiting indefinitely in the parent.
+
+    ``subprocess.run(timeout=...)`` kills and then waits for a timed-out child.
+    That final wait is not bounded when the child is stuck in an uninterruptible
+    filesystem operation. Poll with a timeout instead; if SIGKILL cannot finish
+    the child promptly, a daemon reaper owns the eventual blocking wait.
+    """
+    process = subprocess.Popen(
+        command,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        return process.wait(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired:
+        try:
+            process.kill()
+        except ProcessLookupError:
+            pass
+        try:
+            process.wait(timeout=0.1)
+        except subprocess.TimeoutExpired:
+            threading.Thread(target=process.wait, daemon=True).start()
+        raise
+
+
+def _pytest_external_volume_probe_timeout():
+    """Return the configured positive probe timeout, or the safe default."""
+    configured = os.environ.get(
+        "CWNG_PYTEST_TMP_PROBE_SECONDS",
+        str(_PYTEST_EXTERNAL_VOLUME_PROBE_SECONDS),
+    )
+    try:
+        timeout_seconds = float(configured)
+    except (TypeError, ValueError):
+        return _PYTEST_EXTERNAL_VOLUME_PROBE_SECONDS
+    if timeout_seconds <= 0 or not math.isfinite(timeout_seconds):
+        return _PYTEST_EXTERNAL_VOLUME_PROBE_SECONDS
+    return timeout_seconds
+
+
+def _probe_pytest_external_volume(volume_root, external_base, timeout_seconds):
+    """Return whether the child proved the external scratch base is usable."""
+    command = [
+        sys.executable,
+        "-c",
+        _PYTEST_EXTERNAL_VOLUME_PROBE_CODE,
+        volume_root,
+        external_base,
+    ]
+    timeout_label = f"{timeout_seconds:g}"
+    try:
+        returncode = _pytest_external_volume_probe_runner(command, timeout_seconds)
+    except subprocess.TimeoutExpired:
+        return (
+            False,
+            f"external volume did not answer within {timeout_label}s — falling back",
+        )
+    except Exception as error:
+        detail = " ".join(str(error).split()) or type(error).__name__
+        return False, f"external volume probe could not start: {detail} — falling back"
+
+    if returncode == 0:
+        return True, f"{volume_root} is mounted and writable"
+    if returncode == 3:
+        return False, f"{volume_root} is not mounted — falling back"
+    if returncode < 0:
+        return (
+            False,
+            f"external volume probe was killed by signal {-returncode} — falling back",
+        )
+    return False, f"external volume probe failed with exit {returncode} — falling back"
 
 
 def _isolate_pytest_tempdir():
@@ -472,11 +574,11 @@ def _isolate_pytest_tempdir():
     `test_802`'s. This promotes that workaround to the harness, and the local one
     can go once this has settled.
 
-    Scratch lives on the external volume when it is mounted and writable, with
-    ``CWNG_PYTEST_TMP_BASE`` as an explicit override. Otherwise it remains under
-    the system tempdir, and the selected location and reason are reported.
+    Scratch lives on the external volume when a bounded child process proves it
+    is mounted and writable, with ``CWNG_PYTEST_TMP_BASE`` as an explicit
+    override. Otherwise it remains under the system tempdir, and the selected
+    location and reason are reported.
     """
-    fallback_base = os.path.join(tempfile.gettempdir(), "cwng-pytest")
     override_base = os.environ.get("CWNG_PYTEST_TMP_BASE")
     if override_base is not None:
         base = override_base
@@ -484,27 +586,16 @@ def _isolate_pytest_tempdir():
     else:
         volume_root = _PYTEST_EXTERNAL_VOLUME_ROOT
         external_base = os.path.join(volume_root, "agent-scratch", "cwng-pytest")
-        if _pytest_external_volume_is_mounted(volume_root):
-            try:
-                os.makedirs(external_base, exist_ok=True)
-            except OSError as error:
-                base = fallback_base
-                reason = (
-                    f"{volume_root} is mounted but the external base could not "
-                    f"be created: {error}"
-                )
-            else:
-                if os.access(external_base, os.W_OK):
-                    base = external_base
-                    reason = f"{volume_root} is mounted and writable"
-                else:
-                    base = fallback_base
-                    reason = (
-                        f"{volume_root} is mounted but {external_base} is not writable"
-                    )
+        timeout_seconds = _pytest_external_volume_probe_timeout()
+        usable, reason = _probe_pytest_external_volume(
+            volume_root,
+            external_base,
+            timeout_seconds,
+        )
+        if usable:
+            base = external_base
         else:
-            base = fallback_base
-            reason = f"{volume_root} is not mounted"
+            base = os.path.join(tempfile.gettempdir(), "cwng-pytest")
 
     print(f"pytest temp base: {base} ({reason})", file=sys.stderr)
     _reap_stale_pytest_tempdirs(base)

--- a/tests/unit/test_pytest_tempdir_isolation.py
+++ b/tests/unit/test_pytest_tempdir_isolation.py
@@ -22,10 +22,11 @@ REPO = Path(__file__).resolve().parents[2]
 def no_real_external_volume(monkeypatch):
     """Keep these unit tests independent of the host's actual mounted volumes."""
     monkeypatch.delenv("CWNG_PYTEST_TMP_BASE", raising=False)
+    monkeypatch.delenv("CWNG_PYTEST_TMP_PROBE_SECONDS", raising=False)
     monkeypatch.setattr(
         pytest_conftest,
-        "_pytest_external_volume_is_mounted",
-        lambda _volume_root: False,
+        "_pytest_external_volume_probe_runner",
+        lambda _command, _timeout_seconds: 3,
     )
 
 
@@ -86,9 +87,9 @@ def test_explicit_base_override_wins(monkeypatch, tmp_path, capsys):
     monkeypatch.setenv("CWNG_PYTEST_TMP_BASE", str(override_base))
     monkeypatch.setattr(
         pytest_conftest,
-        "_pytest_external_volume_is_mounted",
-        lambda _volume_root: pytest.fail(
-            "the volume must not be probed with an override"
+        "_pytest_external_volume_probe_runner",
+        lambda _command, _timeout_seconds: pytest.fail(
+            "the external volume probe must not run with an override"
         ),
     )
 
@@ -104,23 +105,29 @@ def test_explicit_base_override_wins(monkeypatch, tmp_path, capsys):
 def test_mounted_writable_volume_uses_external_base(monkeypatch, tmp_path, capsys):
     system_tmp = tmp_path / "system"
     volume_root = tmp_path / "mounted-volume"
+    external_base = volume_root / "agent-scratch" / "cwng-pytest"
     monkeypatch.setattr(tempfile, "tempdir", str(system_tmp))
     monkeypatch.setattr(
         pytest_conftest, "_PYTEST_EXTERNAL_VOLUME_ROOT", str(volume_root)
     )
+
+    def successful_probe(command, timeout_seconds):
+        assert command[-2:] == [str(volume_root), str(external_base)]
+        assert timeout_seconds == 5
+        return 0
+
     monkeypatch.setattr(
         pytest_conftest,
-        "_pytest_external_volume_is_mounted",
-        lambda candidate: candidate == str(volume_root),
+        "_pytest_external_volume_probe_runner",
+        successful_probe,
     )
 
     root = Path(_isolate_pytest_tempdir())
-    expected_base = volume_root / "agent-scratch" / "cwng-pytest"
 
-    assert root.parent == expected_base
-    assert expected_base.is_dir()
+    assert root.parent == external_base
+    assert external_base.is_dir()
     assert capsys.readouterr().err == (
-        f"pytest temp base: {expected_base} "
+        f"pytest temp base: {external_base} "
         f"({volume_root} is mounted and writable)\n"
     )
 
@@ -136,26 +143,25 @@ def test_mounted_unwritable_volume_falls_back_and_reports_why(
     monkeypatch.setattr(
         pytest_conftest, "_PYTEST_EXTERNAL_VOLUME_ROOT", str(volume_root)
     )
+
+    def failed_probe(command, timeout_seconds):
+        assert command[-2:] == [str(volume_root), str(external_base)]
+        assert timeout_seconds == 5
+        return 13
+
     monkeypatch.setattr(
         pytest_conftest,
-        "_pytest_external_volume_is_mounted",
-        lambda candidate: candidate == str(volume_root),
+        "_pytest_external_volume_probe_runner",
+        failed_probe,
     )
-
-    def deny_external_write(candidate, mode):
-        assert candidate == str(external_base)
-        assert mode == os.W_OK
-        return False
-
-    monkeypatch.setattr(os, "access", deny_external_write)
 
     root = Path(_isolate_pytest_tempdir())
     fallback_base = system_tmp / "cwng-pytest"
 
     assert root.parent == fallback_base
     assert capsys.readouterr().err == (
-        f"pytest temp base: {fallback_base} ({volume_root} is mounted but "
-        f"{external_base} is not writable)\n"
+        f"pytest temp base: {fallback_base} "
+        "(external volume probe failed with exit 13 — falling back)\n"
     )
 
 
@@ -173,7 +179,43 @@ def test_missing_external_volume_uses_system_tempdir(monkeypatch, tmp_path, caps
 
     assert root.parent == fallback_base
     assert capsys.readouterr().err == (
-        f"pytest temp base: {fallback_base} ({volume_root} is not mounted)\n"
+        f"pytest temp base: {fallback_base} "
+        f"({volume_root} is not mounted — falling back)\n"
+    )
+
+
+@pytest.mark.unit
+def test_external_probe_timeout_falls_back_and_reports_why(
+    monkeypatch, tmp_path, capsys
+):
+    system_tmp = tmp_path / "system"
+    volume_root = tmp_path / "mounted-volume"
+    external_base = volume_root / "agent-scratch" / "cwng-pytest"
+    monkeypatch.setattr(tempfile, "tempdir", str(system_tmp))
+    monkeypatch.setattr(
+        pytest_conftest, "_PYTEST_EXTERNAL_VOLUME_ROOT", str(volume_root)
+    )
+    monkeypatch.setenv("CWNG_PYTEST_TMP_PROBE_SECONDS", "0.02")
+
+    def hanging_probe(command, timeout_seconds):
+        assert command[-2:] == [str(volume_root), str(external_base)]
+        assert timeout_seconds == 0.02
+        raise pytest_conftest.subprocess.TimeoutExpired(command, timeout_seconds)
+
+    monkeypatch.setattr(
+        pytest_conftest,
+        "_pytest_external_volume_probe_runner",
+        hanging_probe,
+    )
+
+    root = Path(_isolate_pytest_tempdir())
+    fallback_base = system_tmp / "cwng-pytest"
+
+    assert root.parent == fallback_base
+    assert not volume_root.exists(), "the parent touched the fake external volume"
+    assert capsys.readouterr().err == (
+        f"pytest temp base: {fallback_base} "
+        "(external volume did not answer within 0.02s — falling back)\n"
     )
 
 


### PR DESCRIPTION
## Why

#2156 made the pytest temp base prefer the external scratch volume when it is mounted and writable, and it probed that volume **in-process at conftest import time**. On 2026-09-04 the same volume went *mounted but wedged*: `ls` of the volume root timed out, `mkdir` blocked in the kernel, and `dd`/`xattr` returned `Interrupted system call`, while `stat`/`df`/`mount` kept answering from cache. In that state the in-process probe blocks every pytest run at startup with no output, and an in-process alarm cannot rescue an uninterruptible kernel wait.

## What

The mount and writability check now runs in a short-lived **child process** with a hard deadline (`CWNG_PYTEST_TMP_PROBE_SECONDS`, default 5s; non-positive, NaN and non-finite values fall back to the default). The child confirms the mount, creates the scratch dir, and creates/removes a probe file. On timeout it is killed, waited for briefly, and handed to a daemon reaper if it is still uninterruptible, so the parent never waits on the volume. Any timeout, non-zero exit, launch failure or other error falls back to the system tempdir and says why on stderr. The parent performs no `isdir`/`ismount`/`stat`/`access`/`makedirs` on the external path.

Selection order, per-pid subdir, both `TMPDIR` assignments, the stale-dir reaper and the chosen-base stderr line are unchanged.

## Evidence

- `tests/unit/test_pytest_tempdir_isolation.py`: 9 passed, two consecutive runs. Timeouts are injected, so no test sleeps.
- Real fallback, not simulated: with `CWNG_PYTEST_TMP_PROBE_SECONDS=0.001` the live code prints `pytest temp base: /var/folders/.../cwng-pytest (external volume did not answer within 0.001s — falling back)`; with the default it selects the external base; with `CWNG_PYTEST_TMP_BASE` set it short-circuits without probing.
- Mutation: making the timeout branch return success instead of falling back turns `test_external_probe_timeout_falls_back_and_reports_why` red (1 failed, 8 passed); restoring gives 9 passed.

No changelog fragment: every changed path is under `tests/`, which `changelog.d/README.md` exempts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017yPVqJG8yknh7FKJUEEoZk
