### PR TITLE
fix(windows): native startup no longer fails on POSIX-only fcntl imports

### DIFF
--- a/changelog.d/2168-windows-fcntl-startup.md
+++ b/changelog.d/2168-windows-fcntl-startup.md
@@ -1,0 +1,7 @@
+Native Windows source checkouts no longer fail at startup because `fcntl` is
+unavailable. Restore, Kobo exchange capture, and Kobo PATCH spool locks share a
+platform helper using POSIX `flock` or Windows `msvcrt` byte-range locks. Restore
+still refuses a lock held by another process. If neither backend is available,
+locking explicitly degrades to a logged no-op; use one app process and avoid
+concurrent restore/service writers on such platforms. Thanks to Rol3333 for the
+Windows 11 / Python 3.11 report (#2168).

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -19,8 +19,6 @@ from urllib.parse import urlparse
 import shutil  # noqa: F401 -- test/extension monkeypatch compatibility
 import subprocess
 import tempfile
-import fcntl
-import errno
 
 from flask import Blueprint, current_app, flash, redirect, url_for, abort, request, make_response, send_from_directory, g, Response, jsonify
 from markupsafe import Markup
@@ -42,6 +40,7 @@ from .helper import check_valid_domain, send_test_mail, reset_password, generate
 from .embed_helper import get_calibre_binarypath
 from .gdriveutils import is_gdrive_ready, gdrive_support
 from .render_template import render_title_template, get_sidebar_config
+from .services import file_lock
 from .services.worker import WorkerThread
 from .services.kobo_import import (
     KoboContentDatabaseError,
@@ -3628,12 +3627,9 @@ def _acquire_restore_file_lock(lock_name):
     lock_path = os.path.join(tempfile.gettempdir(), lock_name)
     lock_handle = open(lock_path, "a+", encoding="utf-8")
     try:
-        fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-    except OSError as error:
-        lock_handle.close()
-        if error.errno in (errno.EACCES, errno.EAGAIN):
+        if not file_lock.acquire(lock_handle.fileno(), blocking=False):
+            lock_handle.close()
             return None
-        raise
     except Exception:
         lock_handle.close()
         raise
@@ -3643,7 +3639,7 @@ def _acquire_restore_file_lock(lock_name):
 def _release_restore_locks(lock_handles):
     for handle in lock_handles:
         try:
-            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            file_lock.release(handle.fileno())
         except Exception:
             pass
         try:

--- a/cps/services/file_lock.py
+++ b/cps/services/file_lock.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Exclusive locks for persistent, non-truncating lock files.
+
+Prefer POSIX flock; otherwise lock byte zero with Windows msvcrt (including
+on empty files). Callers must use separate descriptors for independent holders
+and must not share a descriptor while acquiring/releasing. The file position is
+preserved. Blocking acquisition waits until acquired; non-blocking acquisition
+returns False only on contention. Other errors propagate.
+
+When neither backend exists, acquisition explicitly degrades to a logged no-op
+and returns True. There is then NO cross-process exclusion: run only one app
+process and avoid concurrent restore/service writers. Release is a no-op too.
+The bespoke cooperative calibre_db_lock protocol is intentionally separate.
+"""
+import errno
+import logging
+import os
+import time
+
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
+
+msvcrt = None
+if fcntl is None:
+    try:
+        import msvcrt
+    except ImportError:
+        pass
+
+log = logging.getLogger(__name__)
+_BUSY = (errno.EACCES, errno.EAGAIN)
+
+
+def _windows_lock(fd, mode):
+    position = os.lseek(fd, 0, os.SEEK_CUR)
+    try:
+        os.lseek(fd, 0, os.SEEK_SET)
+        msvcrt.locking(fd, mode, 1)
+    finally:
+        os.lseek(fd, position, os.SEEK_SET)
+
+
+def acquire(fd, *, blocking=True):
+    """Return True when acquired (or degraded), False when non-blocking/busy."""
+    if fcntl is not None:
+        flags = fcntl.LOCK_EX | (0 if blocking else fcntl.LOCK_NB)
+        try:
+            fcntl.flock(fd, flags)
+        except OSError as error:
+            if not blocking and error.errno in _BUSY:
+                return False
+            raise
+        return True
+    if msvcrt is not None:
+        mode = msvcrt.LK_LOCK if blocking else msvcrt.LK_NBLCK
+        while True:
+            try:
+                _windows_lock(fd, mode)
+                return True
+            except OSError as error:
+                if error.errno not in _BUSY and not (
+                    blocking and error.errno == errno.EDEADLK
+                ):
+                    raise
+                if not blocking:
+                    return False
+                # LK_LOCK gives up after ten retries. Preserve flock's
+                # indefinite blocking contract, without spinning on failure.
+                time.sleep(0.1)
+    log.warning(
+        "File locking is a no-op: neither fcntl nor msvcrt is available; "
+        "cross-process exclusion is disabled. Use a single app process and "
+        "avoid concurrent restore/service writers."
+    )
+    return True
+
+
+def release(fd):
+    """Release a successfully acquired lock; backend errors propagate."""
+    if fcntl is not None:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+    elif msvcrt is not None:
+        _windows_lock(fd, msvcrt.LK_UNLCK)

--- a/cps/services/kobo_exchange_capture.py
+++ b/cps/services/kobo_exchange_capture.py
@@ -28,7 +28,6 @@ best-effort, and :meth:`CaptureSession.finish` swallows storage failures.
 from __future__ import annotations
 
 import base64
-import fcntl
 import gzip
 import hashlib
 import json
@@ -44,6 +43,7 @@ from pathlib import Path
 from gevent import Timeout, get_hub
 
 from .. import constants
+from . import file_lock
 
 
 log = logging.getLogger(__name__)
@@ -507,8 +507,11 @@ class CaptureSession:
             lock_path = root / ".capture.lock"
             lock_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
             try:
-                os.fchmod(lock_fd, 0o600)
-                fcntl.flock(lock_fd, fcntl.LOCK_EX)
+                if hasattr(os, "fchmod"):
+                    os.fchmod(lock_fd, 0o600)
+                else:
+                    os.chmod(lock_path, 0o600)
+                file_lock.acquire(lock_fd)
                 _prune_locked(
                     root,
                     incoming_bytes=len(compressed),
@@ -551,7 +554,7 @@ class CaptureSession:
                         pass
             finally:
                 try:
-                    fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                    file_lock.release(lock_fd)
                 finally:
                     os.close(lock_fd)
 

--- a/cps/services/kobo_patch_spool.py
+++ b/cps/services/kobo_patch_spool.py
@@ -26,7 +26,6 @@ artifact, excluded from annotation backups and support bundles.
 from __future__ import annotations
 
 import base64
-import fcntl
 import gzip
 import hashlib
 import json
@@ -42,6 +41,7 @@ from pathlib import Path
 from gevent import Timeout, get_hub
 
 from .. import constants
+from . import file_lock
 
 
 _current_thread = threading.current_thread
@@ -356,14 +356,21 @@ class _RootLock:
 
     def __enter__(self):
         self.fd = os.open(self.root / ".spool.lock", os.O_CREAT | os.O_RDWR, 0o600)
-        os.fchmod(self.fd, 0o600)
-        fcntl.flock(self.fd, fcntl.LOCK_EX)
+        try:
+            if hasattr(os, "fchmod"):
+                os.fchmod(self.fd, 0o600)
+            else:
+                os.chmod(self.root / ".spool.lock", 0o600)
+            file_lock.acquire(self.fd)
+        except BaseException:
+            os.close(self.fd)
+            raise
         return self
 
     def __exit__(self, exc_type, exc, traceback):
         del exc_type, exc, traceback
         try:
-            fcntl.flock(self.fd, fcntl.LOCK_UN)
+            file_lock.release(self.fd)
         finally:
             os.close(self.fd)
 

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -173,7 +173,7 @@ surfaces; reverse dependents cannot be discovered by that traversal and must be 
 prefixes. The whole `cps/api/` blueprint tree is therefore protected explicitly: its registration in
 `cps/main.py` points toward the handlers, opposite to the import direction walked by the classifier. The
 two-level cutoff only bounds each root's dependency fan-out—it is not what excludes reverse dependents.
-At this revision the derived set is 161 of 225 local Python modules (the closure correctly picks
+At this revision the derived set is 162 of 226 local Python modules (the closure correctly picks
 up `cps/services/device_delivery.py` through the book-action request path, and this branch's
 `cps/user_preferences.py` through the account API path). Measured at `origin/main`
 `e6298e0d560b`, the previous and expanded policies each fired on 26 of the latest 100 first-parent commits;

--- a/tests/unit/test_file_lock_portability.py
+++ b/tests/unit/test_file_lock_portability.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Issue #2168: exercise missing platform modules in fresh interpreters."""
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def run_child(code, tmp_path):
+    result = subprocess.run(
+        [sys.executable, "-c", code], cwd=ROOT,
+        env={**os.environ, "CALIBRE_DBPATH": str(tmp_path)},
+        text=True, capture_output=True, timeout=60,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    return result.stdout
+
+
+@pytest.mark.parametrize("module", [
+    "cps.admin", "cps.services.kobo_exchange_capture",
+    "cps.services.kobo_patch_spool",
+])
+def test_startup_import_without_fcntl(module, tmp_path):
+    run_child(f'''
+import sys
+# None blocks even cached/extension-module imports, solely in this child.
+sys.modules["fcntl"] = None
+import importlib
+importlib.import_module({module!r})
+print("import succeeded: {module}")
+''', tmp_path)
+
+
+def test_windows_backend_contention_release_and_errors(tmp_path):
+    output = run_child('''
+import errno
+import importlib.util
+import os
+import sys
+import types
+
+sys.modules["fcntl"] = None
+import cps.admin as admin
+from cps.services import kobo_exchange_capture as capture, kobo_patch_spool as spool
+held = {}
+calls = []
+failures = []
+fake = types.ModuleType("msvcrt")
+fake.LK_LOCK, fake.LK_NBLCK, fake.LK_UNLCK = 1, 2, 0
+
+def locking(fd, mode, length):
+    offset = os.lseek(fd, 0, os.SEEK_CUR)
+    assert (offset, length) == (0, 1)
+    calls.append(mode)
+    if failures:
+        raise OSError(failures.pop(0), "injected failure")
+    info = os.fstat(fd)
+    key = (info.st_dev, info.st_ino, offset, length)
+    if mode == fake.LK_UNLCK:
+        assert held.pop(key) == fd
+    elif key in held:
+        raise OSError(errno.EACCES, "held by another descriptor")
+    else:
+        held[key] = fd
+
+fake.locking = locking
+sys.modules["msvcrt"] = fake
+# Load the real helper without making unrelated stdlib imports select Windows.
+spec = importlib.util.spec_from_file_location("portable_lock", "cps/services/file_lock.py")
+lock = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(lock)
+# Separate opens of the same inode, including different starting offsets.
+path = os.path.join(os.environ["CALIBRE_DBPATH"], "lock")
+with open(path, "a+b") as first, open(path, "a+b") as second:
+    first.seek(7)
+    second.seek(19)
+    assert lock.acquire(first.fileno()) is True
+    assert lock.acquire(second.fileno(), blocking=False) is False
+    assert first.tell() == 7 and second.tell() == 19
+    lock.release(first.fileno())
+    assert lock.acquire(second.fileno(), blocking=False) is True
+    lock.release(second.fileno())
+    assert calls == [1, 2, 0, 2, 0]
+    assert not held
+    # A timed-out LK_LOCK must continue waiting, not become a no-op.
+    failures.append(errno.EDEADLK)
+    assert lock.acquire(first.fileno()) is True
+    lock.release(first.fileno())
+    for blocking in (True, False):
+        failures.append(errno.EBADF)
+        try:
+            lock.acquire(first.fileno(), blocking=blocking)
+        except OSError as error:
+            assert error.errno == errno.EBADF
+        else:
+            raise AssertionError("unexpected error was swallowed")
+    assert first.tell() == 7
+# Drive all three real callers through the selected backend. Stop capture at
+# the first protected storage operation: payload durability is a separate seam.
+admin.file_lock = capture.file_lock = spool.file_lock = lock
+if hasattr(os, "fchmod"):
+    del os.fchmod
+restore_path = os.path.join(os.environ["CALIBRE_DBPATH"], "restore.lock")
+first = admin._acquire_restore_file_lock(restore_path)
+assert first is not None
+assert admin._acquire_restore_file_lock(restore_path) is None
+admin._release_restore_locks([first])
+root = __import__("pathlib").Path(os.environ["CALIBRE_DBPATH"]) / "spool"
+root.mkdir()
+calls.clear()
+with spool._locked_root(root):
+    assert held
+assert calls == [1, 0] and not held
+capture._capture_root = lambda: root
+class ProtectedOperationReached(Exception):
+    pass
+def stop_inside_lock(*args, **kwargs):
+    assert held
+    raise ProtectedOperationReached()
+capture._prune_locked = stop_inside_lock
+session = capture.CaptureSession(
+    exchange="test", method="POST", path="/test", query_string=b"",
+    headers=[], body=b"[]", authentication="authenticated", user_id=1,
+)
+calls.clear()
+try:
+    session._persist()
+except ProtectedOperationReached:
+    pass
+else:
+    raise AssertionError("capture did not reach protected operation")
+assert calls == [1, 0] and not held
+print("msvcrt: blocking/nonblocking attempted; busy=False; release/reacquire; retry and errors passed")
+''', tmp_path)
+    assert "busy=False" in output
+
+
+def test_no_backend_logs_explicit_degradation(tmp_path):
+    run_child('''
+import importlib.util
+import io
+import logging
+import sys
+sys.modules["fcntl"] = None
+sys.modules["msvcrt"] = None
+spec = importlib.util.spec_from_file_location("portable_lock", "cps/services/file_lock.py")
+lock = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(lock)
+stream = io.StringIO()
+handler = logging.StreamHandler(stream)
+lock.log.addHandler(handler)
+lock.log.setLevel(logging.WARNING)
+assert lock.acquire(-1) is True
+assert lock.acquire(-1, blocking=False) is True
+lock.release(-1)
+assert "neither fcntl nor msvcrt" in stream.getvalue()
+assert "no-op" in stream.getvalue()
+assert "cross-process exclusion is disabled" in stream.getvalue()
+''', tmp_path)
+
+
+def test_restore_lock_two_process_contention(tmp_path):
+    import cps.admin as admin
+
+    path = str(tmp_path / "restore.lock")
+    holder = admin._acquire_restore_file_lock(path)
+    assert holder is not None
+    try:
+        output = run_child(f'''
+from cps.admin import _acquire_restore_file_lock
+assert _acquire_restore_file_lock({path!r}) is None
+print("second process: None while held")
+''', tmp_path)
+        assert "second process: None while held" in output
+    finally:
+        admin._release_restore_locks([holder])
+    run_child(f'''
+from cps.admin import _acquire_restore_file_lock, _release_restore_locks
+handle = _acquire_restore_file_lock({path!r})
+assert handle is not None
+_release_restore_locks([handle])
+''', tmp_path)


### PR DESCRIPTION
Fixes #2168.

## The bug

Calibre-Web-NextGen could not start under native Windows Python. `cps/admin.py` imported the
POSIX-only `fcntl` at module scope (line 22), and `cps/main.py` registers the admin blueprint at
startup, so the import failed before the app existed. Two more modules had the same unguarded
import — `cps/services/kobo_exchange_capture.py` and `cps/services/kobo_patch_spool.py` — and the
latter is also reached at startup (`cps/main.py:132-133` calls
`kobo_patch_spool.start_retention_maintenance()` when Kobo is available), so fixing only `admin.py`
would have moved the failure rather than removed it.

The imports came from our own restore/capture/spool features, not from upstream.

## The fix

`cps/services/file_lock.py` is now the single owner of how an exclusive file lock is taken and
released. It uses POSIX `flock` where available, Windows `msvcrt` byte-range locking (byte zero,
with the file position preserved) where `fcntl` is absent, and degrades to an explicit **logged**
no-op only when neither backend exists. Blocking acquisition waits indefinitely — `msvcrt`'s
`LK_LOCK` gives up after ten tries, so the helper keeps waiting rather than silently returning.
Non-blocking acquisition returns `False` only on genuine contention; every other error propagates.

`cps/admin.py`, `cps/services/kobo_exchange_capture.py` and `cps/services/kobo_patch_spool.py` now
go through it. `_acquire_restore_file_lock` still returns `None` — not a handle, not an exception —
when another process holds the restore lock, so a second restore is still refused.

`cps/services/calibre_db_lock.py` is deliberately unchanged: it already guards its own import, and
its gevent-cooperative poll loop and 120s timeout are not a straight substitution. That
consolidation is recorded as a pending finding rather than widened into this PR.

## Evidence

Red/green run by the reviewer, not the author.

**RED** at `714e5c5232` in a detached worktree with only the new test copied in — 5 failed, 1
passed, the `cps.admin` case failing with the reporter's exact signature:

```
File "cps/admin.py", line 22, in <module>
    import fcntl
ModuleNotFoundError: import of fcntl halted; None in sys.modules
```

**GREEN** on this branch — `54 passed, 2 warnings in 34.91s` across
`tests/unit/test_file_lock_portability.py`, `tests/unit/test_1915_restore_lock.py` and
`tests/unit/test_f5c1146_kobo_patch_recovery_spool.py`. The one test green on both sides is
`test_restore_lock_two_process_contention`, which is the POSIX no-change control.

`tests/unit/test_file_lock_portability.py` drives the three real callers in fresh subprocesses with
`fcntl` genuinely unimportable and a `msvcrt` stand-in that keeps real held-state keyed by
`(st_dev, st_ino, offset, length)`. It asserts byte-zero locking, file-position preservation,
non-blocking contention returning `False`, release-and-reacquire, continued waiting across an
injected `LK_LOCK` give-up, and that `EBADF` propagates instead of being swallowed. It deletes
`os.fchmod` to exercise the Windows `chmod` fallback, and it proves real two-process POSIX
contention still yields `None`.

## Known limitation, stated plainly

No native Windows machine was driven and this repo has no Windows CI. The evidence is macOS with
`fcntl` blocked in a real interpreter and a `msvcrt` stand-in; that the real `msvcrt.locking`
behaves as modelled is ASSUMED, not observed.

Thanks to @Rol3333 for the report, the exact line number, and for pointing at
`cps/services/calibre_db_lock.py` as the pattern to follow.
