### PR TITLE
fix: adding advanced-search results to a shelf includes every match, not just the visible page

### DIFF
--- a/changelog.d/2169-advanced-search-shelf.md
+++ b/changelog.d/2169-advanced-search-shelf.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Adding advanced-search results to a shelf now includes every matching book.** The classic interface keeps results paged while adding books from all pages, including matches beyond the first 60.

--- a/cps/search.py
+++ b/cps/search.py
@@ -385,10 +385,9 @@ def render_adv_search_results(term, offset=None, order=None, limit=None):
         pagination = Pagination(page=1, per_page=limit, total_count=result_count)
         results = q.all()
 
-    # Note: store_combo_ids will now only contain the IDs of the currently visible page.
-    # This improves performance drastically for large search results, but affects
-    # functionality that relies on having all search result IDs (e.g., "download all").
-    ub.store_combo_ids(results)
+    # Bulk shelf additions need every match, without loading off-page Book objects.
+    # ID-only rows have the .id attribute expected by store_ids.
+    ub.store_ids(q.with_entities(db.Books.id).distinct().all())
 
     entries = calibre_db.order_authors(results, list_return=True, combined=True)
     return render_title_template('search.html',

--- a/tests/unit/test_advanced_search_bulk_ids.py
+++ b/tests/unit/test_advanced_search_bulk_ids.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Advanced search must retain every matching ID for shelf mass-add (#2169)."""
+
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+from sqlalchemy import create_engine, event, literal
+from sqlalchemy.orm import sessionmaker
+
+from cps import db, search, ub
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def search_state(monkeypatch):
+    engine = create_engine("sqlite://")
+    with engine.begin() as connection:
+        connection.exec_driver_sql("ATTACH DATABASE ':memory:' AS calibre")
+    db.Base.metadata.create_all(engine)
+    ub.Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    # Core inserts leave the ORM identity map empty so the load listener below
+    # detects even temporary materialization of books outside the visible page.
+    session.execute(db.Books.__table__.insert(), [
+        {"id": i, "title": "Match" if i <= 67 else "Other",
+         "sort": f"{i:03}", "path": "", "author_sort": ""}
+        for i in range(1, 69)
+    ])
+    session.commit()
+    query = (session.query(db.Books, literal(False).label("is_archived"))
+             .filter(db.Books.title == "Match"))
+    monkeypatch.setattr(search, "build_adv_search_query", lambda term: (query, "Match"))
+    monkeypatch.setattr(search.calibre_db, "session", session)
+    monkeypatch.setattr(search.calibre_db, "ensure_session", lambda: None)
+    monkeypatch.setattr(search, "render_title_template", lambda template, **ctx: ctx)
+    monkeypatch.setattr(search, "_", lambda text: text)
+    monkeypatch.setattr(ub, "current_user", SimpleNamespace(id=1))
+    monkeypatch.setattr(ub, "searched_ids", {1: [999], 2: [888]})
+    loaded = []
+
+    def record_load(book, context):
+        loaded.append(book.id)
+
+    event.listen(db.Books, "load", record_load)
+    app = Flask(__name__)
+    app.secret_key = "test"
+    try:
+        with app.test_request_context():
+            yield SimpleNamespace(session=session, loaded=loaded, app=app)
+    finally:
+        event.remove(db.Books, "load", record_load)
+        session.close()
+        engine.dispose()
+
+
+@pytest.mark.parametrize("offset,limit,empty", [
+    pytest.param(0, 60, False, id="first-page"),
+    pytest.param(60, 60, False, id="second-page"),
+    pytest.param(120, 60, False, id="past-last-page"),
+    pytest.param(None, None, False, id="unpaged"),
+    pytest.param(None, 60, False, id="no-offset"),
+    pytest.param(60, None, False, id="no-limit"),
+    pytest.param(0, 60, True, id="empty-page"),
+    pytest.param(None, None, True, id="empty-unpaged"),
+])
+def test_advanced_search_stores_all_matches_without_loading_off_page_books(
+    search_state, offset, limit, empty
+):
+    if empty:
+        search_state.session.query(db.Books).delete()
+        search_state.session.commit()
+    matching_ids = [] if empty else list(range(67, 0, -1))
+    paged = offset is not None and limit is not None
+    visible_ids = matching_ids[offset:offset + limit] if paged else matching_ids
+
+    rendered = search.render_adv_search_results(
+        {"title": "Match"}, offset=offset, limit=limit,
+        order=([db.Books.sort.desc()], "sortdesc"),
+    )
+
+    assert [row.Books.id for row in rendered["entries"]] == visible_ids
+    assert rendered["result_count"] == len(matching_ids)
+    pagination = rendered["pagination"]
+    assert (pagination.page, pagination.per_page, pagination.total_count) == (
+        offset // limit + 1 if paged else 1,
+        limit if paged else max(len(matching_ids), 1),
+        len(matching_ids),
+    )
+    assert sorted(search_state.loaded) == sorted(visible_ids)
+    assert ub.searched_ids[1] == matching_ids
+    assert ub.searched_ids[2] == [888]
+
+
+@pytest.mark.parametrize("existing_ids", [[], list(range(8, 68))],
+                         ids=["empty-shelf", "first-page-already-shelved"])
+def test_massadd_persists_all_67_matches_and_repeat_add_is_idempotent(
+    search_state, monkeypatch, existing_ids
+):
+    from cps import shelf
+
+    session = search_state.session
+    target = ub.Shelf(name="Search results", is_public=0, user_id=1)
+    session.add(target)
+    session.flush()
+    for position, book_id in enumerate(existing_ids, 1):
+        target.books.append(ub.BookShelf(shelf=target.id, book_id=book_id, order=position))
+    session.commit()
+    monkeypatch.setattr(ub, "session", session)
+    monkeypatch.setattr(shelf, "current_user", SimpleNamespace(id=1))
+    monkeypatch.setattr(shelf, "_", lambda text, **kwargs: text)
+    monkeypatch.setattr(shelf, "queue_hardcover_sync", lambda *args: None)
+    monkeypatch.setattr(shelf.config, "config_allow_reverse_proxy_header_login", False,
+                        raising=False)
+    app = search_state.app
+    app.config.update(TESTING=True, LOGIN_DISABLED=True)
+    app.register_blueprint(shelf.shelf)
+    app.add_url_rule("/", endpoint="web.index", view_func=lambda: "index")
+
+    rendered = search.render_adv_search_results(
+        {"title": "Match"}, offset=0, limit=60,
+        order=([db.Books.sort.desc()], "sortdesc"),
+    )
+    assert len(rendered["entries"]) == 60
+    client = app.test_client()
+    for _ in range(2):
+        response = client.post(f"/shelf/massadd/{target.id}")
+        assert response.status_code == 302
+        rows = session.query(ub.BookShelf).filter_by(shelf=target.id).all()
+        assert sorted(row.book_id for row in rows) == list(range(1, 68))
+        assert sorted(row.order for row in rows) == list(range(1, 68))


### PR DESCRIPTION
Addresses #2169 (reporter @Zenloth verifies before it closes).

## What users saw

Advanced-search 67 books in the classic interface, press **Add to shelf**, and exactly 60 arrive — one page. Press it again and nothing happens at all: the shelf reports "Books are already part of the shelf", because the route skips books already present and the id list it is working from is still page 1.

## Root cause

`render_adv_search_results()` fetched only the visible page (`q.offset(offset).limit(limit).all()`) and then stored *that slice* as the user's search-result id list via `ub.store_combo_ids()`. `/shelf/massadd` reads that list, so it could never see past the current page. The in-code comment above the call anticipated the effect on "download all" but not on "add to shelf".

Simple search was never affected: `calibre_db.get_search_results()` stores the full result set and slices only for display. This change makes advanced search consistent with it, without giving up the paged fetch that made the original change worth doing.

## Evidence

**Red/green.** The regression test file `tests/unit/test_advanced_search_bulk_ids.py` was run against the
unfixed `cps/search.py` first (the source restored from `HEAD` before the fix, then put back):

```
FFF.....FF                                                               [100%]
E   assert [7, 6, 5, 4, 3, 2, ...] == [67, 66, 65, 64, 63, 62, ...]
E     At index 0 diff: 7 != 67
E     Right contains 60 more items, first extra item: 60
...
ERROR    cps.shelf:shelf.py:447 Books are already part of Search results
5 failed, 5 passed in 1.83s
```

That `Books are already part of…` line is the reporter's second symptom reproduced exactly: the repeat
press adds nothing because the stored ids are still page 1.

With the fix, the same file passes. Verified independently of the authoring run, twice, plus alongside
the neighbouring shelf/search suites:

```
tests/unit/test_advanced_search_bulk_ids.py                     10 passed in 2.09s
tests/unit/test_advanced_search_bulk_ids.py (second run)        10 passed in 1.69s
+ test_shelf_membership_server_side.py, test_498_advanced_search_mobile_layout.py,
  test_api_v1_search.py, test_499_shelf_count_excludes_archived.py,
  test_612_shelf_nav_accumulation.py                            54 passed in 8.26s
```

**The user-visible flow, not just the function.** Two of the cases POST to `/shelf/massadd/<id>` through
the real shelf blueprint with a Flask test client and then read the persisted `BookShelf` rows: 67
memberships with contiguous order values, from an empty shelf and from a shelf that already holds page 1,
and a second POST changes nothing.

**Paging is still paged.** A SQLAlchemy `load` listener asserts that rendering materialises exactly the
visible page's `Books` objects and no others, on every offset/limit combination including the unpaged and
past-the-last-page cases. The new id query selects `Books.id` only.

**Sort matrix.** `render_adv_search_results` was exercised under `new`, `abc`, `seriesasc` and `authaz`
sorts — `authaz` orders by `Series.name` and by `ng_sort_key(author_sort)`, i.e. a joined column and a
custom SQLite function, which is the case where adding `DISTINCT` to an id-only query could plausibly
have failed. All four render 60 entries and store all 67 ids.

**Visibility is unchanged.** The id query is derived from the same `q` that `build_adv_search_query`
already filtered through `calibre_db.common_filters(True)`, so the stored set is the same
permission-filtered result the page was already showing — only no longer truncated to one page.

**Known, pre-existing:** the `books_series_link` outer join means a book in several series can be counted
more than once by `result_count`, while the id set is `DISTINCT`. That divergence predates this change
and is not introduced by it.

## Scope

Classic (Jinja) interface only. The React SPA and `cps/api/` do not use this id store.



## Independent manager verification (2026-09-05, head 9ef8a68a79b4db53645b1ee9474f01d659e5441e)

Re-run in a separate session from the one that authored the change, on a clean checkout of this head:

- `tests/unit/test_advanced_search_bulk_ids.py` — **10 passed** twice (3.95s, 1.83s).
- **Mutant kill check.** Restoring the exact pre-fix line at the choke point
  (`ub.store_ids(q.with_entities(db.Books.id).distinct().all())` → `ub.store_combo_ids(results)`)
  and re-running: **5 failed, 5 passed**, failing on `first-page`, `second-page`, `past-last-page`,
  `empty-shelf` and `first-page-already-shelved`. The `first-page-already-shelved` failure reads
  `assert [8, 9, 10, ...] == [1, 2, 3, ...]` — the reporter's second symptom. The file was restored
  and the tree confirmed clean at the same SHA afterwards.
- **Button-to-route chain, all links OBSERVED:** `cps/templates/search.html:26` posts to
  `url_for('shelf.search_to_shelf')` → `cps/shelf.py:419` `/shelf/massadd/<shelf_id>` →
  reads `ub.searched_ids[current_user.id]` → written by the changed line in
  `cps/search.py:388`. Nothing else in the tree writes that store except
  `cps/db.py:2315` (simple search), which was already storing the full set.
- **ASSUMED, stated rather than hidden:** no click-through on a deployed instance in a real
  browser. The HTTP route and the persisted `BookShelf` rows are exercised; the Jinja form target
  is unchanged by this diff and was read rather than driven.

`/security-review` not required: no auth/session/CSRF, crypto/secrets, subprocess, user-controlled
file path or new route is touched, and the id set stays inside the same `common_filters(True)` scope
the page already rendered.
