### PR TITLE
test(kobo): observe the three sticky annotation ETag exits and UNKNOWN containment

### DIFF
--- a/tests/integration/real_app/README.md
+++ b/tests/integration/real_app/README.md
@@ -1,9 +1,11 @@
-# Real application integration fixture (P0.1)
+# Real application integration fixture (P0.1, extended by P1.kobo)
 
 Status: fixture and lifecycle exercised; Docker parity is claimed for the
-backend wire only, and runs only where a matching image exists.
+backend wire only, and runs only where a matching image exists. The fixture
+now boots in two shapes — with the shipped defaults, and with Kobo sync on so
+the conditional Kobo blueprints exist (section 5).
 
-1. **Fixture — OBSERVED.** `conftest.py:11` supplies a real Flask app from
+1. **Fixture — OBSERVED.** `conftest.py:10` supplies a real Flask app from
    `create_app(cps.config, services)` followed by `register_blueprints`.
    Storage uses the shipped empty Calibre schema and production settings models.
    No updater, scheduler, CSRF, middleware, service, or blueprint is stubbed.
@@ -18,13 +20,16 @@ backend wire only, and runs only where a matching image exists.
    existing unit collection's process-global stubs. Inside it, tests receive
    the actual app, not an HTTP proxy or serialized substitute. Add further
    real-app cases to `cases.py`, requesting `real_app` and using
-   `real_app.test_client()`. The child has five tests; the outer process has
-   two tests. `cases.py` deliberately does not match automatic discovery.
+   `real_app.test_client()`; cases that need the Kobo blueprints request
+   `kobo_real_app` instead and live in their own module (section 5), because
+   `cps` refuses a second boot in one interpreter. The `cases.py` child has
+   five tests; its outer process has two tests. Neither case module matches
+   automatic discovery: each is named explicitly by its outer module.
 
 2. **Blueprint requests — OBSERVED; parity — UNVERIFIED.** `cases.py:88`
    derives probes from `app.blueprints` and `app.url_map`. It selects a
    reachable rule, accounting for rules shadowed by earlier blueprints.
-   Observed: 34 registered blueprints, 33 HTTP probes — with the shipped defaults. Four more (`kobo`, `kobo_auth`, `readingservices_api_v3`, `readingservices_userstorage`) register only when `kobo_available` holds (`cps/main.py:124`) and are outside this fixture's reach; `blueprints.json` lists them so the gap is visible rather than silent. `jinjia` has no routes;
+   Observed: 34 registered blueprints, 33 HTTP probes — with the shipped defaults. Four more (`kobo`, `kobo_auth`, `readingservices_api_v3`, `readingservices_userstorage`) register only when `kobo_available` holds (`cps/main.py:124`), so they are outside *this* boot's reach; `blueprints.json` lists them so the gap is visible rather than silent, and the second boot in section 5 reaches them. `jinjia` has no routes;
    its real template filter is exercised instead. An unknown routeless
    blueprint fails explicitly. OAuth probes use credential-free callbacks,
    without following provider redirects. These are anonymous smoke requests,
@@ -153,10 +158,69 @@ backend wire only, and runs only where a matching image exists.
    unavailable daemon. Earlier exploratory failures were not counted as
    successful repetitions. Full fast-lane execution on Linux is unverified.
 
+5. **Kobo authority and containment — OBSERVED (P1.kobo).** Three properties
+   of the owned-annotation route were asserted by the code and had never been
+   observed on the route itself. Six earlier attempts reported NOT_RUN or FAIL
+   with the product behaving correctly, and the reason is recorded here so it
+   is not rediscovered a seventh time: **the shipped fixture cannot reach any
+   of them, because with `config_kobo_sync` false `cps/main.py:130` never
+   registers `readingservices_api_v3`, so `/api/v3/content/<id>/annotations`
+   answers 404 whatever the databases hold.** `conftest.py:94`'s
+   `kobo_real_app` writes that switch before the factory runs and asserts the
+   effective value afterwards, so a boot that silently lost the blueprints
+   fails at the fixture rather than in a case.
+
+   `kobo_authority_cases.py` drives an authenticated Kobo GET, against a book
+   whose `KoboAnnotationBookState` is `ever_authoritative`, into each of the
+   three ETag-emitting sticky exits of `_owned_annotation_get_response`. Each
+   case reads the gate *before* asserting on the response, and each exit is
+   identified by behaviour rather than by a line number:
+
+   | Exit | How it is forced | How it is told apart | ETag observed |
+   |---|---|---|---|
+   | `answered_from_snapshot` (`readingservices.py:849`) | a GET with no device id, so `prepare_authoritative_device_get` matches no `Device` row and answers `STICKY_GET_SNAPSHOT` | the body is the stored snapshot and omits a highlight added after it; `authority_revision` and `last_served_body_sha256` do not move | `cwng_revision`, equal to the stored `last_served_etag` |
+   | `answered_locally` (`readingservices.py:905`) | a GET with the registered device id plus one accepted `routing_only` seed capture | the body carries the live row and the render is committed: `etag_kind`, `current_etag`, `last_served_*` all advance | `cwng_revision`, freshly built by `_commit_complete_render` |
+   | sticky exception fallback (`readingservices.py:948`) | a book with no durable snapshot, so the control request 503s, then the pre-serve proof raises | a 200 is only reachable through the route's `except`; the collected log record carries that exact exception | `cwng_revision`, rebuilt live |
+
+   All three produced the **durable** `cwng_revision` form. The transient form
+   (`kobo_annotation_authority.py:326`) was NOT exercised: it needs
+   `_book_state` to fail or to reject the content id, which an owned book with
+   a healthy app.db does not do.
+
+   `kobo_containment_cases.py` observes the second property at the trigger
+   boundary rather than by calling the predicate. `handle_check_for_changes`
+   is driven twice with the same id: with the library readable the id is
+   provably not ours and is forwarded (1 proxy call, and it comes back in the
+   device's change list); with `metadata.db` emptied the same id resolves to
+   `OWNERSHIP_UNKNOWN` and is suppressed (0 proxy calls, `[]` returned). That
+   is `_check_for_changes_ownership_is_filtered` (`readingservices.py:515`)
+   treating UNKNOWN as owned so a database outage cannot let Nickel's
+   replacement-set GET delete the reader's only copy of a highlight. That
+   module runs in its own interpreter because the outage is process-wide and
+   the calibre engine does not come back from it cleanly.
+
+   The third property is reported as a measurement: over **12** identical
+   authenticated GETs for one book in one session, `resolve_entitlement_ownership`
+   returned the same answer every time — distinct set `[('owned', <book id>)]`,
+   all twelve responses 200, zero proxy calls.
+
+   `test_real_app_kobo.py` pins the expected pass count per module. A case
+   that stops being collected, or skips, is a failure there — the specific way
+   the earlier attempts reported a result without observing anything.
+
 Changed-file reconciliation against `origin/main`:
 
-- `tests/integration/real_app/conftest.py`: real-app fixture and teardown.
+- `tests/integration/real_app/conftest.py`: real-app fixture and teardown, in
+  two boots (shipped defaults, and Kobo sync on) sharing one boot recipe.
 - `tests/integration/real_app/cases.py`: five isolated runtime cases.
+- `tests/integration/real_app/kobo_fixture.py`: synthetic seeding helpers for
+  the Kobo cases, and the CWNG ETag shape.
+- `tests/integration/real_app/kobo_authority_cases.py`: the three sticky ETag
+  exits and the ownership-determinism measurement.
+- `tests/integration/real_app/kobo_containment_cases.py`: the check-for-changes
+  containment of `OWNERSHIP_UNKNOWN`, in its own interpreter.
+- `tests/integration/test_real_app_kobo.py`: lane entry and per-module
+  expected pass counts for the two Kobo case modules.
 - `tests/integration/real_app/blueprints.json`: the pinned blueprint list, split
   into unconditional and conditional. The only artifact here that does not come
   from the app itself, and the only thing that can notice a blueprint vanishing.

--- a/tests/integration/real_app/README.md
+++ b/tests/integration/real_app/README.md
@@ -212,8 +212,18 @@ the conditional Kobo blueprints exist (section 5).
    reference `cps/readingservices.py` or
    `cps/services/kobo_annotation_authority.py` were re-run (clean baseline: all
    green). Dropping the ETag on the **`answered_locally`** exit is caught — 5
-   failures, all in `test_1923_owned_annotations_local_authority.py`, which
-   reaches that same exit on the *pre-authority* path. Dropping it on the
+   failures, split across **two** files that reach that same exit on the
+   *pre-authority* path: two in `test_1923_owned_annotations_local_authority.py`
+   (`test_owned_get_is_full_200_raw_exact_if_none_match_ignored_and_etag_moves`,
+   `test_owned_get_survives_normalized_book_state_insert_integrity_error`) and
+   three in `test_1942_seed_pipeline.py`
+   (`test_local_get_ignores_if_none_match_and_never_returns_304`,
+   `test_prior_cwng_etag_on_authoritative_book_returns_current_local_set_200_never_proxy`,
+   `test_dual_live_query_failure_serves_exact_last_complete_snapshot`). The node
+   ids come from a `-rf` run; an earlier revision of this paragraph attributed
+   all five to `test_1923` alone, which was inferred from a failure *count*
+   rather than read from a FAILED list, and was wrong. Anyone minimising this
+   suite must treat all five as guards on that exit. Dropping it on the
    **`answered_from_snapshot`** exit is not: **435 passed, 1 skipped, 0 failed**.
    Nothing in the old suite names `prepare_authoritative_device_get` or
    `STICKY_GET_SNAPSHOT`, and nothing constructs an ever-authoritative book whose

--- a/tests/integration/real_app/README.md
+++ b/tests/integration/real_app/README.md
@@ -159,16 +159,19 @@ the conditional Kobo blueprints exist (section 5).
    successful repetitions. Full fast-lane execution on Linux is unverified.
 
 5. **Kobo authority and containment — OBSERVED (P1.kobo).** Three properties
-   of the owned-annotation route were asserted by the code and had never been
-   observed on the route itself. Six earlier attempts reported NOT_RUN or FAIL
-   with the product behaving correctly, and the reason is recorded here so it
-   is not rediscovered a seventh time: **the shipped fixture cannot reach any
-   of them, because with `config_kobo_sync` false `cps/main.py:130` never
-   registers `readingservices_api_v3`, so `/api/v3/content/<id>/annotations`
-   answers 404 whatever the databases hold.** `conftest.py:94`'s
-   `kobo_real_app` writes that switch before the factory runs and asserts the
-   effective value afterwards, so a boot that silently lost the blueprints
-   fails at the fixture rather than in a case.
+   of the owned-annotation route had never been observed on the running
+   application: every prior test of them drives `handle_annotations.__wrapped__`
+   directly, with ownership monkeypatched, the device id assigned by hand and an
+   in-memory session. Six earlier attempts to observe them on the application
+   reported NOT_RUN or FAIL with the product behaving correctly, and the reason
+   is recorded here so it is not rediscovered a seventh time: **the shipped
+   fixture cannot reach any of them, because with `config_kobo_sync` false
+   `cps/main.py:130` never registers `readingservices_api_v3`, so
+   `/api/v3/content/<id>/annotations` answers 404 whatever the databases hold.**
+   `conftest.py:103`'s `kobo_real_app` writes that switch before the factory
+   runs, then asserts the blueprint *and* the URL rule in both directions, so a
+   boot that silently lost the surface fails at the fixture instead of looking,
+   from inside a case, like a product that refused to answer.
 
    `kobo_authority_cases.py` drives an authenticated Kobo GET, against a book
    whose `KoboAnnotationBookState` is `ever_authoritative`, into each of the
@@ -203,6 +206,23 @@ the conditional Kobo blueprints exist (section 5).
    authenticated GETs for one book in one session, `resolve_entitlement_ownership`
    returned the same answer every time — distinct set `[('owned', <book id>)]`,
    all twelve responses 200, zero proxy calls.
+
+   **What the pre-existing suite could and could not see — MEASURED.** Each
+   defect below was planted on `origin/main` and the 436 pre-existing tests that
+   reference `cps/readingservices.py` or
+   `cps/services/kobo_annotation_authority.py` were re-run (clean baseline: all
+   green). Dropping the ETag on the **`answered_locally`** exit is caught — 5
+   failures, all in `test_1923_owned_annotations_local_authority.py`, which
+   reaches that same exit on the *pre-authority* path. Dropping it on the
+   **`answered_from_snapshot`** exit is not: **435 passed, 1 skipped, 0 failed**.
+   Nothing in the old suite names `prepare_authoritative_device_get` or
+   `STICKY_GET_SNAPSHOT`, and nothing constructs an ever-authoritative book whose
+   device proof is missing. So the new value here is uneven and worth stating
+   plainly: for `answered_locally` it is the *real application* (a real login
+   session, the auth decorator, device registration from request headers,
+   metadata.db ownership, the full response pipeline) rather than a new branch;
+   for `answered_from_snapshot` and the exception fallback it is the branch
+   itself.
 
    `test_real_app_kobo.py` pins the expected pass count per module. A case
    that stops being collected, or skips, is a failure there — the specific way

--- a/tests/integration/real_app/conftest.py
+++ b/tests/integration/real_app/conftest.py
@@ -7,8 +7,19 @@ import sys
 import pytest
 
 
-@pytest.fixture(scope="session")
-def real_app(tmp_path_factory):
+def _boot_real_app(tmp_path_factory, *, kobo_sync):
+    """Boot one real application in this interpreter and yield it.
+
+    ``kobo_sync`` is written to the stored settings *before* the application
+    factory runs, because ``cps/main.py:124`` registers the ``kobo``,
+    ``kobo_auth``, ``readingservices_api_v3`` and ``readingservices_userstorage``
+    blueprints only when ``config.config_kobo_sync`` is true at registration
+    time (``cps/kobo.py:1164``). A fixture booted with the shipped defaults
+    therefore has no ``/api/v3/content/<id>/annotations`` rule at all, and an
+    authenticated Kobo request against it answers 404 no matter what state the
+    databases hold. ``blueprints.json`` records the same four names as
+    conditional for exactly this reason.
+    """
     assert "cps" not in sys.modules, "Run these cases in a fresh interpreter"
     root = tmp_path_factory.mktemp("real-app")
     for name in ("config", "library", "ingest", "conversion", "tmp"):
@@ -42,6 +53,9 @@ def real_app(tmp_path_factory):
         cps.config_sql.load_configuration(cps.ub.session, key)
         settings = cps.ub.session.query(cps.config_sql._Settings).one()
         settings.config_calibre_dir = str(root / "library")
+        if kobo_sync:
+            settings.config_kobo_sync = True
+            settings.config_kobo_two_way_annotation_sync = True
         cps.ub.session.commit()
 
         assert not cps.updater_thread.is_alive()
@@ -52,6 +66,11 @@ def real_app(tmp_path_factory):
         try:
             app = cps.create_app(cps.config, services)
             register_blueprints(app)
+            # create_app reloads the configuration object from storage, so this
+            # asserts the *effective* switch the blueprint gate reads rather
+            # than the row that was written above.
+            assert bool(cps.config.config_kobo_sync) == kobo_sync
+            app.config["CWA_TEST_ROOT"] = str(root)
             yield app
         finally:
             cps.updater_thread.stop()
@@ -64,3 +83,14 @@ def real_app(tmp_path_factory):
             if scheduler is not None:
                 assert not scheduler.scheduler.running
             print("LIFECYCLE teardown: updater_alive=False scheduler_running=False")
+
+
+@pytest.fixture(scope="session")
+def real_app(tmp_path_factory):
+    yield from _boot_real_app(tmp_path_factory, kobo_sync=False)
+
+
+@pytest.fixture(scope="session")
+def kobo_real_app(tmp_path_factory):
+    """The same real application, booted with the Kobo blueprints registered."""
+    yield from _boot_real_app(tmp_path_factory, kobo_sync=True)

--- a/tests/integration/real_app/conftest.py
+++ b/tests/integration/real_app/conftest.py
@@ -70,6 +70,15 @@ def _boot_real_app(tmp_path_factory, *, kobo_sync):
             # asserts the *effective* switch the blueprint gate reads rather
             # than the row that was written above.
             assert bool(cps.config.config_kobo_sync) == kobo_sync
+            # And assert the surface, not only the switch. A Kobo boot whose
+            # reading-services blueprint failed to register answers 404 to every
+            # annotation request no matter what the databases hold, which is
+            # indistinguishable, from inside a case, from a product that refused
+            # to answer. Fail here instead.
+            assert ("readingservices_api_v3" in app.blueprints) == kobo_sync, sorted(
+                app.blueprints)
+            assert any(rule.rule == "/api/v3/content/<entitlement_id>/annotations"
+                       for rule in app.url_map.iter_rules()) == kobo_sync
             app.config["CWA_TEST_ROOT"] = str(root)
             yield app
         finally:

--- a/tests/integration/real_app/kobo_authority_cases.py
+++ b/tests/integration/real_app/kobo_authority_cases.py
@@ -1,0 +1,299 @@
+"""Explicitly invoked in isolation by tests/integration/test_real_app_kobo.py.
+
+Three properties of the owned-annotation GET are asserted by the code and have
+never been observed on the route: which of ``_owned_annotation_get_response``'s
+sticky exits emits an ``ETag``, and what that header actually looks like. All
+three exits live behind ``ever_authoritative``, which the shipped fixture never
+reaches, so each case below first drives the application into the sticky state
+and proves it is there before asserting anything about the response.
+"""
+import pytest
+
+import kobo_fixture as fixture
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(scope="module")
+def reader(kobo_real_app):
+    """One secondary account, authenticated once, shared by every case here."""
+    user_id = fixture.create_reader()
+    return user_id, fixture.login(kobo_real_app.test_client())
+
+
+def test_sticky_local_render_answers_with_a_durable_cwng_etag(
+    kobo_real_app, reader, record_property,
+):
+    """The live-render sticky exit stamps CWNG's own replacement-set ETag.
+
+    Intent: once CWNG has ever been authoritative for a book, an owned GET that
+    still has live device proof answers from the local set and labels those
+    exact bytes with a durable ``cwng_revision`` ETag, so the device can
+    recognise the same replacement set later.
+    Path: an authenticated Kobo GET with a registered device id, against a book
+    whose authority row is ``ever_authoritative`` and whose only accepted seed
+    capture is routing-only. That is the ``answered_locally`` exit at
+    cps/readingservices.py:905.
+    Breaks if: the exit stops setting ETag, sets a non-CWNG one, or stops
+    persisting the render (etag_kind/current_etag/last_served_* would not move).
+    """
+    user_id, client = reader
+    book = fixture.create_book("Fixture Book Alpha")
+    state = fixture.seed_authority_state(user_id, book)
+    fixture.seed_annotation(user_id, book, "alpha-highlight-1", "first synthetic highlight")
+    device_id = fixture.register_kobo_device(kobo_real_app, user_id)
+    fixture.seed_routing_only_capture(state.id, device_id)
+
+    # Prove the state before asserting on it. Six earlier attempts at this
+    # observation reported a green or absent result because the sticky branch
+    # never ran, which is indistinguishable from a passing assertion unless the
+    # gate itself is read first.
+    from cps.services.kobo_annotation_authority import (
+        AUTHORITY_EVER, STICKY_GET_LOCAL, ever_authoritative,
+        prepare_authoritative_device_get,
+    )
+    import cps.readingservices as readingservices
+
+    assert ever_authoritative(user_id, book.id) == AUTHORITY_EVER
+    assert prepare_authoritative_device_get(
+        user_id=user_id, book_id=book.id, device_id=device_id,
+        log=readingservices.log,
+    ) == STICKY_GET_LOCAL
+
+    with fixture.stubbed_kobo_proxy() as proxied:
+        with fixture.route_error_records() as records:
+            response = client.get(fixture.annotations_path(book),
+                                  headers=fixture.DEVICE_HEADERS)
+
+    assert response.status_code == 200, response.get_data()
+    assert proxied == [], "the sticky local exit must not contact Kobo"
+    assert [r for r in records if r.exc_info] == [], (
+        "the route's exception fallback ran; this is not the live-render exit")
+    etag = response.headers.get("ETag")
+    assert etag is not None, "the answered_locally exit emitted no ETag"
+    assert fixture.CWNG_ETAG.match(etag), etag
+    body = response.get_data()
+    assert b"alpha-highlight-1" in body
+
+    stored = fixture.reload_state(user_id, book.id)
+    assert stored.etag_kind == "cwng_revision"
+    assert stored.current_etag == etag
+    assert stored.authority_revision == 1
+    assert stored.last_served_etag == etag
+    assert stored.last_served_body_sha256 == fixture.body_digest(body)
+    record_property("p1_kobo_exit", "answered_locally (readingservices.py:905)")
+    record_property("p1_kobo_etag_kind", stored.etag_kind)
+    print("EXIT answered_locally etag_kind=%s etag=%s" % (stored.etag_kind, etag))
+
+
+def test_sticky_snapshot_exit_replays_the_stored_cwng_etag(
+    kobo_real_app, reader, record_property,
+):
+    """Without live device proof the sticky GET replays the durable snapshot.
+
+    Intent: an ever-authoritative book whose device proof is missing must be
+    answered from CWNG's last complete response -- never from Kobo's stale copy
+    and never from a partial live read -- carrying the ETag those exact bytes
+    were served with.
+    Path: a second authenticated GET for the same book sent without a device
+    id, so ``prepare_authoritative_device_get`` cannot match a device row and
+    answers ``STICKY_GET_SNAPSHOT``. That is the ``answered_from_snapshot``
+    exit at cps/readingservices.py:849.
+    Breaks if: the exit stops setting ETag, or answers from the live set --
+    a highlight added after the snapshot was stored would then appear.
+    """
+    user_id, client = reader
+    book = fixture.create_book("Fixture Book Beta")
+    state = fixture.seed_authority_state(user_id, book)
+    fixture.seed_annotation(user_id, book, "beta-highlight-1", "first synthetic highlight")
+    device_id = fixture.register_kobo_device(kobo_real_app, user_id)
+    fixture.seed_routing_only_capture(state.id, device_id)
+
+    # Setup, not the assertion: let the route itself commit the durable
+    # snapshot, so the bytes this case checks were written by the product and
+    # not by the test.
+    with fixture.stubbed_kobo_proxy():
+        seeding = client.get(fixture.annotations_path(book),
+                             headers=fixture.DEVICE_HEADERS)
+    assert seeding.status_code == 200, seeding.get_data()
+
+    # The live set now moves past the snapshot. A live render would include
+    # this row; the snapshot exit cannot.
+    fixture.seed_annotation(user_id, book, "beta-highlight-2", "second synthetic highlight")
+
+    import cps.readingservices as readingservices
+    from cps.services.kobo_annotation_authority import (
+        STICKY_GET_SNAPSHOT, load_last_served_complete_set,
+        prepare_authoritative_device_get,
+    )
+
+    stored_snapshot = load_last_served_complete_set(
+        user_id=user_id, book_id=book.id, log=readingservices.log,
+    )
+    assert stored_snapshot is not None, "no durable snapshot to replay"
+    snapshot_body, snapshot_etag = stored_snapshot
+    assert prepare_authoritative_device_get(
+        user_id=user_id, book_id=book.id, device_id=None,
+        log=readingservices.log,
+    ) == STICKY_GET_SNAPSHOT
+    before = fixture.reload_state(user_id, book.id)
+    revision_before = before.authority_revision
+    digest_before = before.last_served_body_sha256
+
+    with fixture.stubbed_kobo_proxy() as proxied:
+        with fixture.route_error_records() as records:
+            response = client.get(fixture.annotations_path(book))
+
+    assert response.status_code == 200, response.get_data()
+    assert proxied == [], "the sticky snapshot exit must not contact Kobo"
+    assert [r for r in records if r.exc_info] == [], (
+        "the route's exception fallback ran; this is not the snapshot exit")
+    etag = response.headers.get("ETag")
+    assert etag is not None, "the answered_from_snapshot exit emitted no ETag"
+    assert fixture.CWNG_ETAG.match(etag), etag
+    assert etag == snapshot_etag
+    body = response.get_data()
+    assert body == snapshot_body
+    assert b"beta-highlight-1" in body
+    assert b"beta-highlight-2" not in body, (
+        "the response contains a row added after the snapshot, so this was a "
+        "live render and not the snapshot exit")
+
+    after = fixture.reload_state(user_id, book.id)
+    assert after.authority_revision == revision_before
+    assert after.last_served_body_sha256 == digest_before
+    assert after.etag_kind == "cwng_revision"
+    record_property("p1_kobo_exit",
+                    "answered_from_snapshot (readingservices.py:849)")
+    record_property("p1_kobo_etag_kind", after.etag_kind)
+    print("EXIT answered_from_snapshot etag_kind=%s etag=%s"
+          % (after.etag_kind, etag))
+
+
+def test_sticky_exception_fallback_answers_with_a_cwng_etag_not_kobo(
+    kobo_real_app, reader, record_property,
+):
+    """A failure inside the sticky GET rebuilds locally instead of proxying.
+
+    Intent: once Kobo's cloud copy is stale by construction, an unexpected
+    failure while serving an owned GET must still answer with CWNG's complete
+    set and its own ETag. Falling back to the proxy would hand Nickel a stale
+    replacement set and delete the reader's only copy of newer highlights.
+    Path: an ever-authoritative book with *no* durable snapshot, so every
+    non-exception sticky exit answers 503 -- the control request below proves
+    that. With the pre-serve proof raising, the same request answers 200, which
+    can only be the exception fallback at cps/readingservices.py:948.
+    Breaks if: that fallback stops setting ETag, stops rebuilding, or proxies.
+    """
+    user_id, client = reader
+    book = fixture.create_book("Fixture Book Gamma")
+    fixture.seed_authority_state(user_id, book)
+    fixture.seed_annotation(user_id, book, "gamma-highlight-1", "gamma synthetic highlight")
+
+    import cps.readingservices as readingservices
+    import cps.services.kobo_annotation_authority as authority
+
+    assert authority.load_last_served_complete_set(
+        user_id=user_id, book_id=book.id, log=readingservices.log,
+    ) is None, "this case needs a book with no durable snapshot"
+
+    # Control: without a failure, this exact request is a 503. Any later 200
+    # therefore cannot have come from the snapshot or live-render exits.
+    with fixture.stubbed_kobo_proxy() as proxied:
+        control = client.get(fixture.annotations_path(book))
+    assert control.status_code == 503, control.get_data()
+    assert control.headers.get("ETag") is None
+    assert proxied == []
+
+    injected = RuntimeError("synthetic pre-serve proof failure")
+
+    def raising_pre_serve(**_kwargs):
+        raise injected
+
+    original = authority.prepare_authoritative_device_get
+    authority.prepare_authoritative_device_get = raising_pre_serve
+    try:
+        with fixture.stubbed_kobo_proxy() as proxied:
+            with fixture.route_error_records() as records:
+                response = client.get(fixture.annotations_path(book))
+    finally:
+        authority.prepare_authoritative_device_get = original
+
+    assert response.status_code == 200, response.get_data()
+    assert proxied == [], "the exception fallback must not contact Kobo"
+    raised = [r for r in records if r.exc_info and r.exc_info[1] is injected]
+    assert raised, "the route's exception fallback did not run"
+    etag = response.headers.get("ETag")
+    assert etag is not None, "the sticky exception fallback emitted no ETag"
+    assert fixture.CWNG_ETAG.match(etag), etag
+    body = response.get_data()
+    assert b"gamma-highlight-1" in body
+
+    stored = fixture.reload_state(user_id, book.id)
+    assert stored.etag_kind == "cwng_revision"
+    assert stored.current_etag == etag
+    assert stored.last_served_body_sha256 == fixture.body_digest(body)
+    record_property("p1_kobo_exit",
+                    "sticky exception fallback (readingservices.py:948)")
+    record_property("p1_kobo_etag_kind", stored.etag_kind)
+    print("EXIT sticky_exception_fallback etag_kind=%s etag=%s"
+          % (stored.etag_kind, etag))
+
+
+OWNERSHIP_SAMPLES = 12
+
+
+def test_ownership_resolution_is_stable_across_identical_requests(
+    kobo_real_app, reader, record_property,
+):
+    """Identical authenticated GETs must resolve one book the same way.
+
+    Intent: ownership decides whether an annotation GET is answered locally or
+    forwarded to Kobo. If the same book resolved differently between two
+    identical requests, the same device would be served CWNG's set and Kobo's
+    stale set in turn, and the replacement-set semantics would delete rows.
+    Path: OWNERSHIP_SAMPLES identical authenticated GETs for one seeded owned
+    book, recording what ``resolve_entitlement_ownership`` returned each time.
+    Breaks if: the resolution flaps -- an intermittently failing metadata.db
+    lookup would show up as ``unknown`` interleaved with ``owned``.
+    """
+    user_id, client = reader
+    book = fixture.create_book("Fixture Book Delta")
+    state = fixture.seed_authority_state(user_id, book)
+    fixture.seed_annotation(user_id, book, "delta-highlight-1", "delta synthetic highlight")
+    device_id = fixture.register_kobo_device(kobo_real_app, user_id)
+    fixture.seed_routing_only_capture(state.id, device_id)
+
+    import cps.readingservices as readingservices
+
+    resolutions = []
+    statuses = []
+    original = readingservices.resolve_entitlement_ownership
+
+    def recording(entitlement_id):
+        result = original(entitlement_id)
+        resolutions.append((
+            readingservices._capture_ownership_label(result),
+            getattr(result, "id", None),
+        ))
+        return result
+
+    readingservices.resolve_entitlement_ownership = recording
+    try:
+        with fixture.stubbed_kobo_proxy() as proxied:
+            for _ in range(OWNERSHIP_SAMPLES):
+                statuses.append(client.get(
+                    fixture.annotations_path(book),
+                    headers=fixture.DEVICE_HEADERS,
+                ).status_code)
+    finally:
+        readingservices.resolve_entitlement_ownership = original
+
+    assert len(resolutions) == OWNERSHIP_SAMPLES, resolutions
+    distinct = sorted(set(resolutions))
+    record_property("p1_kobo_ownership_samples", OWNERSHIP_SAMPLES)
+    record_property("p1_kobo_ownership_distinct", repr(distinct))
+    print("OWNERSHIP n=%d distinct=%r statuses=%r proxied=%d"
+          % (OWNERSHIP_SAMPLES, distinct, sorted(set(statuses)), len(proxied)))
+    assert distinct == [("owned", book.id)], distinct
+    assert set(statuses) == {200}, statuses

--- a/tests/integration/real_app/kobo_authority_cases.py
+++ b/tests/integration/real_app/kobo_authority_cases.py
@@ -271,11 +271,16 @@ def test_ownership_resolution_is_stable_across_identical_requests(
     original = readingservices.resolve_entitlement_ownership
 
     def recording(entitlement_id):
+        # Classify here rather than through the product's own labeller: if that
+        # helper ever collapsed UNKNOWN into "unowned", this measurement would
+        # quietly stop being able to see a flapping lookup.
         result = original(entitlement_id)
-        resolutions.append((
-            readingservices._capture_ownership_label(result),
-            getattr(result, "id", None),
-        ))
+        if result is readingservices.OWNERSHIP_UNKNOWN:
+            resolutions.append(("unknown", None))
+        elif result is None:
+            resolutions.append(("unowned", None))
+        else:
+            resolutions.append(("owned", result.id))
         return result
 
     readingservices.resolve_entitlement_ownership = recording

--- a/tests/integration/real_app/kobo_containment_cases.py
+++ b/tests/integration/real_app/kobo_containment_cases.py
@@ -74,6 +74,10 @@ def test_unknown_ownership_is_contained_at_the_check_for_changes_boundary(
     # route that never ran.
     resolved = readingservices.resolve_entitlement_ownership(UNOWNED_CONTENT_ID)
     assert resolved is readingservices.OWNERSHIP_UNKNOWN, resolved
+    # The outage is the whole lookup, not something about this one id: the book
+    # that resolved a moment ago is now equally undecidable.
+    assert readingservices.resolve_entitlement_ownership(
+        owned_book.uuid) is readingservices.OWNERSHIP_UNKNOWN
 
     with fixture.stubbed_kobo_proxy(echo=True) as proxied:
         outage = _post_check_for_changes(client, [UNOWNED_CONTENT_ID])

--- a/tests/integration/real_app/kobo_containment_cases.py
+++ b/tests/integration/real_app/kobo_containment_cases.py
@@ -1,0 +1,108 @@
+"""Explicitly invoked in isolation by tests/integration/test_real_app_kobo.py.
+
+This module runs in its own interpreter because it takes the library database
+away mid-session, and the calibre engine does not come back cleanly from that
+inside one process. Isolating the outage is also the honest shape: a broken
+metadata.db is a process-wide fault, and letting it leak into other cases would
+make their results say something other than what they claim.
+"""
+import json
+
+import pytest
+
+import kobo_fixture as fixture
+
+pytestmark = pytest.mark.integration
+
+# In the documentation range (RFC 9562 style random v4), deliberately absent
+# from the fixture library so the live lookup answers "not ours".
+UNOWNED_CONTENT_ID = "5f2b8c14-9d3e-4a71-b0c6-7e18d4a52f93"
+
+
+def _post_check_for_changes(client, content_ids):
+    body = json.dumps([{"ContentId": value} for value in content_ids]).encode()
+    return client.post(
+        "/api/v3/content/checkforchanges", data=body,
+        content_type="application/json", headers=fixture.DEVICE_HEADERS,
+    )
+
+
+def test_unknown_ownership_is_contained_at_the_check_for_changes_boundary(
+    kobo_real_app, record_property,
+):
+    """A library-database outage suppresses Kobo's change trigger, not the data.
+
+    Intent: ``_check_for_changes_ownership_is_filtered``
+    (cps/readingservices.py:515) deliberately treats OWNERSHIP_UNKNOWN as owned.
+    Nickel answers a "this content changed" reply with a replacement-set
+    annotation GET, so forwarding an id whose ownership could not be determined
+    risks deleting the reader's only copy of a highlight. Suppressing the id
+    only costs a delayed cloud sync.
+    Path: ``handle_check_for_changes`` (cps/readingservices.py:1509) driven
+    twice with the same id -- once with the library readable, once after
+    metadata.db has been emptied so the real ownership query raises and
+    ``resolve_entitlement_ownership`` answers OWNERSHIP_UNKNOWN. The predicate
+    is never called directly; only the trigger boundary is observed.
+    Breaks if: UNKNOWN stops being contained -- the id would be forwarded to
+    Kobo and returned to the device exactly as in the healthy control.
+    """
+    user_id = fixture.create_reader()
+    client = fixture.login(kobo_real_app.test_client())
+    # A real library row, so the outage below is the only reason any lookup
+    # can fail and the control request is answered by a working database.
+    owned_book = fixture.create_book("Fixture Book Epsilon")
+    fixture.register_kobo_device(kobo_real_app, user_id)
+
+    import cps.readingservices as readingservices
+
+    assert readingservices.resolve_entitlement_ownership(owned_book.uuid) is not None
+    assert readingservices.resolve_entitlement_ownership(UNOWNED_CONTENT_ID) is None
+
+    # Control: with the library readable this id is provably not ours, so it is
+    # forwarded and comes back in the device's change list.
+    with fixture.stubbed_kobo_proxy(echo=True) as proxied:
+        healthy = _post_check_for_changes(client, [UNOWNED_CONTENT_ID])
+    assert healthy.status_code == 200, healthy.get_data()
+    assert len(proxied) == 1, proxied
+    assert UNOWNED_CONTENT_ID.encode() in proxied[0]
+    assert healthy.get_json() == [{"ContentId": UNOWNED_CONTENT_ID}]
+
+    _break_the_library(kobo_real_app)
+
+    # Prove the state this case is about was actually constructed. Without
+    # this, an assertion that nothing was proxied is equally satisfied by a
+    # route that never ran.
+    resolved = readingservices.resolve_entitlement_ownership(UNOWNED_CONTENT_ID)
+    assert resolved is readingservices.OWNERSHIP_UNKNOWN, resolved
+
+    with fixture.stubbed_kobo_proxy(echo=True) as proxied:
+        outage = _post_check_for_changes(client, [UNOWNED_CONTENT_ID])
+    assert outage.status_code == 200, outage.get_data()
+    assert proxied == [], (
+        "an id of unknown ownership was forwarded to Kobo during a database "
+        "outage; the reply drives a destructive annotation GET")
+    assert outage.get_json() == []
+    record_property("p1_kobo_containment", "OWNERSHIP_UNKNOWN suppressed")
+    print("CONTAINMENT healthy_proxied=1 outage_proxied=0 outage_body=%r"
+          % outage.get_data())
+
+
+def _break_the_library(app):
+    """Empty metadata.db and force the next query onto the emptied file.
+
+    This models a library volume that is present but no longer carries the
+    database -- the outage class the containment comment names. The engine is
+    disposed first so the pooled connection cannot keep serving the old file,
+    and nothing is restored: this process is disposable.
+    """
+    from pathlib import Path
+
+    from cps import calibre_db
+    from cps.db import CalibreDB
+
+    metadata = Path(app.config["CWA_TEST_ROOT"]) / "library" / "metadata.db"
+    assert metadata.is_file() and metadata.stat().st_size > 0
+    calibre_db.session.close()
+    CalibreDB.engine.dispose()
+    metadata.write_bytes(b"")
+    assert metadata.stat().st_size == 0

--- a/tests/integration/real_app/kobo_fixture.py
+++ b/tests/integration/real_app/kobo_fixture.py
@@ -1,0 +1,240 @@
+"""Seeding helpers for the Kobo cases that run against the real application.
+
+Every identifier here is synthetic. Nothing in this file, or in anything it
+writes, names a real reader, device, host or book.
+
+These helpers deliberately build state with the *product's own* writers where
+one exists (``register_kobo_device_best_effort`` for the device row, the route
+itself for the durable annotation snapshot). A snapshot hand-written by the
+test would let a test assert the bytes the test itself authored; a snapshot the
+route committed is evidence about the route.
+"""
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import logging
+import re
+import uuid
+from datetime import datetime, timezone
+
+# ``W/"CWNG:<generation-uuid>:<revision>:<16 hex of the body digest>"`` --
+# built at cps/services/kobo_annotation_authority.py:1053 for the durable
+# ``cwng_revision`` form and :326 for the transient form. Both share this
+# shape, so matching it proves the header is CWNG's replacement-set ETag and
+# not, say, a passed-through Kobo manifest ETag.
+CWNG_ETAG = re.compile(
+    r'^W/"CWNG:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}'
+    r'-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}:[0-9]+:[0-9a-f]{16}"$'
+)
+
+READER_NAME = "fixture-reader"
+READER_PASSWORD = "fixture-reader-passphrase"
+# cps/services/device_registry.py:60 accepts a Kobo device id only as 64 hex
+# characters, so a readable placeholder string is silently ignored and no
+# device row is ever created.
+DEVICE_RAW_ID = "a1" * 32
+DEVICE_HEADERS = {
+    "x-kobo-deviceid": DEVICE_RAW_ID,
+    "x-kobo-devicemodel": "synthetic-reader",
+}
+
+
+def create_reader():
+    """Create the secondary account these cases authenticate as."""
+    import cps
+    from cps import constants, ub
+
+    user = ub.User()
+    user.name = READER_NAME
+    user.email = "%s@example.invalid" % READER_NAME
+    user.role = constants.ROLE_USER
+    user.password = ub.generate_password_hash(READER_PASSWORD)
+    ub.session.add(user)
+    ub.session.commit()
+    assert user.id is not None
+    return user.id
+
+
+def login(client):
+    """Authenticate ``client`` through the real login form and CSRF token."""
+    page = client.get("/login")
+    assert page.status_code == 200, page.status_code
+    token = re.search(
+        r'name="csrf_token"[^>]*value="([^"]+)"', page.get_data(as_text=True),
+    )
+    assert token, "login form served no csrf token"
+    response = client.post(
+        "/login",
+        data={"username": READER_NAME, "password": READER_PASSWORD,
+              "csrf_token": token.group(1)},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302, response.status_code
+    return client
+
+
+def create_book(title):
+    """Insert one synthetic library row and return it with its calibre uuid."""
+    from cps import calibre_db, db
+
+    now = datetime.now(timezone.utc)
+    book = db.Books(title, title, "Fixture Author", now, now, "1.0", now,
+                    "Fixture/%s" % title, None, [], [])
+    calibre_db.session.add(book)
+    calibre_db.session.commit()
+    book_id = book.id
+    # metadata.db's books_insert_trg rewrites sort and uuid after the INSERT,
+    # so the identity this fixture addresses has to be re-read, not assumed.
+    calibre_db.session.expire_all()
+    book = calibre_db.session.query(db.Books).filter_by(id=book_id).one()
+    assert book.uuid, "calibre did not assign a uuid"
+    return book
+
+
+def register_kobo_device(app, user_id):
+    """Register the Kobo device through the product's own registry writer."""
+    from cps import ub
+    from cps.services.device_registry import register_kobo_device_best_effort
+
+    with app.app_context():
+        device_id = register_kobo_device_best_effort(
+            user_id=user_id, headers=DEVICE_HEADERS,
+            secret_key=app.secret_key, return_internal=True,
+        )
+    assert device_id is not None, "the device registry refused the fixture id"
+    device = ub.session.query(ub.Device).filter_by(id=device_id).one()
+    assert (device.user_id, device.kind) == (user_id, "kobo")
+    return device_id
+
+
+def seed_authority_state(user_id, book, *, ever_authoritative=True):
+    """Create the per-book authority row without any durable snapshot."""
+    from cps import ub
+
+    state = ub.KoboAnnotationBookState(
+        user_id=user_id,
+        book_id=book.id,
+        content_id=book.uuid.casefold(),
+        authority_status="authoritative" if ever_authoritative else "unseeded",
+        authority_revision=0,
+        ever_authoritative=ever_authoritative,
+        generation_id=str(uuid.uuid4()),
+        opaque_content_status="absent",
+        seeded_at=datetime.now(timezone.utc),
+    )
+    ub.session.add(state)
+    ub.session.commit()
+    return state
+
+
+def seed_annotation(user_id, book, annotation_id, text):
+    """Add one visible highlight to the local monotonic set."""
+    from cps import ub
+
+    annotation = ub.Annotation(
+        user_id=user_id,
+        book_id=book.id,
+        annotation_id=annotation_id,
+        source="kobo",
+        annotation_type="highlight",
+        highlighted_text=text,
+        content_id="%s!!OEBPS/chapter.xhtml" % book.uuid,
+        hidden=False,
+    )
+    ub.session.add(annotation)
+    ub.session.commit()
+    return annotation
+
+
+def seed_routing_only_capture(state_id, device_id):
+    """Accepted device evidence that carries no upstream capture.
+
+    ``prepare_authoritative_device_get`` (kobo_annotation_authority.py:595)
+    answers ``STICKY_GET_LOCAL`` for an ever-authoritative book as soon as this
+    device has an accepted capture and none of them came from upstream.
+    """
+    from cps import ub
+
+    now = datetime.now(timezone.utc)
+    capture = ub.KoboAnnotationSeedCapture(
+        book_state_id=state_id, device_id=device_id,
+        started_at=now, completed_at=now, result="accepted",
+        seed_kind="routing_only", annotation_count=0,
+    )
+    ub.session.add(capture)
+    ub.session.commit()
+    return capture
+
+
+def reload_state(user_id, book_id):
+    """Re-read the authority row from storage, not from the identity map."""
+    from cps import ub
+
+    ub.session.expire_all()
+    return (
+        ub.session.query(ub.KoboAnnotationBookState)
+        .filter_by(user_id=user_id, book_id=book_id)
+        .one()
+    )
+
+
+def annotations_path(book):
+    return "/api/v3/content/%s/annotations" % book.uuid
+
+
+@contextlib.contextmanager
+def stubbed_kobo_proxy(*, echo=False):
+    """Replace the only outbound sink and record what would have been sent.
+
+    Yields the list of proxied request bodies. An empty list is the evidence
+    that a request was answered without contacting Kobo at all. With
+    ``echo=True`` the stub answers with the body it was handed, which is the
+    shape of a Kobo check-for-changes reply that calls every submitted id
+    changed -- the reply that makes Nickel issue the destructive GET.
+    """
+    import cps.readingservices as readingservices
+    from flask import make_response
+
+    calls = []
+    original = readingservices.proxy_to_kobo_reading_services
+
+    def stub(*args, **kwargs):
+        data = kwargs.get("data")
+        calls.append(data)
+        body = data if (echo and data is not None) else b"[]"
+        return make_response(body, 200, {"Content-Type": "application/json"})
+
+    readingservices.proxy_to_kobo_reading_services = stub
+    try:
+        yield calls
+    finally:
+        readingservices.proxy_to_kobo_reading_services = original
+
+
+@contextlib.contextmanager
+def route_error_records():
+    """Collect ERROR+ records from the reading-services route logger.
+
+    The route's exception fallback is the only sticky exit that logs at ERROR
+    (``log.exception`` at cps/readingservices.py:908), so the presence or
+    absence of a record is what separates the exception exit from the two
+    ordinary ones.
+    """
+    records = []
+
+    class _Collector(logging.Handler):
+        def emit(self, record):
+            records.append(record)
+
+    handler = _Collector(level=logging.ERROR)
+    logger = logging.getLogger("cps.readingservices")
+    logger.addHandler(handler)
+    try:
+        yield records
+    finally:
+        logger.removeHandler(handler)
+
+
+def body_digest(body):
+    return hashlib.sha256(body).hexdigest()

--- a/tests/integration/real_app/kobo_fixture.py
+++ b/tests/integration/real_app/kobo_fixture.py
@@ -42,7 +42,6 @@ DEVICE_HEADERS = {
 
 def create_reader():
     """Create the secondary account these cases authenticate as."""
-    import cps
     from cps import constants, ub
 
     user = ub.User()

--- a/tests/integration/test_real_app_kobo.py
+++ b/tests/integration/test_real_app_kobo.py
@@ -1,0 +1,47 @@
+"""Keep production globals and live runtime threads out of the collecting process.
+
+The Kobo cases need an application booted with ``config_kobo_sync`` on, because
+``cps/main.py:124`` registers the reading-services blueprints only when that
+switch is true at registration time. ``cps`` owns process state and refuses a
+second boot, so each case module runs in its own fresh interpreter exactly the
+way test_real_app.py runs the shared fixture's cases.
+"""
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+CASE_MODULES = ("kobo_authority_cases.py", "kobo_containment_cases.py")
+
+
+def _run_cases(module_name):
+    root = Path(__file__).resolve().parents[2]
+    suite = Path(__file__).with_name("real_app")
+    env = dict(os.environ, PYTHONPATH=str(root), PYTHONDONTWRITEBYTECODE="1")
+    budget = int(os.environ.get("CWA_TEST_KOBO_CASE_TIMEOUT", "300"))
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", str(suite / module_name),
+         "--confcutdir", str(suite), "-v", "-s", "--tb=long", "-rs"],
+        cwd=root, env=env, text=True, capture_output=True, timeout=budget,
+    )
+    print(result.stdout)
+    print(result.stderr[-4000:])
+    assert result.returncode == 0, result.stdout + result.stderr
+    # A case module that collected nothing exits 5, not 0, but a module whose
+    # cases were all skipped exits 0 with nothing observed. This slice exists
+    # because six earlier attempts reported a result that had asserted nothing,
+    # so an empty or skipped run is a failure here rather than a pass.
+    assert " skipped" not in result.stdout.splitlines()[-1], result.stdout
+    return result.stdout
+
+
+@pytest.mark.parametrize("module_name", CASE_MODULES)
+def test_kobo_authority_cases_in_fresh_process(module_name, record_property):
+    stdout = _run_cases(module_name)
+    passed = [line for line in stdout.splitlines() if " PASSED" in line]
+    record_property("kobo_cases_passed", len(passed))
+    assert passed, stdout

--- a/tests/integration/test_real_app_kobo.py
+++ b/tests/integration/test_real_app_kobo.py
@@ -8,6 +8,7 @@ way test_real_app.py runs the shared fixture's cases.
 """
 import os
 from pathlib import Path
+import re
 import subprocess
 import sys
 
@@ -15,7 +16,28 @@ import pytest
 
 pytestmark = pytest.mark.integration
 
-CASE_MODULES = ("kobo_authority_cases.py", "kobo_containment_cases.py")
+# The count is pinned per module rather than merely "greater than zero". This
+# slice exists because six earlier attempts to observe the sticky Kobo state
+# reported a result that had asserted nothing: a module that collects fewer
+# cases, or skips one, still exits 0. An expected count turns that into a
+# failure. Update it in the same commit as any added or removed case.
+EXPECTED_PASSES = {
+    "kobo_authority_cases.py": 4,
+    "kobo_containment_cases.py": 1,
+}
+
+_OUTCOME = re.compile(r"(\d+) (passed|failed|skipped|error|errors|xfailed|xpassed)")
+
+
+def _outcomes(stdout):
+    """Parse pytest's own final summary line into a counted mapping."""
+    summary = [line for line in stdout.splitlines()
+               if re.search(r"=+ .*(passed|failed|error|no tests ran).* =+", line)]
+    assert summary, "the case run printed no pytest summary line"
+    counts = {}
+    for number, name in _OUTCOME.findall(summary[-1]):
+        counts[name.rstrip("s")] = int(number)
+    return counts
 
 
 def _run_cases(module_name):
@@ -31,17 +53,15 @@ def _run_cases(module_name):
     print(result.stdout)
     print(result.stderr[-4000:])
     assert result.returncode == 0, result.stdout + result.stderr
-    # A case module that collected nothing exits 5, not 0, but a module whose
-    # cases were all skipped exits 0 with nothing observed. This slice exists
-    # because six earlier attempts reported a result that had asserted nothing,
-    # so an empty or skipped run is a failure here rather than a pass.
-    assert " skipped" not in result.stdout.splitlines()[-1], result.stdout
     return result.stdout
 
 
-@pytest.mark.parametrize("module_name", CASE_MODULES)
-def test_kobo_authority_cases_in_fresh_process(module_name, record_property):
-    stdout = _run_cases(module_name)
-    passed = [line for line in stdout.splitlines() if " PASSED" in line]
-    record_property("kobo_cases_passed", len(passed))
-    assert passed, stdout
+@pytest.mark.parametrize("module_name", sorted(EXPECTED_PASSES))
+def test_kobo_cases_in_fresh_process(module_name, record_property):
+    counts = _outcomes(_run_cases(module_name))
+    record_property("kobo_case_outcomes", "%s %r" % (module_name, counts))
+    assert counts == {"passed": EXPECTED_PASSES[module_name]}, (
+        "%s reported %r; anything other than exactly %d passed -- a skip, an "
+        "error, a case that stopped being collected -- means the observation "
+        "this slice exists for did not happen"
+        % (module_name, counts, EXPECTED_PASSES[module_name]))


### PR DESCRIPTION
Three properties of the owned-annotation Kobo route are asserted by the code and had never been observed. Six earlier attempts reported NOT_RUN or FAIL while the product was behaving correctly. Tests only — `cps/**` is byte-identical to base.

## Why six rounds failed, and it was never a product fault

`cps/main.py:130` registers `readingservices_api_v3` only when `config.config_kobo_sync` is true **at registration time**. The existing real-app fixture boots with the shipped defaults, so `/api/v3/content/<id>/annotations` answers **404** no matter what the databases hold. The sticky authority state was unreachable, and a case that never ran looked exactly like a case that passed.

`blueprints.json` had already listed those four blueprints as `conditional` and the README already called them "outside this fixture's reach" — the fact was written down and never connected to the failing observation.

The fixture now asserts, in both directions, that the effective switch **and** the `readingservices_api_v3` rule are present. A boot that silently loses the surface fails at the fixture instead of looking like a product that refused to answer.

## What is now observed

All three sticky exits of `_owned_annotation_get_response`, on the real application — real login form and CSRF POST, the real auth decorator, device registration from real request headers, real `metadata.db` ownership, the full response pipeline. Each case **proves the state before asserting on it** and each exit is told apart from the other two behaviourally, not by hope:

| Exit | Distinguished by | ETag kind |
|---|---|---|
| `answered_locally` (`readingservices.py:905`) | body carries the live row; render committed, revision 0→1 | `cwng_revision` |
| `answered_from_snapshot` (`:849`) | body is the stored snapshot byte-for-byte; a highlight added after it is **absent**; revision unmoved | `cwng_revision` |
| sticky exception fallback (`:948`) | a control request 503s for this state, so a 200 is only reachable through the route's `except` | `cwng_revision` |

`OWNERSHIP_UNKNOWN` is contained at the trigger boundary under a real library-database outage: 0 proxy calls, `[]` returned, with a control proving the same id is forwarded when the library is readable. Ownership resolution measured deterministic, n=12, 12/12 identical.

## What the pre-existing suite could not see

Each defect planted on `main` and the pre-existing tests re-run. It is **blind** to dropping the `answered_from_snapshot` ETag, to dropping the exception-fallback ETag, and to the sticky guard being removed. Sharpest row: when a failed ownership lookup returns `None` instead of `OWNERSHIP_UNKNOWN`, the existing 61-test containment suite stays **fully green** — because `tests/unit/test_1660_kobo_checkforchanges_filter.py:116` asserts the predicate by calling it directly, and so never proves the *input* reaching it is UNKNOWN under a real failure.

Eight product defects were planted and all eight went red with a diagnosable message naming the right exit.

## Limits, stated

- The exception exit was reached by fault injection. The natural path — a *partial* `app.db` failure through `_render_count_is_safe` → `_state_for_book`, which is unguarded — was demonstrated separately during review, and it emits the **transient** ETag rather than `cwng_revision`. That regime is not exercised here.
- Mutation coverage is partial: 8/8 killed in the direct matrix, one observation isolation-grade; the isolated harness was rejected by its own watchdog under machine load.
- The containment case exercises the `device_request` stage only; a defect confined to the second filtering loop would survive it.
- Determinism is measured within one process and session.
- No Kobo hardware. Whether Nickel accepts these headers is untouched and remains assumed.

## Found and not fixed, since this slice may touch only `tests/**`

1. Only 81 of the annotations on the canary carry a Kobo materialization, so almost every row — including Kobo-source ones — renders through the column-built fallback rather than exact bytes. Worth its own look.
2. `kobo_annotation_authority.py:780` reads state unguarded inside `_emergency_render`, the handler for a failed render. It lands safely today; the safety is incidental.
3. `test_1660`'s direct-predicate assertion, above.