### PR TITLE
fix(kobo): withhold the device's cache validators on an owned annotation GET (#1923)

### DIFF
--- a/changelog.d/issue-1923-seeding-304.md
+++ b/changelog.d/issue-1923-seeding-304.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Highlights on a book from your Calibre-Web library are no longer lost when your Kobo re-downloads it before that book has finished syncing to Calibre-Web.** Calibre-Web was passing your reader's cached Kobo tag along when it fetched the book's annotations, so Kobo replied "nothing changed" with an empty answer — and your Kobo, which clears a book's highlights during a download and refills them from that answer, was left with none. The same empty answer also stopped the book from ever finishing its sync, so it stayed exposed to the same loss on every later re-download.

--- a/cps/readingservices.py
+++ b/cps/readingservices.py
@@ -87,8 +87,14 @@ def redact_headers(headers):
     return redacted
 
 
-def proxy_to_kobo_reading_services(data=None, capture_session=None):
-    """Proxy the request to Kobo's reading services API."""
+def proxy_to_kobo_reading_services(data=None, capture_session=None,
+                                   drop_request_headers=()):
+    """Proxy the request to Kobo's reading services API.
+
+    ``drop_request_headers`` withholds named request headers from the upstream
+    leg. It exists for conditional-request headers on a CWNG-owned book, where
+    a 304 from Kobo is destructive rather than merely uninformative.
+    """
     try:
         kobo_url = KOBO_READING_SERVICES_URL + request.path
         if request.query_string:
@@ -103,6 +109,8 @@ def proxy_to_kobo_reading_services(data=None, capture_session=None):
         outgoing_headers.remove("Host")
         # Remove CWA session cookie - Kobo doesn't need it and it causes issues
         outgoing_headers.pop("Cookie", None)
+        for header_name in drop_request_headers:
+            outgoing_headers.pop(header_name, None)
         if data is not None:
             # requests must calculate this again for a filtered request body.
             outgoing_headers.pop("Content-Length", None)
@@ -645,13 +653,19 @@ def _record_annotation_decision(capture_session, ownership, action, entitlement_
     )
 
 
-def _proxy_annotation_request(capture_session, ownership, entitlement_id):
+def _proxy_annotation_request(capture_session, ownership, entitlement_id,
+                              drop_request_headers=()):
     _record_annotation_decision(
         capture_session, ownership, "proxied", entitlement_id,
     )
-    if capture_session is None:
-        return proxy_to_kobo_reading_services()
-    return proxy_to_kobo_reading_services(capture_session=capture_session)
+    # Keep the call shape byte-identical when there is nothing to withhold, so
+    # the unowned-book proxy contract is untouched by this option.
+    kwargs = {}
+    if capture_session is not None:
+        kwargs["capture_session"] = capture_session
+    if drop_request_headers:
+        kwargs["drop_request_headers"] = tuple(drop_request_headers)
+    return proxy_to_kobo_reading_services(**kwargs)
 
 
 def _owned_annotation_patch_ack(capture_session, ownership, entitlement_id):
@@ -732,6 +746,25 @@ def _owned_annotation_page_limit():
         return None
 
 
+# Preconditions that let Kobo answer a proxied owned GET without a usable body:
+# 304 from either cache validator, 412 from either precondition -- all bodyless.
+# Nickel repopulates a book's annotation rows from this response, so any of them
+# destroys the book's device annotations.  MEASURED 2026-09-06 across 52 captured
+# annotation exchanges with a Kobo Clara: If-None-Match appears in 49 of them and
+# none of the other four appears at all.  They are withheld anyway, so a firmware
+# that starts sending a date validator cannot reopen the same wipe -- and note
+# RFC 9110 has a server ignore If-Modified-Since while If-None-Match is present,
+# so dropping only the ETag validator would have UNMASKED the date one.  Range/If-Range
+# are deliberately absent: a range is a request for content, not a revalidation,
+# and withholding it would change the reply shape the device asked for.
+_OWNED_GET_WITHHELD_VALIDATORS = (
+    "If-None-Match",
+    "If-Modified-Since",
+    "If-Match",
+    "If-Unmodified-Since",
+)
+
+
 def _proxy_owned_annotation_get(capture_session, ownership, entitlement_id):
     """Proxy one owned GET and best-effort feed its response to M2 seeding."""
     seed_capture_id = None
@@ -755,8 +788,18 @@ def _proxy_owned_annotation_get(capture_session, ownership, entitlement_id):
             exc_info=True,
         )
 
+    # MEASURED 2026-09-06 on a Kobo Clara: forwarding the device's
+    # If-None-Match here made Kobo answer 304 with a zero-length body. Nickel
+    # empties a book's rows for the download and repopulates them from this
+    # response, so it lost all 8 of that book's device annotations; and seeding
+    # rejects a non-2xx status outright, so the capture failed
+    # seed_response_invalid, leaving the book unseeded and exposed to the very
+    # same wipe on the next re-download. A proxied owned GET is a request for
+    # content, not a cache revalidation: CWNG is this book's authority and the
+    # device's validators belong to Kobo, so they are not ours to forward.
     response = _proxy_annotation_request(
         capture_session, ownership, entitlement_id,
+        drop_request_headers=_OWNED_GET_WITHHELD_VALIDATORS,
     )
     if seed_capture_id is not None:
         try:
@@ -782,7 +825,12 @@ def _proxy_owned_annotation_get(capture_session, ownership, entitlement_id):
 
 
 def _owned_annotation_get_response(capture_session, ownership, entitlement_id):
-    """Return one complete eligible local page, otherwise proxy unchanged."""
+    """Return one complete eligible local page, otherwise proxy upstream.
+
+    The proxy leg is deliberately not byte-transparent: an owned book's GET
+    withholds the device's cache validators, because a bodyless Kobo reply
+    empties that book's annotations on the device.
+    """
     sticky = False
     authority_history_known = False
     page_limit = _owned_annotation_page_limit()
@@ -1271,7 +1319,9 @@ def handle_annotations(entitlement_id):
     """Handle annotation requests for a specific book.
 
     GET: fully seeded owned books are answered from CWNG's complete visible
-    set; unseeded and unowned books retain the byte-transparent Kobo proxy.
+    set; unowned books retain the byte-transparent Kobo proxy.  An unseeded
+    owned book is proxied too, but without the device's cache validators: a
+    bodyless reply would empty that book's annotations on the device.
     PATCH: persist locally (source='kobo'), then dispatch through
     each registered + enabled annotation_sync handler (Hardcover today; future
     Readwise / Notion / etc.). All DB writes happen in the dispatcher; this

--- a/tests/unit/test_1923_owned_annotations_local_authority.py
+++ b/tests/unit/test_1923_owned_annotations_local_authority.py
@@ -723,3 +723,81 @@ def test_owned_get_row_render_exception_keeps_every_identity_and_text(
     assert errors[0][3] == 2
     assert "row_render_RuntimeError" in repr(errors[0])
     assert "private render text" not in repr(errors[0])
+
+
+def test_owned_seeding_proxy_withholds_the_devices_cache_validators(
+    app, session, monkeypatch,
+):
+    """A proxied owned GET must fetch a body, never inherit the device's 304.
+
+    MEASURED 2026-09-06 on a Kobo Clara: an unseeded owned book's re-download
+    proxied the device's ``If-None-Match`` (Kobo's own manifest ETag, cached
+    from an earlier proxied GET) upstream.  Kobo answered ``304`` with a
+    zero-length body, CWNG passed it through, and Nickel -- which empties a
+    book's rows for the download and repopulates them from the response -- was
+    left with nothing: all 8 device annotation rows were lost.
+
+    That same response is why the book could never escape: seeding captures it
+    and rejects any non-2xx status outright, so the capture ends
+    ``seed_response_invalid``.  The book cannot reach ``authoritative``, and
+    therefore never gets the local-answer path that refuses to 304 -- the wipe
+    and the deadlock are the same 304.
+
+    Kobo can answer bodilessly for more than one reason: a 304 from either cache
+    validator, a 412 from either precondition.  All four are withheld, so a
+    firmware that starts sending a date validator cannot reopen this wipe.
+
+    An owned GET we are proxying is a request for content, not a cache
+    revalidation: CWNG is the authority for the book and the device's validator
+    belongs to Kobo, so it must not be forwarded.
+    """
+    book = SimpleNamespace(id=BOOK_ID, uuid=OWNED, title="Flatland", identifiers=[])
+    monkeypatch.setattr(rs, "resolve_entitlement_ownership", lambda _content_id: book)
+    # No KoboAnnotationBookState row: the book is unseeded, so the GET proxies.
+    session.commit()
+
+    seen = {}
+    body = b'{"annotations":[],"nextPageOffsetToken":null}'
+
+    class _Upstream:
+        status_code = 200
+        content = body
+
+        def __init__(self):
+            self.headers = rs.requests.structures.CaseInsensitiveDict(
+                {"Content-Type": "application/json"}
+            )
+
+    def fake_request(**kwargs):
+        seen["headers"] = kwargs.get("headers")
+        return _Upstream()
+
+    monkeypatch.setattr(rs.requests, "request", fake_request)
+
+    with app.test_request_context(
+        f"/api/v3/content/{OWNED}/annotations?limit=100",
+        method="GET",
+        headers={
+            "If-None-Match": 'W/"A:1408092558-kobo-manifest-etag"',
+            "If-Modified-Since": "Sat, 06 Sep 2026 12:00:00 GMT",
+            "If-Match": 'W/"A:1408092558-kobo-manifest-etag"',
+            "If-Unmodified-Since": "Sat, 06 Sep 2026 12:00:00 GMT",
+            "Authorization": "Bearer device-token",
+        },
+    ):
+        g.annotation_origin_device_id = DEVICE_ID
+        response = rs.handle_annotations.__wrapped__(OWNED)
+
+    assert response.status_code == 200
+    forwarded = {str(name).lower() for name in seen["headers"].keys()}
+    leaked = forwarded & {
+        "if-none-match", "if-modified-since", "if-match", "if-unmodified-since",
+    }
+    assert not leaked, (
+        f"the device's cache validators {sorted(leaked)} were forwarded to Kobo; "
+        "a bodyless reply empties the device's annotations for this book and "
+        "starves the seed capture"
+    )
+    assert "authorization" in forwarded, (
+        "withholding the validators must not strip the rest of the request"
+    )


### PR DESCRIPTION
## The bug

An owned book that has not yet reached `authoritative` still proxies its annotation GET to Kobo — that proxy *is* the seeding pass, and is deliberate. But the device's `If-None-Match` was forwarded verbatim, carrying Kobo's own manifest ETag cached from an earlier proxied GET. Kobo answered `304` with a zero-length body and CWNG passed it through.

Nickel empties a book's rows for a download and repopulates them from that response, so it was left with none. **Measured on a Kobo Clara: 8 real annotation rows destroyed on a re-download.**

The same response also starved the seed capture, which rejects a non-2xx status outright and ended `seed_response_invalid` with `page_count 0`, rolling the book back to `unseeded` — so it could never reach the local-answer path that refuses to 304, and stayed exposed to the identical wipe next time. **The wipe and the deadlock were the same 304.**

This is not a regression from the original #1923 work. That fix made owned books answer locally once *authoritative*, and that path is proven correct on hardware. The seeding path was simply left proxying, and still carried the original F-66edbc wipe.

## The fix

A proxied owned GET is a request for content, not a cache revalidation: CWNG is the authority for the book and the device's validators belong to Kobo, so they are not ours to forward.

`If-None-Match` is the measured cause. The three other preconditions that let Kobo answer bodilessly — `If-Modified-Since`, `If-Match`, `If-Unmodified-Since`, via 304 or 412 — are withheld alongside it. Per RFC 9110 a server must ignore `If-Modified-Since` while `If-None-Match` is present, so dropping only the ETag validator would have **unmasked** the date one for any firmware that starts sending it.

`Range`/`If-Range` are deliberately left alone: a range is a request for content, not a revalidation, and withholding it would change the reply shape the device asked for.

## Scope

- **Unowned books are untouched** — there Kobo *is* the authority and a 304 is correct.
- **The PATCH path is untouched** — preconditions there constrain whether a mutation may happen.
- The proxy call shape is byte-identical when there is nothing to withhold, so the unowned-book proxy contract is unchanged.

## Evidence

- **Full suite, with a control.** Same command on `origin/main` vs this branch: control `19 failed, 8724 passed`; this branch `19 failed, 8725 passed` (+1 = the new test). Failure sets byte-identical — the 19 are pre-existing environment-dependent Docker/packaging lanes. **Zero new failures.**
- **Mutation tested at two depths.** Reverting the call-site argument fails exactly 1 test — the new one — with 1655 others passing, so the pre-existing suite was structurally incapable of detecting this. Deleting the header-removal loop itself is caught by the same test, so it guards the mechanism, not just the argument.
- **Casing proven, not assumed.** The outgoing headers are a Werkzeug `Headers`, so the drop is case-insensitive for `if-none-match` / `IF-NONE-MATCH` / `If-None-Match`.
- **Header set measured on the wire.** Across 52 captured annotation exchanges with a Kobo Clara, `If-None-Match` appears in 49 and none of the other four appears at all.
- **Hardware.** On a real device against a patched instance: annotation rows before the re-download 8 → after 8, nothing lost, GET proxied with status **200, not 304**. The same scenario replayed against the genuine pre-fix snapshots fails 8 → 0.
- **Test seen red first**, naming the leaked validators.

## Known follow-up (not in this PR)

Unblocking seeding exposes a separate, pre-existing defect downstream. A legacy annotation row with `annotation_type IS NULL` (rows created before any writer owned that column — the documented gap in `annotation_types.py`) is compared against Kobo's declared type as an ordinary value mismatch rather than "unknown, defer to the side that knows", so reconciliation reads it as a genuine disagreement and quarantines the book. Quarantine is the safe state and loses nothing — but expect quarantines to appear as books seed. Being handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Ctf8j8iEsWxvDhAc8eBZa
