### PR TITLE
fix(kobo): an unknown annotation type is absence, not disagreement (#1923)

### DIFF
--- a/changelog.d/2182.md
+++ b/changelog.d/2182.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Highlights made before Calibre-Web recorded what kind of highlight they were no longer stop a book from finishing its sync to your Kobo.** Those older highlights have no saved type, and Calibre-Web was reading that missing information as a disagreement with your Kobo rather than as something it simply did not know yet — so the book was held back for safety and could never finish. Calibre-Web now takes the missing detail from your Kobo, which is the only place it was ever recorded, and the book syncs. A real disagreement, where the two sides genuinely say different things, is still held back.

--- a/cps/services/annotation_sync/__init__.py
+++ b/cps/services/annotation_sync/__init__.py
@@ -152,10 +152,17 @@ def _book_uuid(book):
 
 
 def _kobo_payload_matches_row(annotation, payload, span, normalized_content_id):
-    """True only when applying the payload would leave every stored field unchanged."""
+    """Whether the payload agrees with the row's known content.
+
+    A legacy NULL type is absence of classification, not a competing claim.
+    Reconciliation separately stores the captured classification. Callers that
+    need a strict write no-op must also check for type enrichment.
+    """
     def supplied(mapping, key, current):
         return mapping.get(key) if key in mapping else current
 
+    local_type = getattr(annotation, "annotation_type", None)
+    incoming_type = to_storage_type(supplied(payload, "type", local_type))
     chapter_progress = span.get("chapterProgress")
     next_context = annotation.context_string
     if "contextString" in span or "context" in span:
@@ -163,7 +170,7 @@ def _kobo_payload_matches_row(annotation, payload, span, normalized_content_id):
     current = (
         annotation.highlighted_text, annotation.note_text,
         to_storage_color(annotation.highlight_color),
-        to_storage_type(getattr(annotation, "annotation_type", None)),
+        incoming_type if local_type is None else to_storage_type(local_type),
         annotation.chapter_progress, annotation.content_id,
         annotation.start_container_path, annotation.end_container_path,
         annotation.start_offset, annotation.end_offset,
@@ -177,9 +184,7 @@ def _kobo_payload_matches_row(annotation, payload, span, normalized_content_id):
         # changes nothing must not be counted as a change just because the
         # stored spelling is older than the wire one.
         to_storage_color(supplied(payload, "highlightColor", annotation.highlight_color)),
-        to_storage_type(supplied(
-            payload, "type", getattr(annotation, "annotation_type", None),
-        )),
+        incoming_type,
         chapter_progress if chapter_progress is not None else annotation.chapter_progress,
         normalized_content_id or annotation.content_id,
         supplied(span, "startPath", annotation.start_container_path),
@@ -319,7 +324,15 @@ def _upsert_annotation(
             # no-op, but a real edit can share the same second and must not be
             # eaten merely because its clock ties. Equal-clock divergent
             # payloads therefore use arrival order as the deterministic tie.
-            if _kobo_payload_matches_row(ann, payload, span, normalized_content_id):
+            # Compatibility permits an unknown local type, but a live PATCH
+            # can still teach us that type. Preserve that write (and its raw
+            # sidecar) rather than dropping new classification as a retry.
+            stored_type = to_storage_type(getattr(ann, "annotation_type", None))
+            payload_type = to_storage_type(payload.get("type", stored_type))
+            if (
+                stored_type == payload_type
+                and _kobo_payload_matches_row(ann, payload, span, normalized_content_id)
+            ):
                 return None
     created = ann is None
     if created:

--- a/cps/services/kobo_annotation_seeding.py
+++ b/cps/services/kobo_annotation_seeding.py
@@ -20,6 +20,7 @@ from sqlalchemy.exc import IntegrityError
 
 from cps import ub
 from cps.services import kobo_annotation_stage0
+from cps.services.annotation_types import to_storage_type
 
 
 LOCAL_PAGE_CAPACITY = 100
@@ -802,6 +803,16 @@ def _reconcile_and_promote(capture_id, *, book, user, device_id, log):
             if baseline is None:
                 raise ValueError("captured annotation has no server baseline")
             applied = False
+            if equivalent_before and annotation.annotation_type is None:
+                native_type = to_storage_type(payload.get("type"))
+                if native_type is not None and len(native_type) <= 32:
+                    # Compatibility is not a write no-op: retain the captured
+                    # classification in generic storage too. Only fill absence;
+                    # every other field already agrees. Do not apply the whole
+                    # payload or let an older device clock suppress this proof.
+                    annotation.annotation_type = native_type
+                    annotation.content_revision = (annotation.content_revision or 1) + 1
+                    annotation.server_modified_at = _now()
             if not equivalent_before and _baseline_allows_insert(
                 baseline, annotation,
             ):

--- a/tests/unit/test_1942_seed_pipeline.py
+++ b/tests/unit/test_1942_seed_pipeline.py
@@ -2023,3 +2023,93 @@ def test_additive_migration_is_idempotent_and_backfills_safety_history(tmp_path)
             "FROM kobo_annotation_seed_capture WHERE id=3"
         )).scalar_one() == 1
     engine.dispose()
+
+
+@pytest.mark.parametrize("stored_clock", [
+    datetime(2026, 8, 29, 1, 0, 0), datetime(2035, 1, 1),
+])
+@pytest.mark.parametrize("local_type,incoming_type,compatible", [
+    (None, "highlight", True),
+    (None, "dogear", True),
+    (None, "future-type", True),
+    ("highlight", "dogear", False),
+    ("dogear", "highlight", False),
+    ("future-type", "highlight", False),
+    ("highlight", "Highlight", True),
+])
+def test_seed_type_absence_is_compatible_but_disagreement_quarantines(
+    app, session, monkeypatch, local_type, incoming_type, compatible, stored_clock,
+):
+    _book(monkeypatch).uuid = OWNED
+    _device(session, DEVICE_A)
+    state = _state(session, status="unseeded", ever=False, content_id=OWNED)
+    row = _annotation_row(
+        "legacy-type", annotation_type=local_type, client_modified_at=stored_clock,
+    )
+    session.add(row)
+    session.commit()
+    payload = _wire_annotation("legacy-type")
+    payload["type"] = incoming_type
+    monkeypatch.setattr(
+        rs, "proxy_to_kobo_reading_services",
+        lambda **_k: _upstream_response([payload]),
+    )
+
+    with _request(app):
+        g.annotation_origin_device_id = DEVICE_A
+        response = rs.handle_annotations.__wrapped__(OWNED)
+
+    assert response.status_code == 200
+    session.refresh(state)
+    capture = session.query(ub.KoboAnnotationSeedCapture).one()
+    assert state.authority_status == ("authoritative" if compatible else "quarantined")
+    assert capture.reconciliation_conflict_count == (0 if compatible else 1)
+    session.refresh(row)
+    enriched = local_type is None and compatible
+    assert row.annotation_type == (incoming_type if enriched else local_type)
+    assert row.content_revision == (2 if enriched else 1)
+    assert row.client_modified_at == stored_clock
+    materialization = session.query(ub.KoboAnnotationMaterialization).one_or_none()
+    if compatible:
+        assert materialization.serveable is True
+        assert materialization.materialization_revision == row.content_revision
+        assert json.loads(materialization.raw_annotation_json)["type"] == incoming_type
+        with _request(app):
+            g.annotation_origin_device_id = DEVICE_A
+            rendered = rs.handle_annotations.__wrapped__(OWNED)
+        assert rendered.status_code == 200
+        assert json.loads(rendered.get_data())["annotations"][0]["type"] == incoming_type
+    else:
+        assert capture.failure_reason == "seed_row_conflict_unresolved"
+        assert materialization is None
+
+
+@pytest.mark.parametrize("local_type,changed", [
+    (None, True), ("dogear", True), ("highlight", False),
+])
+def test_equal_clock_patch_type_compatibility(session, local_type, changed):
+    from cps.services import annotation_sync
+
+    row = _annotation_row("equal-clock", annotation_type=local_type)
+    session.add(row)
+    session.commit()
+    result = annotation_sync._upsert_annotation(
+        session, _wire_annotation("equal-clock"),
+        SimpleNamespace(id=BOOK_ID, uuid=OWNED), SimpleNamespace(id=USER_ID),
+    )
+    assert (result is not None) is changed
+    session.commit()
+    session.refresh(row)
+    assert row.annotation_type == ("highlight" if changed else local_type)
+    assert row.content_revision == (2 if changed else 1)
+
+
+def test_unknown_type_does_not_mask_other_content_conflicts():
+    from cps.services import annotation_sync
+
+    row = _annotation_row("different-text", annotation_type=None)
+    payload = _wire_annotation("different-text")
+    payload["highlightedText"] = "a competing passage"
+    assert not annotation_sync.kobo_payload_matches_annotation(
+        row, payload, SimpleNamespace(id=BOOK_ID, uuid=OWNED),
+    )


### PR DESCRIPTION
Follow-up to #2181. That PR stopped an annotation wipe and, by unblocking seeding, exposed this pre-existing defect downstream.

## The bug

Seeding reconciles Kobo's captured annotation set against the rows CWNG already holds, comparing each pair with a strict 12-field tuple equality. One compared field is `annotation_type`.

**Measured on real data: 4 of a book's 8 rows carried `annotation_type IS NULL` while Kobo declared `"highlight"`.** Every other reconciled field matched byte-for-byte — highlighted text, colour, `chapter_progress`, `content_id`, both container paths, both offsets, `context_string`, `hidden`. The comparison nonetheless evaluated `to_storage_type(None)` against `to_storage_type("highlight")` as an ordinary value mismatch, which is indistinguishable from a genuine disagreement, so those ids landed in `conflict_ids` and `_reconcile_and_promote` quarantined the book on its first seed. It could then never become authoritative.

A local NULL is the **absence** of a classification, not a competing claim.

## The fix

Three coordinated parts:

1. **Compatibility.** When the stored type is NULL, both sides of the comparison resolve to the incoming type. When it is *set*, it is still compared strictly — local `note` against Kobo `highlight` must still conflict, and a test pins exactly that.
2. **Enrichment, not silence.** `_kobo_payload_matches_row` also serves as `_upsert_annotation`'s "would this write change nothing?" check. Bare compatibility would therefore have *skipped the very write that fills the column*, leaving it NULL forever and making the fix cosmetic. That early return now additionally requires the types to agree.
3. **Reconciliation fills an absent type** from the captured object, bumping `content_revision` without touching the device's client clock.

## No migration is needed, and writing one would be wrong

`ub.backfill_legacy_annotation_types` already exists and already runs at startup. It is idempotent and never overwrites a value. It deliberately fills only NULLs derivable from a recorded web-reader `position_type`, and `derive_legacy_annotation_type` states that a legacy Kobo row has no such discriminator, so inspecting its text or selector "would guess which writer and input produced it."

These rows are Kobo-origin — only Kobo knows their type. Seeding enrichment is the correct repair channel; a migration could only invent the value.

## Reach

613 of 3146 annotation rows carry a NULL type, and 3059 of the 3065 rows that render through `_fallback_object` are Kobo-source. Only one book had actually quarantined, because the wipe fixed in #2181 was failing captures *before* reconciliation was ever reached — fixing that is what surfaced this.

## Evidence

- **Seen red**, verified directly by stashing only the two production files and re-running: 6 failed / 12 passed. The 6 are exactly the `None`-typed compatibility cases; the 12 disagreement and case-normalisation cases already passed and stayed passing, so the red is precise and the safety property was never at risk.
- Targeted file green: 63 passed in `tests/unit/test_1942_seed_pipeline.py`.
- Full suite with a control on the merge-base. **Zero attributable failures in any file this change can affect.** The only differences sit in `tests/unit/test_mutation_harness.py`, which is independently established as load-sensitive: two same-configuration runs on identical code produced the same failure count with a completely different failing subset, and the file passes 168/168 in isolation. Root cause there is a fixed `timeout=5` around operations that spawn Python interpreters — tracked separately. It is *not* claimed that extra test cases add no contention at all; only that nothing attributable appears in the affected code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
