### PR TITLE
fix(api): a TLS-terminating proxy hop is not a cross-site origin (#2180)

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,20 @@ Behind multiple proxies (e.g. Cloudflare Tunnel then nginx then CWA), set the pr
 - TRUSTED_PROXY_COUNT=2
 ```
 
+Set `TRUSTED_PROXY_COUNT` to the number of trusted proxy hops: for
+HAProxy → traefik → container, use `2`. With `X-Forwarded-Proto: https, http`,
+the default of `1` selects the inner hop's `http`; `2` selects the browser-facing
+`https`. If headers have different chain lengths, use the per-header overrides below.
+
+The New UI's API Origin guard accepts a same-host HTTPS origin even when the
+proxy-derived URL is HTTP, so upstream TLS termination does not block writes.
+The reverse direction (HTTP origin against an HTTPS-derived URL) is still rejected.
+For a `Rejected cross-site` warning, check `TRUSTED_PROXY_COUNT` and the forwarded
+headers. If the proxy rewrites Host without preserving the public host in
+`X-Forwarded-Host`, set `CWNG_TRUSTED_ORIGINS` to your public origin
+(comma-separated for multiple origins). Correct proxy configuration is still
+needed for generated URLs and other scheme-sensitive behavior.
+
 Without this, CWA may see different client IPs across requests and trigger Session Protection warnings, forcing re-login on every page load. It can also mistake an externally secure OIDC callback for plain HTTP. Default is `1`.
 
 `TRUSTED_PROXY_COUNT` applies one trust depth to `X-Forwarded-For`,

--- a/changelog.d/2180.md
+++ b/changelog.d/2180.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- **New UI writes no longer fail with 403 behind upstream TLS termination (#2180).**
+  The API Origin guard accepts same-host HTTPS origins when the proxy-derived
+  URL is HTTP, while continuing to reject the reverse scheme downgrade and
+  foreign hosts. Rejection logs now point to `TRUSTED_PROXY_COUNT` and
+  `CWNG_TRUSTED_ORIGINS`, with bounded request values. Proxy documentation
+  explains the hop count for HAProxy → traefik → container deployments.

--- a/cps/api/__init__.py
+++ b/cps/api/__init__.py
@@ -133,7 +133,10 @@ def _reject_cross_site_mutation():
     untrusted origin and 401 for a trusted one, disclosing which origins are trusted.
 
     Host comparison uses request.host_url, which ProxyFix has already rewritten from
-    X-Forwarded-Host/Proto, so this holds behind a reverse proxy and on a subpath. The
+    X-Forwarded-Host/Proto. A same-host HTTPS origin also passes when host_url is
+    HTTP: TLS may have terminated upstream of the trusted hop (#2180). The reverse
+    direction remains rejected: an HTTP caller against an HTTPS expected origin is
+    a downgrade, not this TLS-termination shape. Ports remain deliberately ignored. The
     setup it cannot infer is a proxy that rewrites Host and forwards no
     X-Forwarded-Host (or sends only the standardised `Forwarded:` header, which
     neither ProxyFix nor ReverseProxied consumes) — there request.host_url is the
@@ -152,13 +155,19 @@ def _reject_cross_site_mutation():
     if stated_key is None:
         accepted = False        # stated but unusable ("null", malformed) — never our SPA
     else:
-        accepted = stated_key == _origin_key(request.host_url) or any(
-            stated_key == _origin_key(extra) for extra in _EXTRA_TRUSTED_ORIGINS)
+        expected_key = _origin_key(request.host_url)
+        accepted = (
+            stated_key == expected_key
+            or (stated_key[0] == "https" and expected_key == ("http", stated_key[1]))
+            or any(stated_key == _origin_key(extra) for extra in _EXTRA_TRUSTED_ORIGINS)
+        )
     if accepted:
         return None
     # Bounded: the value is attacker-controlled and this runs before the per-route
     # rate limits, so an unbounded %r would let a caller size our log lines.
-    log.warning("Rejected cross-site %s %s (stated origin %.128r, expected %.128r)",
+    log.warning("Rejected cross-site %s %.128s (stated origin %.128r, expected %.128r). "
+                "Check TRUSTED_PROXY_COUNT for your proxy hops; if the proxy rewrites Host, "
+                "set CWNG_TRUSTED_ORIGINS to the public origin.",
                 request.method, request.path, stated, request.host_url)
     return jsonify({"error": {"code": "cross_site_request",
                               "message": "Cross-site request rejected"}}), 403

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -26,7 +26,7 @@ NETWORK_SHARE_MODE=false
 # DISABLE_LIBRARY_AUTOMOUNT=false
 
 # Trusted reverse-proxy hops. Default: 1.
-# Change this if CWNG is running behind multiple proxies (e.g., Cloudflare Tunnel + reverse proxy).
+# Set to the number of trusted proxy hops (e.g., HAProxy -> traefik -> container needs 2).
 # TRUSTED_PROXY_COUNT=1
 # If different proxies append or replace different X-Forwarded-* headers, override
 # their trust depths independently. Each defaults to TRUSTED_PROXY_COUNT (or 1).

--- a/tests/unit/test_1370_api_origin_check.py
+++ b/tests/unit/test_1370_api_origin_check.py
@@ -144,8 +144,8 @@ def test_default_port_is_not_a_mismatch():
 
 
 @pytest.mark.unit
-def test_scheme_mismatch_is_rejected():
-    """Same host over a different scheme is a different origin."""
+def test_scheme_downgrade_is_rejected():
+    """An HTTP caller against an HTTPS deployment is not TLS termination."""
     verdict = _gate("/api/v1/tags/1", "POST",
                     {"Origin": "http://cwng.local"},
                     base="https://cwng.local/")
@@ -228,56 +228,72 @@ def test_real_proxyfix_forwarded_host_deployment_passes(fwd_host):
 
 
 @pytest.mark.unit
-def test_tls_terminating_proxy_that_forwards_no_proto_is_rejected():
-    """Pin the one deployment this hook does NOT infer, so it is a documented
-    behaviour rather than a surprise 403 in someone's logs.
-
-    A proxy can forward the public host correctly and still leave Flask believing
-    the request arrived over HTTP, because it sends no X-Forwarded-Proto (and no
-    X-Scheme, and PROXY_SCHEME is unset). host_url is then http://books.example.com
-    while the browser states https://books.example.com, the schemes differ, and
-    every write is refused.
-
-    Scheme is deliberately kept in the comparison — it is a real origin boundary,
-    unlike the port. Such a deployment is already visibly wrong today (url_for
-    emits http:// links for it, per the note at cps/__init__.py:86), and it has
-    three fixes: forward X-Forwarded-Proto, set PROXY_SCHEME, or name the public
-    address in CWNG_TRUSTED_ORIGINS. The CHANGELOG entry says so.
-    """
+@pytest.mark.parametrize("forwarded_proto,stated_scheme,expected_scheme,accepted", [
+    ("https, http", "https", "http", True),  # HAProxy -> traefik -> container
+    (None, "https", "http", True),  # TLS terminator omits forwarded proto
+    ("http, https", "http", "https", False),  # reverse direction stays rejected
+])
+def test_tls_proxy_scheme_direction(forwarded_proto, stated_scheme, expected_scheme, accepted):
+    """#2180: the inner hop's scheme must not block a same-host HTTPS write."""
     from werkzeug.middleware.proxy_fix import ProxyFix
-    from cps.api import api_v1
-    app = flask.Flask(__name__)
-    app.testing = True
-    app.config["WTF_CSRF_ENABLED"] = False
-    app.config["SECRET_KEY"] = "test"
-    app.config["RATELIMIT_ENABLED"] = False
+    app = _app()
     app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_prefix=1)
-    app.register_blueprint(api_v1)
+    path = "/api/v1/books/66/delete"
+    endpoint, _ = app.url_map.bind("").match(path, method="POST")
+    reached = []
 
+    def view(book_id):
+        reached.append(book_id)
+        return flask.jsonify(expected=flask.request.host_url)
+
+    app.view_functions[endpoint] = view
+    headers = {"Origin": f"{stated_scheme}://ebooks.MYDOMAIN.com",
+               "X-Forwarded-Host": "ebooks.MYDOMAIN.com"}
+    if forwarded_proto is not None:
+        headers["X-Forwarded-Proto"] = forwarded_proto
     with patch("cps.api.current_user") as cu, patch("cps.api.config") as cfg:
         cu.is_authenticated = True
         cfg.config_allow_reverse_proxy_header_login = False
         cfg.config_anonbrowse = 0
-        resp = app.test_client().post(
-            "/api/v1/tags/1",
-            headers={"Origin": "https://books.example.com",
-                     "X-Forwarded-Host": "books.example.com"},   # no -Proto
-            base_url="http://calibre-web:8083/")
-    assert resp.status_code == 403
+        resp = app.test_client().post(path, headers=headers,
+                                      base_url="http://calibre-web:8083/")
+    if accepted:
+        assert resp.status_code == 200, resp.get_json()
+        assert reached == [66]
+        assert resp.get_json()["expected"].lower() == f"{expected_scheme}://ebooks.mydomain.com/"
+    else:
+        assert resp.status_code == 403
+        assert resp.get_json()["error"]["code"] == "cross_site_request"
+        assert reached == []
 
-    # And the documented remedy actually clears it.
-    with patch("cps.api.current_user") as cu, patch("cps.api.config") as cfg, \
-            patch("cps.api._EXTRA_TRUSTED_ORIGINS", ("https://books.example.com",)):
-        cu.is_authenticated = True
-        cfg.config_allow_reverse_proxy_header_login = False
-        cfg.config_anonbrowse = 0
-        resp = app.test_client().post(
-            "/api/v1/tags/1",
-            headers={"Origin": "https://books.example.com",
-                     "X-Forwarded-Host": "books.example.com"},
-            base_url="http://calibre-web:8083/")
-    assert resp.status_code != 403, (
-        "CWNG_TRUSTED_ORIGINS did not rescue the no-X-Forwarded-Proto deployment")
+
+@pytest.mark.unit
+@pytest.mark.parametrize("origin", [
+    "https://ebooks.MYDOMAIN.com.evil.example",
+    "https://ebooks.MYDOMAIN.com@evil.example",
+    "https://ebooks.MYDOMAIN.com:notaport",
+    "null",
+])
+def test_tls_proxy_exception_still_rejects_hostile_origins(origin):
+    verdict = _gate("/api/v1/books/66/delete", "POST", {"Origin": origin},
+                    base="http://ebooks.MYDOMAIN.com/")
+    assert verdict is not None
+    assert verdict[1] == 403
+
+
+@pytest.mark.unit
+def test_rejection_log_gives_bounded_proxy_remedies():
+    origin = "https://evil.example/" + "x" * 4096
+    with patch("cps.api.log.warning") as warning:
+        verdict = _gate("/api/v1/books/66/delete", "POST", {"Origin": origin})
+    assert verdict[1] == 403
+    fmt, *args = warning.call_args.args
+    message = fmt % tuple(args)
+    assert "TRUSTED_PROXY_COUNT" in message
+    assert "CWNG_TRUSTED_ORIGINS" in message
+    assert origin not in message
+    assert "x" * 129 not in message
+    assert len(message) < 600
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Fixes #2180.

## The report

Every write from the New UI returns 403 behind a TLS-terminating reverse-proxy chain, while the old UI is unaffected:

```
WARN {cps.api:161} Rejected cross-site POST /api/v1/books/66/delete
(stated origin 'https://ebooks.MYDOMAIN.com', expected 'http://ebooks.MYDOMAIN.com/')
```

Same host, same port. Only the **scheme** differs.

## Root cause

The reporter runs HAProxy → traefik → container: two hops. `TRUSTED_PROXY_COUNT` defaults to `1`, and ProxyFix reads the Nth-from-the-right `X-Forwarded-Proto`, so with `https, http` it selects the **inner** hop's `http`. `request.host_url` is therefore `http://ebooks.MYDOMAIN.com/` while the browser truthfully states `https://…`, and `_reject_cross_site_mutation` rejects on that difference alone. The old UI never reaches this hook.

## The change

The hook accepts a stated **https** origin when the host matches an **http**-derived `request.host_url`. That is the upstream-TLS-termination shape and nothing else:

- the reverse direction (`http` origin against an `https`-derived expected origin) is a downgrade and stays rejected;
- foreign hosts, hostname-prefix (`…com.evil.example`), userinfo-dressed hosts (`…com@evil.example`), malformed ports and `null` all stay rejected;
- `CWNG_TRUSTED_ORIGINS` behaviour is unchanged.

This is the same trade the hook already documents and makes for the **port**, which it deliberately excludes for exactly this class of proxy behaviour. An attacker serving plaintext HTTP on the operator's own hostname is an active network position — a bigger boundary than this hook — and the CSRF token plus the `SameSite=Lax` session cookie both still apply.

The rejection log now names `TRUSTED_PROXY_COUNT` and `CWNG_TRUSTED_ORIGINS` so the next operator to hit this can act on the warning instead of filing an issue to find out what it means. `request.path` picked up the same `%.128` bound the origin already had. README and `examples/.env.example` state the hop count for a multi-proxy chain.

## Verification

Red/green run independently of the authoring leg, by mutating the fix at its choke point and re-running the suite:

| Mutation | Result |
|---|---|
| remove the new accept branch (i.e. revert the fix) | `test_tls_proxy_scheme_direction[https, http-https-http-True]` and `[None-https-http-True]` **fail**; 28 pass |
| make the branch host-blind (`expected_key[0] == "http"`, dropping host equality) | **8 fail**, including the hostile-origin cases and the end-to-end cross-site test |
| drop the remedies from the rejection log | `test_rejection_log_gives_bounded_proxy_remedies` **fails**; 29 pass |
| unmutated `afec451fe6` | `tests/unit/test_1370_api_origin_check.py` + `tests/unit/test_1821_proxyfix_hops.py`: **33 passed** |

The over-permissive mutant matters as much as the reverting one: it shows the new branch's host binding is defended by several independent tests rather than waved through.

`test_tls_proxy_scheme_direction` drives a real `POST /api/v1/books/66/delete` through the real WSGI stack — actual `ProxyFix(x_proto=1)`, actual blueprint `before_request` chain, actual routing — with the reporter's literal `X-Forwarded-Proto: https, http`, and asserts the handler is reached and `host_url` really is the `http://` value from the report.

Author leg's wider run: `test_1370_api_origin_check` + `test_1821_proxyfix_hops` + `test_api_v1_auth_gate` + `test_csrf_mobile_safari` + `test_reverseproxy_env_overrides` + `test_1931_spa_reverse_proxy_auth` + `test_1248_reverseproxy_segment_boundary` + `test_571_reverse_proxy_prefix` + `test_readme_prefix_proxy_docs` — 153 passed.

**Stated limit:** verification is at the HTTP layer through the real middleware stack, not against a deployed container behind an actual HAProxy → traefik chain. The diff changes one `before_request` predicate and touches no SPA code, so the browser layer is unchanged.

## Security review

`/security-review` on this diff returned no finding above its confidence bar. The strongest case it considered — a same-hostname HTTPS service on another port as a CSRF launch pad — does not survive: on a deployment the app perceives as HTTPS that was already accepted before this change (ports are excluded pre-existing), and in the genuinely new shape the browser blocks the `fetch` as active mixed content while a top-level form POST carries no `SameSite=Lax` session cookie. `CSRFProtect` is enforced globally and there is no CORS grant anywhere in `cps/`.

`expected_key is None` (malformed `Host`) compares `False` against the 2-tuple rather than raising, and `stated_key` is unconditionally a 2-tuple in that branch.


## Merge-tick verification (independent, 2026-09-07T18:00Z manager)

Re-run from a fresh worktree checked out at `afec451fe6` — not inherited from the authoring leg or from the tick that opened this PR. Five mutants of the choke point, three of them chosen here rather than replayed:

| Mutant | Result |
|---|---|
| revert the accept branch | 2 failed / 31 passed — both `test_tls_proxy_scheme_direction` accept cases |
| host-blind (`expected_key[0] == "http"`) | **8 failed** / 25 passed — hostile-origin, prefix, userinfo, end-to-end cross-site and the trusted-origins rescue |
| **direction-symmetric** (accept the downgrade too) | 2 failed / 31 passed — `test_scheme_downgrade_is_rejected` and the `http, https` parametrisation |
| **drop the `CWNG_TRUSTED_ORIGINS` clause** | 1 failed / 32 passed — `test_trusted_origins_env_var_rescues_a_host_rewriting_proxy` |
| drop the log remedies | 1 failed / 32 passed |
| unmutated | 33 passed, twice, in separate processes; `test_1370` alone → 30 passed (no cross-file order dependency) |

The two added mutants answer questions the diff raises on its face. **Direction-symmetric** proves the one-way constraint is pinned by an executing test rather than only by the comment. **Dropping the trusted-origins clause** was the coverage question: this PR deletes `test_tls_terminating_proxy_that_forwards_no_proto_is_rejected`, which was the only place the `CWNG_TRUSTED_ORIGINS` rescue was asserted *in that context* — the mutant shows `test_trusted_origins_env_var_rescues_a_host_rewriting_proxy` still covers the clause, so the deletion drops a now-wrong assertion and not the coverage.

15/15 required checks green on `afec451fe6`, including Integration Tests (Docker) and E2E Tests (SPA). No new dependencies, no license change, no new external service URL; the five changed files are the guard, its tests, `changelog.d/`, `README.md` and `examples/.env.example`.

**Limit restated, not resolved:** still not exercised against a live HAProxy → traefik chain. The evidence is the real WSGI/ProxyFix/blueprint stack under the reporter's literal headers.
