### PR TITLE
fix(kobo): missing highlighted text is absence, not disagreement (#1923)

### DIFF
--- a/changelog.d/null-highlighted-text-seeding.md
+++ b/changelog.d/null-highlighted-text-seeding.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Bookmarks and highlights saved before Calibre-Web recorded their text no longer stop a book from finishing its sync to your Kobo.** Those older entries have no saved text, and Calibre-Web was reading that missing text as a disagreement with your Kobo rather than as something it simply did not have yet — so the book was held back for safety and could never finish. Calibre-Web now takes the text from your Kobo, which is where it was recorded, and the book syncs. If the two genuinely hold different text, the book is still held back and your copy is left untouched.

--- a/cps/services/annotation_sync/__init__.py
+++ b/cps/services/annotation_sync/__init__.py
@@ -154,21 +154,23 @@ def _book_uuid(book):
 def _kobo_payload_matches_row(annotation, payload, span, normalized_content_id):
     """Whether the payload agrees with the row's known content.
 
-    A legacy NULL type is absence of classification, not a competing claim.
-    Reconciliation separately stores the captured classification. Callers that
-    need a strict write no-op must also check for type enrichment.
+    A legacy NULL type or highlighted text is absence, not a competing claim.
+    Reconciliation separately stores the captured values. Callers that need a
+    strict write no-op must also check for type and text enrichment.
     """
     def supplied(mapping, key, current):
         return mapping.get(key) if key in mapping else current
 
     local_type = getattr(annotation, "annotation_type", None)
     incoming_type = to_storage_type(supplied(payload, "type", local_type))
+    local_text = annotation.highlighted_text
+    incoming_text = supplied(payload, "highlightedText", local_text)
     chapter_progress = span.get("chapterProgress")
     next_context = annotation.context_string
     if "contextString" in span or "context" in span:
         next_context = span.get("contextString") or span.get("context")
     current = (
-        annotation.highlighted_text, annotation.note_text,
+        incoming_text if local_text is None else local_text, annotation.note_text,
         to_storage_color(annotation.highlight_color),
         incoming_type if local_type is None else to_storage_type(local_type),
         annotation.chapter_progress, annotation.content_id,
@@ -177,7 +179,7 @@ def _kobo_payload_matches_row(annotation, payload, span, normalized_content_id):
         annotation.context_string, bool(annotation.hidden),
     )
     incoming = (
-        supplied(payload, "highlightedText", annotation.highlighted_text),
+        incoming_text,
         supplied(payload, "noteText", annotation.note_text),
         # Both sides through the same normaliser: the device's hex and a
         # legacy row's colour NAME are the same colour, and a PATCH that
@@ -324,13 +326,16 @@ def _upsert_annotation(
             # no-op, but a real edit can share the same second and must not be
             # eaten merely because its clock ties. Equal-clock divergent
             # payloads therefore use arrival order as the deterministic tie.
-            # Compatibility permits an unknown local type, but a live PATCH
-            # can still teach us that type. Preserve that write (and its raw
-            # sidecar) rather than dropping new classification as a retry.
+            # Compatibility permits an unknown local type or text, but a live
+            # PATCH can still supply either. Preserve that write (and its raw
+            # sidecar) rather than dropping enrichment as a retry.
             stored_type = to_storage_type(getattr(ann, "annotation_type", None))
             payload_type = to_storage_type(payload.get("type", stored_type))
             if (
                 stored_type == payload_type
+                and ann.highlighted_text == payload.get(
+                    "highlightedText", ann.highlighted_text,
+                )
                 and _kobo_payload_matches_row(ann, payload, span, normalized_content_id)
             ):
                 return None

--- a/cps/services/kobo_annotation_seeding.py
+++ b/cps/services/kobo_annotation_seeding.py
@@ -803,14 +803,25 @@ def _reconcile_and_promote(capture_id, *, book, user, device_id, log):
             if baseline is None:
                 raise ValueError("captured annotation has no server baseline")
             applied = False
-            if equivalent_before and annotation.annotation_type is None:
-                native_type = to_storage_type(payload.get("type"))
-                if native_type is not None and len(native_type) <= 32:
-                    # Compatibility is not a write no-op: retain the captured
-                    # classification in generic storage too. Only fill absence;
-                    # every other field already agrees. Do not apply the whole
-                    # payload or let an older device clock suppress this proof.
-                    annotation.annotation_type = native_type
+            if equivalent_before:
+                # Compatibility is not a write no-op: retain captured values
+                # in generic storage too. Only fill absence; every known field
+                # already agrees. Do not apply the whole payload or let an
+                # older device clock suppress this proof.
+                enriched = False
+                if annotation.annotation_type is None:
+                    native_type = to_storage_type(payload.get("type"))
+                    if native_type is not None and len(native_type) <= 32:
+                        annotation.annotation_type = native_type
+                        enriched = True
+                if (
+                    annotation.highlighted_text is None
+                    and payload.get("highlightedText") is not None
+                ):
+                    # Empty text is Kobo's explicit dogear value, not absence.
+                    annotation.highlighted_text = payload["highlightedText"]
+                    enriched = True
+                if enriched:
                     annotation.content_revision = (annotation.content_revision or 1) + 1
                     annotation.server_modified_at = _now()
             if not equivalent_before and _baseline_allows_insert(

--- a/tests/unit/test_1094_failed_conversion_imports_original.py
+++ b/tests/unit/test_1094_failed_conversion_imports_original.py
@@ -295,14 +295,21 @@ class TestConversionDeadline:
             raise subprocess.TimeoutExpired(cmd, 1234)
 
         monkeypatch.setattr(ingest_processor, "_run_converter_streaming", _fake_run)
+        # Anchor the budget clock the way the sibling budget tests do. It is
+        # measured from module import, so an unpinned assertion is really
+        # asserting how early this test happens to run inside its xdist worker
+        # -- which any PR that adds tests can change. Pinning a known 100s spend
+        # also makes the subtraction observable: with nothing elapsed, "what is
+        # LEFT of the budget" and "the raw total" are indistinguishable.
+        monkeypatch.setattr(ingest_processor, "_PROCESS_START_MONOTONIC",
+                            time.monotonic() - 100)
         nbp = _conversion_processor(tmp_path)
         ok, out = nbp.convert_book()
 
         # The converter receives what is LEFT of the budget, not the raw total,
-        # so two stages can't each spend the whole thing. In a unit test almost
-        # nothing has elapsed, so it lands just under the total.
-        assert captured.get("timeout") == pytest.approx(1234, abs=60)
-        assert captured.get("timeout") <= 1234
+        # so two stages can't each spend the whole thing.
+        assert captured.get("timeout") == pytest.approx(1134, abs=5)
+        assert captured.get("timeout") < 1234
         assert (ok, out) == (False, ""), (
             "a deadline overrun must be reported as an ordinary conversion "
             "failure so main() imports the original"

--- a/tests/unit/test_1942_seed_pipeline.py
+++ b/tests/unit/test_1942_seed_pipeline.py
@@ -2113,3 +2113,108 @@ def test_unknown_type_does_not_mask_other_content_conflicts():
     assert not annotation_sync.kobo_payload_matches_annotation(
         row, payload, SimpleNamespace(id=BOOK_ID, uuid=OWNED),
     )
+
+
+@pytest.mark.parametrize("stored_clock", [
+    datetime(2026, 8, 29, 1, 0, 0), datetime(2035, 1, 1),
+])
+@pytest.mark.parametrize("unknown_type", [False, True])
+@pytest.mark.parametrize("local_text,incoming_text,incoming_type,compatible", [
+    (None, "", "dogear", True),
+    (None, "captured passage", "highlight", True),
+    (None, None, "highlight", True),
+    ("local passage", "competing passage", "highlight", False),
+    ("", "captured passage", "highlight", False),
+    ("local passage", "", "dogear", False),
+    ("local passage", None, "highlight", False),
+    ("same passage", "same passage", "highlight", True),
+])
+def test_seed_text_absence_enriches_but_disagreement_quarantines(
+    app, session, monkeypatch, stored_clock, local_text, incoming_text,
+    incoming_type, compatible, unknown_type,
+):
+    _book(monkeypatch).uuid = OWNED
+    _device(session, DEVICE_A)
+    state = _state(session, status="unseeded", ever=False, content_id=OWNED)
+    row = _annotation_row(
+        "legacy-text", highlighted_text=local_text,
+        annotation_type=None if unknown_type else incoming_type,
+        client_modified_at=stored_clock,
+    )
+    session.add(row)
+    session.commit()
+    payload = _wire_annotation("legacy-text")
+    payload.update(highlightedText=incoming_text, type=incoming_type)
+    monkeypatch.setattr(
+        rs, "proxy_to_kobo_reading_services",
+        lambda **_k: _upstream_response([payload]),
+    )
+
+    with _request(app):
+        g.annotation_origin_device_id = DEVICE_A
+        response = rs.handle_annotations.__wrapped__(OWNED)
+
+    assert response.status_code == 200
+    session.refresh(state)
+    capture = session.query(ub.KoboAnnotationSeedCapture).one()
+    assert state.authority_status == ("authoritative" if compatible else "quarantined")
+    assert capture.reconciliation_conflict_count == (0 if compatible else 1)
+    session.refresh(row)
+    text_enriched = compatible and local_text is None and incoming_text is not None
+    enriched = text_enriched or (compatible and unknown_type)
+    assert row.highlighted_text == (incoming_text if text_enriched else local_text)
+    assert row.annotation_type == (None if unknown_type and not compatible else incoming_type)
+    assert row.content_revision == (2 if enriched else 1)
+    assert row.client_modified_at == stored_clock
+    materialization = session.query(ub.KoboAnnotationMaterialization).one_or_none()
+    if compatible:
+        assert materialization.serveable is True
+        assert materialization.materialization_revision == row.content_revision
+        assert json.loads(materialization.raw_annotation_json)["highlightedText"] == incoming_text
+        with _request(app):
+            g.annotation_origin_device_id = DEVICE_A
+            rendered = rs.handle_annotations.__wrapped__(OWNED)
+        assert rendered.status_code == 200
+        assert json.loads(rendered.get_data())["annotations"][0]["highlightedText"] == incoming_text
+    else:
+        assert capture.failure_reason == "seed_row_conflict_unresolved"
+        assert materialization is None
+
+
+@pytest.mark.parametrize("incoming_text", ["", "captured passage", None])
+def test_equal_clock_patch_text_enrichment_and_retry(session, incoming_text):
+    from cps.services import annotation_sync
+
+    row = _annotation_row("equal-clock-text", highlighted_text=None)
+    session.add(row)
+    session.commit()
+    payload = _wire_annotation("equal-clock-text")
+    payload["highlightedText"] = incoming_text
+    book = SimpleNamespace(id=BOOK_ID, uuid=OWNED)
+    user = SimpleNamespace(id=USER_ID)
+    result = annotation_sync._upsert_annotation(session, payload, book, user)
+    assert (result is not None) is (incoming_text is not None)
+    session.commit()
+    session.refresh(row)
+    assert row.highlighted_text == incoming_text
+    assert row.content_revision == (2 if incoming_text is not None else 1)
+    assert annotation_sync._upsert_annotation(session, payload, book, user) is None
+
+
+@pytest.mark.parametrize("local_text", [None, "known passage", ""])
+def test_omitted_highlighted_text_is_noop(session, local_text):
+    from cps.services import annotation_sync
+
+    row = _annotation_row("omitted-text", highlighted_text=local_text)
+    session.add(row)
+    session.commit()
+    payload = _wire_annotation("omitted-text")
+    del payload["highlightedText"]
+    book = SimpleNamespace(id=BOOK_ID, uuid=OWNED)
+    assert annotation_sync.kobo_payload_matches_annotation(row, payload, book)
+    assert annotation_sync._upsert_annotation(
+        session, payload, book, SimpleNamespace(id=USER_ID),
+    ) is None
+    session.refresh(row)
+    assert row.highlighted_text == local_text
+    assert row.content_revision == 1


### PR DESCRIPTION
Third instance of the defect fixed in #2182 and #2181's follow-up — found by running a predicate across every compared field rather than waiting for the next book to quarantine.

## The bug

Reconciliation compares a captured Kobo annotation against the local row with a strict tuple equality. A mismatch on any field quarantines a book that has never been authoritative.

**Measured:** Kobo sends `highlightedText` on *every* annotation object — as an **empty string** for dogears (13 of 13 captured) and non-empty for highlights (9 of 9).

The trap is a three-part conjunction, and any one part absent makes it harmless:

1. `supplied(mapping, key, current)` falls back to the stored value only when the key is **absent**. Kobo supplies the key, so it returns `""` instead of falling back.
2. `highlighted_text` is compared **raw** — alone among the four, it has no normaliser (`highlight_color` has `to_storage_color`, `annotation_type` has `to_storage_type`) to collapse `None` and `""`.
3. A legacy row holds `NULL`.

So `None` meets `""`, reads as a genuine disagreement, and quarantines. A real book (350) is unseeded with four such dogear rows and would have quarantined on its next re-download.

## The fix

A local NULL is the **absence** of a value, not a competing claim. Three coordinated parts, mirroring #2182:

1. **Compatibility** — when the stored text is NULL both sides resolve to the incoming value. When it is *set* it still compares strictly.
2. **Enrichment, not silence** — `_kobo_payload_matches_row` also serves as `_upsert_annotation`'s "would this write change nothing?" check, so bare compatibility would skip the write that fills the column. That early return now additionally requires exact text equality.
3. **Reconciliation fills an absent text** from the captured object, bumping `content_revision` once even when type and text are enriched together, and never touching the device's clock.

`payload.get("highlightedText") is not None` is deliberate: `""` is Kobo's explicit dogear value and is stored, while an omitted field or an explicit null leaves NULL alone — neither carries information. No length guard is needed here unlike the type, because `highlighted_text` is `Column(String)` (unbounded) where `annotation_type` is `Column(String(32))`.

## Safety property preserved

A genuine disagreement must still conflict. Tests pin all four directions: local text vs different text; `""` vs real text; real text vs `""`; and populated text vs an explicit incoming null. Each asserts quarantine, one reconciliation conflict, that the local text is left untouched, and that no materialization is produced — across equal and future stored client clocks, and with the local type both known and NULL.

## Evidence

- **Seen red**, verified independently by reverting only the two production files to the merge-base and re-running: `AssertionError: assert 'quarantined' == 'authoritative'`.
- Targeted file green: 101 passed in `tests/unit/test_1942_seed_pipeline.py`.
- **Full suite with a control on the merge-base.** Control `23 failed / 8802 passed`; this branch `20 failed / 8843 passed`. Every difference lies inside `tests/unit/test_mutation_harness.py` and moves in **both** directions — one failure on the branch the control lacks, four on the control the branch lacks, including the sibling parametrisation of the same test. That file is independently established as nondeterministic under load: its failures are `IsolationError: cannot inspect process environment: errno 5` from `sysctl(KERN_PROCARGS2)`, explicitly `timeout=False`, and it passes 168/168 in isolation. **Zero failures attributable to this change**, and +41 passing from the new tests.

## The predicate, for the next field — now measured, with denominators

A field conflicts precisely when **Kobo supplies a value for that row's type** and CWNG holds NULL.

I measured the supply side directly rather than reasoning about it, by decompressing the stored
capture bodies and counting **key presence only** (no annotation content read out) — 22 annotation
objects across 4 captured pages:

| key | on `dogear` | on `highlight` |
|---|---|---|
| `highlightedText` | **13/13, every one the empty string** | 9/9, non-empty |
| `highlightColor` | 0/13 | **9/9** |
| `noteText` | **0/13** | **0/9** |

That confirms this fix's premise exactly, and it clears `note_text`: an absent key makes `supplied()`
fall back to the stored value, so no conflict is possible.

**The denominator matters, so here it is.** Those 22 objects are *only* types `dogear` and
`highlight`. My instance also holds 48 rows of type `markup` and 4 of type `note`, and **not one
object of either type has ever been captured**. So "Kobo never supplies `noteText`" is earned for
dogear and highlight and **unearned for `note` and `markup`** — a `note` annotation carrying note
text on the wire is entirely plausible and simply was not sampled. Those 48 `markup` rows all hold
NULL `highlighted_text`, and this fix covers them **by construction** — it keys on the local NULL,
not on the row's type — but their `note_text` is neither fixed nor measured.

**Scope first — who can even reach reconciliation.** Only an account with two-way Kobo annotation
sync enabled ever seeds, and on my instance that is **exactly one of 11 accounts**. Restricted to it:

- `highlight_color` is NULL on **18 rows, every one a dogear** — and Kobo supplies `highlightColor`
  on 0/13 dogears, so no conflict is reachable.
- `note_text` is NULL on **51 rows across 5 books**, all of types `dogear`, `highlight` or unknown —
  the types where `noteText` is measured 0/22.
- There are **no `markup` rows at all** on that account, so the unmeasured type is out of scope.

**A correction to my own earlier claim, and then a correction to the correction.** I first wrote that
every current NULL-colour row is a dogear. Taken across the whole instance that is false — there are
19, and one has a NULL `annotation_type` too. But that row, and all 48 `markup` rows, sit on accounts
with sync **disabled**, so they can never reach this code. Within the account that can, the original
claim holds exactly: 18 of 18 are dogears.

So `highlight_color` and `note_text` are **not** latent bugs waiting for a fix here; they are fields
whose NULLs are unreachable by construction on measured evidence. The type clause in the predicate is
what makes that checkable — without it, `highlight_color` false-positives on every dogear. If a future
instance enables sync on an account holding `markup` rows, `note_text` is the field to re-measure
first, because all 48 of those rows hold NULL and no capture has ever contained that type.
---

## Second commit: a flaky conversion-deadline test this branch *triggers*

CI went red on `test_1094_failed_conversion_imports_original.py::TestConversionDeadline::test_convert_book_passes_the_deadline_to_the_converter`. **My first call was that it had no causal path to this change. That was wrong**, and `main` passing it on every recent run is what forced the re-look.

**Mechanism.** `scripts/ingest_processor.py:45` sets `_PROCESS_START_MONOTONIC` at *module import*, and `:460` returns `total - (now - _PROCESS_START_MONOTONIC)`. The "elapsed" being subtracted is therefore **how long that xdist worker has been alive**, not how long the test took. This branch adds 41 tests, which shifts xdist's distribution, so the worker reached this test ~65s into its life. Observed twice: **1166.812** and **1169.398** against `pytest.approx(1234, abs=60)`.

So this change is the *proximate trigger* of a latent test defect rather than a defect in the change — but it is not unrelated, and filing it as unrelated would have been false. It was also the **only** test in that file not pinning the clock; its siblings at `:352`, `:367` and `:380` already do, one of them commenting that "the suite's own runtime counts against a budget that is deliberately measuring wall clock".

**The fix is also strictly stronger.** Pinning a known 100s spend makes the subtraction *observable*. Measured against a mutant that drops it (`return total`):

| assertion | mutant result |
|---|---|
| new — `approx(1134, abs=5)` and `< 1234` | **FAILS** (`assert 1234 == 1134 ± 5`) |
| old — `approx(1234, abs=60)` | **PASSES** (1234 is within 60 of 1234; 1234 ≤ 1234) |

The old test could not observe the subtraction it was written to check. It was flaky *and* vacuous on the same property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

