### PR TITLE
test(conversion): pin the clock before the first budget measurement too

### DIFF
--- a/tests/unit/test_1094_failed_conversion_imports_original.py
+++ b/tests/unit/test_1094_failed_conversion_imports_original.py
@@ -352,6 +352,15 @@ class TestConversionBudgetIsSharedAcrossStages:
 
     def test_second_stage_gets_less_than_the_first(self, monkeypatch):
         monkeypatch.setenv("CWA_CONVERSION_DEADLINE_SECONDS", "600")
+        # Pin the clock before the FIRST measurement too. Leaving it unpinned
+        # meant `first` used the real import-time anchor, so a worker that had
+        # already outlived the 600s budget got `first` clamped to the 0.1 floor
+        # and the comparison below inverted. Not hypothetical and not flaky:
+        # OBSERVED on main in a 756s suite leg as `assert 199.99999687499803
+        # < 0.1`. Pinning an unspent budget also makes `first` an assertable
+        # value rather than whatever the schedule happened to leave.
+        monkeypatch.setattr(ingest_processor, "_PROCESS_START_MONOTONIC",
+                            time.monotonic())
         first = ingest_processor.conversion_budget_remaining()
         # Simulate the first conversion having burned real time. Anchored to
         # now, not to the import-time value: the suite's own runtime counts
@@ -360,6 +369,9 @@ class TestConversionBudgetIsSharedAcrossStages:
                             time.monotonic() - 400)
         second = ingest_processor.conversion_budget_remaining()
 
+        assert first == pytest.approx(600, abs=5), (
+            "an unspent budget is the whole allowance"
+        )
         assert second < first, "the second stage must not get a fresh full budget"
         assert second == pytest.approx(200, abs=5), (
             "after 400s of a 600s budget, ~200s must remain"


### PR DESCRIPTION
## The bug

`TestConversionBudgetIsSharedAcrossStages::test_second_stage_gets_less_than_the_first` pinned `_PROCESS_START_MONOTONIC` only around its **second** measurement:

```python
first = ingest_processor.conversion_budget_remaining()      # real import-time anchor
monkeypatch.setattr(ingest_processor, "_PROCESS_START_MONOTONIC",
                    time.monotonic() - 400)                 # pins only what follows
second = ingest_processor.conversion_budget_remaining()
assert second < first
```

`conversion_budget_remaining()` returns `max(0.1, total - (now - _PROCESS_START_MONOTONIC))`. Once the worker has been alive longer than the 600s budget, the subtraction goes negative, the floor clamps `first` to **0.1**, and the assertion inverts to `200 < 0.1`.

**Deterministic, not flaky.** Observed on `main` in a 756s suite leg as `assert 199.99999687499803 < 0.1`.

## Evidence

Reproduced directly by simulating a worker that has outlived the budget (patching the module object the test actually imports — patching `scripts.ingest_processor` instead yields a *different* object and silently patches nothing, which is how a first attempt at this reproduction "passed"):

| | 700s-old worker |
|---|---|
| before this change | **FAILS** — `assert 199.9999966250034 < 0.1` |
| after | passes |

Sweeping the **whole file** at simulated worker ages of 700s and 3600s gives exactly **1 failed / 69 passed** before the change and **70 passed** after — so this is the last measurement in the file reading a real clock.

## A correction

When I pinned the sibling test in #2190 I wrote that it was the only test in the file not pinning the clock. That was wrong. The sibling *does* pin — but around one of its two measurements. I had checked for the presence of a `monkeypatch.setattr` line in the test body rather than whether every measurement was covered by one, and a partial pin reads identically to a full one at that level of inspection.

The assertion is also now strictly stronger: pinning an unspent budget makes `first` an assertable value rather than whatever the schedule happened to leave, so the test states that an unspent budget is the whole allowance.
