### PR TITLE
fix(kobo): a highlight uploaded over the login session keeps its device (#1853)

### DIFF
--- a/changelog.d/1853-kobo-highlight-device-attribution.md
+++ b/changelog.d/1853-kobo-highlight-device-attribution.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Highlights made on a Kobo are attributed to that Kobo again, instead of "Unknown device".** When the e-reader uploaded a highlight over its login session without repeating its hardware identifier, the server could not tell which device the highlight came from and stored it unattributed — so the Highlights page labelled it "Unknown device" and it never appeared under the reader that made it. The device's identity is now retained for the length of its login session, and is only ever resolved to an active Kobo belonging to the signed-in user.

--- a/cps/readingservices.py
+++ b/cps/readingservices.py
@@ -227,6 +227,16 @@ def requires_reading_services_auth_and_config(f):
                     g.annotation_origin_device_id = register_kobo_device_best_effort(
                         user_id=current_user.id, headers=request.headers, return_internal=True,
                     )
+                    if request.method == "PATCH" and _is_annotation_path(request.path):
+                        # Authority gates use the header-only identity above. A
+                        # cookie may attribute an upload without changing which
+                        # replacement set or acknowledgement the device receives.
+                        g.annotation_upload_device_id = g.annotation_origin_device_id
+                        if request.headers.get("x-kobo-deviceid") is None:
+                            g.annotation_upload_device_id = register_kobo_device_best_effort(
+                                user_id=current_user.id, headers=request.headers,
+                                return_internal=True, allow_session_fallback=True,
+                            )
                 except KoboDeviceLimitReached as error:
                     return make_response(jsonify({"error": str(error)}), 409)
                 except Exception:
@@ -1015,7 +1025,9 @@ def _stage_patch_for_recovery(raw_body, entitlement_id):
             raw_body=raw_body,
             entitlement_id=entitlement_id,
             user_id=getattr(current_user, "id", None),
-            origin_device_id=getattr(g, "annotation_origin_device_id", None),
+            origin_device_id=getattr(
+                g, "annotation_upload_device_id", getattr(g, "annotation_origin_device_id", None),
+            ),
         )
     except Exception:
         log.error(
@@ -1471,7 +1483,9 @@ def handle_annotations(entitlement_id):
                                 annotation_count=len(updated),
                             )
                 dispatch_kwargs = {
-                    "origin_device_id": getattr(g, "annotation_origin_device_id", None),
+                    "origin_device_id": getattr(
+                        g, "annotation_upload_device_id", getattr(g, "annotation_origin_device_id", None),
+                    ),
                 }
                 if raw_materializations is not None:
                     dispatch_kwargs.update(

--- a/cps/services/device_registry.py
+++ b/cps/services/device_registry.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import sessionmaker
 
 log = logging.getLogger(__name__)
 SCHEME = "kobo-header-hmac-sha256-v1"
+KOBO_SESSION_DEVICE_KEY = "_kobo_device_public_id"
 KOREADER_SCHEME = "koreader-client-hmac-sha256-v1"
 WEBREADER_SCHEME = "webreader-cookie-hmac-sha256-v2"
 WEBREADER_SCHEME_PREFIX = "webreader-cookie-hmac-sha256-"
@@ -273,16 +274,36 @@ def upsert_kobo_device(session, *, user_id, headers, secret_key, seen_at=None):
     return device
 
 
-def register_kobo_device_best_effort(*, user_id, headers, secret_key=None, return_internal=False):
-    """Observe in an isolated transaction; surface only the intentional cap."""
+def register_kobo_device_best_effort(*, user_id, headers, secret_key=None, return_internal=False,
+                                   allow_session_fallback=False):
+    """Resolve the request's Kobo, retaining identity across its login session.
+
+    Reading Services uses the login cookie and need not repeat the store API's
+    hardware header. Retain only the public registry id in that signed cookie;
+    a headerless upload must still resolve an active Kobo owned by this user.
+    An explicit hardware header always takes precedence, even if invalid.
+    Fallback is opt-in for attribution; download authority keeps its existing
+    header-only device resolution.
+    """
     owned = None
     try:
-        from flask import current_app
+        from flask import current_app, has_request_context, session as login_session
         from cps import ub
+        in_request = has_request_context()
+        if headers.get("x-kobo-deviceid") is None and not allow_session_fallback:
+            return None
+        previous_id = login_session.pop(KOBO_SESSION_DEVICE_KEY, None) if in_request else None
         key = secret_key if secret_key is not None else current_app.secret_key
         owned = sessionmaker(bind=ub.session.get_bind())()
-        device = upsert_kobo_device(owned, user_id=user_id, headers=headers, secret_key=key)
+        if headers.get("x-kobo-deviceid") is None and previous_id is not None:
+            device = owned.query(ub.Device).filter_by(
+                public_id=previous_id, user_id=user_id, kind="kobo", active=True,
+            ).first()
+        else:
+            device = upsert_kobo_device(owned, user_id=user_id, headers=headers, secret_key=key)
         owned.commit()
+        if in_request and device is not None and device.active:
+            login_session[KOBO_SESSION_DEVICE_KEY] = device.public_id
         return (device.id if return_internal else device.public_id) if device else None
     except KoboDeviceLimitReached:
         if owned is not None:

--- a/tests/unit/test_kobo_highlight_session_attribution.py
+++ b/tests/unit/test_kobo_highlight_session_attribution.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Kobo login -> cookie-authenticated PATCH -> Highlights device label (#1853).
+
+The exchanges are synthetic: the regression condition is a Reading Services
+upload that does not repeat the hardware header from the store API login.
+Auth, device registration, annotation persistence and UI serialization are real.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+
+@pytest.fixture
+def reader(tmp_path, monkeypatch):
+    from cps import annotations, constants, kobo, kobo_auth, readingservices, ub
+    from cps.cw_login import LoginManager
+    from cps.usermanagement import load_user
+    from cps.services import annotation_backup, annotation_sync
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'reader.sqlite'}")
+    ub.Base.metadata.create_all(engine)
+    database = sessionmaker(bind=engine)()
+    monkeypatch.setattr(ub, "session", database)
+    monkeypatch.setattr(ub, "session_commit", lambda: database.commit() or True)
+    monkeypatch.setattr(constants, "CONFIG_DIR", str(tmp_path))
+    monkeypatch.setattr(annotation_backup, "WORKER_AUTOSTART", False)
+    annotation_backup.reset_for_tests()
+    monkeypatch.setattr(annotation_sync, "_HANDLERS", {})
+    monkeypatch.setattr(annotation_sync, "_background_enqueue", lambda: None)
+    monkeypatch.setattr(kobo_auth, "limiter", SimpleNamespace(check=lambda: None, current_limits=[]))
+    monkeypatch.setattr(kobo.config, "config_kobo_sync", True, raising=False)
+    monkeypatch.setattr(kobo.config, "config_kobo_proxy", False, raising=False)
+    monkeypatch.setattr(kobo.config, "config_kobo_two_way_annotation_sync", False, raising=False)
+    monkeypatch.setattr(kobo.config, "config_allow_reverse_proxy_header_login", False, raising=False)
+    book = SimpleNamespace(id=42, uuid="00000000-0000-4000-8000-000000000042", title="Test book")
+    monkeypatch.setattr(readingservices, "resolve_entitlement_ownership", lambda _id: book)
+    monkeypatch.setattr(readingservices, "get_book_by_entitlement_id", lambda _id: book)
+    monkeypatch.setattr(readingservices, "proxy_to_kobo_reading_services", lambda **_kw: ("", 200))
+    monkeypatch.setattr(readingservices, "_begin_exchange_capture", lambda *_a, **_kw: None)
+    monkeypatch.setattr(annotations, "_resolve_book_or_404", lambda _id: book)
+    monkeypatch.setattr(annotations, "_resolve_annotation_anchor", lambda *_a: (None, "unresolved"))
+
+    user = ub.User(name="reader", email="reader@example.invalid", password="unused", role=0)
+    database.add(user)
+    database.flush()
+    token = ub.RemoteAuthToken()
+    token.user_id = user.id
+    token.auth_token = "reader-token"
+    token.token_type = 1
+    database.add(token)
+    database.commit()
+    app = Flask(__name__)
+    app.config.update(TESTING=True, SECRET_KEY="synthetic-session-secret")
+    manager = LoginManager(app)
+    manager.user_loader(load_user)
+    app.register_blueprint(kobo.kobo)
+    app.register_blueprint(readingservices.readingservices_api_v3)
+    app.register_blueprint(annotations.annotations_bp)
+    yield SimpleNamespace(app=app, db=database, book=book, user=user)
+    database.close()
+    engine.dispose()
+    annotation_backup.reset_for_tests()
+
+
+HEADERS = {"x-kobo-deviceid": "a" * 64, "x-kobo-devicemodel": "Kobo Clara"}
+
+
+@pytest.mark.parametrize("patch_headers", [HEADERS, {}], ids=["repeated-header", "session-only"])
+def test_new_kobo_highlight_names_the_device_from_its_login(reader, patch_headers):
+    """Losing identity between login and PATCH must fail on the new stored row."""
+    from cps import ub
+
+    client = reader.app.test_client()
+    response = client.post("/kobo/reader-token/v1/auth/device", headers=HEADERS, json={})
+    assert response.status_code == 200
+    device = reader.db.query(ub.Device).one()
+    assert device.display_name == "Kobo Clara"
+    assert reader.db.query(ub.Annotation).count() == 0
+
+    response = client.patch(
+        f"/api/v3/content/{reader.book.uuid}/annotations",
+        headers=patch_headers,
+        json={"updatedAnnotations": [{"id": "new-highlight", "type": "highlight",
+                                      "highlightedText": "A newly highlighted passage.",
+                                      "clientLastModifiedUtc": "2026-09-07T18:00:00Z",
+                                      "location": {"span": {"chapterFilename": "chapter.xhtml",
+                                                            "startPath": "span#kobo.1.1",
+                                                            "endPath": "span#kobo.1.1",
+                                                            "startChar": 0, "endChar": 10}}}]},
+    )
+    assert response.status_code == 200, response.get_data(as_text=True)
+    reader.db.expire_all()
+    row = reader.db.query(ub.Annotation).one()
+    assert row.origin_device_id == device.id, (
+        f"new Kobo highlight stored origin_device_id={row.origin_device_id!r}; "
+        f"registered Kobo Clara has id={device.id}"
+    )
+    response = client.get("/annotations/42/data.json")
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["annotations"][0]["origin_device_id"] == device.public_id
+    assert body["devices"][device.public_id]["label"] == "Kobo Clara"
+
+
+@pytest.mark.parametrize("condition", ["separate-session", "retired", "other-user", "invalid-header"])
+def test_session_attribution_requires_a_current_device_owned_by_this_user(reader, condition):
+    """An existing Devices row is insufficient without valid session provenance."""
+    from cps import ub
+
+    client = reader.app.test_client()
+    assert client.post("/kobo/reader-token/v1/auth/device", headers=HEADERS, json={}).status_code == 200
+    device = reader.db.query(ub.Device).one()
+    if condition == "separate-session":
+        client = reader.app.test_client()
+        assert client.post("/kobo/reader-token/v1/auth/device", json={}).status_code == 200
+    elif condition == "retired":
+        device.active = False
+        reader.db.commit()
+    elif condition == "other-user":
+        other = ub.User(name="other", email="other@example.invalid", password="unused", role=0)
+        reader.db.add(other)
+        reader.db.flush()
+        token = ub.RemoteAuthToken()
+        token.user_id, token.auth_token, token.token_type = other.id, "other-token", 1
+        reader.db.add(token)
+        reader.db.commit()
+        assert client.post("/kobo/other-token/v1/auth/device", json={}).status_code == 200
+    else:
+        # Explicit but invalid hardware identity must invalidate the old binding.
+        assert client.post("/kobo/reader-token/v1/auth/device",
+                           headers={"x-kobo-deviceid": "invalid"}, json={}).status_code == 200
+
+    response = client.patch(
+        f"/api/v3/content/{reader.book.uuid}/annotations",
+        json={"updatedAnnotations": [{"id": "unattributed-highlight", "type": "highlight",
+                                      "highlightedText": "Keep this highlight.",
+                                      "clientLastModifiedUtc": "2026-09-07T18:00:00Z",
+                                      "location": {"span": {"chapterFilename": "chapter.xhtml",
+                                                            "startPath": "span#kobo.1.1",
+                                                            "endPath": "span#kobo.1.1",
+                                                            "startChar": 0, "endChar": 10}}}]},
+    )
+    assert response.status_code == 200, response.get_data(as_text=True)
+    reader.db.expire_all()
+    row = reader.db.query(ub.Annotation).one()
+    assert row.origin_device_id is None
+    assert row.highlighted_text == "Keep this highlight."


### PR DESCRIPTION
Fixes the "Unknown device" label on highlights that a Kobo uploads over its login session.

## What was wrong

A Kobo authenticates to the store API with a hardware identifier header (`x-kobo-deviceid`), and
`cps/kobo_auth.py:201` uses it to register the device and stamp the request. But Reading Services
uploads run on the **login cookie** and need not repeat that header. When they don't,
`register_kobo_device_best_effort` resolved no device at all (the fingerprint is empty, so
`upsert_kobo_device` returned `None` before ever looking at the existing identity), the annotation
was constructed with `origin_device_id = NULL`
(`cps/services/annotation_sync/__init__.py:349`), and the Highlights page rendered a null origin as
"Unknown device".

The device row existed the whole time. Only the link from the upload back to it was lost.

## The fix

The resolved device's **public** registry id is retained in the signed login session, and a
headerless annotation upload may fall back to it. The fallback is deliberately narrow:

- **Opt-in.** `allow_session_fallback` defaults to false; only the annotation `PATCH` path passes it.
  Every download/authority gate keeps its existing header-only resolution, so which replacement set
  or acknowledgement a device receives is unchanged.
- **Ownership-checked.** The stored id only resolves a device that is still `active`, is `kind="kobo"`,
  and belongs to the authenticated user. A stale id from a previous user of the same cookie matches
  nothing and attribution falls back to null.
- **Header wins.** An explicit hardware header always takes precedence, including when it is invalid.

## Evidence

Regression test `tests/unit/test_kobo_highlight_session_attribution.py` drives registered Flask routes
— real Kobo auth, real device registration, real annotation persistence, and the Highlights data
endpoint — starting from zero annotations.

- **Red on unmodified `origin/main` (cb48e56d85):** `1 failed, 5 passed` —
  `AssertionError: new Kobo highlight stored origin_device_id=None; registered Kobo Clara has id=1`
- **Green with the fix:** `6 passed`

**Independent mutation pass** (manager, not the author leg) — each mutant caught by exactly one test:

| Mutant at the choke point | Result |
|---|---|
| session fallback ignores `user_id` (cross-user attribution) | 1 failed, 5 passed |
| session fallback accepts a retired/inactive device | 1 failed, 5 passed |
| no session fallback at the call site (the original defect) | 1 failed, 5 passed |
| stored session id wins over an explicit hardware header | 1 failed, 5 passed |

**Adjacent suites**, re-run independently and **twice** (identical both times): 142 Kobo / annotation /
device / kosync / webreader unit modules — **1748 passed, 1 skipped** (the skip needs
`CWNG_REAL_KOBO_DB`). `tests/integration/test_real_app_kobo.py` — **2 passed**. Kobo auth smoke —
**9 passed**.

**Security review** (change touches session handling, so the gate applies): **no qualifying findings.**
Paths traced: other callers reaching the fallback; the unconditional session `pop`; disclosure via
storing `public_id` in the signed cookie; cross-user attribution across a re-login on a reused cookie
(logout does not clear the session, so the key survives — the ownership filter is what neutralises it,
and the mutation table above proves that filter is load-bearing); header-only binding to the wrong
user; `g` leakage into authority gates.

## Stated limit

This fixes a defect that is **reproduced and proven**. It is **not** proven to be the exact cause of
the symptom @hayvan96 reported in discussion #1853 — that would need a capture showing their Clara's
annotation PATCH omitting the hardware header while carrying the login cookie. Their thread stays
open and is not closed by this PR.

One known rough edge, not a security issue and not fixed here: if the header path resolves no device
(identity bound to another user, or an empty header), the stored session id has already been popped
and is not restored, so attribution stays null until a good header arrives.

Reported by @hayvan96 in #1853.
