### PR TITLE
test(kobo): prove a 296-book dual-format library drains across sync sessions (#2201)

### DIFF
--- a/notes/2201-kobo-multipage-drain.md
+++ b/notes/2201-kobo-multipage-drain.md
@@ -1,0 +1,143 @@
+# Issue #2201: executed multi-session delivery comparison
+
+Current main at `9ce113de64c418887d19ab084fef56760625fe5e` delivers the
+296-book reproduction completely. This change adds coverage, not a runtime fix.
+
+## Reproduction
+
+`tests/unit/test_2201_kobo_multipage_drain.py` drives the real sync handler
+through Flask HTTP dispatch. Each of eight sessions sends the preceding
+response's opaque sync token. The test never acknowledges a pending page by
+calling ledger helpers: the handler consumes the token and updates delivery
+state itself.
+
+The fixture uses real SQLAlchemy models and SQLite queries. All 296 books have
+both EPUB and KEPUB rows, the production page limit stays at 100, and all books
+share a last-modified second and creation time. Four cases cross sync-all and
+shelf-only scope with uniform or mixed literal SQLite timestamp text:
+
+```
+2026-01-01 00:00:00
+2026-01-01 00:00:00.000000
+2026-01-01 00:00:00+00:00
+2026-01-01 00:00:00.000000+00:00
+```
+
+Every book also belongs to a sync-enabled shelf with a newer membership date,
+2026-02-01. That date deliberately exercises a cursor advanced beyond the
+undelivered books. UUIDs are counted from emitted entitlements, not inferred
+from database counts. First delivery must be NewEntitlement, and subsequent
+empty sessions must stay empty. Local pages intentionally omit the continuation
+header so firmware can persist their tokens between sessions (#1634).
+
+## Observed results
+
+| Code | Sync-all sessions | Shelf-only sessions |
+| --- | --- | --- |
+| v4.1.43 (`bdead55920e066ff529da0865c712b5dcdf7cfd3`) | 100 New, 100 Changed, 96 Changed, then five empty | 100 New, then seven empty |
+| `0e3b86005a736f467fb16db68f79acfe2f318100` | 100 New, 100 New, 96 New, then five empty | Same |
+| Current main | 100 New, 100 New, 96 New, then five empty | Same |
+
+Uniform and mixed timestamp text produced identical results. All responses
+were HTTP 200. No existing Kobo test was edited, deleted, or weakened.
+
+The v4.1.43 failure output includes these two distinct assertions (each appears
+for both timestamp shapes):
+
+```
+E   AssertionError: Only 100/296 books received NewEntitlement; changed before new=196; pages=[(100, 0, None), (0, 100, None), (0, 96, None), (0, 0, None), (0, 0, None), (0, 0, None), (0, 0, None), (0, 0, None)]
+E   AssertionError: Only 100/296 books received NewEntitlement; changed before new=0; pages=[(100, 0, None), (0, 0, None), (0, 0, None), (0, 0, None), (0, 0, None), (0, 0, None), (0, 0, None), (0, 0, None)]
+```
+
+The closing commit is **0e3b86005a, Fix Kobo new-vs-changed classification
+across sync pages (#2025)**. Its two relevant changes explain the measurement:
+
+- Classification uses the requesting device's delivery ledger, replacing a
+  creation-time watermark that labeled page two's never-delivered books Changed.
+- A missing device-ledger entry admits a book independently of the timestamp
+  cursor, recovering books excluded after the newer shelf membership date was
+  folded into page one's cursor.
+
+This was checked by executing the same four cases on that commit itself, not
+only by reading its diff. Both normalized timestamp ordering and format-join
+deduplication already exist in the tested tag. Neither needs another fix for
+this reproduction.
+
+## Verification and historical harness adaptation
+
+Executed pytest invocations used the existing repository virtualenv, with
+isolated CALIBRE_DBPATH and CWNG_PYTEST_TMP_BASE directories. Historical runs
+used a detached worktree on the external scratch volume. Test selection and
+verbatim final result lines:
+
+```
+python -m pytest -q -s tests/unit/test_2201_kobo_multipage_drain.py
+======================= 4 passed, 1232 warnings in 5.59s =======================
+
+# v4.1.43, then 0e3b86005a, in the historical worktree:
+python -m pytest -q -s -p comparison_adapter tests/unit/test_2201_kobo_multipage_drain.py
+======================= 4 failed, 1960 warnings in 4.50s =======================
+======================= 4 passed, 1960 warnings in 5.06s =======================
+
+python -m pytest -q tests/unit/*kobo*.py
+=============== 1071 passed, 1 skipped, 15566 warnings in 45.00s ===============
+```
+
+The commands above show test selection; executable and scratch environment paths
+are omitted. The handoff report records the full invocations. The skipped test
+requires CWNG_REAL_KOBO_DB to point to an actual KoboReader.sqlite copy.
+
+The historical worktree received unchanged copies of the new test and its
+`test_kobo_replay_topup_pagination.py` population helper. Historical production
+files stayed unchanged. Its existing #1925 fixture exposed a request-context
+helper and a non-callable WSGI placeholder rather than a dispatchable route.
+The temporary comparison plugin adapted only that boundary:
+
+```python
+import pytest
+from flask import Flask, g
+
+
+@pytest.fixture(autouse=True)
+def dispatch_tag_sync(sync_harness):
+    from cps import kobo
+
+    class ProxiedWsgi:
+        is_proxied = True
+
+        def __call__(self, environ, start_response):
+            return Flask.wsgi_app(sync_harness.app, environ, start_response)
+
+    sync_harness.app.wsgi_app = ProxiedWsgi()
+
+    def dispatched_sync():
+        g.annotation_origin_device_id = sync_harness.device.id
+        return kobo.HandleSyncRequest.__wrapped__()
+
+    sync_harness.app.add_url_rule(
+        '/v1/library/sync', view_func=dispatched_sync,
+    )
+```
+
+During construction, three preliminary runs failed because the new fixture
+omitted the shelf relationship, addressed the wrong attached database, and
+incorrectly treated absence of continuation as proof that the whole library
+was exhausted. These were test-development errors, not product regressions.
+The historical failures reported above occur with the corrected test that
+passes on main.
+
+## Limits
+
+There is no physical Kobo, NFS mount, or ARM64 host in this verification.
+Authentication/device registration is represented by the existing test fixture;
+permission filtering, filesystem layout/download URLs, external integrations,
+and collection serialization are stubbed at its established boundaries.
+The real entitlement serialization, candidate selection, pagination, token
+encoding/decoding, and delivery acknowledgment run against SQLite.
+
+This proves complete entitlement announcement across successive sessions for
+the tested shapes. It does not prove firmware downloads/imports the EPUB/KEPUB
+bytes, real device handling of an unknown ChangedEntitlement, timing or locking
+on NFS, ARM64 runtime behavior, proxy-store interactions, or recovery from the
+reporter's actual existing device/database state. No production deployment or
+GitHub operation was performed.

--- a/tests/unit/test_2201_kobo_multipage_drain.py
+++ b/tests/unit/test_2201_kobo_multipage_drain.py
@@ -1,0 +1,110 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""A bulk-imported dual-format library must reach the reader across sessions.
+
+Use HTTP dispatch and the returned opaque token for acknowledgment; do not
+promote delivery ledgers from the test. SQLite timestamps are literal TEXT so
+ORM serialization cannot erase the mixed-spelling page-boundary case.
+"""
+
+from datetime import datetime
+
+import pytest
+
+from tests.unit.test_1925_kobo_sync_dedownload import sync_harness
+from tests.unit.test_kobo_replay_topup_pagination import _populate_library
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize("shelf_only", [False, True], ids=["all", "shelf"])
+@pytest.mark.parametrize("mixed_text", [False, True], ids=["tied", "mixed-text"])
+def test_bulk_library_drains_across_sync_sessions(
+    sync_harness, monkeypatch, shelf_only, mixed_text,
+):
+    from cps import db, kobo, ub
+
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+        raising=False,
+    )
+    books = _populate_library(sync_harness, 296, tied=True)
+    expected = {str(book.uuid) for book in books}
+    session = sync_harness.session
+    sync_harness.user.kobo_only_shelves_sync = shelf_only
+    shelf = ub.Shelf(name="Bulk import", user_id=sync_harness.user.id,
+                     kobo_sync=True)
+    session.add(shelf)
+    session.flush()
+    for book in books:
+        session.add(db.Data(book.id, "KEPUB", 3_000_000, book.path))
+        session.add(ub.BookShelf(
+            book_id=book.id, ub_shelf=shelf, order=book.id,
+            date_added=datetime(2026, 2, 1),
+        ))
+    session.commit()
+    spellings = (
+        "2026-01-01 00:00:00",
+        "2026-01-01 00:00:00.000000",
+        "2026-01-01 00:00:00+00:00",
+        "2026-01-01 00:00:00.000000+00:00",
+    )
+    for index, book in enumerate(books):
+        session.connection().exec_driver_sql(
+            "UPDATE books SET last_modified = ? WHERE id = ?",
+            (spellings[index % len(spellings)] if mixed_text else spellings[1],
+             book.id),
+        )
+    session.commit()
+    session.expire_all()
+
+    token = None
+    delivered = []
+    changed_before_new = []
+    pages = []
+    terminal = False
+    client = sync_harness.app.test_client()
+    # Each request is a successive sync session. Local pages intentionally
+    # omit continuation so firmware persists their cursor (#1634). Once a
+    # session delivers nothing, further sessions must stay quiet.
+    for _ in range(8):
+        headers = {"x-kobo-deviceid": "a" * 64,
+                   "x-kobo-devicemodel": "Kobo Clara BW"}
+        if token is not None:
+            headers[sync_harness.token_header] = token
+        response = client.get("/v1/library/sync", headers=headers)
+        assert response.status_code == 200, response.get_data(as_text=True)
+        token = response.headers[sync_harness.token_header]
+        new = []
+        changed = []
+        for item in response.get_json():
+            for kind in ("NewEntitlement", "ChangedEntitlement"):
+                if kind not in item:
+                    continue
+                entitlement = item[kind]["BookEntitlement"]
+                assert not entitlement["IsRemoved"]
+                book_uuid = entitlement["Id"]
+                if kind == "NewEntitlement":
+                    new.append(book_uuid)
+                else:
+                    changed.append(book_uuid)
+                    if book_uuid not in delivered:
+                        changed_before_new.append(book_uuid)
+        pages.append((len(new), len(changed), response.headers.get("x-kobo-sync")))
+        assert len(new) + len(changed) <= kobo.SYNC_ITEM_LIMIT
+        if terminal:
+            assert not new and not changed, pages
+        delivered.extend(new)
+        if not new and not changed and response.headers.get("x-kobo-sync") != "continue":
+            terminal = True
+
+    assert set(delivered) == expected, (
+        f"Only {len(set(delivered))}/296 books received NewEntitlement; "
+        f"changed before new={len(changed_before_new)}; pages={pages}"
+    )
+    assert not changed_before_new, pages
+    assert len(delivered) == len(expected), pages
+    assert terminal, pages
+    print(f"drain shelf_only={shelf_only} mixed_text={mixed_text}: {pages}")


### PR DESCRIPTION
## What this is

Issue #2201 reports a Kobo library of 296 books that never finishes syncing: ~100 books arrive, the
cursor stops advancing, and deleting the sync entries sometimes yields a *different* ~100. That is
the signature of fork #347 — keyset pagination over a non-unique `last_modified`.

The reporter is on the published tag **v4.1.43**. This branch establishes, by executing the
behaviour, that **current `main` already drains their library completely**, identifies the commit
that closed it, and lands the coverage that was missing. **There is no runtime change here** — the
diff is one test file and one notes document.

## What was measured

`tests/unit/test_2201_kobo_multipage_drain.py` drives the real `/v1/library/sync` handler through
Flask HTTP dispatch across eight successive sessions, carrying each response's opaque sync token
into the next request the way firmware does. It never promotes delivery state through ledger
helpers — the handler consumes the token and does that itself. 296 books, each with **both** an EPUB
and a KEPUB row, all sharing one `last_modified` second, all on a sync-enabled shelf whose
membership date deliberately postdates them. Four cases cross sync-all vs. shelf-only against
uniform vs. mixed literal SQLite timestamp spellings.

| Code under test | sync-all | shelf-only |
|---|---|---|
| v4.1.43 (`bdead55920`) | 100 New, then 100 + 96 **Changed** for books never delivered | 100 New, then seven empty sessions |
| `0e3b86005a` (#2025) | 100 / 100 / 96 New, then quiet | complete |
| main `9ce113de64` | 100 / 100 / 96 New, then quiet | complete |

`0e3b86005a` — *Fix Kobo new-vs-changed classification across sync pages (#2025)* — is the closing
commit. Two of its changes account for the difference: the per-device entitlement ledger replaced
the creation-time watermark for New-vs-Changed classification, and a book missing from the
requesting device's ledger stays eligible independently of the timestamp cursor.

Mixed timestamp spellings behaved identically to uniform ones. Timestamp normalization and
format-join dedup were already present in v4.1.43, so this reproduction does **not** justify further
change to either.

## Evidence

Authoring leg (Astra), then independently re-run and extended by the manager on `cfd7a07a14`:

```
tests/unit/test_2201_kobo_multipage_drain.py   4 passed in 4.83s
tests/unit/test_2201_kobo_multipage_drain.py   4 passed in 4.72s   (second, separate process)
tests/unit/*kobo*.py                           1071 passed, 1 skipped in 44.13s
```

A test that only ever passes proves nothing, so the manager mutated `cps/kobo.py` on current main at
each of the two mechanisms named above and confirmed the new test is capable of detecting both —
and that each mutant reproduces a *different* one of the reporter's two symptoms:

| Mutant | Result |
|---|---|
| `device_entitlement_recovery_filter` forced to `None` (ledger-recovery arm removed) | **2 failed** (both shelf-only cases), 2 passed |
| per-device ledger no longer classifies New (`if False and …`) | **4 failed** |

The complementary split is the point: the recovery arm is what rescues the shelf-only stall, and the
ledger classification is what rescues the sync-all "announced as Changed before it was ever New"
case. Working tree restored and verified clean after each mutant.

The one skipped test needs `CWNG_REAL_KOBO_DB` pointing at a real Kobo database copy. No existing
Kobo test was edited, deleted or weakened.

## What this does not establish

No physical Kobo, no NFS mount, no ARM64 host was involved. This proves complete *entitlement
announcement* across sessions for the tested library shapes. It does not prove firmware download of
the actual bytes, how firmware treats an unknown `ChangedEntitlement`, NFS timing or locking, ARM64
behaviour, proxy-store interaction, or recovery from the reporter's existing on-device state.
Authentication and device registration use the existing fixture's stubs.

Closes nothing on its own: #2201 stays open until the reporter is on code that contains
`0e3b86005a`, which means the release train.
