### PR TITLE
fix(changelog): gate fragments on real assembly, and repair 16 unshippable ones

### DIFF
--- a/changelog.d/1857-kobo-sync-header-budget.md
+++ b/changelog.d/1857-kobo-sync-header-budget.md
@@ -1,1 +1,6 @@
-Kobo sync now warns when a fresh response or stored pending-page replay has at least 4096 bytes of application response headers. The warning reports only header/token byte counts and store-proxy enablement, and points to the existing README nginx buffer-size remedy. Diagnostic failures leave delivery unchanged. The token-budget regression now includes populated durable-page cursors, a 32-character delivery epoch, and Flask's production JSON serialization.
+### Added
+
+- **Kobo sync now warns when a fresh response or stored pending-page replay has
+  at least 4096 bytes of application response headers.** The warning reports only
+  header/token byte counts and store-proxy enablement, and points to the existing
+  README nginx buffer-size remedy. Diagnostic failures leave delivery unchanged.

--- a/changelog.d/1931-spa-reverse-proxy-auth.md
+++ b/changelog.d/1931-spa-reverse-proxy-auth.md
@@ -1,4 +1,6 @@
-Fixed reverse-proxy SSO opening the Classic login instead of the New UI. The
-existing app-wide request hook already identifies configured proxy-header users
-on `/app/` and `/api/v1/auth/me`; these deployments now use that working SPA
-path by default. (#1931, reported by @justemu)
+### Fixed
+
+- **Reverse-proxy SSO no longer opens the Classic login instead of the New UI.**
+  The existing app-wide request hook already identifies configured proxy-header
+  users on `/app/` and `/api/v1/auth/me`; these deployments now use that working
+  SPA path by default. (#1931, reported by @justemu)

--- a/changelog.d/1939-shelf-bulk-selection.md
+++ b/changelog.d/1939-shelf-bulk-selection.md
@@ -1,3 +1,10 @@
-Regular and smart shelves in the New UI now have Select mode and the same bulk actions as the catalog. Personal Library users can remove several shelved books from their library at once. Selection survives loading more books, successful changes refresh the grid, and failed books stay selected for retry. Shelf reordering and the individual Remove from shelf action remain available. Addresses iroQuai’s feedback on fork issue #1939.
+### Added
 
-Long shelf names wrap on narrow screens so the floating bulk actions stay visible and reachable on phones.
+- **Regular and smart shelves in the New UI now have Select mode and the same
+  bulk actions as the catalog.** Personal Library users can remove several
+  shelved books from their library at once. Selection survives loading more
+  books, successful changes refresh the grid, and failed books stay selected for
+  retry. Shelf reordering and the individual Remove from shelf action remain
+  available. Long shelf names wrap on narrow screens so the floating bulk actions
+  stay visible and reachable on phones. Addresses iroQuai’s feedback on fork
+  issue #1939.

--- a/changelog.d/1997-dockerignore.md
+++ b/changelog.d/1997-dockerignore.md
@@ -1,3 +1,0 @@
-### Internal
-
-- The Docker build context no longer includes `changelog.d/`.

--- a/changelog.d/2047-fresh-appdb-settings.md
+++ b/changelog.d/2047-fresh-appdb-settings.md
@@ -1,3 +1,4 @@
 ### Fixed
 
-- Fresh bare-metal installs now create the complete `app.db` settings schema before configuring the Calibre library.
+- **Fresh bare-metal installs now create the complete `app.db` settings schema
+  before configuring the Calibre library.**

--- a/changelog.d/2055-typecheck-tests.md
+++ b/changelog.d/2055-typecheck-tests.md
@@ -1,3 +1,0 @@
-### Internal
-
-- Frontend e2e and unit test files are now type-checked in the fast CI lane; an undefined identifier in test code fails in minutes instead of surfacing as a runtime error in the e2e suite.

--- a/changelog.d/2144-kobo-read-status.md
+++ b/changelog.d/2144-kobo-read-status.md
@@ -1,2 +1,4 @@
-Kobo sync now sends books marked read through a configured Calibre custom
-column as `Finished`, and Kobo completions update that same column.
+### Added
+
+- **Kobo sync now sends books marked read through a configured Calibre custom
+  column as `Finished`.** Kobo completions update that same column.

--- a/changelog.d/2168-windows-fcntl-startup.md
+++ b/changelog.d/2168-windows-fcntl-startup.md
@@ -1,7 +1,9 @@
-Native Windows source checkouts no longer fail at startup because `fcntl` is
-unavailable. Restore, Kobo exchange capture, and Kobo PATCH spool locks share a
-platform helper using POSIX `flock` or Windows `msvcrt` byte-range locks. Restore
-still refuses a lock held by another process. If neither backend is available,
-locking explicitly degrades to a logged no-op; use one app process and avoid
-concurrent restore/service writers on such platforms. Thanks to Rol3333 for the
-Windows 11 / Python 3.11 report (#2168).
+### Fixed
+
+- **Native Windows source checkouts no longer fail at startup because `fcntl` is
+  unavailable.** Restore, Kobo exchange capture, and Kobo PATCH spool locks share
+  a platform helper using POSIX `flock` or Windows `msvcrt` byte-range locks.
+  Restore still refuses a lock held by another process. If neither backend is
+  available, locking explicitly degrades to a logged no-op; use one app process
+  and avoid concurrent restore/service writers on such platforms. Thanks to
+  Rol3333 for the Windows 11 / Python 3.11 report (#2168).

--- a/changelog.d/2171-swedish-admin-translations.md
+++ b/changelog.d/2171-swedish-admin-translations.md
@@ -1,3 +1,5 @@
-**More administration screens translated into Swedish**
+### Added
 
-Swedish speakers now see translated administration settings and messages in more places, with 39 reviewed translations contributed by @yeager.
+- **More administration screens translated into Swedish.** Swedish speakers now
+  see translated administration settings and messages in more places, with 39
+  reviewed translations contributed by @yeager.

--- a/changelog.d/2187-traditional-chinese-taiwan-translations.md
+++ b/changelog.d/2187-traditional-chinese-taiwan-translations.md
@@ -1,3 +1,7 @@
-**More screens translated into Traditional Chinese (Taiwan)**
+### Added
 
-Traditional Chinese (Taiwan) speakers now see translated settings, library actions, and device messages in more places, with 1,298 translations contributed by @hug0-l in PR #2187. This update also translates the latest original-device actions and corrects a Simplified Chinese character and placeholders in draft translations.
+- **More screens translated into Traditional Chinese (Taiwan).** Traditional
+  Chinese (Taiwan) speakers now see translated settings, library actions, and
+  device messages in more places, with 1,298 translations contributed by @hug0-l
+  in PR #2187. This update also translates the latest original-device actions and
+  corrects a Simplified Chinese character and placeholders in draft translations.

--- a/changelog.d/annotations-survive-library-removal.md
+++ b/changelog.d/annotations-survive-library-removal.md
@@ -1,6 +1,6 @@
 ### Fixed
 
-- Keep highlights, notes, bookmarks, and reading progress intact and readable
-  from the annotation archive after a book is removed from My Library,
+- **Highlights, notes, bookmarks, and reading progress survive removing a book
+  from My Library.** They stay intact and readable from the annotation archive,
   including when the personal library becomes empty and when viewing data by
   e-reader. Re-adding the book resumes from the same retained reading state.

--- a/changelog.d/f50a5cb-cover-write-staging.md
+++ b/changelog.d/f50a5cb-cover-write-staging.md
@@ -5,6 +5,7 @@
   Google Drive cover. After a successful metadata commit, local covers publish
   with an atomic rename and existing Drive covers update on the same file ID;
   publication failures trigger metadata compensation.
-- A process death between the metadata commit and cover publication can still
+- **An interrupted cover publication is cleaned up on the next startup.** A
+  process death between the metadata commit and cover publication can still
   leave metadata claiming a cover that was not published. On the next startup,
   the orphan stage is logged and removed without guessing whether to publish it.

--- a/changelog.d/kobo-partial-token-position-echo.md
+++ b/changelog.d/kobo-partial-token-position-echo.md
@@ -1,3 +1,5 @@
 ### Fixed
 
-- Kobo reading-position confirmations interrupted by a partial or store sync token are retried for books that remain entitled, while an entitlement removal cancels the device's pending repair state.
+- **Kobo reading-position confirmations interrupted by a partial or store sync
+  token are now retried.** Books that remain entitled are retried, while an
+  entitlement removal cancels the device's pending repair state.

--- a/changelog.d/kobo-position-after-download.md
+++ b/changelog.d/kobo-position-after-download.md
@@ -1,3 +1,4 @@
 ### Fixed
 
-- Kobo readers keep the server's furthest reading position when a book finishes downloading after its reading-state sync.
+- **Kobo readers keep the server's furthest reading position when a book
+  finishes downloading after its reading-state sync.**

--- a/changelog.d/my-library-admin-intro.md
+++ b/changelog.d/my-library-admin-intro.md
@@ -20,5 +20,5 @@
   two modes are now selectable cards (the same checked-tint idiom as the
   Account page), and the longer explanation of how switching works sits one tap
   behind an info toggle instead of always occupying the card.
-- The "Set up My Library for all users" header button is removed; the intro
+- **The "Set up My Library for all users" header button is removed.** The intro
   card's Try/Undo flow is the one place that bulk action lives.

--- a/changelog.d/reader-note-clear.md
+++ b/changelog.d/reader-note-clear.md
@@ -1,3 +1,6 @@
-**Clear notes consistently in either reader.**
+### Fixed
 
-Erasing a note in the classic reader now saves the same empty note as removing it in the new reader. Your highlight stays in place, and the cleared note stays out of displayed notes and text exports.
+- **Clear notes consistently in either reader.** Erasing a note in the classic
+  reader now saves the same empty note as removing it in the new reader. Your
+  highlight stays in place, and the cleared note stays out of displayed notes and
+  text exports.

--- a/tests/unit/test_changelog_fragments.py
+++ b/tests/unit/test_changelog_fragments.py
@@ -35,6 +35,7 @@ Project preamble.
 
 
 def _workspace(tmp_path: Path, changelog: str = BASE_CHANGELOG) -> tuple[Path, Path]:
+    tmp_path.mkdir(parents=True, exist_ok=True)
     changelog_path = tmp_path / "CHANGELOG.md"
     fragments = tmp_path / "changelog.d"
     fragments.mkdir()
@@ -254,3 +255,39 @@ def test_current_repository_changelog_shape_accepts_a_fragment(tmp_path: Path) -
         encoding="utf-8"
     )
     assert not fragment.exists()
+
+
+def test_every_fragment_in_the_repository_can_actually_be_assembled(
+    tmp_path: Path,
+) -> None:
+    """The gates above this one only ever parse fragments the test itself wrote.
+
+    ``check_changelog_diff.py`` makes a PR prove it *added* a correctly *named*
+    fragment; nothing made it prove the fragment *parses*. So a malformed body
+    merges green and is not discovered until the release train tries to drain
+    the directory -- which is where v4.1.44 found ten unshippable fragments at
+    once, 11 days and 251 commits after the previous release. Assembly is the
+    only consumer of these files, so assembly is the gate.
+
+    Each fragment is assembled alone so one bad file names itself instead of
+    masking the rest behind the assembler's first error.
+    """
+    staged = [
+        path
+        for path in sorted((ROOT / "changelog.d").glob("*.md"))
+        if path.name != "README.md"
+    ]
+
+    broken = []
+    for index, path in enumerate(staged):
+        changelog, fragments = _workspace(tmp_path / f"probe{index}")
+        (fragments / path.name).write_bytes(path.read_bytes())
+        result = _run(changelog, fragments)
+        if result.returncode != 0:
+            broken.append(f"  {path.name}: {result.stderr.strip()}")
+
+    assert not broken, (
+        f"{len(broken)} of {len(staged)} fragment(s) in changelog.d/ cannot be "
+        "assembled, so the release train cannot drain the directory:\n"
+        + "\n".join(broken)
+    )


### PR DESCRIPTION
## What this fixes

`scripts/check_changelog_diff.py` makes every PR prove it **added** a correctly **named** fragment. Nothing made it prove the fragment **parses**.

`tests/unit/test_changelog_fragments.py` covers the assembler thoroughly — 10 cases — but every one of them writes its own synthetic fragment into a `tmp_path`. The suite has never once read the real `changelog.d/`. So a malformed body merges green, and is only discovered when the release train tries to drain the directory.

**Measured today:** 16 of 149 fragments could not be assembled. The assembler refuses the whole directory on its first bad file, so this was 16 sequential failures standing between `main` and a release that is already 11 days and 251 commits overdue.

## The gate

Assembly is the only consumer of these files, so assembly is the gate. The new test stages the real directory and assembles **each fragment on its own**, so one bad file names itself instead of hiding the other fifteen behind the first error.

```
before:  16 of 149 fragment(s) in changelog.d/ cannot be assembled  (FAILED)
after:   11 passed
```

That per-fragment design is what found the true count: a first-line scan only saw 10. Six more were malformed deeper in the file (lines 3, 8 and 23).

## The repairs

Each author's wording and credits are preserved; only structure was added.

| Defect | Count | Fragments |
|---|---|---|
| No `### <category>` heading at all | 8 | `1857`, `1931`, `1939`, `2144`, `2168`, `2171`, `2187`, `reader-note-clear` |
| List entry with no `- **bold lead**` | 6 | `2047`, `annotations-survive-library-removal`, `f50a5cb-cover-write-staging`, `kobo-partial-token-position-echo`, `kobo-position-after-download`, `my-library-admin-intro` |
| `### Internal` — not an accepted category | 2 | `1997-dockerignore`, `2055-typecheck-tests` |

The two `### Internal` fragments are **removed rather than recategorised**: `CHANGELOG.md` states its own policy in its header — *"Internal refactors, CI changes, and test-only work don't appear here — this file is for things you can see or feel when running the app."* A Docker build-context tweak and a CI type-check lane are both squarely inside that exclusion.

One editorial trim: `1857` ended on a sentence describing its own regression test, which is likewise not something a reader can see or feel when running the app.

## Verification

- `tests/unit/test_changelog_fragments.py` — **seen red at 16/149**, green after: `11 passed`
- Full changelog suite (`fragments`, `diff_guard`, `entry_integrity`, `release_sections`, `tag_sections`, `1437_version_matches`) — `67 passed`
- `changelog_requirement_errors()` run against this PR's own 17-file list — no fragment required

## Why it's separate from the release

This lands on its own so the v4.1.44 roll is pure bookkeeping and this fix protects every release after it, not just the next one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpjL5oprdZGDErDMkPT1qq
