### PR TITLE
fix(annotations): measure virtualized row heights so the device selector stays inside its row

### DIFF
--- a/changelog.d/annotation-row-overflow.md
+++ b/changelog.d/annotation-row-overflow.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- **Keep highlight device selectors reachable.** Highlights and notes now size
+  their virtualized rows to the rendered content, including notes, device group
+  headers, and selection controls on desktop and touch screens. Long highlights
+  no longer overlap the following row or hide their device selector beneath it.
+  Large lists still unmount off-screen rows and preserve the visible passage
+  when row measurements change.

--- a/frontend/e2e/annotation-row-geometry.spec.ts
+++ b/frontend/e2e/annotation-row-geometry.spec.ts
@@ -1,0 +1,133 @@
+import { test, expect, type Page, type Locator } from '@playwright/test';
+
+async function fixture(page: Page, count = 595) {
+  await page.route('**/annotations/2/data.json', route => route.fulfill({ json: {
+    annotation_count: count, devices: {},
+    annotations: Array.from({ length: count }, (_, index) => ({
+      annotation_id: `geometry-${index}`,
+      highlighted_text: index % 3 === 2 ? '' : `Passage ${index}: ${'A long passage that wraps across lines even on a desktop. '.repeat(12)}`,
+      position_type: index % 3 === 2 ? 'unanchored' : null,
+      note_text: index % 3 === 1 ? null : `Note ${index} about this passage`,
+      highlight_color: 'yellow', chapter_progress: null, source: 'kobo',
+      origin_device_id: null, assigned_device_id: null, anchor_status: 'ok',
+    })),
+  } }));
+  await page.route('**/api/annotations/devices?*', route => route.fulfill({ json: { devices: [
+    { public_id: 'reader', label: 'Reader', model: 'Kobo', type: 'kobo', active: true },
+  ] } }));
+  await page.route('**/annotations/2/geometry-*', route => route.fulfill({ json: {} }));
+}
+
+async function reachable(select: Locator) {
+  await select.scrollIntoViewIfNeeded();
+  await expect.poll(() => select.evaluate(element => {
+    const own = element.closest('[data-virtual-row]')!.getBoundingClientRect();
+    const rect = element.getBoundingClientRect();
+    const hit = document.elementFromPoint(rect.x + rect.width / 2, rect.y + rect.height / 2);
+    return {
+      contained: rect.top >= own.top && rect.bottom <= own.bottom && rect.left >= own.left && rect.right <= own.right,
+      hit: hit === element || element.contains(hit),
+    };
+  }), { message: 'device selector must fit its own row and receive the hit at its centre' }).toEqual({ contained: true, hit: true });
+}
+
+test('wrapped highlights with notes keep their device selector inside the row and hit-testable', async ({ page }, testInfo) => {
+  await fixture(page);
+  await page.goto('/app/book/2/annotations');
+  const rows = page.locator('[data-virtual-row]');
+  await expect(rows.first()).toBeVisible();
+  // The next row must be present: otherwise there is nothing to steal the hit.
+  await expect(rows.nth(1)).toBeVisible();
+  await reachable(rows.first().locator('select'));
+  await rows.first().locator('select').selectOption('reader');
+  await expect(rows.first().locator('select')).toHaveValue('reader');
+  await page.getByRole('button', { name: 'Dismiss', exact: true }).click();
+  await reachable(rows.nth(1).locator('select')); // no note
+  await reachable(rows.nth(2).locator('select')); // standalone note
+  await page.getByRole('button', { name: 'Select', exact: true }).click();
+  await reachable(rows.first().locator('select'));
+  await page.getByLabel('Group by').selectOption('device');
+  await expect.poll(() => rows.evaluateAll(elements => elements.every((element, index) => {
+    const rect = element.getBoundingClientRect();
+    const content = element.firstElementChild!.getBoundingClientRect();
+    const next = elements[index + 1]?.getBoundingClientRect();
+    return content.top >= rect.top && content.bottom <= rect.bottom && (!next || rect.bottom <= next.top + 0.1);
+  }))).toBe(true);
+  await page.getByLabel('Group by').selectOption('book');
+  await page.setViewportSize({ width: testInfo.project.name === 'desktop' ? 390 : 800, height: 844 });
+  await reachable(rows.first().locator('select'));
+  // Layout measurement on mount and the resize fallback must also work on
+  // browsers/test environments without ResizeObserver.
+  await page.addInitScript(() => { Object.defineProperty(window, 'ResizeObserver', { value: undefined, configurable: true }); });
+  await page.reload();
+  await reachable(rows.first().locator('select'));
+  await page.setViewportSize({ width: 375, height: 667 });
+  await reachable(rows.first().locator('select'));
+});
+
+test('remeasurement anchors the visible passage and keeps a large list windowed', async ({ page }, testInfo) => {
+  await fixture(page, 5950);
+  await page.goto('/app/book/2/annotations');
+  const viewport = page.locator('[data-virtualized-list]');
+  await expect(page.locator('[data-virtual-row]').first()).toBeVisible();
+  await viewport.evaluate(element => { element.scrollTop = 20000; });
+  await expect.poll(() => page.locator('[data-virtual-row]').first().getAttribute('aria-posinset')).not.toBe('1');
+  // Let the newly mounted estimates be replaced before changing a row above
+  // the visible passage, like a late font/content update would do.
+  await page.evaluate(() => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve))));
+  const before = await viewport.evaluate(element => {
+    const rows = Array.from(element.querySelectorAll<HTMLElement>('[data-virtual-row]'));
+    const top = element.getBoundingClientRect().top;
+    const anchor = rows.find(row => row.getBoundingClientRect().bottom > top)!;
+    const growing = rows[0];
+    const result = { anchor: anchor.getAttribute('aria-posinset')!, y: anchor.getBoundingClientRect().top,
+      growing: growing.getAttribute('aria-posinset')!, height: growing.getBoundingClientRect().height, mounted: rows.length };
+    (growing.firstElementChild as HTMLElement).style.minHeight = `${result.height + 80}px`;
+    return result;
+  });
+  const growing = page.locator(`[data-virtual-row][aria-posinset="${before.growing}"]`);
+  await expect.poll(() => growing.evaluate(element => element.getBoundingClientRect().height)).toBeGreaterThan(before.height + 70);
+  const anchor = page.locator(`[data-virtual-row][aria-posinset="${before.anchor}"]`);
+  await expect.poll(async () => Math.abs((await anchor.boundingBox())!.y - before.y)).toBeLessThan(1);
+  const counts = [before.mounted];
+  for (const fraction of [0.5, 1, 0]) {
+    await viewport.evaluate((element, fraction) => { element.scrollTop = element.scrollHeight * fraction; }, fraction);
+    await page.evaluate(() => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve))));
+    const count = await page.locator('[data-virtual-row]').count();
+    counts.push(count);
+    expect(count).toBeLessThan(100);
+  }
+  console.log(`${testInfo.project.name}: total=5950, mounted at middle/half/end/top=${counts.join('/')}`);
+
+  // Visit a whole list so every estimate is replaced, then compare the canvas
+  // to the sum of real border boxes. Revisit the beginning to catch cache drift.
+  await fixture(page, 60);
+  await page.reload();
+  await expect(page.locator('[data-virtual-row]').first()).toBeVisible();
+  const geometry = await viewport.evaluate(async element => {
+    const measured = new Map<number, number>();
+    const settle = () => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+    let contiguous = true;
+    for (let step = 0; step < 100; step++) {
+      await settle();
+      const rows = Array.from(element.querySelectorAll('[data-virtual-row]'));
+      rows.forEach((row, index) => {
+        const rect = row.getBoundingClientRect();
+        measured.set(Number(row.getAttribute('aria-posinset')), rect.height);
+        if (index) contiguous &&= Math.abs(rows[index - 1].getBoundingClientRect().bottom - rect.top) < 0.1;
+      });
+      if (element.scrollTop + element.clientHeight >= element.scrollHeight - 1) break;
+      element.scrollTop += element.clientHeight / 2;
+    }
+    const canvas = element.querySelector('[role="list"]')!.getBoundingClientRect().height;
+    element.scrollTop = 0;
+    await settle();
+    return { seen: measured.size, sum: [...measured.values()].reduce((a, b) => a + b, 0), canvas,
+      revisited: element.querySelector('[role="list"]')!.getBoundingClientRect().height, contiguous };
+  });
+  expect(geometry.seen).toBe(60);
+  expect(geometry.contiguous).toBe(true);
+  expect(Math.abs(geometry.sum - geometry.canvas)).toBeLessThan(0.1);
+  expect(geometry.revisited).toBe(geometry.canvas);
+  console.log(`${testInfo.project.name}: measured all 60 rows, summed height=${geometry.sum}, canvas=${geometry.canvas}`);
+});

--- a/frontend/src/components/VirtualizedList.module.css
+++ b/frontend/src/components/VirtualizedList.module.css
@@ -5,10 +5,12 @@
   min-height: 240px;
   height: min(68vh, 760px);
   scrollbar-gutter: stable;
+  overflow-anchor: none;
 }
 
 .canvas { position: relative; width: 100%; }
-.row { position: absolute; inset: 0 0 auto; width: 100%; }
+/* Include child margins in the measured border box. */
+.row { display: flow-root; position: absolute; inset: 0 0 auto; width: 100%; }
 
 @media (max-width: 600px) {
   .viewport { height: calc(100dvh - 240px); min-height: 320px; }

--- a/frontend/src/components/VirtualizedList.tsx
+++ b/frontend/src/components/VirtualizedList.tsx
@@ -1,4 +1,6 @@
-import { useCallback, useLayoutEffect, useRef, useState, type ReactNode, type UIEvent } from 'react';
+import { useLayoutEffect, useRef, useState, type ReactNode } from 'react';
+import { flushSync } from 'react-dom';
+import { rowAt, rowOffsets, rowWindow } from './virtualGeometry';
 import styles from './VirtualizedList.module.css';
 
 interface VirtualizedListProps<T> {
@@ -6,84 +8,106 @@ interface VirtualizedListProps<T> {
   itemKey: (item: T) => string;
   renderItem: (item: T, index: number) => ReactNode;
   ariaLabel: string;
-  rowHeight?: number;
+  estimatedRowHeight?: number;
   overscanViewports?: number;
   className?: string;
 }
 
-/** Fixed-row local-data virtualization shared by annotation surfaces.
+/** Measured local-data virtualization shared by annotation surfaces.
  *
  * `useIntersectionObserver` deliberately does not fit this job: it appends
  * pages and leaves earlier DOM mounted. This window removes off-screen rows,
  * keeping a 595-row annotation set bounded to the viewport plus overscan.
+ * Unmounted rows use cached measurements (or an estimate until first mounted).
  */
 export function VirtualizedList<T>({
-  items,
-  itemKey,
-  renderItem,
-  ariaLabel,
-  rowHeight = 72,
-  overscanViewports = 2,
-  className = '',
+  items, itemKey, renderItem, ariaLabel, estimatedRowHeight = 72,
+  overscanViewports = 2, className = '',
 }: VirtualizedListProps<T>) {
   const viewportRef = useRef<HTMLDivElement>(null);
-  const [viewportHeight, setViewportHeight] = useState(600);
-  // Store the derived row index, not the raw pixel offset: a pixel value in
-  // state forces a React render on every scroll event (~60-120/s) even when
-  // the visible window has not moved by a single row (#1813 item 5).
-  const [scrollRow, setScrollRow] = useState(0);
-  const scrollFrame = useRef(0);
+  const heights = useRef(new Map<string, number>());
+  const width = useRef(0);
+  const pendingTop = useRef<number | null>(null);
+  const frame = useRef(0);
+  const [, setMeasurement] = useState(0);
+  // Only window boundaries enter scroll state, never the pixel offset (#1813).
+  const [window, setWindow] = useState({ start: 0, end: 1 });
+  const keys = items.map(itemKey);
+  const offsets = rowOffsets(keys, heights.current, estimatedRowHeight);
+  const start = Math.min(window.start, Math.max(0, items.length - 1));
+  const end = Math.min(items.length, Math.max(start + 1, window.end));
 
+  // Remeasure after every commit: renderItem can change content or selection
+  // without changing keys. Layout effects settle new windows before paint.
   useLayoutEffect(() => {
-    const node = viewportRef.current;
-    if (!node) return;
-    const measure = () => setViewportHeight(node.clientHeight || 600);
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+    if (pendingTop.current !== null) {
+      viewport.scrollTop = pendingTop.current;
+      pendingTop.current = null;
+    }
+    const updateWindow = (table: number[]) => {
+      const next = rowWindow(table, viewport.scrollTop, viewport.clientHeight || 600, overscanViewports);
+      setWindow(current => current.start === next.start && current.end === next.end ? current : next);
+    };
+    const measure = () => {
+      // Anchor the first visible row, including the pixel position within it.
+      // Changing estimates above it must not move the passage being read.
+      const anchor = rowAt(offsets, viewport.scrollTop);
+      const within = viewport.scrollTop - offsets[anchor];
+      let changed = false;
+      if (width.current !== viewport.clientWidth) {
+        width.current = viewport.clientWidth;
+        heights.current.clear();
+        changed = true;
+      }
+      const liveKeys = new Set(keys);
+      for (const key of heights.current.keys()) if (!liveKeys.has(key)) heights.current.delete(key);
+      viewport.querySelectorAll<HTMLElement>('[data-virtual-row]').forEach(row => {
+        const key = keys[Number(row.getAttribute('aria-posinset')) - 1];
+        const height = row.getBoundingClientRect().height;
+        // jsdom has no layout. Keep estimates there, without requiring RO.
+        if (height > 0 && heights.current.get(key) !== height) {
+          heights.current.set(key, height);
+          changed = true;
+        }
+      });
+      if (changed) {
+        const next = rowOffsets(keys, heights.current, estimatedRowHeight);
+        pendingTop.current = next[anchor] + within;
+        setMeasurement(value => value + 1);
+      } else updateWindow(offsets);
+    };
     measure();
-    const observer = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(measure);
-    observer?.observe(node);
-    return () => observer?.disconnect();
-  }, []);
-
-  const onScroll = useCallback((event: UIEvent<HTMLDivElement>) => {
-    const top = event.currentTarget.scrollTop;
-    cancelAnimationFrame(scrollFrame.current);
-    scrollFrame.current = requestAnimationFrame(() => {
-      const row = Math.floor(top / rowHeight);
-      setScrollRow((current) => (current === row ? current : row));
-    });
-  }, [rowHeight]);
-
-  const visibleCount = Math.max(1, Math.ceil(viewportHeight / rowHeight));
-  const overscan = visibleCount * overscanViewports;
-  const start = Math.max(0, scrollRow - overscan);
-  const end = Math.min(items.length, start + visibleCount + overscan * 2);
-  const visible = items.slice(start, end);
+    // RO runs outside React's commit. Flush its offsets/anchor correction
+    // before the browser paints the resized content at stale positions.
+    const observer = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(() => flushSync(measure));
+    observer?.observe(viewport);
+    viewport.querySelectorAll('[data-virtual-row]').forEach(row => observer?.observe(row));
+    const onScroll = () => {
+      cancelAnimationFrame(frame.current);
+      frame.current = requestAnimationFrame(() => updateWindow(offsets));
+    };
+    viewport.addEventListener('scroll', onScroll);
+    // Also provides width/viewport remeasurement without ResizeObserver.
+    globalThis.addEventListener('resize', measure);
+    return () => {
+      observer?.disconnect();
+      cancelAnimationFrame(frame.current);
+      viewport.removeEventListener('scroll', onScroll);
+      globalThis.removeEventListener('resize', measure);
+    };
+  });
 
   return (
-    <div
-      ref={viewportRef}
-      className={`${styles.viewport} ${className}`.trim()}
-      onScroll={onScroll}
-      data-virtualized-list
-    >
-      <div
-        className={styles.canvas}
-        role="list"
-        aria-label={ariaLabel}
-        style={{ height: `${items.length * rowHeight}px` }}
-      >
-        {visible.map((item, offset) => {
+    <div ref={viewportRef} className={`${styles.viewport} ${className}`.trim()} data-virtualized-list>
+      <div className={styles.canvas} role="list" aria-label={ariaLabel} style={{ height: offsets[items.length] }}>
+        {items.slice(start, end).map((item, offset) => {
           const index = start + offset;
           return (
-            <div
-              key={itemKey(item)}
-              className={styles.row}
-              role="listitem"
-              aria-posinset={index + 1}
-              aria-setsize={items.length}
-              data-virtual-row
-              style={{ height: `${rowHeight}px`, transform: `translateY(${index * rowHeight}px)` }}
-            >
+            <div key={keys[index]} className={styles.row} role="listitem"
+              aria-posinset={index + 1} aria-setsize={items.length} data-virtual-row
+              style={{ transform: `translateY(${offsets[index]}px)` }}>
               {renderItem(item, index)}
             </div>
           );

--- a/frontend/src/components/virtualGeometry.ts
+++ b/frontend/src/components/virtualGeometry.ts
@@ -1,0 +1,25 @@
+/** Unmeasured rows are estimates only; measured border boxes own all offsets. */
+export function rowOffsets(keys: readonly string[], heights: ReadonlyMap<string, number>, estimate: number): number[] {
+  const offsets = [0];
+  for (const key of keys) offsets.push(offsets[offsets.length - 1] + (heights.get(key) ?? estimate));
+  return offsets;
+}
+
+/** Index containing top, clamped at either end (including an empty list). */
+export function rowAt(offsets: readonly number[], top: number): number {
+  let low = 0;
+  let high = Math.max(0, offsets.length - 2);
+  while (low < high) {
+    const middle = Math.ceil((low + high) / 2);
+    if (offsets[middle] <= top) low = middle;
+    else high = middle - 1;
+  }
+  return low;
+}
+
+export function rowWindow(offsets: readonly number[], top: number, height: number, overscan: number) {
+  return {
+    start: rowAt(offsets, Math.max(0, top - height * overscan)),
+    end: Math.min(offsets.length - 1, rowAt(offsets, top + height * (1 + overscan)) + 1),
+  };
+}

--- a/frontend/src/pages/Annotations.module.css
+++ b/frontend/src/pages/Annotations.module.css
@@ -15,14 +15,14 @@
 .toolbar details { position: relative; }.toolbar summary { cursor: pointer; list-style: none; }.exportMenu { position: absolute; z-index: 9; right: 0; top: 44px; min-width: 150px; padding: var(--sp-1); border: 1px solid var(--border); border-radius: var(--r-md); background: var(--surface-2); }.exportMenu a { width: 100%; border: 0; }
 .exportMenu strong { display: block; padding: var(--sp-2) var(--sp-3); color: var(--text-muted); font-size: var(--fs-xs); }
 .mobileDataAction { display: none; }
-.item { height: calc(100% - 6px); margin: 3px 0; display: flex; align-items: stretch; gap: var(--sp-2); background: var(--surface-1); border: 1px solid var(--border); border-radius: var(--r-md); padding: var(--sp-2); }
+.item { margin: 3px 0; display: flex; align-items: stretch; gap: var(--sp-2); background: var(--surface-1); border: 1px solid var(--border); border-radius: var(--r-md); padding: var(--sp-2); }
 .bar { width: 3px; border-radius: 2px; flex: none; }.body { flex: 1; min-width: 0; cursor: default; }
 .quote { margin: 0; color: var(--text); font-size: var(--fs-sm); line-height: 1.35; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
 .note { margin: 2px 0 0; color: var(--text-muted); font-size: var(--fs-xs); font-style: italic; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .meta { display: flex; align-items: center; gap: var(--sp-1); margin-top: 3px; color: var(--text-muted); font-size: var(--fs-xs); min-height: 28px; }
 .meta select { max-width: 220px; min-height: 32px; color: var(--text-muted); border-radius: var(--r-sm); padding: 0 var(--sp-1); }.meta .unknown, .unknown { font-style: italic; }
 .rowSelect { display: grid; place-items: center; min-width: 44px; cursor: pointer; }.rowSelect input { width: 20px; height: 20px; }.selecting { min-height: 64px; cursor: pointer; }
-.groupHeader { height: calc(100% - 8px); margin: 4px 0; position: sticky; top: 0; display: flex; align-items: center; gap: var(--sp-3); padding: 0 var(--sp-3); border-bottom: 1px solid var(--border); background: var(--surface-0); }.groupHeader span { color: var(--text-muted); }.groupHeader button { margin-left: auto; min-height: 40px; color: var(--accent); }
+.groupHeader { margin: 4px 0; position: sticky; top: 0; display: flex; align-items: center; gap: var(--sp-3); padding: 0 var(--sp-3); border-bottom: 1px solid var(--border); background: var(--surface-0); }.groupHeader span { color: var(--text-muted); }.groupHeader button { margin-left: auto; min-height: 40px; color: var(--accent); }
 .failure { color: var(--warning); }.failed { border-color: var(--warning); }
 .anchorWarning { display: inline-flex; align-items: center; gap: 3px; color: var(--warning); }
 .toast { position: fixed; z-index: 30; left: 50%; bottom: var(--sp-5); transform: translateX(-50%); display: flex; align-items: center; gap: var(--sp-3); min-width: min(520px, calc(100vw - 32px)); padding: var(--sp-3) var(--sp-4); border: 1px solid var(--border); border-radius: var(--r-md); background: var(--surface-2); box-shadow: var(--shadow-lg); }.toast button { min-height: 44px; color: var(--accent); font-weight: 700; }

--- a/frontend/src/pages/Annotations.tsx
+++ b/frontend/src/pages/Annotations.tsx
@@ -287,7 +287,7 @@ export function Annotations({ id }: { id: string }) {
       {error ? <EmptyState message={error instanceof Error ? error.message : t('Could not load highlights and notes.')} /> : !annotations.length ?
         <EmptyState message={t('Nothing here yet. Highlight or write a note while reading, or import from a Kobo device.')} /> :
         <VirtualizedList items={entries} itemKey={(entry) => entry.kind === 'group' ? `group-${entry.id}` : entry.annotation.annotation_id}
-          rowHeight={78} ariaLabel={t('Highlights and notes')} renderItem={(entry) => entry.kind === 'group' ? (
+          ariaLabel={t('Highlights and notes')} renderItem={(entry) => entry.kind === 'group' ? (
             <div className={styles.groupHeader}><strong>{entry.label}</strong><span>{entry.count}</span>
               {selecting && <button type="button" onClick={() => setSelected((current) => new Set([...current, ...filtered.filter((row) => assignmentOf(row) === entry.id).map((row) => row.annotation_id)]))}>{t('Select all in group')}</button>}
             </div>

--- a/frontend/unit/virtual-geometry.test.ts
+++ b/frontend/unit/virtual-geometry.test.ts
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { rowAt, rowOffsets, rowWindow } from '../src/components/virtualGeometry.ts';
+
+test('measured heights survive reordering and define contiguous offsets and pixel windows', () => {
+  const heights = new Map([['long-note', 123.5], ['header', 31], ['note', 56.25]]);
+  const offsets = rowOffsets(['header', 'long-note', 'unseen', 'note'], heights, 72);
+  assert.deepEqual(offsets, [0, 31, 154.5, 226.5, 282.75]);
+  assert.equal(rowAt(offsets, 154.49), 1);
+  assert.equal(rowAt(offsets, 154.5), 2);
+  assert.deepEqual(rowWindow(offsets, 155, 60, 1), { start: 1, end: 4 });
+  assert.deepEqual(rowOffsets(['note', 'header'], heights, 72), [0, 56.25, 87.25]);
+});


### PR DESCRIPTION
Fixes #2075 (the layout half). Reported by @iroQuai.

> longer highlights (or with notes attatched) mess up the layout; the dropdown selector falls out
> of the box and sometimes isnt even reachable anymore (both in desktop as mobile view)

## Cause

`Annotations.tsx` rendered through `VirtualizedList` with a fixed `rowHeight={78}`, and the
component both sized every row box to exactly that and positioned it at
`translateY(index * rowHeight)` with `.row { position: absolute }`.

The row's real height is not fixed. `.quote` is a two-line clamp, `.note` adds another line when
the annotation carries one, and `.meta` — the strip that *contains* the device `<select>` — sits
below both at `min-height: 28px`, growing to 36px under `max-width: 600px` and 44px under
`@media (pointer: coarse)`. A highlight that wraps and also has a note overflows its slot, and the
next absolutely-positioned row is painted over the part that escaped. That single mechanism
produces both reported symptoms: the control appears outside its card, and where it appears it is
not hit-testable, because a neighbouring row owns that pixel.

## Change

`VirtualizedList` now measures rendered row heights and derives offsets and canvas height from a
running offset table (`virtualGeometry.ts`), using the estimate only for rows not yet mounted.
Rows no longer carry an imposed height; `.item` and `.groupHeader` drop their `calc(100% - …)`
heights and size to content.

The properties the previous implementation existed for are kept:

- **Windowing.** Off-screen rows stay unmounted. Measured at 5,950 annotations: 29/29/19/17 mounted
  rows across a desktop traversal, 21/21/14/12 on mobile.
- **No per-pixel render on scroll** (#1813 item 5). Only window boundaries enter state, and the
  setter bails out when they are unchanged.
- **Truthful geometry.** After visiting all 60 rows of a list, the sum of real border boxes equals
  the canvas height exactly (5767.5px desktop, 6487.5px mobile), rows stay contiguous, and
  revisiting the top does not drift.
- **Anchoring.** When a row above the viewport is remeasured, the visible passage moves less than
  1px instead of jumping.
- **No `ResizeObserver` required.** Guarded, with a window-resize fallback; jsdom keeps estimates.

No new dependencies (`flushSync` comes from the existing `react-dom` ^18.3.1), no license changes,
no new external URLs.

## Evidence

`frontend/e2e/annotation-row-geometry.spec.ts` asserts what the user actually hits: the device
`<select>`'s rect lies within its own `[data-virtual-row]`, **and** `document.elementFromPoint` at
the select's centre returns that select. Desktop and mobile projects, across wrapped-with-note,
note-free, standalone-note, selecting mode, device grouping, viewport changes, and a
`ResizeObserver`-less reload.

**Red** (product files reverted, spec kept): `4 failed, 1 passed`.

```
Error: device selector must fit its own row and receive the hit at its centre
  Expected: { "contained": true,  "hit": true  }
  Received: { "contained": false, "hit": false }     [desktop and mobile]

Error: expect(received).toBeGreaterThan(expected)
  Expected: > 148
  Received:   78                                     [desktop and mobile]
```

**Green:** `5 passed`; whole annotation suite `32 passed, 1 skipped` (the skip is a touch-only test's
desktop invocation; its mobile invocation passes).

`frontend/unit/virtual-geometry.test.ts` pins the offset table. Red with measured-height lookup
removed — `actual [0, 72, 144, 216, 288]` vs `expected [0, 31, 154.5, 226.5, 282.75]` — green with
it. Typecheck and the full unit suite: `85 pass, 0 fail`.

Why the existing suite was green through this bug: `annotation-device-assignment.spec.ts` stubs
`highlighted_text: 'Highlight ${index}'`, which never wraps, so no row it renders could exceed 78px.

Full trail in `state/completed.log` and the delegation JSONL.
