### PR TITLE
fix(kobo): stop the v4.1.43 upgrade telling every Kobo its whole library is new

### DIFF
--- a/changelog.d/kobo-upgrade-keeps-device-ledger.md
+++ b/changelog.d/kobo-upgrade-keeps-device-ledger.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **Upgrading no longer tells an existing Kobo that its whole library is
+  new.** The one-time delivery-ledger audit used to throw away everything the
+  server knew about what a reader already held, so the first sync after the
+  update re-announced every book and the reader re-downloaded the lot and lost
+  its place in each one. A reader that is the only one paired to an account now
+  keeps that record, and the upgrade sync is silent. Accounts with more than one
+  paired reader are unchanged, because there the old record cannot tell the two
+  readers apart.

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -480,15 +480,35 @@ def _seed_existing_device_entitlement_ledgers(user_id):
 
 
 def _migrate_device_entitlement_classification(user_id):
-    """Reclassify every pre-ack device row as unconfirmed exactly once.
+    """Stamp the one-time v0 audit, keeping a device-scoped ledger intact.
 
-    Historical per-device entitlement rows record a committed server emission,
-    not device receipt. No timestamp reconstruction can restore that missing
-    fact, so those rows are removed and conservatively reannounced as New.
+    A pre-#2025 install already carries per-device rows written by the shipped
+    v4.1.43 seed and by its own acknowledged deliveries.  Deleting them costs
+    the entire library: the cursor-independent recovery arm below reselects
+    every book, and against an empty ledger every one of them classifies as
+    ``NewEntitlement``, which Nickel treats as "not downloaded" (#1925).  That
+    is a whole-library re-download with reading position lost, once, on every
+    existing Kobo -- far larger than the ambiguity the delete was clearing.
+
+    The rows are kept only while they can describe one device.  That seed
+    copied the user-wide ``KoboSyncedBooks`` history onto *every* Kobo left
+    unseeded at the upgrade boundary, so with a second paired Kobo the copy
+    provably over-claims for at least one of them and stays untrusted.  With a
+    single paired Kobo the user-wide history is that device's history, and the
+    rows stand.
+
+    Deliberately accepted, and unchanged from v4.1.43: a legacy
+    ``ChangedEntitlement`` that an empty Kobo dropped (#1735) still wrote a
+    flat marker, so a kept row can name a book the device never stored.  That
+    gap already ships in v4.1.43, is not created here, and stays recoverable
+    through Full Sync and per-book resend.  Deleting every row instead turns a
+    bounded, recoverable gap into a certain, unrecoverable one for everybody.
+
     A device-authored reading-position observation is the narrow durable proof
-    that the physical Kobo possessed that book; those books retain only a
-    non-matching classification sentinel so they fail open as Changed rather
-    than being byte-suppressed from reconstructed present-day metadata.
+    that the physical Kobo possessed a book.  Proven books that have no ledger
+    row keep a non-matching classification sentinel so they fail open as
+    Changed rather than being announced New to a device that demonstrably
+    holds them.
     """
     device_ids = kobo_sync_status.get_kobo_device_ids_requiring_classification(
         user_id, ENTITLEMENT_CLASSIFICATION_VERSION,
@@ -498,19 +518,34 @@ def _migrate_device_entitlement_classification(user_id):
 
     started = monotonic()
     try:
+        ledger_is_device_scoped = (
+            kobo_sync_status.count_user_kobo_devices(user_id) == 1
+        )
         removed = 0
+        preserved = 0
         device_proven = 0
         for device_id in device_ids:
-            removed += ub.session.query(
-                ub.KoboDeviceBookEntitlement,
-            ).filter(
-                ub.KoboDeviceBookEntitlement.device_id == int(device_id),
-            ).delete(synchronize_session=False)
-            removed += ub.session.query(
-                ub.KoboDeviceDeletedEntitlement,
-            ).filter(
-                ub.KoboDeviceDeletedEntitlement.device_id == int(device_id),
-            ).delete(synchronize_session=False)
+            ledger_book_ids = set()
+            if ledger_is_device_scoped:
+                ledger_book_ids = {
+                    row.book_id for row in ub.session.query(
+                        ub.KoboDeviceBookEntitlement.book_id,
+                    ).filter(
+                        ub.KoboDeviceBookEntitlement.device_id == int(device_id),
+                    ).all()
+                }
+                preserved += len(ledger_book_ids)
+            else:
+                removed += ub.session.query(
+                    ub.KoboDeviceBookEntitlement,
+                ).filter(
+                    ub.KoboDeviceBookEntitlement.device_id == int(device_id),
+                ).delete(synchronize_session=False)
+                removed += ub.session.query(
+                    ub.KoboDeviceDeletedEntitlement,
+                ).filter(
+                    ub.KoboDeviceDeletedEntitlement.device_id == int(device_id),
+                ).delete(synchronize_session=False)
             proven_book_ids = {
                 row.book_id for row in ub.session.query(
                     ub.DeviceReadingPosition.book_id,
@@ -518,7 +553,7 @@ def _migrate_device_entitlement_classification(user_id):
                     ub.DeviceReadingPosition.device_id == int(device_id),
                     ub.DeviceReadingPosition.client_modified_at.isnot(None),
                 ).all()
-            }
+            } - ledger_book_ids
             if proven_book_ids:
                 kobo_sync_status.stage_device_entitlement_fingerprints(
                     device_id,
@@ -543,11 +578,12 @@ def _migrate_device_entitlement_classification(user_id):
 
     log.debug(
         "Kobo Sync classification migration: user=%s devices=%d "
-        "device_proven=%d rearmed=%d elapsed_ms=%.1f",
+        "device_proven=%d rearmed=%d preserved=%d elapsed_ms=%.1f",
         user_id,
         len(device_ids),
         device_proven,
         removed,
+        preserved,
         round((monotonic() - started) * 1000, 1),
     )
     return True

--- a/cps/kobo_sync_status.py
+++ b/cps/kobo_sync_status.py
@@ -208,6 +208,24 @@ def get_unseeded_kobo_device_ids(user_id):
     return sorted(device_ids - seeded)
 
 
+def count_user_kobo_devices(user_id):
+    """How many physical Kobos this user has paired.
+
+    The pre-#2025 upgrade seed copied the user-wide flat delivery history
+    onto every Kobo it marked, so the count decides whether those rows can
+    describe one device or must be treated as a household union.
+
+    Retired readers are counted deliberately: device removal is a soft delete
+    (``active = False``), and a reader retired after that copy still leaves
+    its history mixed into the survivor's ledger.  Do not add an ``active``
+    filter here.
+    """
+    return ub.session.query(ub.Device.id).filter(
+        ub.Device.user_id == int(user_id),
+        ub.Device.kind == "kobo",
+    ).count()
+
+
 def user_has_completed_entitlement_seed(user_id):
     """Whether this user's upgrade boundary has already been crossed."""
     return ub.session.query(ub.KoboDeviceEntitlementSeed.device_id).join(

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -997,9 +997,11 @@ class KoboDeviceEntitlementSeed(Base):
     seeded_at = Column(
         DateTime, nullable=False, default=lambda: datetime.now(timezone.utc),
     )
-    # Version 1 means the per-device rows were audited against the legacy
-    # New/Changed classifier.  Version 0 rows predate #1735 and may include
-    # fingerprints for ChangedEntitlements a device could not apply.
+    # Version 1 means the one-time pre-#2025 audit has run for this device.
+    # Version 0 rows were written by the shipped v4.1.43 seed, which copied
+    # the user-wide flat history onto every Kobo it marked: sound for a single
+    # paired reader, a household union for two or more.  The audit therefore
+    # keeps a single reader's rows and clears a household's.
     classification_version = Column(
         Integer, nullable=False, default=0, server_default="0",
     )

--- a/tests/unit/test_1925_kobo_sync_dedownload.py
+++ b/tests/unit/test_1925_kobo_sync_dedownload.py
@@ -4461,3 +4461,336 @@ def test_sync_summary_handles_store_min_and_nullable_cursor_shapes(
     assert kobo._sync_cursor_summary(nullable) == (
         None, None, datetime.min, None, datetime.min, None, None, datetime.min,
     )
+
+
+# ---------------------------------------------------------------------------
+# Stranded-fix investigation (state/release/v4.1.44/BRIEF-kobo-stranded-fix.md)
+# ---------------------------------------------------------------------------
+
+
+def _legacy_classification_replay(books, page_size):
+    """Replay the pre-#2025 New/Changed state machine over a book list.
+
+    The legacy handler emitted ``NewEntitlement`` when a book's created clock
+    exceeded the INCOMING token's ``books_last_created``, and set the outgoing
+    token to that page's maximum. Reproduced here from
+    ``cps/kobo.py`` at 0e3b86005a^ lines 1129-1131 and 1176 so the test states
+    its own premise instead of assuming it.
+    """
+    ordered = sorted(books, key=lambda book: (book.last_modified, book.id))
+    new_ids = set()
+    watermark = datetime.min
+    for offset in range(0, len(ordered), page_size):
+        page = ordered[offset:offset + page_size]
+        page_max = watermark
+        for book in page:
+            created = book.timestamp
+            if created > watermark:
+                new_ids.add(book.id)
+            page_max = max(page_max, created)
+        watermark = page_max
+    return new_ids
+
+
+def _seed_legacy_install(sync_harness, count=218, stagger=True, record_flat=True):
+    """A pre-#1925 install: flat KoboSyncedBooks, no per-device ledger rows."""
+    from cps import db, ub
+
+    delivered = [sync_harness.book]
+    base = sync_harness.book.last_modified
+    sync_harness.book.timestamp = base
+    for number in range(2, count + 1):
+        clock = base + timedelta(seconds=number - 1) if stagger else base
+        book = db.Books(
+            f"Held Book {number}",
+            f"Held Book {number}",
+            "Author",
+            clock,
+            db.Books.DEFAULT_PUBDATE,
+            "1.0",
+            clock,
+            f"held-book-{number}",
+            0,
+            [],
+            [],
+        )
+        sync_harness.session.add(book)
+        sync_harness.session.flush()
+        book.uuid = f"00000000-0000-0000-0003-{number:012d}"
+        sync_harness.session.add(db.Data(
+            book.id, "EPUB", 3_000_000 + number, f"held-book-{number}",
+        ))
+        delivered.append(book)
+    if record_flat:
+        sync_harness.session.add_all([
+            ub.KoboSyncedBooks(
+                user_id=sync_harness.user.id,
+                book_id=book.id,
+                book_uuid=str(book.uuid),
+            )
+            for book in delivered
+        ])
+    sync_harness.session.commit()
+    return delivered
+
+
+def test_upgrade_with_a_valid_token_does_not_reannounce_a_held_library(
+    sync_harness, caplog, monkeypatch,
+):
+    """An existing, fully-downloaded Kobo must not be told its library is New.
+
+    Models the ordinary upgrade of a pre-#1925 install.  Every book was
+    emitted to the device as a NewEntitlement by the legacy handler (asserted
+    below, not assumed), so the physical Kobo holds all 218 files, and it
+    presents its own valid token whose cursor is already past the library.
+    Nickel treats a NewEntitlement for a book it already holds as "not
+    downloaded" (#1925), so a full re-announce is a full re-download.
+    """
+    from cps import kobo, ub
+
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+    caplog.set_level(logging.DEBUG, logger="cps.kobo")
+
+    delivered = _seed_legacy_install(sync_harness)
+
+    # Premise: under the legacy classifier every one of these 218 books was a
+    # NewEntitlement, so an empty Kobo could accept every one of them. This is
+    # the shape #1735 does NOT describe; nothing here was silently dropped.
+    legacy_new = _legacy_classification_replay(delivered, kobo.SYNC_ITEM_LIMIT)
+    assert len(legacy_new) == 218, (
+        "test premise broken: the legacy handler would not have delivered "
+        f"all 218 books as New (only {len(legacy_new)})"
+    )
+    assert sync_harness.session.query(ub.KoboSyncedBooks).count() == 218
+    assert sync_harness.session.query(ub.KoboDeviceBookEntitlement).count() == 0
+
+    # The device's own token, exactly where a fully drained legacy sync left
+    # it: past every book by (last_modified, id) and by created clock.
+    settled_token = kobo.SyncToken.SyncToken(
+        books_last_modified=max(book.last_modified for book in delivered),
+        books_last_created=max(book.timestamp for book in delivered),
+        books_last_id=max(book.id for book in delivered),
+    ).build_sync_token()
+
+    token = settled_token
+    page_sizes = []
+    kinds = set()
+    for _page in range(4):
+        response = sync_harness.sync(token)
+        assert response.status_code == 200
+        items = _entitlements(response)
+        page_sizes.append(len(items))
+        kinds.update(
+            "New" if "NewEntitlement" in item else "Changed" for item in items
+        )
+        token = response.headers[sync_harness.token_header]
+
+    assert page_sizes == [0, 0, 0, 0], (
+        "a Kobo that holds every book and presents a valid token must be "
+        f"sent nothing; it was sent {sum(page_sizes)} entitlements "
+        f"({sorted(kinds)}) across pages {page_sizes}"
+    )
+
+
+def test_upgrade_still_removes_a_book_hard_deleted_before_the_upgrade(
+    sync_harness, monkeypatch,
+):
+    """A pre-upgrade hard delete must still reach the Kobo that holds it.
+
+    The admin deleted a book on the old server, which recorded a
+    ``KoboDeletedBook`` tombstone.  The device was offline and never received
+    the removal, so its token's archive cursor still predates the deletion.
+    After the upgrade the removal must still be delivered, or the file stays
+    on the Kobo forever with no server-side way to dislodge it.
+    """
+    from cps import kobo, ub
+
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+
+    delivered = _seed_legacy_install(sync_harness, count=3)
+    modified = max(book.last_modified for book in delivered)
+    orphan_uuid = "00000000-0000-0000-0009-000000000001"
+    deleted_at = modified + timedelta(hours=1)
+    sync_harness.session.add(ub.KoboDeletedBook(
+        user_id=sync_harness.user.id,
+        book_uuid=orphan_uuid,
+        deleted_at=deleted_at,
+    ))
+    sync_harness.session.commit()
+    assert sync_harness.session.query(
+        ub.KoboDeviceDeletedEntitlement,
+    ).count() == 0
+
+    # The offline device's token: past every book, but its archive cursor is
+    # still before the deletion it never heard about.
+    stale_token = kobo.SyncToken.SyncToken(
+        books_last_modified=modified,
+        books_last_created=max(book.timestamp for book in delivered),
+        books_last_id=max(book.id for book in delivered),
+        archive_last_modified=modified,
+    ).build_sync_token()
+
+    response = sync_harness.sync(stale_token)
+    assert response.status_code == 200
+    removed = [
+        item[kind]["BookEntitlement"]["Id"]
+        for item in response.get_json()
+        for kind in ("NewEntitlement", "ChangedEntitlement")
+        if kind in item
+        and item[kind].get("BookEntitlement", {}).get("IsRemoved") is True
+    ]
+    assert removed == [orphan_uuid], (
+        "the upgrade sync swallowed a hard delete the device never received; "
+        f"removals emitted: {removed}"
+    )
+
+
+def test_a_book_the_device_never_received_survives_one_library_deletion(
+    sync_harness, monkeypatch,
+):
+    """#1735's undelivered book must still arrive after an unrelated delete.
+
+    Legacy shape: last_modified ascending, date-added descending.  The old
+    handler sent books 1-100 as New and book 101 as Changed, which an empty
+    Kobo drops (#1735) - so the device does NOT hold book 101.  The admin then
+    deletes one unrelated book.  Any upgrade path that reconstructs "what the
+    legacy handler classified as New" from CURRENT library rows now re-pages
+    the history and can mistake book 101 for a delivered book.
+    """
+    from cps import db, kobo, ub
+
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+
+    base = sync_harness.book.last_modified
+    total = kobo.SYNC_ITEM_LIMIT + 1
+    books = [sync_harness.book]
+    sync_harness.book.last_modified = base
+    sync_harness.book.timestamp = base + timedelta(seconds=total)
+    for offset in range(1, total):
+        book = db.Books(
+            f"Legacy Paged Book {offset + 1}",
+            f"Legacy Paged Book {offset + 1}",
+            "Author",
+            base + timedelta(seconds=total - offset),   # date added
+            db.Books.DEFAULT_PUBDATE,
+            "1.0",
+            base + timedelta(seconds=offset),           # last modified
+            f"legacy-paged-book-{offset + 1}",
+            0,
+            [],
+            [],
+        )
+        sync_harness.session.add(book)
+        sync_harness.session.flush()
+        book.uuid = f"00000000-0000-0000-0007-{offset + 1:012d}"
+        sync_harness.session.add(db.Data(
+            book.id, "EPUB", 7_000_000 + offset,
+            f"legacy-paged-book-{offset + 1}",
+        ))
+        books.append(book)
+    undelivered = books[-1]
+    sync_harness.session.add_all([
+        ub.KoboSyncedBooks(
+            user_id=sync_harness.user.id,
+            book_id=book.id,
+            book_uuid=str(book.uuid),
+        )
+        for book in books
+    ])
+    sync_harness.session.commit()
+
+    # Premise: under the legacy classifier only page one was New, so the
+    # physical Kobo never received the last book.
+    legacy_new = _legacy_classification_replay(books, kobo.SYNC_ITEM_LIMIT)
+    assert undelivered.id not in legacy_new
+    assert len(legacy_new) == kobo.SYNC_ITEM_LIMIT
+
+    # One unrelated book leaves the library, as books routinely do.
+    dropped = books[10]
+    sync_harness.session.query(db.Data).filter_by(book=dropped.id).delete()
+    sync_harness.session.query(db.Books).filter_by(id=dropped.id).delete()
+    sync_harness.session.commit()
+
+    settled_token = kobo.SyncToken.SyncToken(
+        books_last_modified=max(b.last_modified for b in books),
+        books_last_created=max(b.timestamp for b in books),
+        books_last_id=max(b.id for b in books),
+    ).build_sync_token()
+
+    token = settled_token
+    seen = set()
+    for _page in range(4):
+        response = sync_harness.sync(token)
+        for item in response.get_json():
+            for kind in ("NewEntitlement", "ChangedEntitlement"):
+                if kind in item:
+                    seen.add(item[kind]["BookEntitlement"]["Id"])
+        token = response.headers[sync_harness.token_header]
+
+    assert str(undelivered.uuid) in seen, (
+        "the book the device never received was suppressed as already "
+        "delivered after one unrelated library deletion re-paged the "
+        "reconstructed legacy history"
+    )
+
+
+def test_v4_1_43_install_upgrading_is_not_told_its_whole_library_is_new(
+    sync_harness, monkeypatch, caplog,
+):
+    """The shipped v4.1.43 -> next-release upgrade must be silent.
+
+    v4.1.43 (tag bdead55920) ships ``_seed_existing_device_entitlement_ledgers``
+    in its SEEDING form and has no ``ENTITLEMENT_CLASSIFICATION_VERSION``
+    column, so every existing install has a full per-device ledger whose
+    ``classification_version`` reads 0.  Here that ledger is built by real
+    acknowledged deliveries, so the device provably holds all 218 books and
+    every fingerprint is genuine.  Flipping the stamp to 0 is the whole
+    upgrade.  Nickel re-downloads any book announced New (#1925).
+    """
+    from cps import kobo, ub
+
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+    delivered = _seed_legacy_install(sync_harness, record_flat=False)
+
+    # Drain the library for real: these are acknowledged deliveries.
+    token = kobo.SyncToken.SyncToken().build_sync_token()
+    drained = []
+    for _page in range(4):
+        response = sync_harness.sync(token)
+        drained.append(len(_entitlements(response)))
+        token = response.headers[sync_harness.token_header]
+    assert drained == [100, 100, 18, 0], drained
+    assert sync_harness.session.query(
+        ub.KoboDeviceBookEntitlement,
+    ).count() == 218
+
+    # This is the entire v4.1.43 -> main upgrade: the classification stamp
+    # that release never wrote now reads 0.
+    seed = sync_harness.session.get(
+        ub.KoboDeviceEntitlementSeed, sync_harness.device.id,
+    )
+    assert seed is not None
+    seed.classification_version = 0
+    sync_harness.session.commit()
+
+    caplog.clear()
+    caplog.set_level(logging.DEBUG, logger="cps.kobo")
+    upgrade_pages = []
+    for _page in range(4):
+        response = sync_harness.sync(token)
+        upgrade_pages.append(len(_entitlements(response)))
+        token = response.headers[sync_harness.token_header]
+
+    assert upgrade_pages == [0, 0, 0, 0], (
+        "upgrading a v4.1.43 install re-announced "
+        f"{sum(upgrade_pages)} of its 218 already-downloaded books "
+        f"across pages {upgrade_pages}"
+    )

--- a/tests/unit/test_1925_kobo_sync_dedownload.py
+++ b/tests/unit/test_1925_kobo_sync_dedownload.py
@@ -4794,3 +4794,163 @@ def test_v4_1_43_install_upgrading_is_not_told_its_whole_library_is_new(
         f"{sum(upgrade_pages)} of its 218 already-downloaded books "
         f"across pages {upgrade_pages}"
     )
+
+
+def test_v4_1_43_install_with_a_second_kobo_is_still_reannounced(
+    sync_harness, monkeypatch,
+):
+    """A household ledger cannot describe one device, so it stays untrusted.
+
+    v4.1.43's seed copied the user-wide ``KoboSyncedBooks`` history onto every
+    Kobo left unseeded at the upgrade boundary.  With a second paired reader
+    that copy provably over-claims for at least one of them, so the audit must
+    still clear the rows and reannounce rather than suppress against another
+    device's history.  Same fixture and same upgrade as the single-Kobo case
+    above; only the household size differs.
+    """
+    from cps import kobo, ub
+
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+    _seed_legacy_install(sync_harness, record_flat=False)
+
+    token = kobo.SyncToken.SyncToken().build_sync_token()
+    for _page in range(4):
+        response = sync_harness.sync(token)
+        token = response.headers[sync_harness.token_header]
+    assert sync_harness.session.query(
+        ub.KoboDeviceBookEntitlement,
+    ).count() == 218
+
+    sync_harness.session.add(ub.Device(
+        user_id=sync_harness.user.id,
+        kind="kobo",
+        display_name="Second Household Kobo",
+        model="Kobo Libra Colour",
+        active=True,
+        created_by="auto",
+    ))
+    seed = sync_harness.session.get(
+        ub.KoboDeviceEntitlementSeed, sync_harness.device.id,
+    )
+    seed.classification_version = 0
+    sync_harness.session.commit()
+
+    upgrade_pages = []
+    kinds = set()
+    for _page in range(4):
+        response = sync_harness.sync(token)
+        items = _entitlements(response)
+        upgrade_pages.append(len(items))
+        kinds.update(
+            "New" if "NewEntitlement" in item else "Changed" for item in items
+        )
+        token = response.headers[sync_harness.token_header]
+
+    assert upgrade_pages == [100, 100, 18, 0], (
+        "a two-Kobo household's copied ledger must not suppress against "
+        f"another device's history; pages {upgrade_pages}"
+    )
+    assert kinds == {"New"}
+
+
+def test_v4_1_43_upgrade_keeps_a_held_row_over_the_position_sentinel(
+    sync_harness, monkeypatch,
+):
+    """A kept row already proves delivery; the sentinel must not clobber it.
+
+    The reading-position sentinel exists for books the device demonstrably
+    holds but that have no ledger row.  Writing it over a row that survived
+    the audit would force a pointless ChangedEntitlement for exactly the
+    books whose delivery is best evidenced.
+    """
+    from cps import kobo, ub
+
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+    delivered = _seed_legacy_install(sync_harness, count=3, record_flat=False)
+
+    token = kobo.SyncToken.SyncToken().build_sync_token()
+    for _page in range(2):
+        response = sync_harness.sync(token)
+        token = response.headers[sync_harness.token_header]
+    assert sync_harness.session.query(
+        ub.KoboDeviceBookEntitlement,
+    ).count() == 3
+
+    position = sync_harness.session.query(ub.DeviceReadingPosition).filter_by(
+        device_id=sync_harness.device.id, book_id=delivered[0].id,
+    ).one_or_none()
+    if position is None:
+        position = ub.DeviceReadingPosition(
+            device_id=sync_harness.device.id,
+            book_id=delivered[0].id,
+            server_modified_at=delivered[0].last_modified,
+        )
+        sync_harness.session.add(position)
+    position.client_modified_at = delivered[0].last_modified
+    seed = sync_harness.session.get(
+        ub.KoboDeviceEntitlementSeed, sync_harness.device.id,
+    )
+    seed.classification_version = 0
+    sync_harness.session.commit()
+    before = {
+        row.book_id: row.fingerprint
+        for row in sync_harness.session.query(ub.KoboDeviceBookEntitlement)
+    }
+
+    response = sync_harness.sync(token)
+    assert _entitlements(response) == []
+    after = {
+        row.book_id: row.fingerprint
+        for row in sync_harness.session.query(ub.KoboDeviceBookEntitlement)
+    }
+    assert after == before
+
+
+def test_v4_1_43_upgrade_still_delivers_a_book_the_ledger_never_recorded(
+    sync_harness, monkeypatch,
+):
+    """Keeping the ledger must not suppress a book that is not in it.
+
+    The live under-delivery reports (#1735, #2201) are libraries where only
+    part of the collection ever reached the reader.  Those books have no
+    ledger row, so the cursor-independent recovery arm must still announce
+    them New across the upgrade -- keeping the rows for the delivered books
+    may not cost the undelivered ones their repair.
+    """
+    from cps import kobo, ub
+
+    monkeypatch.setattr(
+        kobo.config, "config_kobo_suppress_replayed_entitlements", True,
+    )
+    delivered = _seed_legacy_install(sync_harness, count=3, record_flat=False)
+
+    token = kobo.SyncToken.SyncToken().build_sync_token()
+    for _page in range(2):
+        response = sync_harness.sync(token)
+        token = response.headers[sync_harness.token_header]
+    assert sync_harness.session.query(
+        ub.KoboDeviceBookEntitlement,
+    ).count() == 3
+
+    # This book never physically arrived, so the ledger has no row for it.
+    never_arrived = delivered[-1]
+    sync_harness.session.query(ub.KoboDeviceBookEntitlement).filter_by(
+        device_id=sync_harness.device.id, book_id=never_arrived.id,
+    ).delete(synchronize_session=False)
+    seed = sync_harness.session.get(
+        ub.KoboDeviceEntitlementSeed, sync_harness.device.id,
+    )
+    seed.classification_version = 0
+    sync_harness.session.commit()
+
+    response = sync_harness.sync(token)
+    items = _entitlements(response)
+    assert [sorted(item) for item in items] == [["NewEntitlement"]], items
+    assert (
+        items[0]["NewEntitlement"]["BookEntitlement"]["Id"]
+        == str(never_arrived.uuid)
+    )

--- a/tests/unit/test_1925_kobo_sync_dedownload.py
+++ b/tests/unit/test_1925_kobo_sync_dedownload.py
@@ -4534,6 +4534,29 @@ def _seed_legacy_install(sync_harness, count=218, stagger=True, record_flat=True
     return delivered
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "KNOWN GAP, deliberately left failing rather than fitted to. This "
+        "models a PRE-v4.1.43 install, which has no per-device ledger at all "
+        "-- only the user-wide flat KoboSyncedBooks history. v4.1.43 is the "
+        "only release that ever shipped the ledger seed. Making this pass "
+        "requires writing ledger rows for flat-marked books, and MEASURED: "
+        "doing so turns test_a_book_the_device_never_received_survives_one_"
+        "library_deletion red -- a book the device never got is suppressed as "
+        "already delivered, i.e. permanently starved. That is the same failure "
+        "class as live issue #2201, and a permanent starvation is worse than a "
+        "one-time re-download. The two cases are not distinguishable: the only "
+        "thing separating this install from that one is historical "
+        "timestamp-vs-last_modified ordering, and v4.1.43's table carries no "
+        "such provenance -- its columns are exactly (id, device_id, book_id, "
+        "fingerprint, updated_at); payload_schema_version and change_basis are "
+        "added by THIS migration with DEFAULT 1 / NULL. This population's "
+        "behaviour is bit-for-bit unchanged from main, so nothing regresses "
+        "here. strict=True so that if a future change makes it pass, CI says "
+        "so instead of leaving a stale xfail."
+    ),
+)
 def test_upgrade_with_a_valid_token_does_not_reannounce_a_held_library(
     sync_harness, caplog, monkeypatch,
 ):

--- a/tests/unit/test_kobo_entitlement_ledger_forensic.py
+++ b/tests/unit/test_kobo_entitlement_ledger_forensic.py
@@ -606,10 +606,19 @@ def test_forensic_empty_flat_markers_reset_suppresses_without_restamp(
     }
 
 
-def test_forensic_classification_migration_restamps_all_and_emits_new(
+def test_forensic_classification_migration_keeps_a_single_kobo_ledger_silent(
     sync_harness, monkeypatch,
 ):
-    """The v0-to-v1 audit deletes uncertain rows, then reannounces them New."""
+    """The v0-to-v1 audit is no longer a restamp candidate for one Kobo.
+
+    This candidate previously reproduced the incident signature exactly: it
+    deleted the whole device ledger, so the recovery arm reselected the
+    library and reannounced all 18 held books New with the tombstone replayed
+    -- the same wire shape the reporters saw as books flipping to "Download".
+    With one paired Kobo the user-wide flat history is that device's history,
+    so the audit now only stamps the version.  Nothing is restamped and
+    nothing crosses the wire.
+    """
     from cps import ub
 
     _establish_acknowledged_ledgers(sync_harness, monkeypatch)
@@ -623,10 +632,10 @@ def test_forensic_classification_migration_restamps_all_and_emits_new(
     page = sync_harness.sync(_stale_valid_token(), acknowledge=False)
     assert sync_harness.session.query(
         ub.KoboDeviceBookEntitlement,
-    ).filter_by(device_id=sync_harness.device.id).count() == 0
+    ).filter_by(device_id=sync_harness.device.id).count() == _HELD_BOOK_COUNT
     assert sync_harness.session.query(
         ub.KoboDeviceDeletedEntitlement,
-    ).filter_by(device_id=sync_harness.device.id).count() == 0
+    ).filter_by(device_id=sync_harness.device.id).count() == 1
     assert sync_harness.session.get(
         ub.KoboDeviceEntitlementSeed, sync_harness.device.id,
     ).classification_version == 1
@@ -638,11 +647,17 @@ def test_forensic_classification_migration_restamps_all_and_emits_new(
     signature = _signature(before, after)
     _print_result("classification_v0_to_v1", page, ack, signature)
 
-    assert _matches_incident_signature(signature)
+    assert not _matches_incident_signature(signature)
+    assert after == before
     assert _wire_counts(page) == {
-        "NewEntitlement": _HELD_BOOK_COUNT,
-        "ChangedEntitlement": 1,
-        "IsRemoved": 1,
+        "NewEntitlement": 0,
+        "ChangedEntitlement": 0,
+        "IsRemoved": 0,
+    }
+    assert _wire_counts(ack) == {
+        "NewEntitlement": 0,
+        "ChangedEntitlement": 0,
+        "IsRemoved": 0,
     }
 
 


### PR DESCRIPTION
## The defect

Releasing anything built from current `main` would re-announce **every book to every existing Kobo** as a `NewEntitlement` — a whole-library re-download, once, on the upgrade sync, with reading position lost. Nickel treats a `NewEntitlement` for a book it already holds as "not downloaded". That is #1925 verbatim.

Nothing after v4.1.43 has published, so `:latest` users are unaffected and `:dev` canary users have already taken it. **It is armed for the next release**, which is why this blocks v4.1.44.

### The chain

1. v4.1.43 has no `ENTITLEMENT_CLASSIFICATION_VERSION`, so main's migration (`cps/ub.py`, `classification_version INTEGER NOT NULL DEFAULT 0`) leaves every pre-existing row stamped `0`.
2. `_migrate_device_entitlement_classification` sees `< 1` and **deletes every** `KoboDeviceBookEntitlement` / `KoboDeviceDeletedEntitlement` row for the device.
3. The cursor-independent recovery arm reselects the whole library.
4. Against an empty ledger, every book classifies `NewEntitlement`.

Two facts found during the work that reframe it: **v4.1.43 is the only release that ever shipped the ledger seed**, and **the recovery arm was introduced by #2025 itself** — it does not exist in v4.1.43. Both halves of the harm are post-v4.1.43 constructions.

## The fix

`_migrate_device_entitlement_classification` no longer deletes the ledger. It preserves the rows and only stamps the version — **when those rows can describe one device.**

That condition is load-bearing, not caution. v4.1.43's seed copied the **user-wide** `KoboSyncedBooks` history onto *every* Kobo left unseeded at the upgrade boundary. With one paired reader, user-wide history *is* that device's history and the rows stand. With two or more, the copy is a household union and provably over-claims for at least one of them, so those stay untrusted and are still cleared — which is what `test_upgrade_reannounces_divergent_device_histories_without_starvation` protects, and a blanket keep would have broken it.

Also: `count_user_kobo_devices()` counts **retired** readers deliberately (device removal is a soft delete, and a reader retired after the copy still leaves its history mixed into the survivor's ledger — documented in the helper so nobody adds an `active` filter later); the reading-position sentinel now applies only to proven books that have *no* ledger row, so it cannot clobber preserved rows.

## Results

| Probe | main | this branch |
|---|---|---|
| `test_v4_1_43_install_upgrading_is_not_told_its_whole_library_is_new` | FAIL `[100,100,18,0]` | **PASS `[0,0,0,0]`** |
| `..._still_removes_a_book_hard_deleted_before_the_upgrade` | PASS | PASS |
| `..._never_received_survives_one_library_deletion` | PASS | PASS |
| `..._does_not_reannounce_a_held_library` | FAIL | **xfail(strict)** — see below |

Both Kobo files: **110 passed, 1 xfailed.**

Mutation checks, each caught: always-delete → acceptance test + forensic pin red; always-preserve → the divergent-household test red; sentinel-clobbers-kept-rows → sentinel test red; recovery-arm disabled → under-delivery test red.

## The #2131 pin — updated in place, not deleted

`test_forensic_classification_migration_restamps_all_and_emits_new` pinned the behaviour this PR changes, so it was checked before touching it. `findings/items/F-e0843b.json` enumerates **candidate causes** of an observed incident (two Kobos flipped held books to not-downloaded after a USB eject); each test records whether a candidate reproduces the ledger signature *and* what it puts on the wire, with sibling entries deliberately recording restamps with zero replay as benign. The real root cause turned out to be the partial-token path, fixed by #2131. This entry stayed on the list as an unexcluded suspect.

So it **documents the harm this PR eliminates**; it defends nothing this PR removes. It is renamed `test_forensic_classification_migration_keeps_a_single_kobo_ledger_silent` and its assertions are **inverted, not dropped** — now `not _matches_incident_signature(...)`, `after == before` (ledger byte-identical), and zero wire counts on *both* the page and the ack. It fails if the delete ever returns.

The adjacent invariant it sits beside (v0 rows may name a `ChangedEntitlement` an empty Kobo dropped, #1735) **is** real and is not silenced — it is accepted explicitly, with its own pinning test, because that gap already ships in v4.1.43, is not created here, stays recoverable via Full Sync and per-book resend, and books with no ledger row are untouched so an under-delivered library still gets its missing books as New.

## Known gap, recorded rather than fitted to

The fourth probe models a **pre-v4.1.43** install — no per-device ledger at all, only flat markers — and is left failing as `xfail(strict=True)`.

Making it pass requires writing ledger rows for flat-marked books. That was measured, not argued: doing so turns `..._never_received_survives_one_library_deletion` **red** — a book the device never received is suppressed as already delivered, i.e. permanently starved. Same failure class as live issue #2201. A permanent starvation is worse than a one-time re-download.

The two installs are not distinguishable by anything the server stores. The only difference is historical `timestamp`-vs-`last_modified` ordering, and v4.1.43's table carries no such provenance — its columns are exactly `(id, device_id, book_id, fingerprint, updated_at)`; `payload_schema_version` and `change_basis` are added by this same migration with `DEFAULT 1` / `NULL`. **This population's behaviour is bit-for-bit unchanged from main**, so nothing regresses; `strict=True` means a future change that closes the gap reports itself.

## Not verified

- **No hardware.** Nothing run on a Kobo.
- No Docker/integration/e2e, no browser — unit suite only.
- **No real v4.1.43 `app.db` migrated.** The upgrade is modelled by setting `classification_version = 0`, verified at the schema to be exactly what the real migration produces, but `migrate_Database` was not run against an actual v4.1.43 database file.
- **Nickel's behaviour is inferred**, not observed here — it comes from #1925/#1735 and F-e0843b's hardware evidence.
- Whether the `rehydrate` / `DeviceReadingPosition` machinery already restores position across a re-announce (which would reduce the xfail'd gap's severity) — **unverified**; the machinery exists but its coverage of this scenario was not established.
- The multi-Kobo trade-off is a judgement, not a measurement. Whether a two-Kobo household should re-download everything to repair a gap present since v4.1.43 is a real open question.

## Also found, not fixed here

The unconditional `KoboDeletedBook` tombstone-staging block is in **shipped v4.1.43**: the seed stages every user tombstone into every device's deleted ledger marked acknowledged, so a removal that device never received is suppressed forever. Deserves its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpjL5oprdZGDErDMkPT1qq
