### PR TITLE
fix(tasks): escape converter output before rendering it in the tasks table

### DIFF
--- a/cps/tasks_status.py
+++ b/cps/tasks_status.py
@@ -65,7 +65,11 @@ def render_task_status(tasklist):
                 else:
                     ret['status'] = _('Unknown Status')
 
-            ret['taskMessage'] = "{}: {}".format(task.name, task.message) if task.message else task.name
+            # task.message/task.error can carry converter output (e.g. calibre
+            # or kepubify stderr), which sometimes contains stray HTML - escape
+            # them the same way `user` already is so the tasks table shows the
+            # text instead of letting the browser render it as markup.
+            ret['taskMessage'] = "{}: {}".format(task.name, escape(task.message)) if task.message else task.name
             ret['progress'] = "{} %".format(int(task.progress * 100))
             ret['user'] = escape(user)  # prevent xss
 
@@ -73,7 +77,7 @@ def render_task_status(tasklist):
             ret['task_id'] = task.id
             ret['stat'] = task.stat
             ret['is_cancellable'] = task.is_cancellable
-            ret['error'] = task.error
+            ret['error'] = escape(task.error) if task.error else task.error
 
             rendered_tasklist.append(ret)
 

--- a/tests/unit/test_1076_task_status_html_escaping.py
+++ b/tests/unit/test_1076_task_status_html_escaping.py
@@ -1,0 +1,66 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+# See CONTRIBUTORS for full list of authors.
+
+"""Regression test for fork issue #1076: conversion tasks reporting HTML
+instead of showing the underlying text.
+
+`ebook-convert`/kepubify failures land in `task.message`/`task.error` as raw
+subprocess output, which sometimes contains stray HTML fragments (e.g. a
+converter error that embeds part of the source markup). The `/tasks` page
+renders `taskMessage` and `error` straight into a bootstrap-table cell with no
+client-side escaping, and `render_task_status` already escaped `user` for the
+same reason (see the `# prevent xss` comment) but not these two fields - so a
+converter message containing `<...>` was interpreted as markup by the browser
+instead of shown as text.
+"""
+
+from types import SimpleNamespace
+
+from cps import tasks_status
+from cps.services.worker import STAT_FAIL
+
+
+def _task(name="Convert book", message=None, error=None, stat=STAT_FAIL):
+    return SimpleNamespace(
+        start_time=None,
+        runtime=None,
+        stat=stat,
+        name=name,
+        message=message,
+        progress=1.0,
+        id="task-id",
+        is_cancellable=False,
+        error=error,
+    )
+
+
+def test_task_message_with_html_is_escaped(monkeypatch):
+    user = SimpleNamespace(name="alice", role_admin=lambda: False)
+    monkeypatch.setattr(tasks_status, "current_user", user)
+
+    task = _task(message="failed on <b>chapter1.html</b>")
+    rendered = tasks_status.render_task_status([(1, "alice", None, task, False)])
+
+    assert rendered[0]["taskMessage"] == "Convert book: failed on &lt;b&gt;chapter1.html&lt;/b&gt;"
+
+
+def test_task_error_with_html_is_escaped(monkeypatch):
+    user = SimpleNamespace(name="alice", role_admin=lambda: False)
+    monkeypatch.setattr(tasks_status, "current_user", user)
+
+    task = _task(error="Calibre failed with error: <div>parse error</div>")
+    rendered = tasks_status.render_task_status([(1, "alice", None, task, False)])
+
+    assert rendered[0]["error"] == "Calibre failed with error: &lt;div&gt;parse error&lt;/div&gt;"
+
+
+def test_task_without_error_keeps_none(monkeypatch):
+    user = SimpleNamespace(name="alice", role_admin=lambda: False)
+    monkeypatch.setattr(tasks_status, "current_user", user)
+
+    task = _task(error=None)
+    rendered = tasks_status.render_task_status([(1, "alice", None, task, False)])
+
+    assert rendered[0]["error"] is None


### PR DESCRIPTION
`render_task_status` in `cps/tasks_status.py` already escapes `user` with a `# prevent xss` comment, but built `taskMessage` from `task.name`/`task.message` unescaped and passed `task.error` through as-is. Both fields can carry real calibre/kepubify subprocess output: `_convert_calibre`/`_convert_kepubify` in `cps/tasks/convert.py` build the error string from the converter's own stderr, and any unhandled exception during a run lands in `task.error` via `str(exception)`.

The /tasks page has no per-column formatter for these fields, so bootstrap-table drops the JSON value straight into the cell as HTML. When a conversion fails on a malformed source file and the converter's error output happens to contain `<...>`, the browser renders that fragment as markup instead of showing it as text.

Escaped `task.message` and `task.error` the same way `user` already is, in the same function.

Fixes #1076 as best I can tell. The report itself was a bare Discord forward with no repro steps or screenshot, so I can't confirm this is the exact case, but it matches the description ("reporting HTML rather than rendering the code") and is the only place these two fields reach the browser unescaped.

Added `tests/unit/test_1076_task_status_html_escaping.py`: a `task.message`/`task.error` containing `<b>...</b>`/`<div>...</div>` now comes back HTML-escaped, and a task with no error still returns `None`. Ran the full unit suite (`pytest tests/unit`, Python 3.12 since the project needs >=3.11): 8781 passed, 33 failed, none related to this change. The failures are pre-existing environment gaps: Linux-only s6-overlay/inotify tests, a bash 4+ construct macOS's bundled bash 3.2 doesn't support, and CI-lane/changelog tests that expect this repo's full git history.
