### PR TITLE
feature: calibre content server

### DIFF
--- a/changelog.d/calibre-content-server.md
+++ b/changelog.d/calibre-content-server.md
@@ -1,0 +1,8 @@
+### Added
+
+- **An embedded calibre content server can run alongside the web UI.** Off by
+  default; when enabled, calibre's own content server starts as a managed
+  subprocess with either basic-auth credentials or an explicit anonymous-writes
+  mode, plus a configurable listen address and trusted IPs. CWA's calibredb
+  operations route through the running server so the two never contend for the
+  library, and the server reloads when the library database changes externally.

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -8,6 +8,7 @@
 import os
 import re
 import json
+import ipaddress
 import operator
 import sys
 import string
@@ -3048,9 +3049,29 @@ def _configuration_update_helper():
                 and to_save.get("config_calibre_server_anonymous_writes") != "on"
                 and not (server_username and server_password)):
             return _configuration_result(_('Please enter a content server username and password, or allow anonymous writes'))
+        listen_address = strip_whitespaces(to_save.get("config_calibre_server_listen", ""))
+        if listen_address:
+            try:
+                ipaddress.ip_address(listen_address)
+            except ValueError:
+                return _configuration_result(_('Invalid content server listen address: %(address)s',
+                                               address=listen_address))
+        trusted_ips = []
+        for entry in to_save.get("config_calibre_server_trusted_ips", "").split(","):
+            entry = strip_whitespaces(entry)
+            if not entry:
+                continue
+            try:
+                ipaddress.ip_network(entry, strict=False)
+            except ValueError:
+                return _configuration_result(_('Invalid content server trusted IP/CIDR entry: %(entry)s', entry=entry))
+            trusted_ips.append(entry)
+        to_save["config_calibre_server_trusted_ips"] = ",".join(trusted_ips)
         content_server_changed |= _config_checkbox(to_save, "config_calibre_server_enabled")
         content_server_changed |= _config_int(to_save, "config_calibre_server_port")
+        content_server_changed |= _config_string(to_save, "config_calibre_server_listen")
         content_server_changed |= _config_checkbox(to_save, "config_calibre_server_anonymous_writes")
+        content_server_changed |= _config_string(to_save, "config_calibre_server_trusted_ips")
         content_server_changed |= _config_string(to_save, "config_calibre_server_username")
         if to_save.get("config_calibre_server_password_e") and not config.config_calibre_server_password_e:
             content_server_changed |= _config_string(to_save, "config_calibre_server_password_e")

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -59,6 +59,7 @@ from .ui_themes import config_theme_code
 from .cw_babel import (get_available_locale,
                        get_user_locale_language, sanitize_locale_for_write)
 from . import debug_info
+from . import content_server
 from .string_helper import strip_whitespaces
 from .sqlite_utils import copy_sqlite_database
 from .custom_column_sort import load_eligible_columns, persist_configured_columns
@@ -2855,6 +2856,7 @@ def _db_configuration_update_helper():
 
 def _configuration_update_helper():
     reboot_required = False
+    content_server_changed = False
     to_save = request.form.to_dict()
     prev_hardcover_sync = config.hardcover_sync_enabled()
     prev_kobo_prefer_kepub = bool(config.config_kobo_prefer_kepub)
@@ -3039,6 +3041,20 @@ def _configuration_update_helper():
         reboot_required |= _config_string(to_save, "config_limiter_uri")
         reboot_required |= _config_string(to_save, "config_limiter_options")
 
+        # Calibre content server configuration
+        server_username = to_save.get("config_calibre_server_username", config.config_calibre_server_username)
+        server_password = to_save.get("config_calibre_server_password_e") or config.config_calibre_server_password_e
+        if (to_save.get("config_calibre_server_enabled") == "on"
+                and to_save.get("config_calibre_server_anonymous_writes") != "on"
+                and not (server_username and server_password)):
+            return _configuration_result(_('Please enter a content server username and password, or allow anonymous writes'))
+        content_server_changed |= _config_checkbox(to_save, "config_calibre_server_enabled")
+        content_server_changed |= _config_int(to_save, "config_calibre_server_port")
+        content_server_changed |= _config_checkbox(to_save, "config_calibre_server_anonymous_writes")
+        content_server_changed |= _config_string(to_save, "config_calibre_server_username")
+        if to_save.get("config_calibre_server_password_e") and not config.config_calibre_server_password_e:
+            content_server_changed |= _config_string(to_save, "config_calibre_server_password_e")
+
         # Rarfile Content configuration
         _config_string(to_save, "config_rarfile_location")
         unrar_warning = None
@@ -3053,6 +3069,11 @@ def _configuration_update_helper():
         _configuration_result(_("Oops! Database Error: %(error)s.", error=e.orig))
 
     config.save()
+    if content_server_changed:
+        if config.config_calibre_server_enabled:
+            content_server.start()
+        else:
+            content_server.stop()
     if queue_kepub_backfill:
         from .tasks.kepub_backfill import enqueue_kepub_backfill
         if not enqueue_kepub_backfill(current_user.name):
@@ -3073,6 +3094,17 @@ def _configuration_update_helper():
     return _configuration_result(None, reboot_required, " ".join(filter(None, [unrar_warning, arch_warning])))
 
 
+@admi.route("/admin/config/clear_calibre_server_password", methods=['POST'])
+@user_login_required
+@admin_required
+def clear_calibre_server_password():
+    config.config_calibre_server_password_e = ""
+    config.save()
+    if config.config_calibre_server_enabled:
+        content_server.start()
+    return _configuration_result()
+
+
 def _configuration_result(error_flash=None, reboot=False, warning_flash=None):
     resp = {}
     if error_flash:
@@ -3087,6 +3119,8 @@ def _configuration_result(error_flash=None, reboot=False, warning_flash=None):
             resp['result'].append({'type': "warning", 'message': warning_flash})
     resp['reboot'] = reboot
     resp['config_upload'] = config.config_upload_formats
+    resp['calibre_server_password_set'] = bool(config.config_calibre_server_password_e)
+    resp['calibre_server_password_env'] = config.config_calibre_server_env['password']
     return Response(json.dumps(resp), mimetype='application/json')
 
 

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -254,7 +254,9 @@ class _Settings(_Base):
 
     config_calibre_server_enabled = Column(Boolean, default=False)
     config_calibre_server_port = Column(Integer, default=8080)
+    config_calibre_server_listen = Column(String, default="127.0.0.1")
     config_calibre_server_anonymous_writes = Column(Boolean, default=False)
+    config_calibre_server_trusted_ips = Column(String, default="")
     config_calibre_server_username = Column(String, default="")
     config_calibre_server_password_e = Column(String)
 

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -252,6 +252,12 @@ class _Settings(_Base):
     config_limiter_options = Column(String, default="")
     config_check_extensions = Column(Boolean, default=True)
 
+    config_calibre_server_enabled = Column(Boolean, default=False)
+    config_calibre_server_port = Column(Integer, default=8080)
+    config_calibre_server_anonymous_writes = Column(Boolean, default=False)
+    config_calibre_server_username = Column(String, default="")
+    config_calibre_server_password_e = Column(String)
+
     def __repr__(self):
         return self.__class__.__name__
 
@@ -659,6 +665,19 @@ class ConfigSQL(object):
                         setattr(self, k, "")
                 else:
                     setattr(self, k, v)
+
+        env_port = os.environ.get("CALIBRE_SERVER_PORT")
+        env_username = os.environ.get("CALIBRE_SERVER_USERNAME")
+        env_password = os.environ.get("CALIBRE_SERVER_PASSWORD")
+        if env_port and env_port.isdigit():
+            self.config_calibre_server_port = int(env_port)
+        if env_username:
+            self.config_calibre_server_username = env_username
+        if env_password:
+            self.config_calibre_server_password_e = env_password
+        self.config_calibre_server_env = {"port": bool(env_port),
+                                          "username": bool(env_username),
+                                          "password": bool(env_password)}
 
         # Fork issue #312: the prior force-reset-to-/dev/stdout block
         # silently broke admin → View Logs for every install — the on-disk

--- a/cps/content_server.py
+++ b/cps/content_server.py
@@ -19,12 +19,15 @@
 import os
 import subprocess
 import sys
+import threading
+import time
 
 from . import config, constants, logger
 
 log = logger.create()
 
 _process = None
+_lock = threading.RLock()
 
 
 def library_arguments():
@@ -35,9 +38,58 @@ def library_arguments():
         config.config_calibre_server_port, os.path.basename(config.config_calibre_dir.rstrip("/")))]
 
 
+def _db_mtime(db_path):
+    mtime = None
+    for path in (db_path, db_path + "-wal"):
+        try:
+            stamp = os.path.getmtime(path)
+        except OSError:
+            continue
+        if mtime is None or stamp > mtime:
+            mtime = stamp
+    return mtime
+
+
+def _watch(process, db_path):
+    """Reload the content server when the library database is changed behind its back.
+
+    calibre-server keeps the library in memory and never notices writes made
+    directly to metadata.db (web UI edits, ingest, calibredb), so external
+    changes stay invisible to its clients until it reloads. Restart it once
+    the database has changed and then been quiet for 30 seconds, so it is
+    never bounced in the middle of a burst of writes.
+    """
+    last = None
+    changed = None
+    while True:
+        time.sleep(5)
+        with _lock:
+            if _process is not process or process.poll() is not None:
+                return
+        mtime = _db_mtime(db_path)
+        if mtime is None:
+            continue
+        if last is None:
+            last = mtime
+        elif mtime != last:
+            last = mtime
+            changed = time.time()
+        elif changed and time.time() - changed >= 30:
+            log.info("Library database changed, reloading calibre content server")
+            with _lock:
+                if _process is process and process.poll() is None:
+                    _locked_start()
+            return
+
+
 def start():
+    with _lock:
+        _locked_start()
+
+
+def _locked_start():
     global _process
-    stop()
+    _locked_stop()
     if not config.config_calibre_server_enabled or not config.config_calibre_dir:
         return
     binary = os.path.join(config.config_binariesdir or "",
@@ -74,9 +126,17 @@ def start():
         _process = None
         return
     log.info("Calibre content server started on port %s", config.config_calibre_server_port)
+    threading.Thread(target=_watch,
+                     args=(_process, os.path.join(config.config_calibre_dir, "metadata.db")),
+                     daemon=True).start()
 
 
 def stop():
+    with _lock:
+        _locked_stop()
+
+
+def _locked_stop():
     global _process
     if _process is not None and _process.poll() is None:
         _process.terminate()

--- a/cps/content_server.py
+++ b/cps/content_server.py
@@ -27,6 +27,14 @@ log = logger.create()
 _process = None
 
 
+def library_arguments():
+    """calibredb arguments addressing the library through the content server, empty when it is not running."""
+    if not config.config_calibre_server_enabled or not config.config_calibre_dir:
+        return []
+    return ["--with-library", "http://127.0.0.1:{}/#{}".format(
+        config.config_calibre_server_port, os.path.basename(config.config_calibre_dir.rstrip("/")))]
+
+
 def start():
     global _process
     stop()

--- a/cps/content_server.py
+++ b/cps/content_server.py
@@ -37,9 +37,13 @@ def start():
     if not os.path.isfile(binary):
         log.error("calibre-server binary not found: %s", binary)
         return
-    args = [binary, "--port", str(config.config_calibre_server_port)]
+    args = [binary, "--port", str(config.config_calibre_server_port),
+            "--listen-on", config.config_calibre_server_listen or "127.0.0.1",
+            "--disable-fallback-to-detected-interface"]
     if config.config_calibre_server_anonymous_writes:
-        args += ["--enable-local-write", "--trusted-ips", "0.0.0.0/0,::/0"]
+        args.append("--enable-local-write")
+        if config.config_calibre_server_trusted_ips:
+            args += ["--trusted-ips", config.config_calibre_server_trusted_ips]
     elif config.config_calibre_server_username and config.config_calibre_server_password_e:
         userdb = os.path.join(constants.CONFIG_DIR, "content_server_users.sqlite")
         try:

--- a/cps/content_server.py
+++ b/cps/content_server.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+
+#   This file is part of the Calibre-Web (https://github.com/janeczku/calibre-web)
+#     Copyright (C) 2026 OzzieIsaacs
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import subprocess
+import sys
+
+from . import config, constants, logger
+
+log = logger.create()
+
+_process = None
+
+
+def start():
+    global _process
+    stop()
+    if not config.config_calibre_server_enabled or not config.config_calibre_dir:
+        return
+    binary = os.path.join(config.config_binariesdir or "",
+                          "calibre-server.exe" if sys.platform == "win32" else "calibre-server")
+    if not os.path.isfile(binary):
+        log.error("calibre-server binary not found: %s", binary)
+        return
+    args = [binary, "--port", str(config.config_calibre_server_port)]
+    if config.config_calibre_server_anonymous_writes:
+        args += ["--enable-local-write", "--trusted-ips", "0.0.0.0/0,::/0"]
+    elif config.config_calibre_server_username and config.config_calibre_server_password_e:
+        userdb = os.path.join(constants.CONFIG_DIR, "content_server_users.sqlite")
+        try:
+            os.remove(userdb)
+        except OSError:
+            pass
+        result = subprocess.run([binary, "--userdb", userdb, "--manage-users", "--", "add",
+                                 config.config_calibre_server_username,
+                                 config.config_calibre_server_password_e],
+                                capture_output=True, text=True)
+        if result.returncode != 0:
+            log.error("Failed to create calibre content server user: %s", result.stderr)
+            return
+        args += ["--enable-auth", "--auth-mode", "basic", "--userdb", userdb]
+    args.append(config.config_calibre_dir)
+    try:
+        _process = subprocess.Popen(args)
+    except OSError as ex:
+        log.error("Failed to start calibre content server: %s", ex)
+        _process = None
+        return
+    log.info("Calibre content server started on port %s", config.config_calibre_server_port)
+
+
+def stop():
+    global _process
+    if _process is not None and _process.poll() is None:
+        _process.terminate()
+        try:
+            _process.wait(10)
+        except subprocess.TimeoutExpired:
+            _process.kill()
+        log.info("Calibre content server stopped")
+    _process = None

--- a/cps/cwa_functions.py
+++ b/cps/cwa_functions.py
@@ -7,7 +7,7 @@
 from flask import Blueprint, redirect, flash, url_for, request, send_from_directory, abort, jsonify, current_app
 from flask_babel import gettext as _, lazy_gettext as _l
 
-from . import logger, config, constants, csrf, helper, ub, calibre_db
+from . import logger, config, constants, csrf, helper, ub, calibre_db, content_server
 from .constants import LOG_ARCHIVE
 from .metadata_constants import DEFAULT_METADATA_PROVIDER_HIERARCHY_JSON
 from .usermanagement import login_required_if_no_ano, user_login_required
@@ -57,6 +57,11 @@ from .tasks.ops import TaskConvertLibraryRun, TaskEpubFixerRun
 
 switch_theme = Blueprint('switch_theme', __name__)
 library_refresh = Blueprint('library_refresh', __name__)
+def _restart_content_server_when_done(process):
+    process.wait()
+    content_server.start()
+
+
 convert_library = Blueprint('convert_library', __name__)
 epub_fixer = Blueprint('epub_fixer', __name__)
 cover_enforcer_ui = Blueprint('cover_enforcer_ui', __name__)
@@ -2001,7 +2006,10 @@ def _service_log_path(filename: str) -> str:
 ##———————————————————END OF SHARED VARIABLES & FUNCTIONS———————————————————————##
 
 def convert_library_start(queue):
+    # convert_library works on the format files on disk, so it needs the library to itself
+    content_server.stop()
     cl_process = subprocess.Popen(['python3', os.path.join(constants.SCRIPTS_DIR, 'convert_library.py')])
+    Thread(target=_restart_content_server_when_done, args=(cl_process,), daemon=True).start()
     queue.put(cl_process)
 
 def get_tmp_conversion_dir() -> str:

--- a/cps/embed_helper.py
+++ b/cps/embed_helper.py
@@ -23,7 +23,7 @@ except ImportError:  # pragma: no cover - unit/minimal environments
 
 from .file_helper import get_temp_dir
 from .subproc_wrapper import process_open
-from . import logger, config
+from . import logger, config, content_server
 from .constants import SUPPORTED_CALIBRE_BINARIES
 
 log = logger.create()
@@ -86,10 +86,10 @@ def _do_calibre_export_blocking(book_id, book_format):
         if config.config_calibre_split:
             my_env['CALIBRE_OVERRIDE_DATABASE_PATH'] = os.path.join(config.config_calibre_dir, "metadata.db")
         library_path = config.get_book_path()
-        opf_command = [calibredb_binarypath, 'export', '--dont-write-opf', '--dont-save-cover',
-                       '--with-library', library_path,
-                       '--to-dir', tmp_dir, '--formats', book_format, "--template", "{}".format(temp_file_name),
-                       str(book_id)]
+        opf_command = ([calibredb_binarypath, 'export', '--dont-write-opf', '--dont-save-cover']
+                       + (content_server.library_arguments() or ['--with-library', library_path])
+                       + ['--to-dir', tmp_dir, '--formats', book_format, "--template", "{}".format(temp_file_name),
+                          str(book_id)])
         p = process_open(opf_command, quotes, my_env)
         embed_timeout = _embed_timeout()
         try:

--- a/cps/main.py
+++ b/cps/main.py
@@ -179,6 +179,9 @@ def main():
     _start_runtime_tasks(app)
 
     from . import web_server
+    from . import content_server
 
+    content_server.start()
     success = web_server.start()
+    content_server.stop()
     sys.exit(0 if success else 1)

--- a/cps/server.py
+++ b/cps/server.py
@@ -288,6 +288,8 @@ class WebServer(object):
             return True
 
         log.info("Performing restart of Calibre-Web NextGen")
+        from . import content_server
+        content_server.stop()
         args = self._get_args_for_reloading()
         os.execv(args[0].lstrip('"').rstrip('"'), args)
 

--- a/cps/static/js/main.js
+++ b/cps/static/js/main.js
@@ -63,6 +63,17 @@ $(document).on("change", "input[type=\"checkbox\"][data-control]", function () {
     });
 });
 
+// Same as above, but hides the related fields when the checkbox is checked
+$(document).on("change", "input[type=\"checkbox\"][data-control-invert]", function () {
+    var $this = $(this);
+    var name = $this.data("control-invert");
+    var showOrHide = !$this.prop("checked");
+
+    $("[data-related=\"" + name + "\"]").each(function () {
+        $(this).toggle(showOrHide);
+    });
+});
+
 // Generic control/related handler to show/hide fields based on a select' value
 $(document).on("change", "select[data-control]", function() {
     var $this = $(this);
@@ -794,6 +805,7 @@ $(function() {
 
     // Init all data control handlers to default
     $("input[data-control]").trigger("change");
+    $("input[data-control-invert]").trigger("change");
     $("select[data-control]").trigger("change");
     $("select[data-controlall]").trigger("change");
 
@@ -1030,6 +1042,11 @@ $(function() {
         $("#flash_danger").remove();
         $.post(getPath() + request_path, formData, function(data) {
             $('#config_upload_formats').val(data.config_upload);
+            $("#config_calibre_server_password_e").val("")
+                .prop("disabled", data.calibre_server_password_set)
+                .attr("placeholder", data.calibre_server_password_set ? "********" : "");
+            $("#calibre_server_password_clear_group")
+                .toggle(data.calibre_server_password_set && !data.calibre_server_password_env);
             if(data.reboot) {
                 $("#spinning_success").show();
                 var rebootInterval = setInterval(function(){
@@ -1062,6 +1079,14 @@ $(function() {
     $("#kobo_kepub_backfill").click(function() {
         this.blur();
         submitConfigForm($(this).closest("form"), this);
+    });
+
+    $("#config_calibre_server_password_clear").click(function() {
+        $.post(getPath() + "/admin/config/clear_calibre_server_password", function(data) {
+            $("#config_calibre_server_password_e").val("").prop("disabled", false).removeAttr("placeholder");
+            $("#calibre_server_password_clear_group").hide();
+            handle_response(data.result);
+        });
     });
 
     $("#delete_shelf").click(function(event) {

--- a/cps/tasks/convert.py
+++ b/cps/tasks/convert.py
@@ -19,6 +19,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from flask_babel import lazy_gettext as N_
 
 from cps.services.worker import CalibreTask
+from cps import content_server
 from cps import db
 from cps import ub
 from cps import logger, config
@@ -406,8 +407,8 @@ class TaskConvert(CalibreTask):
                 else:
                     library_path = config.config_calibre_dir
 
-                opf_command = [calibredb_binarypath, 'show_metadata', '--as-opf', str(self.book_id),
-                               '--with-library', library_path]
+                opf_command = ([calibredb_binarypath, 'show_metadata', '--as-opf', str(self.book_id)]
+                               + (content_server.library_arguments() or ['--with-library', library_path]))
                 p = process_open(opf_command, quotes, my_env, newlines=False)
                 lines = list()
                 calibre_traceback = stream_process_output(p, lines.append)

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -290,8 +290,20 @@
         <input type="number" min="1" max="65535" class="form-control" name="config_calibre_server_port" id="config_calibre_server_port" value="{% if config.config_calibre_server_port != None %}{{ config.config_calibre_server_port }}{% endif %}" autocomplete="off" {% if config.config_calibre_server_env['port'] %}disabled{% endif %}>
       </div>
       <div class="form-group" style="margin-left:10px;">
-        <input type="checkbox" id="config_calibre_server_anonymous_writes" name="config_calibre_server_anonymous_writes" data-control-invert="calibre-server-auth" {% if config.config_calibre_server_anonymous_writes %}checked{% endif %}>
+        <label for="config_calibre_server_listen">{{_('Content Server Listen Address')}}</label>
+        <input type="text" class="form-control" name="config_calibre_server_listen" id="config_calibre_server_listen" value="{% if config.config_calibre_server_listen != None %}{{ config.config_calibre_server_listen }}{% endif %}" autocomplete="off" placeholder="127.0.0.1">
+        <p class="help-block">{{_('127.0.0.1 keeps the content server reachable only from this machine. Enter 0.0.0.0 to expose it on the network, which is required to reach it from another container or host.')}}</p>
+      </div>
+      <div class="form-group" style="margin-left:10px;">
+        <input type="checkbox" id="config_calibre_server_anonymous_writes" name="config_calibre_server_anonymous_writes" data-control="calibre-server-trusted" data-control-invert="calibre-server-auth" {% if config.config_calibre_server_anonymous_writes %}checked{% endif %}>
         <label for="config_calibre_server_anonymous_writes">{{_('Allow Anonymous Writes (no username or password required)')}}</label>
+      </div>
+      <div data-related="calibre-server-trusted">
+        <div class="form-group" style="margin-left:10px;">
+          <label for="config_calibre_server_trusted_ips">{{_('Addresses Allowed to Write Without a Password (Comma Separated IPs/CIDRs)')}}</label>
+          <input type="text" class="form-control" name="config_calibre_server_trusted_ips" id="config_calibre_server_trusted_ips" value="{% if config.config_calibre_server_trusted_ips != None %}{{ config.config_calibre_server_trusted_ips }}{% endif %}" autocomplete="off">
+          <p class="help-block">{{_('Leave empty to allow unauthenticated writes only from this machine. Every address listed here can add, edit and delete books in the library without any credentials, so keep it as narrow as possible.')}}</p>
+        </div>
       </div>
       <div data-related="calibre-server-auth">
         <div class="form-group" style="margin-left:10px;">

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -280,6 +280,33 @@
       </div>
     </div>
     {% endif %}
+    <div class="form-group">
+      <input type="checkbox" id="config_calibre_server_enabled" name="config_calibre_server_enabled" data-control="calibre-server-settings" {% if config.config_calibre_server_enabled %}checked{% endif %}>
+      <label for="config_calibre_server_enabled">{{_('Enable Calibre Content Server')}}</label>
+    </div>
+    <div data-related="calibre-server-settings">
+      <div class="form-group" style="margin-left:10px;">
+        <label for="config_calibre_server_port">{{_('Content Server Port')}}</label>
+        <input type="number" min="1" max="65535" class="form-control" name="config_calibre_server_port" id="config_calibre_server_port" value="{% if config.config_calibre_server_port != None %}{{ config.config_calibre_server_port }}{% endif %}" autocomplete="off" {% if config.config_calibre_server_env['port'] %}disabled{% endif %}>
+      </div>
+      <div class="form-group" style="margin-left:10px;">
+        <input type="checkbox" id="config_calibre_server_anonymous_writes" name="config_calibre_server_anonymous_writes" data-control-invert="calibre-server-auth" {% if config.config_calibre_server_anonymous_writes %}checked{% endif %}>
+        <label for="config_calibre_server_anonymous_writes">{{_('Allow Anonymous Writes (no username or password required)')}}</label>
+      </div>
+      <div data-related="calibre-server-auth">
+        <div class="form-group" style="margin-left:10px;">
+          <label for="config_calibre_server_username">{{_('Content Server Username')}}</label>
+          <input type="text" class="form-control" name="config_calibre_server_username" id="config_calibre_server_username" value="{% if config.config_calibre_server_username != None %}{{ config.config_calibre_server_username }}{% endif %}" autocomplete="off" {% if config.config_calibre_server_env['username'] %}disabled{% endif %}>
+        </div>
+        <div class="form-group" style="margin-left:10px;">
+          <label for="config_calibre_server_password_e">{{_('Content Server Password')}}</label>
+          <input type="password" class="form-control" name="config_calibre_server_password_e" id="config_calibre_server_password_e" value="" autocomplete="off" {% if config.config_calibre_server_password_e %}placeholder="********" disabled{% endif %} {% if config.config_calibre_server_env['password'] %}disabled{% endif %}>
+        </div>
+        <div class="form-group" id="calibre_server_password_clear_group" style="margin-left:10px;{% if not config.config_calibre_server_password_e or config.config_calibre_server_env['password'] %}display:none;{% endif %}">
+          <button type="button" id="config_calibre_server_password_clear" class="btn btn-default">{{_('Reset Password')}}</button>
+        </div>
+      </div>
+    </div>
     {% if feature_support['goodreads'] %}
     <div class="form-group">
       <input type="checkbox" id="config_use_goodreads" name="config_use_goodreads" data-control="goodreads-settings" {% if config.config_use_goodreads %}checked{% endif %}>

--- a/scripts/calibre_library_target.py
+++ b/scripts/calibre_library_target.py
@@ -1,0 +1,27 @@
+import os
+import sqlite3
+
+APP_DB = "/config/app.db"
+
+
+def library_arguments(library_dir):
+    """calibredb arguments addressing the library.
+
+    While the Calibre content server is running it holds the library, and calibredb
+    refuses to open the same library directly. Address it through the server instead,
+    which is what calibre recommends. Falls back to the library path when the content
+    server is disabled or its setting cannot be read.
+    """
+    path_args = ["--library-path={}".format(library_dir)]
+    try:
+        con = sqlite3.connect("file:{}?mode=ro".format(APP_DB), uri=True, timeout=5)
+        try:
+            enabled, port = con.execute("select config_calibre_server_enabled, config_calibre_server_port "
+                                        "from settings").fetchone()
+        finally:
+            con.close()
+    except (sqlite3.Error, TypeError):
+        return path_args
+    if not enabled:
+        return path_args
+    return ["--with-library", "http://127.0.0.1:{}/#{}".format(port, os.path.basename(str(library_dir).rstrip("/")))]

--- a/scripts/cover_enforcer.py
+++ b/scripts/cover_enforcer.py
@@ -12,6 +12,7 @@ import re
 import shutil
 import sqlite3
 import subprocess
+from calibre_library_target import library_arguments
 import sys
 import tempfile
 import time
@@ -337,7 +338,7 @@ class Book:
                 # fresh volume.
                 os.makedirs(metadata_temp_dir, exist_ok=True)
                 result = subprocess.run(
-                    ["calibredb", "export", "--with-library", self.calibre_library, "--to-dir", metadata_temp_dir, self.book_id],
+                    ["calibredb", "export", "--to-dir", metadata_temp_dir, self.book_id] + library_arguments(self.calibre_library),
                     env=self.calibre_env, check=False, capture_output=True, text=True, timeout=60
                 )
                 
@@ -1143,7 +1144,7 @@ class Enforcer:
 
     def print_library_list(self) -> None:
         """Uses the calibredb command line utility to list the books in the library"""
-        subprocess.run(["calibredb", "list", "--with-library", self.calibre_library], env=self.calibre_env, check=True)
+        subprocess.run(["calibredb", "list"] + library_arguments(self.calibre_library), env=self.calibre_env, check=True)
 
 
     def delete_log(self, auto=True, log_path="None"):

--- a/scripts/ingest_processor.py
+++ b/scripts/ingest_processor.py
@@ -11,6 +11,7 @@ import json
 import os
 import subprocess
 import sys
+from calibre_library_target import library_arguments
 import tempfile
 import time
 import shutil
@@ -1782,7 +1783,7 @@ class NewBookProcessor:
         command = [
             "calibre-debug", "-e", str(helper), "--",
             "--action", action,
-            "--library-path", self.library_dir,
+            *library_arguments(self.library_dir),
             "--path", str(staged_path),
             "--identity-path", str(staged_identity_path),
             "--expected-import-sha256", imported_digest,
@@ -2472,7 +2473,7 @@ class NewBookProcessor:
             mark_ingest_batch_active()
             wait_for_duplicate_full_scan_to_finish()
             result = subprocess.run([
-                "calibredb", "add_format", str(book_id), str(staged_path), f"--library-path={self.library_dir}"
+                "calibredb", "add_format", str(book_id), str(staged_path), *library_arguments(self.library_dir)
             ], env=self.calibre_env, check=True, capture_output=True, text=True)
             print(f"[ingest-processor] Added new format for book id {book_id}: {os.path.basename(str(staged_path))}", flush=True)
             mark_ingest_batch_dirty()


### PR DESCRIPTION
Description
I had a previous PR open for this but I closed it, apologies for having to do any initial steps twice. Runs calibre's own content server alongside the web UI, off by default. When enabled, calibre-server starts as a managed subprocess against the library, giving external tools a real calibre API endpoint (OPDS, cdb/* writes) without a second container.
Admin config gains the toggle, port, listen address, and trusted-IP settings. Access is either basic-auth (a userdb generated from configured credentials) or an explicit anonymous-writes mode; the password field supports set/clear without redisplaying the stored value.
calibredb is routed through the running server: calibre-server holds the library open and calibredb refuses to open it directly while it does, so the metadata embedder, conversion task, cover enforcer, and ingest processor address the library through the server, falling back to the library path when disabled. convert-library needs the library to itself, so the server is stopped around it and restarted afterwards.
The server reloads when the library database changes externally, so it never serves stale records.
Deliberately left out: no tests are added — the feature is a subprocess lifecycle manager whose behavior is integration-level (starting a real calibre-server binary); I'm happy to add a unit test around the argument construction if you'd like one. Changelog fragment included at changelog.d/calibre-content-server.md.

CWA PR:
https://github.com/crocodilestick/Calibre-Web-Automated/pull/1530

Database Migration
NO migration file. New settings columns are added automatically by the existing settings-table column migration on startup.

How was this tested?
Docker (linux/amd64) on an Ubuntu server host.
- Weeks of real use pushing books/metadata/deletes into the running server from an external tool, alongside normal ingest and cover enforcement. No more library lock fights since calibredb goes through the server.
- Both auth modes work, including setting and clearing the password from the admin page.
- Changes made to the library from outside show up without restarting CWA.
- convert-library stops the server and brings it back when done.