### PR TITLE
fix(covers): replace a writable cover in place when the book folder refuses new files

### DIFF
--- a/changelog.d/cover-store-unwritable-book-dir.md
+++ b/changelog.d/cover-store-unwritable-book-dir.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- **Setting a cover no longer fails with "not a valid image file" when the server cannot create files in the book's folder.**
+  A folder owned by another user (for example one created by a root process on a network share) blocked every cover
+  change since v4.1.43 because the new cover was staged as a sibling file first. When the existing cover itself is
+  writable, the server now replaces it in place instead of refusing; when it is not, the error names the folder and
+  the user ids involved instead of blaming the image.

--- a/cps/helper.py
+++ b/cps/helper.py
@@ -2368,7 +2368,10 @@ class InPlaceStagedCoverWrite(StagedCoverWrite):
                 content = staged_file.read()
             # No O_CREAT: creating the file would need the directory permission
             # this path exists to do without, and it must fail loudly instead.
-            fd = os.open(self.target_path, os.O_WRONLY | os.O_TRUNC)
+            fd = os.open(
+                self.target_path,
+                os.O_WRONLY | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0),
+            )
             try:
                 _write_all(fd, content)
                 os.fsync(fd)
@@ -2509,7 +2512,10 @@ def _open_cover_stage(filepath, saved_filename):
         fd, staged_path = tempfile.mkstemp(prefix=prefix, suffix=".stage", dir=filepath)
         return fd, staged_path, False
     except PermissionError as ex:
-        if not (os.path.isfile(target) and os.access(target, os.W_OK)):
+        # A symlinked target is never rewritten in place: the rename path
+        # replaced the link itself, and following it here would write through
+        # to wherever the link points.
+        if os.path.islink(target) or not (os.path.isfile(target) and os.access(target, os.W_OK)):
             raise
         log.warning(
             "Book folder %s refuses new entries (owner uid %s, server uid %s): %s. "

--- a/cps/helper.py
+++ b/cps/helper.py
@@ -2347,6 +2347,49 @@ class StagedCoverWrite:
             return False, str(ex)
 
 
+class InPlaceStagedCoverWrite(StagedCoverWrite):
+    """A validated stage elsewhere, published by rewriting the live cover in place.
+
+    Used only when the book folder refuses new entries (a folder owned by
+    another uid on a network share is the measured case) but the existing
+    ``cover.jpg`` itself is writable. Overwriting an existing file needs no
+    directory permission, which is exactly what the pre-#2127 store relied on.
+    The rewrite is not an atomic rename: a crash between truncate and fsync
+    leaves a torn cover, which the next successful save repairs. That is the
+    trade for not refusing the user's cover outright; the honest alternative
+    (a permission error) is still what they get when no writable cover exists.
+    """
+
+    def publish(self):
+        if self._published:
+            return True, None
+        try:
+            with open(self.staged_path, "rb") as staged_file:
+                content = staged_file.read()
+            # No O_CREAT: creating the file would need the directory permission
+            # this path exists to do without, and it must fail loudly instead.
+            fd = os.open(self.target_path, os.O_WRONLY | os.O_TRUNC)
+            try:
+                _write_all(fd, content)
+                os.fsync(fd)
+            finally:
+                os.close(fd)
+            self._published = True
+        except (IOError, OSError) as ex:
+            log.error(
+                "Publishing cover in place failed target=%s: %s: %s",
+                self.target_path,
+                type(ex).__name__,
+                ex,
+            )
+            return False, str(ex)
+        try:
+            os.remove(self.staged_path)
+        except OSError as ex:
+            log.warning("Could not remove published cover stage %s: %s", self.staged_path, ex)
+        return True, None
+
+
 class GDriveStagedCoverWrite(StagedCoverWrite):
     """Locally validated cover bytes awaiting a post-commit Drive upload."""
 
@@ -2435,12 +2478,60 @@ def _validate_and_normalize_staged_cover(staged_path):
         verified.load()
 
 
+class _CoverNotDecodable(Exception):
+    """The staged bytes are not an image we accept (wraps the decoder error)."""
+
+
+def _describe_owner(path):
+    try:
+        return os.stat(path).st_uid
+    except OSError:
+        return "?"
+
+
+def _server_uid():
+    return os.geteuid() if hasattr(os, "geteuid") else "?"
+
+
+def _open_cover_stage(filepath, saved_filename):
+    """Create the stage file, beside the target when the folder allows it.
+
+    Returns ``(fd, staged_path, in_place)``. ``in_place`` is True when the book
+    folder refused a new entry and the existing target is writable, in which
+    case the stage lives in the temp directory (where the startup scavenger
+    already looks) and publication rewrites the target in place. A folder that
+    refuses new entries with no writable target is a real permission failure
+    and the PermissionError is re-raised for the caller to report as such.
+    """
+    prefix = ".{}.cwng-".format(saved_filename)
+    target = os.path.join(filepath, saved_filename)
+    try:
+        fd, staged_path = tempfile.mkstemp(prefix=prefix, suffix=".stage", dir=filepath)
+        return fd, staged_path, False
+    except PermissionError as ex:
+        if not (os.path.isfile(target) and os.access(target, os.W_OK)):
+            raise
+        log.warning(
+            "Book folder %s refuses new entries (owner uid %s, server uid %s): %s. "
+            "Replacing the existing cover in place instead of by atomic rename. "
+            "Give the folder the server's uid to restore the atomic path.",
+            filepath, _describe_owner(filepath), _server_uid(), ex,
+        )
+    fd, staged_path = tempfile.mkstemp(prefix=prefix, suffix=".stage", dir=get_temp_dir())
+    return fd, staged_path, True
+
+
 def save_cover_from_filestorage(filepath, saved_filename, img, handle_factory=None):
     """Write and validate a temporary sibling, returning a publish handle.
 
     Despite the historical name, this function deliberately does not replace
     ``saved_filename``.  It is the single storage primitive used by every cover
     surface; callers own the surrounding metadata transaction.
+
+    The failure message distinguishes bytes that are not an image from bytes
+    that could not be stored: a permission problem on the book folder is
+    reported as one, with the folder and the uids involved, never as a bad
+    image (measured on a household library, 2026-09-10).
     """
     if not os.path.exists(filepath):
         try:
@@ -2451,12 +2542,9 @@ def save_cover_from_filestorage(filepath, saved_filename, img, handle_factory=No
     target = os.path.join(filepath, saved_filename)
     staged_path = None
     fd = None
+    in_place = False
     try:
-        fd, staged_path = tempfile.mkstemp(
-            prefix=".{}.cwng-".format(saved_filename),
-            suffix=".stage",
-            dir=filepath,
-        )
+        fd, staged_path, in_place = _open_cover_stage(filepath, saved_filename)
         try:
             staged_mode = os.stat(target).st_mode & 0o777
         except OSError:
@@ -2469,7 +2557,7 @@ def save_cover_from_filestorage(filepath, saved_filename, img, handle_factory=No
                 log.error("Cover save aborted: empty response body (url=%s, content-type=%s, http=%s)",
                           getattr(getattr(img, "request", None), "url", "?"), ct,
                           getattr(img, "status_code", "?"))
-                raise ValueError("empty response body")
+                raise _CoverNotDecodable("empty response body")
             _write_all(fd, img.content)
             os.fsync(fd)
         else:
@@ -2495,14 +2583,38 @@ def save_cover_from_filestorage(filepath, saved_filename, img, handle_factory=No
                 os.fsync(sync_fd)
             finally:
                 os.close(sync_fd)
-        _validate_and_normalize_staged_cover(staged_path)
+        try:
+            _validate_and_normalize_staged_cover(staged_path)
+        except (ValueError, OSError) as decode_error:
+            # PIL raises OSError subclasses (UnidentifiedImageError, truncated
+            # data) for bad bytes; that is an image problem, not a storage one.
+            raise _CoverNotDecodable(decode_error)
         if handle_factory is not None:
             return handle_factory(staged_path), None
+        if in_place:
+            return InPlaceStagedCoverWrite(staged_path, target), None
         return StagedCoverWrite(staged_path, target), None
-    except (IOError, OSError, ValueError) as e:
+    except _CoverNotDecodable as e:
+        log.error("Cover rejected target=%s: not a decodable image: %s", target, e)
+        message = _("Cover-file is not a valid image file, or could not be stored")
+    except PermissionError as e:
+        log.error(
+            "Cover storage refused target=%s: %s (folder %s owner uid %s, server uid %s). "
+            "The server cannot create files in this book folder; give the folder the "
+            "server's uid or make it group-writable.",
+            target, e, filepath, _describe_owner(filepath), _server_uid(),
+        )
+        message = _(
+            "Cover could not be stored: the server has no permission to write into "
+            "the book folder %(folder)s (folder owner uid %(owner)s, server uid %(uid)s).",
+            folder=filepath, owner=_describe_owner(filepath), uid=_server_uid(),
+        )
+    except (IOError, OSError) as e:
         log.error("Cover staging failed target=%s: %s: %s", target, type(e).__name__, e)
+        message = _("Cover could not be stored: %(reason)s", reason=str(e))
     except Exception as e:
         log.error("Cover staging failed (unexpected) target=%s: %s: %s", target, type(e).__name__, e)
+        message = _("Cover-file is not a valid image file, or could not be stored")
     finally:
         if fd is not None:
             try:
@@ -2514,7 +2626,7 @@ def save_cover_from_filestorage(filepath, saved_filename, img, handle_factory=No
             os.remove(staged_path)
         except OSError:
             pass
-    return None, _("Cover-file is not a valid image file, or could not be stored")
+    return None, message
 
 
 # saves book cover to gdrive or locally

--- a/tests/unit/test_cover_store_unwritable_book_dir.py
+++ b/tests/unit/test_cover_store_unwritable_book_dir.py
@@ -1,0 +1,182 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""A book folder the server cannot add entries to must not block a cover change.
+
+Measured on the household library 2026-09-10: three book folders were created by
+a root process over NFS (uid 0, mode 755) while every file inside stayed at the
+server's uid. Since the cover store started staging a sibling file (#2127),
+``tempfile.mkstemp`` in such a folder raises ``PermissionError`` and the user
+was told "Cover-file is not a valid image file, or could not be stored" for a
+perfectly good JPEG. Before #2127 the same save worked, because overwriting an
+existing, writable ``cover.jpg`` needs no directory write permission.
+"""
+
+import io
+import os
+import stat
+from types import SimpleNamespace
+
+from PIL import Image
+import pytest
+from werkzeug.datastructures import FileStorage
+
+
+pytestmark = pytest.mark.unit
+
+OLD_COVER = b"the byte-identical previous cover"
+INVALID_IMAGE_MESSAGE = "Cover-file is not a valid image file, or could not be stored"
+
+
+def _jpeg_bytes(color=(21, 84, 160)):
+    output = io.BytesIO()
+    Image.new("RGB", (8, 11), color).save(output, format="JPEG")
+    return output.getvalue()
+
+
+def _storage(data=None, filename="cover.jpg"):
+    return FileStorage(
+        stream=io.BytesIO(data if data is not None else _jpeg_bytes()),
+        filename=filename,
+        content_type="image/jpeg",
+    )
+
+
+@pytest.fixture
+def library(tmp_path, monkeypatch):
+    """A local library with one book folder plus a separate temp dir."""
+    from cps import helper
+
+    root = tmp_path / "library"
+    book_dir = root / "Author" / "Book (7)"
+    book_dir.mkdir(parents=True)
+    temp_dir = tmp_path / "temp"
+    temp_dir.mkdir()
+    monkeypatch.setattr(helper.config, "config_use_google_drive", False, raising=False)
+    monkeypatch.setattr(helper.config, "get_book_path", lambda: str(root))
+    monkeypatch.setattr(helper, "get_temp_dir", lambda: str(temp_dir))
+    return SimpleNamespace(root=root, book_dir=book_dir, temp_dir=temp_dir, book_path="Author/Book (7)")
+
+
+def _deny_new_entries(directory):
+    """Make ``directory`` unwritable for the current user, like a folder owned
+    by another uid. Root ignores mode bits, so the tests that depend on this
+    cannot prove anything when run as root."""
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        pytest.skip("directory permission bits do not bind root")
+    directory.chmod(stat.S_IRUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
+
+
+def _restore(directory):
+    directory.chmod(0o755)
+
+
+def _stage_files(directory):
+    return sorted(p.name for p in directory.iterdir() if p.name.endswith(".stage"))
+
+
+def test_unwritable_book_dir_with_writable_cover_is_replaced_in_place(library):
+    from cps import helper
+
+    cover = library.book_dir / "cover.jpg"
+    cover.write_bytes(OLD_COVER)
+    _deny_new_entries(library.book_dir)
+    try:
+        staged, message = helper.save_cover(_storage(), library.book_path)
+        assert staged is not None, message
+        # Nothing touches the live cover before the metadata owner publishes.
+        assert cover.read_bytes() == OLD_COVER
+        assert _stage_files(library.book_dir) == []
+        assert len(_stage_files(library.temp_dir)) == 1
+
+        published, error = staged.publish()
+        assert published, error
+        with Image.open(cover) as decoded:
+            assert decoded.format == "JPEG"
+            assert decoded.size == (8, 11)
+        # The stage does not outlive the publish in either location.
+        assert _stage_files(library.temp_dir) == []
+        assert _stage_files(library.book_dir) == []
+    finally:
+        _restore(library.book_dir)
+
+
+def test_unwritable_book_dir_discard_leaves_cover_and_removes_stage(library):
+    from cps import helper
+
+    cover = library.book_dir / "cover.jpg"
+    cover.write_bytes(OLD_COVER)
+    _deny_new_entries(library.book_dir)
+    try:
+        staged, message = helper.save_cover(_storage(), library.book_path)
+        assert staged is not None, message
+        assert staged.discard() == (True, None)
+        assert cover.read_bytes() == OLD_COVER
+        assert _stage_files(library.temp_dir) == []
+    finally:
+        _restore(library.book_dir)
+
+
+def test_unwritable_book_dir_without_cover_names_the_permission_problem(library):
+    from cps import helper
+
+    _deny_new_entries(library.book_dir)
+    try:
+        staged, message = helper.save_cover(_storage(), library.book_path)
+        assert staged is None
+        text = str(message)
+        # The user is told what actually went wrong, not that their image is bad.
+        assert "permission" in text.lower()
+        assert str(library.book_dir) in text
+        # Pinned to the dedicated permission branch: it names both uids so an
+        # admin can see the mismatch without reading the server log.
+        assert "server uid" in text
+        assert INVALID_IMAGE_MESSAGE not in text
+        assert not (library.book_dir / "cover.jpg").exists()
+        assert _stage_files(library.temp_dir) == []
+    finally:
+        _restore(library.book_dir)
+
+
+def test_writable_book_dir_still_stages_beside_the_cover(library):
+    """The atomic same-directory rename stays the normal path."""
+    from cps import helper
+
+    cover = library.book_dir / "cover.jpg"
+    cover.write_bytes(OLD_COVER)
+    staged, message = helper.save_cover(_storage(), library.book_path)
+    assert staged is not None, message
+    assert len(_stage_files(library.book_dir)) == 1
+    assert _stage_files(library.temp_dir) == []
+    assert staged.publish() == (True, None)
+    with Image.open(cover) as decoded:
+        assert decoded.format == "JPEG"
+
+
+def test_undecodable_upload_is_still_reported_as_an_invalid_image(library):
+    from cps import helper
+
+    cover = library.book_dir / "cover.jpg"
+    cover.write_bytes(OLD_COVER)
+    staged, message = helper.save_cover(_storage(b"definitely not an image body"), library.book_path)
+    assert staged is None
+    assert str(message) == INVALID_IMAGE_MESSAGE
+    assert cover.read_bytes() == OLD_COVER
+    assert _stage_files(library.book_dir) == []
+
+
+def test_undecodable_upload_into_unwritable_dir_is_an_invalid_image_not_a_permission_error(library):
+    """Classification follows the failure, not the directory: bad bytes stay a
+    bad-image message even when the fallback stage was used."""
+    from cps import helper
+
+    cover = library.book_dir / "cover.jpg"
+    cover.write_bytes(OLD_COVER)
+    _deny_new_entries(library.book_dir)
+    try:
+        staged, message = helper.save_cover(_storage(b"definitely not an image body"), library.book_path)
+        assert staged is None
+        assert str(message) == INVALID_IMAGE_MESSAGE
+        assert cover.read_bytes() == OLD_COVER
+        assert _stage_files(library.temp_dir) == []
+    finally:
+        _restore(library.book_dir)

--- a/tests/unit/test_cover_store_unwritable_book_dir.py
+++ b/tests/unit/test_cover_store_unwritable_book_dir.py
@@ -180,3 +180,23 @@ def test_undecodable_upload_into_unwritable_dir_is_an_invalid_image_not_a_permis
         assert _stage_files(library.temp_dir) == []
     finally:
         _restore(library.book_dir)
+
+
+def test_symlinked_cover_in_unwritable_dir_is_refused_not_written_through(library, tmp_path):
+    """The rename path replaced a symlink itself; the in-place path must not
+    follow it and rewrite whatever it points at."""
+    from cps import helper
+
+    elsewhere = tmp_path / "elsewhere.bin"
+    elsewhere.write_bytes(OLD_COVER)
+    cover = library.book_dir / "cover.jpg"
+    cover.symlink_to(elsewhere)
+    _deny_new_entries(library.book_dir)
+    try:
+        staged, message = helper.save_cover(_storage(), library.book_path)
+        assert staged is None
+        assert "permission" in str(message).lower()
+        assert elsewhere.read_bytes() == OLD_COVER
+        assert _stage_files(library.temp_dir) == []
+    finally:
+        _restore(library.book_dir)


### PR DESCRIPTION
## Outcome

Setting a cover on a book whose folder the server cannot add files to no longer fails, and when it genuinely cannot be stored the error says why instead of blaming the image.

## Root cause (OBSERVED on the household instance, 2026-09-10)

| Step | Evidence |
|---|---|
| User applies the Amazon candidate for book 570 | server log: `Cover download ok … bytes=109119` |
| Store stages a sibling file in the book folder (#2127) | `Cover staging failed … PermissionError: [Errno 13] … /.cover.jpg.cwng-….stage` |
| Folder is `uid 0, mode 755` on NFS; every file inside is the server's uid 1000 | `ls -ln` in the container; 3 of 250 book folders affected, all created today by a root process outside the web app |
| UI reports "Cover-file is not a valid image file, or could not be stored" | `cover_picker._apply_response` relays the storage primitive's single fallback message |

Before #2127 this save worked: overwriting an existing writable `cover.jpg` needs no directory permission. The regression is the new requirement, and the message hid it.

## Fix

- `_open_cover_stage`: `mkstemp` beside the target as before; on `PermissionError`, if the target exists and is writable, stage in the temp directory (already scanned by the startup scavenger) and return an `InPlaceStagedCoverWrite`, which publishes by truncate + write + fsync of the existing file. The torn-write window is documented on the class; a folder with no writable cover re-raises.
- Failure classification: decoder errors → the invalid-image message; `PermissionError` → a message naming the folder, its owner uid and the server uid, plus a log line with the remediation; other `OSError` → "could not be stored: <reason>".

## Tests

`tests/unit/test_cover_store_unwritable_book_dir.py`, 6 cases. Seen red: 3 failed on `main` with the household log's exact `PermissionError`; green after the change. Mutating the fallback guard (`if True: raise`) turns the same 3 red again. The 44 pre-existing staging tests and the 430-test cover sweep pass. Tests skip under root, where mode bits do not bind.

## Not done here

The three root-owned folders on the household library stay root-owned; fixing ownership is a host-side `chown`, outside this PR. The process that creates them as root is not identified (not the web app, not the ingest; both logged nothing at that minute).
