### PR TITLE
Kobo: make a re-download harmless (no spurious re-send; highlights restored and re-anchored)

### DIFF
--- a/CHANGES-vs-upstream.md
+++ b/CHANGES-vs-upstream.md
@@ -68,6 +68,8 @@ Format: each row is one fork-PR, mapped to its upstream PR or issue (if any), wi
 
 ### Bug fixes
 
+- **Kobo re-downloads are harmless.** An on-demand EPUB→KEPUB materialisation no longer advances `books.last_modified` (helper SSOT) and `DownloadUrls[].Size` leaves the entitlement fingerprint (payload schema v2), so the device is not told the book changed; each Kobo download is ledgered per device and the next annotations GET from that device is served from the server's own rows, re-anchored by text against the current KEPUB when the chapter names changed. New table `kobo_device_book_download`, auto-created. | SHA `TBD` | release `TBD`.
+
 - **Clearing a note now agrees in the classic and new readers.** Explicit web-reader clears store an empty string; omitted notes and existing NULLs stay unknown. Kobo column rendering treats either empty representation as no note. No migration. | SHA `TBD` | release `TBD`.
 
 - **Hardcover's automatic ID crawler can now be turned off without disabling reading-progress or annotation sync** (fork issue [#2103](https://github.com/new-usemame/Calibre-Web-NextGen/issues/2103)). The CWA settings schedule has an explicit `Never (auto-fetch off)` value; refreshing the schedule removes only the recurring Hardcover crawler job and leaves the canonical `config_hardcover_sync` setting untouched. Unknown persisted schedule values are diagnosed and fall back to the backward-compatible weekly default, while invalid form submissions retain the prior stored value. Fork-original. | SHA `TBD` | release `TBD`.

--- a/changelog.d/kobo-redownload-harmless.md
+++ b/changelog.d/kobo-redownload-harmless.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Re-downloading a book on a Kobo no longer wipes its highlights, and a book is no longer re-sent just because the reader downloaded it.** When the KEPUB was built on demand from the stored EPUB, the book's clock advanced and the next sync told the device the book had changed, so it removed and re-fetched the book seconds after the reader had found her place. That materialisation now leaves the clock alone. After any download, the first annotation request from that device is answered from the highlights the server already holds instead of being forwarded to Kobo's empty cloud set, and highlights whose chapter no longer exists in the new file are re-anchored by their text so they still render.

--- a/cps/helper.py
+++ b/cps/helper.py
@@ -149,6 +149,39 @@ def mark_book_modified(book, *, set_dirty=True, unsync=False):
         kobo_sync_status.remove_synced_book(book.id, all=True)
 
 
+KOBO_DELIVERABLE_FORMATS = frozenset({"KEPUB", "EPUB", "EPUB3"})
+
+
+def mark_book_format_materialised(book, new_format, *, set_dirty=False):
+    """Single source of truth for "a converted/derived format row was added".
+
+    Advances ``last_modified`` (through :func:`mark_book_modified`) ONLY when
+    the new format makes the book Kobo-deliverable for the first time, e.g. a
+    PDF-only book gaining its first EPUB: the sync selects books by
+    ``Books.last_modified > sync_token``, so without a bump that book would
+    never be offered.
+
+    A KEPUB derived from an existing EPUB (or vice versa) leaves the clock
+    alone. The entitlement Nickel holds still describes the same source
+    bytes, and advancing the clock re-sent it on the next sync; Nickel answers
+    a ChangedEntitlement by marking the book not-downloaded. OBSERVED
+    2026-09-11 on a Libra Colour: the on-demand KEPUB minted by the reader's
+    own re-download bumped the clock, and the second de-download came 25 s
+    after she had re-found her place.
+
+    Returns ``True`` when the clock was advanced.
+    """
+    new_format = (new_format or "").upper()
+    if new_format not in KOBO_DELIVERABLE_FORMATS:
+        return False
+    for row in getattr(book, "data", None) or ():
+        existing = (getattr(row, "format", None) or "").upper()
+        if existing in KOBO_DELIVERABLE_FORMATS and existing != new_format:
+            return False
+    mark_book_modified(book, set_dirty=set_dirty)
+    return True
+
+
 def log_metadata_change(book, changed=None):
     """Queue a CWA metadata/cover *file-level* enforcement for ``book`` (#707).
 
@@ -3106,6 +3139,20 @@ def get_download_link(book_id, book_format, client):
     if not data1:
         log.error("Requested format %s for book id %s not found in database", book_format.upper(), book_id)
         abort(404)
+
+    if client == "kobo":
+        # The device is about to replace its local copy; remember that so the
+        # annotation GET that follows is answered from CWNG's own rows.
+        try:
+            from flask import g
+            from .services.kobo_post_download_restore import record_download
+            record_download(
+                device_id=getattr(g, "annotation_origin_device_id", None),
+                book_id=book.id, book_format=book_format, log=log,
+            )
+        except Exception:
+            log.warning("Kobo download ledger update failed for book %s",
+                        book.id, exc_info=True)
 
     # collect downloaded books only for registered user and not for anonymous user
     if current_user.is_authenticated:

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -70,7 +70,13 @@ KOB0_COVER_RESET_PROGRESS_EPSILON = 1.0
 # the server intentionally changes the entitlement renderer's declared shape;
 # unchanged book/tombstone bases will then be lazily re-fingerprinted instead
 # of being re-delivered to Nickel.
-ENTITLEMENT_PAYLOAD_SCHEMA_VERSION = 1
+# v2: the entitlement fingerprint no longer covers ``DownloadUrls[].Size``.
+# Materialising a KEPUB from a stored EPUB swaps the served Data row, which
+# changed Size and therefore the fingerprint while the canonical book basis
+# (``last_modified``) stayed put; that was delivered as a ChangedEntitlement
+# and de-downloaded the book on the device that had just fetched it. Content
+# provenance is the basis; Size is a description of a derived artifact.
+ENTITLEMENT_PAYLOAD_SCHEMA_VERSION = 2
 
 # Stored in KoboDeviceEntitlementSeed, never sent to the device. Version 1
 # replaces Books.timestamp watermark classification with the physical-device
@@ -84,10 +90,35 @@ kobo_auth.register_url_value_preprocessor(kobo)
 log = logger.create()
 
 
+def _fingerprint_projection(value):
+    """Copy ``value`` without the download ``Size`` members (schema v2)."""
+    if isinstance(value, dict):
+        projected = {}
+        for key, member in value.items():
+            if key == "DownloadUrls" and isinstance(member, list):
+                projected[key] = [
+                    {k: v for k, v in entry.items() if k != "Size"}
+                    if isinstance(entry, dict) else entry
+                    for entry in member
+                ]
+            else:
+                projected[key] = _fingerprint_projection(member)
+        return projected
+    if isinstance(value, list):
+        return [_fingerprint_projection(item) for item in value]
+    return value
+
+
 def _entitlement_fingerprint(entitlement):
-    """Stable hash of fields that can change Nickel's local book record."""
+    """Stable hash of fields that can change Nickel's local book record.
+
+    ``DownloadUrls[].Size`` is excluded: it changes when a derived artifact
+    (on-demand KEPUB) replaces the served row without any change to the
+    source bytes the device already holds. Real content changes advance
+    ``Books.last_modified`` and are caught by the change basis.
+    """
     payload = json.dumps(
-        entitlement,
+        _fingerprint_projection(entitlement),
         sort_keys=True,
         separators=(",", ":"),
         ensure_ascii=False,

--- a/cps/readingservices.py
+++ b/cps/readingservices.py
@@ -875,6 +875,19 @@ def _owned_annotation_get_response(capture_session, ownership, entitlement_id):
         sticky = history == AUTHORITY_EVER
         has_cursor = request.args.get("pageOffsetToken") is not None
         if sticky:
+            from cps.services.kobo_annotation_authority import (
+                reanchor_after_download,
+            )
+            from cps.services.kobo_annotation_reanchor import reanchor_for_book
+            reanchor_after_download(
+                user_id=current_user.id,
+                book_id=ownership.id,
+                device_id=getattr(g, "annotation_origin_device_id", None),
+                log=log,
+                reanchor=lambda rows: reanchor_for_book(
+                    ownership, entitlement_id, rows, log=log,
+                ),
+            )
             pre_serve = prepare_authoritative_device_get(
                 user_id=current_user.id,
                 book_id=ownership.id,

--- a/cps/readingservices.py
+++ b/cps/readingservices.py
@@ -909,6 +909,36 @@ def _owned_annotation_get_response(capture_session, ownership, entitlement_id):
             page_limit = sticky_render_page_limit(
                 current_user.id, ownership.id, page_limit,
             )
+        if not sticky and not has_cursor:
+            # First GET after this device downloaded the file: Nickel has just
+            # emptied the book's local set, so CWNG's own rows are the best
+            # answer regardless of the seeding gates (see
+            # services/kobo_post_download_restore.py).
+            from cps.services.kobo_annotation_authority import (
+                render_post_download_restore,
+            )
+            from cps.services.kobo_annotation_reanchor import reanchor_for_book
+            restored = render_post_download_restore(
+                user_id=current_user.id,
+                book_id=ownership.id,
+                entitlement_id=entitlement_id,
+                device_id=getattr(g, "annotation_origin_device_id", None),
+                log=log,
+                reanchor=lambda rows: reanchor_for_book(
+                    ownership, entitlement_id, rows, log=log,
+                ),
+            )
+            if restored is not None:
+                body, etag = restored
+                _record_annotation_decision(
+                    capture_session, ownership, "restored_after_download",
+                    entitlement_id,
+                )
+                response = make_response(body, 200)
+                response.headers["Content-Type"] = "application/json"
+                response.headers["Content-Length"] = str(len(body))
+                response.headers["ETag"] = etag
+                return response
         if not sticky and (has_cursor or not local_get_is_eligible(
             settings=config,
             user=current_user,

--- a/cps/services/kobo_annotation_authority.py
+++ b/cps/services/kobo_annotation_authority.py
@@ -1215,6 +1215,54 @@ def _render_rows(rows, entitlement_id, reasons):
     return objects
 
 
+def reanchor_after_download(*, user_id, book_id, device_id, log, reanchor):
+    """Sticky (already authoritative) books: re-anchor rows after a download.
+
+    The authoritative path already serves CWNG's rows, so nothing needs to be
+    restored; but a re-converted file may have renamed its chapters, and rows
+    that point at vanished chapters render nowhere. Consume the device's
+    pending download and re-anchor before the render. Returns the number of
+    rows considered, or ``None`` when nothing was pending.
+    """
+    from cps.services import kobo_post_download_restore as ledger
+
+    try:
+        pending = ledger.pending_download(device_id=device_id, book_id=book_id)
+    except Exception:
+        _safe_rollback()
+        log.warning(
+            "Kobo post-download reanchor lookup failed user_id=%s book_id=%s",
+            user_id, book_id, exc_info=True,
+        )
+        return None
+    if pending is None:
+        return None
+    try:
+        rows = _simple_annotation_rows(user_id, book_id, 2 ** 31 - 2)
+        annotations = [row[0] if isinstance(row, tuple) else row for row in rows]
+        if annotations:
+            reanchor(annotations)
+        ledger.settle_pending_download(
+            pending,
+            state=ledger.RESTORE_SERVED if annotations else ledger.RESTORE_EMPTY,
+            count=len(annotations),
+        )
+        ub.session.commit()
+    except Exception:
+        _safe_rollback()
+        log.warning(
+            "Kobo post-download reanchor failed user_id=%s book_id=%s device_id=%s",
+            user_id, book_id, device_id, exc_info=True,
+        )
+        return None
+    log.info(
+        "Kobo post-download reanchor considered %d annotation(s) "
+        "user_id=%s book_id=%s device_id=%s",
+        len(annotations), user_id, book_id, device_id,
+    )
+    return len(annotations)
+
+
 def render_post_download_restore(*, user_id, book_id, entitlement_id, device_id,
                                  log, reanchor=None):
     """Answer the first annotation GET after a device download from CWNG rows.

--- a/cps/services/kobo_annotation_authority.py
+++ b/cps/services/kobo_annotation_authority.py
@@ -1147,7 +1147,6 @@ def _emergency_render(*, user_id, book_id, entitlement_id, page_limit,
 
 def _render_owned_annotations(*, user_id, book_id, entitlement_id, page_limit,
                               device_id, log):
-    objects = []
     reasons = []
     rows = _annotation_rows(user_id, book_id, page_limit)
     if len(rows) > page_limit:
@@ -1158,21 +1157,9 @@ def _render_owned_annotations(*, user_id, book_id, entitlement_id, page_limit,
         row_ids={annotation.annotation_id for annotation, _ in rows},
     ):
         return None
-    for annotation, materialization in rows:
-        try:
-            raw = _exact_raw(annotation, materialization)
-            if raw is not None:
-                objects.append(raw)
-                continue
-            mapped, faithful, reason = _fallback_object(annotation, entitlement_id)
-            if not faithful:
-                reasons.append(f"column_fallback:{reason}")
-            objects.append(_encode_object(mapped))
-        except Exception as error:
-            # A single malformed row or serializer bug cannot abort a
-            # replacement-set GET.  Preserve at least its id and user text.
-            objects.append(_encode_object(_emergency_object(annotation, entitlement_id)))
-            reasons.append(_failure_reason("row_render", error))
+    # A single malformed row or serializer bug cannot abort a
+    # replacement-set GET.  Preserve at least its id and user text.
+    objects = _render_rows(rows, entitlement_id, reasons)
 
     body = b'{"annotations":[' + b",".join(objects) \
         + b'],"nextPageOffsetToken":null}'
@@ -1205,6 +1192,122 @@ def _render_owned_annotations(*, user_id, book_id, entitlement_id, page_limit,
     _log_degraded(
         log, user_id=user_id, book_id=book_id,
         visible_count=len(rows), reasons=reasons,
+    )
+    return body, etag
+
+
+def _render_rows(rows, entitlement_id, reasons):
+    """Encode rows to wire objects without ever dropping one."""
+    objects = []
+    for annotation, materialization in rows:
+        try:
+            raw = _exact_raw(annotation, materialization)
+            if raw is not None:
+                objects.append(raw)
+                continue
+            mapped, faithful, reason = _fallback_object(annotation, entitlement_id)
+            if not faithful:
+                reasons.append(f"column_fallback:{reason}")
+            objects.append(_encode_object(mapped))
+        except Exception as error:
+            objects.append(_encode_object(_emergency_object(annotation, entitlement_id)))
+            reasons.append(_failure_reason("row_render", error))
+    return objects
+
+
+def render_post_download_restore(*, user_id, book_id, entitlement_id, device_id,
+                                 log, reanchor=None):
+    """Answer the first annotation GET after a device download from CWNG rows.
+
+    Returns ``(body, etag)`` or ``None`` (nothing pending, or nothing to
+    restore: the caller then proxies exactly as before).
+
+    The seeding gates exist so that a partial local set never replaces a
+    fuller one on the device. Right after a download the device set is
+    empty by construction, so any non-empty local set is strictly better
+    than the proxied answer, which on the measured household instance was
+    Kobo's empty cloud set. Serving it makes CWNG this book's authority from
+    now on (``ever_authoritative``), exactly as a completed seed would.
+    """
+    from cps.services import kobo_post_download_restore as ledger
+
+    try:
+        pending = ledger.pending_download(device_id=device_id, book_id=book_id)
+    except Exception:
+        _safe_rollback()
+        log.warning(
+            "Kobo post-download restore lookup failed user_id=%s book_id=%s",
+            user_id, book_id, exc_info=True,
+        )
+        return None
+    if pending is None:
+        return None
+
+    reasons = []
+    try:
+        rows = _annotation_rows(user_id, book_id, 2 ** 31 - 2)
+    except Exception:
+        _safe_rollback()
+        rows = _simple_annotation_rows(user_id, book_id, 2 ** 31 - 2)
+    if not rows:
+        ledger.settle_pending_download(pending, state=ledger.RESTORE_EMPTY, count=0)
+        ub.session.commit()
+        log.info(
+            "Kobo post-download restore: no local annotations for "
+            "user_id=%s book_id=%s device_id=%s; proxying",
+            user_id, book_id, device_id,
+        )
+        return None
+
+    if reanchor is not None:
+        try:
+            reanchor([annotation for annotation, _ in rows])
+        except Exception as error:
+            _safe_rollback()
+            reasons.append(_failure_reason("reanchor", error))
+
+    objects = _render_rows(rows, entitlement_id, reasons)
+    body = b'{"annotations":[' + b",".join(objects) \
+        + b'],"nextPageOffsetToken":null}'
+    digest = hashlib.sha256(body).hexdigest()
+    state, normalized_content_id, state_reason = _book_state(
+        user_id, book_id, entitlement_id,
+    )
+    if state_reason is not None:
+        reasons.append(state_reason)
+
+    if state is None:
+        etag = _transient_etag(user_id, book_id, normalized_content_id, digest)
+    else:
+        now = datetime.now(timezone.utc)
+        state.authority_status = "authoritative"
+        state.ever_authoritative = True
+        state.quarantine_reason = None
+        if state.seeded_at is None:
+            state.seeded_at = now
+        try:
+            etag = _commit_complete_render(
+                state=state, body=body, digest=digest, annotation_count=len(rows),
+            )
+        except Exception as error:
+            _safe_rollback()
+            reasons.append(_failure_reason("book_state_commit", error))
+            etag = _transient_etag(user_id, book_id, normalized_content_id, digest)
+
+    try:
+        ledger.settle_pending_download(
+            pending, state=ledger.RESTORE_SERVED, count=len(rows),
+        )
+        ub.session.commit()
+    except Exception as error:
+        _safe_rollback()
+        reasons.append(_failure_reason("download_ledger_commit", error))
+
+    log.info(
+        "Kobo post-download restore served %d annotation(s) user_id=%s "
+        "book_id=%s device_id=%s%s",
+        len(rows), user_id, book_id, device_id,
+        (" reasons=" + ",".join(reasons)) if reasons else "",
     )
     return body, etag
 

--- a/cps/services/kobo_annotation_reanchor.py
+++ b/cps/services/kobo_annotation_reanchor.py
@@ -1,0 +1,247 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Re-anchor Kobo highlights whose chapter file no longer exists in the book.
+
+When a book's EPUB is re-converted (a better PDF conversion, a split spine)
+the chapter filenames and the ``kobo.N.M`` span ids change underneath every
+existing highlight. OBSERVED (notes/KOBO-HIGHLIGHTS-STATE.md §6): Nickel keeps
+such rows but rewrites their ContentID to a file that no longer exists, so
+they are invisible and the reader cannot even delete them.
+
+CWNG holds the highlighted text, so it can find the passage again in the
+current KEPUB and rewrite the location before serving the set back to the
+device. Rows whose chapter still exists are left alone; rows whose text is
+not found (or found in several places) are served unchanged and logged, never
+dropped.
+"""
+
+from __future__ import annotations
+
+import html
+import os
+import posixpath
+import re
+import unicodedata
+import zipfile
+from xml.etree import ElementTree
+
+from cps import config, ub
+
+_SPAN = re.compile(
+    r'<span[^>]*\bclass="koboSpan"[^>]*\bid="(kobo\.\d+\.\d+)"[^>]*>(.*?)</span>',
+    re.S,
+)
+_TAG = re.compile(r"<[^>]+>")
+_WS = re.compile(r"\s+")
+_QUOTES = str.maketrans({
+    "‘": "'", "’": "'", "“": '"', "”": '"',
+    " ": " ", "‐": "-", "‑": "-", "–": "-", "—": "-",
+})
+
+
+def normalize(text):
+    """Whitespace-, quote- and case-insensitive comparison form."""
+    if not text:
+        return ""
+    text = unicodedata.normalize("NFKC", text).translate(_QUOTES)
+    return _WS.sub(" ", text).strip().casefold()
+
+
+def _span_text(inner):
+    return html.unescape(_TAG.sub("", inner))
+
+
+class Chapter:
+    """One content document: its kobo spans and a searchable flat text."""
+
+    def __init__(self, filename, markup):
+        self.filename = filename
+        self.spans = []          # (span_id, start, end) in flat-text coordinates
+        parts = []
+        cursor = 0
+        for match in _SPAN.finditer(markup):
+            text = _span_text(match.group(2))
+            if not text:
+                continue
+            parts.append(text)
+            self.spans.append((match.group(1), cursor, cursor + len(text)))
+            cursor += len(text)
+        self.text = "".join(parts)
+        # map of normalized text -> original index, built lazily
+        self._norm = None
+        self._index = None
+
+    def _build(self):
+        norm_chars, index = [], []
+        pending_space = False
+        for pos, ch in enumerate(self.text):
+            folded = unicodedata.normalize("NFKC", ch).translate(_QUOTES)
+            for out in folded.casefold():
+                if out.isspace():
+                    pending_space = True
+                    continue
+                if pending_space and norm_chars:
+                    norm_chars.append(" ")
+                    index.append(pos)
+                pending_space = False
+                norm_chars.append(out)
+                index.append(pos)
+        self._norm = "".join(norm_chars)
+        self._index = index
+
+    def find(self, needle):
+        """Return [(start, end)] original-text ranges matching ``needle``."""
+        if self._norm is None:
+            self._build()
+        if not needle:
+            return []
+        hits = []
+        start = self._norm.find(needle)
+        while start >= 0:
+            end = start + len(needle) - 1
+            hits.append((self._index[start], self._index[end] + 1))
+            start = self._norm.find(needle, start + 1)
+        return hits
+
+    def locate(self, pos, *, end=False):
+        """Map a flat-text position to ``(span_id, offset_in_span)``."""
+        for span_id, s0, s1 in self.spans:
+            if (s0 <= pos < s1) or (end and pos == s1):
+                return span_id, pos - s0
+        return None
+
+
+def _escape_span_id(span_id):
+    return "span#" + span_id.replace(".", "\\.")
+
+
+class KepubIndex:
+    """Spine documents of one KEPUB, keyed by zip path."""
+
+    def __init__(self, path):
+        self.chapters = {}
+        self.order = []
+        with zipfile.ZipFile(path) as archive:
+            opf_path = self._opf_path(archive)
+            base = posixpath.dirname(opf_path)
+            for href in self._spine_hrefs(archive.read(opf_path)):
+                name = posixpath.normpath(posixpath.join(base, href)) if base else href
+                try:
+                    markup = archive.read(name).decode("utf-8", "replace")
+                except KeyError:
+                    continue
+                chapter = Chapter(name, markup)
+                if chapter.spans:
+                    self.chapters[name] = chapter
+                    self.order.append(name)
+        self.basenames = {}
+        for name in self.order:
+            self.basenames.setdefault(posixpath.basename(name), name)
+
+    @staticmethod
+    def _opf_path(archive):
+        root = ElementTree.fromstring(archive.read("META-INF/container.xml"))
+        for el in root.iter():
+            if el.tag.endswith("rootfile"):
+                return el.get("full-path")
+        raise KeyError("container.xml has no rootfile")
+
+    @staticmethod
+    def _spine_hrefs(opf_bytes):
+        root = ElementTree.fromstring(opf_bytes)
+        items = {}
+        for el in root.iter():
+            if el.tag.endswith("}item") or el.tag == "item":
+                items[el.get("id")] = el.get("href")
+        hrefs = []
+        for el in root.iter():
+            if el.tag.endswith("}itemref") or el.tag == "itemref":
+                href = items.get(el.get("idref"))
+                if href:
+                    hrefs.append(href)
+        return hrefs
+
+    def has_chapter(self, chapter_filename):
+        if not chapter_filename:
+            return False
+        name = chapter_filename.split("#", 1)[0]
+        return name in self.chapters or posixpath.basename(name) in self.basenames
+
+
+def _kepub_path(book):
+    rows = list(getattr(book, "data", None) or ())
+    for wanted in ("KEPUB", "EPUB"):
+        for row in rows:
+            if (getattr(row, "format", "") or "").upper() == wanted:
+                return os.path.join(
+                    config.get_book_path(), book.path,
+                    row.name + "." + wanted.lower(),
+                )
+    return None
+
+
+def reanchor_rows(index, rows, entitlement_id, *, log):
+    """Rewrite the location of rows whose chapter is gone; return the changed rows."""
+    entitlement = (entitlement_id or "").strip().strip("{}")
+    changed = []
+    for row in rows:
+        content_id = row.content_id or ""
+        chapter = content_id.split("!!", 1)[1] if "!!" in content_id else ""
+        if index.has_chapter(chapter):
+            continue
+        needle = normalize(row.highlighted_text)
+        if len(needle) < 4:
+            log.info("Kobo reanchor: row %s has no usable text; served as-is",
+                     row.annotation_id)
+            continue
+        hits = []
+        for name in index.order:
+            for start, end in index.chapters[name].find(needle):
+                hits.append((name, start, end))
+                if len(hits) > 1:
+                    break
+            if len(hits) > 1:
+                break
+        if len(hits) != 1:
+            log.info(
+                "Kobo reanchor: row %s text %s in the current book; served as-is",
+                row.annotation_id, "not found" if not hits else "is ambiguous",
+            )
+            continue
+        name, start, end = hits[0]
+        chapter_obj = index.chapters[name]
+        first = chapter_obj.locate(start)
+        last = chapter_obj.locate(end, end=True)
+        if first is None or last is None:
+            continue
+        row.content_id = "{}!!{}".format(entitlement, name)
+        row.start_container_path = _escape_span_id(first[0])
+        row.start_offset = first[1]
+        row.end_container_path = _escape_span_id(last[0])
+        row.end_offset = last[1]
+        row.chapter_progress = (start / len(chapter_obj.text)) if chapter_obj.text else 0.0
+        row.context_string = chapter_obj.text[max(0, start - 60):end + 60]
+        changed.append(row)
+    return changed
+
+
+def reanchor_for_book(book, entitlement_id, rows, *, log):
+    """Re-anchor ``rows`` against the book's current KEPUB and persist."""
+    path = _kepub_path(book)
+    if not path or not os.path.isfile(path):
+        return []
+    def _chapter(row):
+        content_id = row.content_id or ""
+        return content_id.split("!!", 1)[1] if "!!" in content_id else ""
+
+    index = KepubIndex(path)
+    if all(index.has_chapter(_chapter(row)) for row in rows):
+        return []
+    changed = reanchor_rows(index, rows, entitlement_id, log=log)
+    if changed:
+        ub.session.commit()
+        log.info(
+            "Kobo reanchor: rewrote %d of %d annotation location(s) for book %s",
+            len(changed), len(rows), getattr(book, "id", None),
+        )
+    return changed

--- a/cps/services/kobo_post_download_restore.py
+++ b/cps/services/kobo_post_download_restore.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Make a Kobo re-download harmless: remember it, then restore from CWNG rows.
+
+Nickel treats every (re-)download as "forget what I had for this book": it
+empties the book's local annotations and asks ``/annotations`` for the
+replacement set, and it re-reports the reading position from the start.
+The entitlement ledger (#1925) stops *spurious* re-sends; this module covers
+the re-sends that are legitimate (a re-converted file) or unavoidable, so the
+reader never loses her highlights again.
+
+Two halves:
+
+* :func:`record_download` runs on the Kobo file-download route and upserts one
+  ``pending`` row per (device, book).
+* :func:`consume_pending_download` is asked by the owned annotation GET; when
+  a pending row exists for the requesting device it is consumed and the
+  caller serves CWNG's own rows instead of proxying.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy.exc import SQLAlchemyError
+
+from cps import ub
+
+RESTORE_PENDING = "pending"
+RESTORE_SERVED = "served"
+RESTORE_EMPTY = "empty"
+
+
+def _now():
+    return datetime.now(timezone.utc)
+
+
+def record_download(*, device_id, book_id, book_format, log):
+    """Upsert the pending-restore row; best effort, never raises to the route."""
+    if device_id is None or book_id is None:
+        return None
+    try:
+        row = (
+            ub.session.query(ub.KoboDeviceBookDownload)
+            .filter(
+                ub.KoboDeviceBookDownload.device_id == device_id,
+                ub.KoboDeviceBookDownload.book_id == book_id,
+            )
+            .one_or_none()
+        )
+        if row is None:
+            row = ub.KoboDeviceBookDownload(device_id=device_id, book_id=book_id)
+            ub.session.add(row)
+        row.book_format = (book_format or "")[:16] or None
+        row.downloaded_at = _now()
+        row.restore_state = RESTORE_PENDING
+        row.restored_at = None
+        row.restored_count = None
+        ub.session.commit()
+        return row
+    except SQLAlchemyError:
+        ub.session.rollback()
+        log.warning(
+            "Could not record Kobo download device_id=%s book_id=%s",
+            device_id, book_id, exc_info=True,
+        )
+        return None
+
+
+def pending_download(*, device_id, book_id):
+    """Return the pending row for this device/book, or ``None``."""
+    if device_id is None or book_id is None:
+        return None
+    return (
+        ub.session.query(ub.KoboDeviceBookDownload)
+        .filter(
+            ub.KoboDeviceBookDownload.device_id == device_id,
+            ub.KoboDeviceBookDownload.book_id == book_id,
+            ub.KoboDeviceBookDownload.restore_state == RESTORE_PENDING,
+        )
+        .one_or_none()
+    )
+
+
+def settle_pending_download(row, *, state, count=None):
+    """Mark the pending row consumed. The caller owns the commit."""
+    row.restore_state = state
+    row.restored_at = _now()
+    row.restored_count = count

--- a/cps/tasks/convert.py
+++ b/cps/tasks/convert.py
@@ -180,7 +180,8 @@ class TaskConvert(CalibreTask):
                         # Recovery adopted a Kobo-visible file that existed on
                         # disk without a Data row; mirror the ordinary
                         # conversion path's cursor provenance update below.
-                        helper.mark_book_modified(cur_book, set_dirty=False)
+                        helper.mark_book_format_materialised(
+                            cur_book, self.settings['new_book_format'])
                     local_db.session.commit()
                 except SQLAlchemyError as e:
                     local_db.session.rollback()
@@ -222,7 +223,11 @@ class TaskConvert(CalibreTask):
                     try:
                         local_db.session.merge(new_format)
                         if self.settings['new_book_format'].upper() in ['KEPUB', 'EPUB', 'EPUB3']:
-                            helper.mark_book_modified(cur_book, set_dirty=False)
+                            # A derived sibling format (EPUB -> KEPUB) must not
+                            # advance the Kobo entitlement clock: the device
+                            # already holds these bytes (see helper docstring).
+                            helper.mark_book_format_materialised(
+                                cur_book, self.settings['new_book_format'])
                         local_db.session.commit()
                     except SQLAlchemyError as e:
                         local_db.session.rollback()

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -948,6 +948,43 @@ class KoboDeviceBookEntitlement(Base):
     )
 
 
+class KoboDeviceBookDownload(Base):
+    """Latest file download of one book by one physical Kobo (#1925 follow-up).
+
+    Nickel discards a book's local annotations and reading position when it
+    re-downloads the file, then asks ``/annotations`` for the replacement set.
+    This row is the server-side memory that such a request is the first one
+    after a download, so CWNG can answer it from its own rows instead of
+    proxying to a Kobo cloud that never held them (OBSERVED 2026-09-11: the
+    proxied answer was an empty set and the reader's 22 highlights vanished).
+    ``restore_state`` is ``pending`` until that first request is answered.
+    """
+    __tablename__ = 'kobo_device_book_download'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    device_id = Column(
+        Integer, ForeignKey('device.id', ondelete='CASCADE'), nullable=False,
+    )
+    # calibre's Books row lives in metadata.db: no cross-database foreign key.
+    book_id = Column(Integer, nullable=False)
+    book_format = Column(String(16), nullable=True)
+    downloaded_at = Column(
+        DateTime, nullable=False, default=lambda: datetime.now(timezone.utc),
+    )
+    restore_state = Column(
+        String(16), nullable=False, default='pending', server_default='pending',
+    )
+    restored_at = Column(DateTime, nullable=True)
+    restored_count = Column(Integer, nullable=True)
+
+    __table_args__ = (
+        UniqueConstraint(
+            'device_id', 'book_id', name='uq_kobo_device_book_download_device_book',
+        ),
+        Index('ix_kobo_device_book_download_book', 'book_id'),
+    )
+
+
 class KoboDeviceDeletedEntitlement(Base):
     """Last hard-delete entitlement delivered to one physical Kobo.
 
@@ -2326,6 +2363,7 @@ def add_missing_tables(engine, _session):
         ("kobo_device_deleted_entitlement", KoboDeviceDeletedEntitlement.__table__),
         ("kobo_device_entitlement_seed", KoboDeviceEntitlementSeed.__table__),
         ("kobo_device_pending_sync_page", KoboDevicePendingSyncPage.__table__),
+        ("kobo_device_book_download", KoboDeviceBookDownload.__table__),
     )
     for table_name, table in tables + kobo_entitlement_tables:
         # Explicit transaction control means even schema inspection begins a

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -173,7 +173,7 @@ surfaces; reverse dependents cannot be discovered by that traversal and must be 
 prefixes. The whole `cps/api/` blueprint tree is therefore protected explicitly: its registration in
 `cps/main.py` points toward the handlers, opposite to the import direction walked by the classifier. The
 two-level cutoff only bounds each root's dependency fan-out—it is not what excludes reverse dependents.
-At this revision the derived set is 168 of 228 local Python modules (the closure correctly picks
+At this revision the derived set is 169 of 230 local Python modules (the closure correctly picks
 up `cps/services/device_delivery.py` through the book-action request path, and this branch's
 `cps/user_preferences.py` through the account API path). It also now picks up the cover picker and
 its services: `cps/api/actions.py` gained a personal-cover `kind: "generated"` that calls into

--- a/tests/unit/test_1925_kobo_sync_dedownload.py
+++ b/tests/unit/test_1925_kobo_sync_dedownload.py
@@ -1736,16 +1736,18 @@ def test_entitlement_payload_shape_matches_declared_schema_version(
         }
 
     pinned_schema_and_hashes = {
+        # v2: DownloadUrls[].Size is excluded from the fingerprint so that an
+        # on-demand KEPUB materialised from the stored EPUB does not re-send.
         "live": (
-            1,
-            "28ba9f171cd833b2779b549c9bff86347447d40c011439a06408babe656da0c2",
+            2,
+            "2af6cd084a1ef108e0ac55a0749d1283f15a0c87bbd8cbe533d50cbc425b7bfe",
         ),
         "archived_live": (
-            1,
-            "ad2030d15995f1083b42c90f751af6e24b6a74c02cddfe0e6e5af38674cb7e02",
+            2,
+            "3cd2f24b0cd16744100508bd58afe1c2d9f1f8e447d837e257854c452bd7d521",
         ),
         "hard_delete": (
-            1,
+            2,
             "8d72ce590309549d65cf110a0d44b61d2145bb2401ca4d6bf204ad41f5244011",
         ),
     }

--- a/tests/unit/test_kobo_entitlement_ledger_forensic.py
+++ b/tests/unit/test_kobo_entitlement_ledger_forensic.py
@@ -678,8 +678,11 @@ def test_forensic_payload_schema_transition_restamps_without_wire_entitlement(
         "ChangedEntitlement": 0,
         "IsRemoved": 0,
     }
-    assert {row["schema"] for row in after["books"].values()} == {1}
-    assert {row["schema"] for row in after["deleted"].values()} == {1}
+    from cps import kobo
+
+    current = kobo.ENTITLEMENT_PAYLOAD_SCHEMA_VERSION
+    assert {row["schema"] for row in after["books"].values()} == {current}
+    assert {row["schema"] for row in after["deleted"].values()} == {current}
 
 
 def test_forensic_older_valid_sync_token_version_suppresses_without_restamp(

--- a/tests/unit/test_kobo_redownload_harmless.py
+++ b/tests/unit/test_kobo_redownload_harmless.py
@@ -1,0 +1,529 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""A Kobo (re-)download must be harmless.
+
+OBSERVED 2026-09-11 on a household Libra Colour (book 567): a re-converted
+EPUB was legitimately re-sent; the reader's re-download minted the KEPUB on
+demand, which advanced ``Books.last_modified`` and re-sent the entitlement a
+second time 25 s after she had re-found her place. After each download the
+device asked ``/annotations`` and CWNG proxied an empty Kobo cloud set over
+her 22 locally held highlights.
+
+Three layers, each with its own seen-red test here:
+
+* A1 — a derived sibling format (EPUB -> KEPUB) does not advance the clock and
+  does not change the entitlement fingerprint.
+* B1 — the first annotation GET after a device download is answered from
+  CWNG's own rows.
+* B2 — rows whose chapter vanished from the current KEPUB are re-anchored by
+  their highlighted text before they are served.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import os
+import zipfile
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask, g, make_response
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from cps import ub
+import cps.readingservices as rs
+from cps.services import kobo_annotation_authority as authority
+from cps.services import kobo_annotation_reanchor as reanchor
+from cps.services import kobo_post_download_restore as ledger
+
+from tests.unit.test_1925_kobo_sync_dedownload import (  # noqa: F401 - fixture
+    _entitlements,
+    sync_harness,
+)
+
+pytestmark = pytest.mark.unit
+
+OWNED = "c008eeb9-9ab2-4d0e-9af4-77b0abf73c97"
+BOOK_ID = 567
+USER_ID = 3
+DEVICE_ID = 1
+
+
+# ---------------------------------------------------------------- A1: clock
+
+
+def _book(*formats):
+    return SimpleNamespace(
+        id=1, last_modified=datetime(2026, 9, 1, tzinfo=timezone.utc),
+        data=[SimpleNamespace(format=f, name="b") for f in formats],
+    )
+
+
+def test_first_kobo_deliverable_format_advances_the_clock(monkeypatch):
+    from cps import helper
+
+    monkeypatch.setattr(helper.calibre_db, "set_metadata_dirty", lambda *_a: None, raising=False)
+    book = _book("PDF")
+    before = book.last_modified
+
+    assert helper.mark_book_format_materialised(book, "EPUB") is True
+    assert book.last_modified > before
+
+
+def test_derived_sibling_format_leaves_the_clock_alone(monkeypatch):
+    from cps import helper
+
+    book = _book("EPUB")
+    before = book.last_modified
+
+    assert helper.mark_book_format_materialised(book, "KEPUB") is False
+    assert book.last_modified == before
+    assert helper.mark_book_format_materialised(_book("KEPUB", "PDF"), "EPUB") is False
+
+
+def test_on_demand_kepub_conversion_does_not_touch_last_modified(tmp_path, monkeypatch):
+    """The convert task path that ran on the household instance."""
+    import cps.helper  # noqa: F401 - normal import order
+    from cps.tasks import convert
+
+    book_path = tmp_path / "hellenistic"
+    (tmp_path / "hellenistic.epub").write_bytes(b"source")
+    (tmp_path / "hellenistic.kepub").write_bytes(b"derived")
+    book = SimpleNamespace(
+        id=BOOK_ID, title="Hellenistic Astrology", path="Brennan/Hellenistic",
+        last_modified=datetime(2026, 9, 10, 23, 6, tzinfo=timezone.utc),
+        data=[SimpleNamespace(name="hellenistic", format="EPUB")],
+    )
+    clock_before = book.last_modified
+
+    class Query:
+        def filter(self, *_a):
+            return self
+
+        def one_or_none(self):
+            return None
+
+    class Session:
+        def query(self, *_a):
+            return Query()
+
+        def merge(self, _row):
+            pass
+
+        def commit(self):
+            pass
+
+        def rollback(self):
+            pass
+
+        def close(self):
+            pass
+
+    class LocalDB:
+        def __init__(self, **_k):
+            self.session = Session()
+
+        def get_book(self, _id):
+            return book
+
+        def get_book_format(self, *_a):
+            return None
+
+    monkeypatch.setattr(convert.db, "CalibreDB", LocalDB)
+    monkeypatch.setattr(convert.config, "config_kepubifypath", "/bin/kepubify", raising=False)
+    monkeypatch.setattr(convert.config, "config_use_google_drive", False, raising=False)
+    monkeypatch.setattr(convert, "_log_fragment_anchored_toc", lambda *_a: None)
+    task = convert.TaskConvert(
+        str(book_path), BOOK_ID, "convert",
+        {"old_book_format": "EPUB", "new_book_format": "KEPUB"}, None,
+    )
+    monkeypatch.setattr(task, "_convert_kepubify", lambda *_a: (0, None))
+    monkeypatch.setattr(task, "_handleSuccess", lambda: None)
+
+    assert task._convert_ebook_format() == "hellenistic.kepub"
+    assert book.last_modified == clock_before
+
+
+def _materialise_kepub(sync_harness, size=2_345_678):
+    """What the on-demand convert task does: add the KEPUB row, notify the SSOT."""
+    from cps import db, helper
+
+    sync_harness.session.add(db.Data(
+        sync_harness.book.id, "KEPUB", size, "stable-book",
+    ))
+    sync_harness.session.commit()
+    sync_harness.session.expire(sync_harness.book, ["data"])
+    helper.mark_book_format_materialised(sync_harness.book, "KEPUB")
+    sync_harness.session.commit()
+
+
+def test_materialised_kepub_is_not_resent_on_the_next_sync(sync_harness, monkeypatch):
+    from cps import kobo
+
+    monkeypatch.setattr(kobo.config, "config_kobo_suppress_replayed_entitlements", True)
+    first = sync_harness.sync()
+    assert len(_entitlements(first)) == 1
+    token = first.headers[sync_harness.token_header]
+
+    _materialise_kepub(sync_harness)
+    second = sync_harness.sync(token)
+
+    assert _entitlements(second) == [], (
+        "a KEPUB minted from the stored EPUB must not re-send the entitlement; "
+        "Nickel answers a ChangedEntitlement by de-downloading the book"
+    )
+
+
+def test_materialised_kepub_size_change_is_suppressed_on_a_stale_token(
+    sync_harness, monkeypatch, caplog,
+):
+    """The Size of the served row changes; the source bytes did not."""
+    from cps import kobo
+
+    monkeypatch.setattr(kobo.config, "config_kobo_suppress_replayed_entitlements", True)
+    caplog.set_level(logging.DEBUG, logger="cps.kobo")
+    first = sync_harness.sync()
+    assert len(_entitlements(first)) == 1
+
+    _materialise_kepub(sync_harness)
+    stale_token = kobo.SyncToken.SyncToken().build_sync_token()
+    second = sync_harness.sync(stale_token)
+
+    assert _entitlements(second) == []
+    summaries = [
+        r.getMessage() for r in caplog.records
+        if r.getMessage().startswith("Kobo Sync summary:")
+    ]
+    assert "suppressed_replay=1" in summaries[-1]
+
+
+def test_control_real_last_modified_bump_is_still_delivered(sync_harness, monkeypatch):
+    from cps import kobo
+
+    monkeypatch.setattr(kobo.config, "config_kobo_suppress_replayed_entitlements", True)
+    first = sync_harness.sync()
+    token = first.headers[sync_harness.token_header]
+
+    _materialise_kepub(sync_harness)
+    sync_harness.book.last_modified = datetime.now() + timedelta(seconds=5)
+    sync_harness.session.commit()
+    second = sync_harness.sync(token)
+
+    assert len(_entitlements(second)) == 1
+
+
+# ---------------------------------------------------------------- B1: restore
+
+
+@pytest.fixture
+def session(monkeypatch):
+    engine = create_engine("sqlite:///:memory:", future=True)
+    ub.Base.metadata.create_all(engine)
+    database = sessionmaker(bind=engine, future=True)()
+    monkeypatch.setattr(ub, "session", database)
+    monkeypatch.setattr(ub, "session_commit", lambda: database.commit() or True)
+    database.add(ub.Device(
+        id=DEVICE_ID, user_id=USER_ID, kind="kobo", display_name="Libra",
+        model="Kobo Libra Colour", active=True, created_by="auto",
+    ))
+    database.commit()
+    yield database
+    database.close()
+    engine.dispose()
+
+
+@pytest.fixture
+def app(monkeypatch):
+    application = Flask(__name__)
+    monkeypatch.setattr(
+        rs, "current_user",
+        SimpleNamespace(
+            id=USER_ID, name="reader", is_authenticated=True,
+            kobo_two_way_annotation_sync=True,
+        ),
+    )
+    monkeypatch.setattr(rs.config, "config_kobo_two_way_annotation_sync", True, raising=False)
+    monkeypatch.setattr(
+        "cps.services.kobo_annotation_stage0.schema_capable", lambda _e: True,
+    )
+    monkeypatch.setattr(rs, "_begin_exchange_capture", lambda *_a, **_k: None)
+    authority.reset_skip_log_for_testing()
+    return application
+
+
+def _highlight(annotation_id, text, **overrides):
+    values = {
+        "user_id": USER_ID, "book_id": BOOK_ID, "annotation_id": annotation_id,
+        "source": "kobo", "annotation_type": "highlight",
+        "highlighted_text": text, "highlight_color": "#E8AFCF", "note_text": None,
+        "content_id": f"{OWNED}!!Hellenistic Astrology - Chris Brennan.src_split_000.html",
+        "chapter_progress": 0.15, "start_container_path": "span#kobo\\.130\\.8",
+        "end_container_path": "span#kobo\\.130\\.8", "start_offset": 250,
+        "end_offset": 329, "context_string": "",
+        "client_modified_at": datetime(2026, 9, 9, 22, 5, 22), "hidden": False,
+        "content_revision": 1,
+    }
+    values.update(overrides)
+    return ub.Annotation(**values)
+
+
+def _unseeded_owned(monkeypatch, session):
+    book = SimpleNamespace(id=BOOK_ID, uuid=OWNED, title="Hellenistic Astrology", identifiers=[])
+    monkeypatch.setattr(rs, "resolve_entitlement_ownership", lambda _c: book)
+    session.add(ub.KoboAnnotationBookState(
+        user_id=USER_ID, book_id=BOOK_ID, content_id=OWNED,
+        authority_status="unseeded", authority_revision=0,
+        generation_id="00000000-0000-0000-0000-000000000567",
+        opaque_content_status="unknown",
+    ))
+    session.commit()
+    return book
+
+
+def _get(app, device_id=DEVICE_ID):
+    with app.test_request_context(f"/api/v3/content/{OWNED}/annotations?limit=100"):
+        g.annotation_origin_device_id = device_id
+        return rs.handle_annotations.__wrapped__(OWNED)
+
+
+def test_download_route_records_a_pending_restore_for_the_device(session, monkeypatch, tmp_path):
+    from cps import helper
+
+    book = SimpleNamespace(
+        id=BOOK_ID, title="Hellenistic Astrology", authors=[], path="x",
+        data=[SimpleNamespace(name="b", format="KEPUB", uncompressed_size=1)],
+    )
+    data = book.data[0]
+    monkeypatch.setattr(helper, "calibre_db", SimpleNamespace(
+        get_filtered_book=lambda *_a, **_k: book,
+        get_book_format=lambda *_a: data,
+    ))
+    monkeypatch.setattr(helper, "current_user", SimpleNamespace(
+        id=USER_ID, name="reader", is_authenticated=True, is_anonymous=False,
+        role_admin=lambda: False,
+    ))
+    monkeypatch.setattr(helper.ub, "update_download", lambda *_a: None)
+    monkeypatch.setattr(helper, "get_valid_filename", lambda name, **_k: name)
+    monkeypatch.setattr(helper, "CWA_DB", lambda: SimpleNamespace(log_activity=lambda **_k: None))
+    served = {}
+    monkeypatch.setattr(
+        helper, "do_download_file",
+        lambda *a, **k: served.setdefault("called", True) and make_response(b"bytes"),
+    )
+    app = Flask(__name__)
+    with app.test_request_context(f"/kobo/token/download/{BOOK_ID}/kepub"):
+        g.annotation_origin_device_id = DEVICE_ID
+        helper.get_download_link(BOOK_ID, "kepub", "kobo")
+
+    assert served == {"called": True}
+    row = session.query(ub.KoboDeviceBookDownload).one()
+    assert (row.device_id, row.book_id, row.restore_state) == (DEVICE_ID, BOOK_ID, "pending")
+
+    # a second download re-arms the row rather than duplicating it
+    row.restore_state = "served"
+    session.commit()
+    with app.test_request_context(f"/kobo/token/download/{BOOK_ID}/kepub"):
+        g.annotation_origin_device_id = DEVICE_ID
+        helper.get_download_link(BOOK_ID, "kepub", "kobo")
+    rows = session.query(ub.KoboDeviceBookDownload).all()
+    assert [r.restore_state for r in rows] == ["pending"]
+
+
+def test_first_get_after_download_is_answered_from_local_rows(app, session, monkeypatch):
+    _unseeded_owned(monkeypatch, session)
+    session.add_all([
+        _highlight("f843c039-80ab-4022-be22-8415e6e2db33",
+                   "these are techniques that can do things"),
+        _highlight("c7d9ceab-71f1-4b80-8588-e7b8d75ce865",
+                   "I believe that my perspective as a practicing astrologer",
+                   start_container_path="span#kobo\\.132\\.3",
+                   end_container_path="span#kobo\\.132\\.3"),
+    ])
+    session.commit()
+    ledger.record_download(device_id=DEVICE_ID, book_id=BOOK_ID, book_format="kepub",
+                           log=logging.getLogger("test"))
+    monkeypatch.setattr(
+        rs, "proxy_to_kobo_reading_services",
+        lambda **_k: pytest.fail("the post-download GET went to Kobo's empty cloud set"),
+    )
+
+    response = _get(app)
+
+    assert response.status_code == 200
+    payload = json.loads(response.get_data())
+    by_id = {a["id"]: a for a in payload["annotations"]}
+    assert len(by_id) == 2
+    assert by_id["c7d9ceab-71f1-4b80-8588-e7b8d75ce865"]["highlightedText"].startswith("I believe")
+    assert by_id["f843c039-80ab-4022-be22-8415e6e2db33"]["location"]["span"]["startPath"] == "span#kobo\\.130\\.8"
+    assert response.headers["ETag"].startswith('W/"CWNG:')
+
+    state = session.query(ub.KoboAnnotationBookState).one()
+    assert state.authority_status == "authoritative"
+    assert state.ever_authoritative is True
+    download = session.query(ub.KoboDeviceBookDownload).one()
+    assert (download.restore_state, download.restored_count) == ("served", 2)
+
+    # CWNG is the authority from now on: the next GET (no pending download)
+    # is still answered locally with the same set.
+    again = _get(app)
+    assert again.status_code == 200
+    assert json.loads(again.get_data()) == payload
+
+
+def test_restore_is_scoped_to_the_device_that_downloaded(app, session, monkeypatch):
+    _unseeded_owned(monkeypatch, session)
+    session.add(_highlight("a-1", "some passage"))
+    session.add(ub.Device(
+        id=2, user_id=USER_ID, kind="kobo", display_name="Clara",
+        model="Kobo Clara BW", active=True, created_by="auto",
+    ))
+    session.commit()
+    ledger.record_download(device_id=2, book_id=BOOK_ID, book_format="kepub",
+                           log=logging.getLogger("test"))
+    upstream = b'{"annotations":[],"nextPageOffsetToken":null}'
+    monkeypatch.setattr(
+        rs, "proxy_to_kobo_reading_services",
+        lambda **_k: make_response(upstream, 200, {"ETag": 'W/"0"'}),
+    )
+
+    response = _get(app, device_id=DEVICE_ID)
+
+    assert response.get_data() == upstream
+    assert session.query(ub.KoboDeviceBookDownload).one().restore_state == "pending"
+
+
+def test_empty_local_set_after_download_still_proxies(app, session, monkeypatch):
+    _unseeded_owned(monkeypatch, session)
+    ledger.record_download(device_id=DEVICE_ID, book_id=BOOK_ID, book_format="kepub",
+                           log=logging.getLogger("test"))
+    upstream = b'{"annotations":[{"id":"cloud-only"}],"nextPageOffsetToken":null}'
+    monkeypatch.setattr(
+        rs, "proxy_to_kobo_reading_services",
+        lambda **_k: make_response(upstream, 200, {"ETag": 'W/"kobo"'}),
+    )
+
+    response = _get(app)
+
+    assert response.get_data() == upstream
+    download = session.query(ub.KoboDeviceBookDownload).one()
+    assert (download.restore_state, download.restored_count) == ("empty", 0)
+    # the ordinary seed path ran from the upstream answer, not from our (empty) rows
+    assert session.query(ub.Annotation).count() == 1
+
+
+# ---------------------------------------------------------------- B2: re-anchor
+
+
+def _kepub(path, chapters):
+    """chapters: [(zip name, [(span id, text), ...])]."""
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr("mimetype", "application/epub+zip")
+        z.writestr("META-INF/container.xml",
+                   '<?xml version="1.0"?><container version="1.0" '
+                   'xmlns="urn:oasis:names:tc:opendocument:xmlns:container"><rootfiles>'
+                   '<rootfile full-path="OEBPS/content.opf" '
+                   'media-type="application/oebps-package+xml"/></rootfiles></container>')
+        items = "".join(
+            '<item id="c%d" href="%s" media-type="application/xhtml+xml"/>'
+            % (i, os.path.relpath(name, "OEBPS")) for i, (name, _s) in enumerate(chapters)
+        )
+        refs = "".join('<itemref idref="c%d"/>' % i for i in range(len(chapters)))
+        z.writestr("OEBPS/content.opf",
+                   '<?xml version="1.0"?><package xmlns="http://www.idpf.org/2007/opf" '
+                   'version="3.0"><manifest>%s</manifest><spine>%s</spine></package>'
+                   % (items, refs))
+        for name, spans in chapters:
+            body = "".join(
+                '<p><span class="koboSpan" id="%s">%s</span></p>' % (sid, text)
+                for sid, text in spans
+            )
+            z.writestr(name, '<?xml version="1.0"?><html xmlns="http://www.w3.org/1999/xhtml">'
+                       '<body>%s</body></html>' % body)
+
+
+def test_rows_whose_chapter_vanished_are_reanchored_by_their_text(tmp_path):
+    path = tmp_path / "book.kepub"
+    _kepub(path, [
+        ("OEBPS/chap0001.xhtml", [
+            ("kobo.1.1", "CHAPTER ONE"),
+            ("kobo.2.1", "The quick brown fox jumps over the lazy dog."),
+        ]),
+        ("OEBPS/chap0021.xhtml", [
+            ("kobo.1.1", "CHAPTER TWENTY-ONE"),
+            ("kobo.156.1", "In short, these are techniques that can do things that we "
+                           "didn’t even think were possible, and the tradition"),
+            ("kobo.156.2", " shows it. Repeated phrase here."),
+            ("kobo.157.1", "Repeated phrase here."),
+        ]),
+    ])
+    index = reanchor.KepubIndex(str(path))
+    log = logging.getLogger("test")
+    moved = _highlight("moved", "these are techniques that can do things that we didn't even think were possible")
+    ambiguous = _highlight("ambiguous", "Repeated phrase here.")
+    missing = _highlight("missing", "text that is nowhere in the book")
+    stays = _highlight("stays", "The quick brown fox",
+                       content_id=f"{OWNED}!!OEBPS/chap0001.xhtml",
+                       start_container_path="span#kobo\\.2\\.1", start_offset=0,
+                       end_container_path="span#kobo\\.2\\.1", end_offset=19)
+
+    changed = reanchor.reanchor_rows(index, [moved, ambiguous, missing, stays], OWNED, log=log)
+
+    assert [row.annotation_id for row in changed] == ["moved"]
+    assert moved.content_id == f"{OWNED}!!OEBPS/chap0021.xhtml"
+    assert moved.start_container_path == "span#kobo\\.156\\.1"
+    assert moved.end_container_path == "span#kobo\\.156\\.1"
+    span_text = ("In short, these are techniques that can do things that we "
+                 "didn’t even think were possible, and the tradition")
+    assert span_text[moved.start_offset:moved.end_offset] == (
+        "these are techniques that can do things that we didn’t even think were possible"
+    )
+    assert 0 <= moved.chapter_progress < 0.5
+    # untouched rows keep their (stale or valid) location; nothing is dropped
+    assert ambiguous.content_id.endswith("src_split_000.html")
+    assert missing.content_id.endswith("src_split_000.html")
+    assert stays.start_offset == 0 and stays.content_id.endswith("chap0001.xhtml")
+
+
+def test_reanchor_spans_a_span_boundary(tmp_path):
+    path = tmp_path / "book.kepub"
+    _kepub(path, [("OEBPS/c.xhtml", [
+        ("kobo.1.1", "Alpha beta gamma "),
+        ("kobo.1.2", "delta epsilon."),
+    ])])
+    row = _highlight("x", "gamma delta")
+
+    reanchor.reanchor_rows(reanchor.KepubIndex(str(path)), [row], OWNED, log=logging.getLogger("t"))
+
+    assert (row.start_container_path, row.start_offset) == ("span#kobo\\.1\\.1", 11)
+    assert (row.end_container_path, row.end_offset) == ("span#kobo\\.1\\.2", 5)
+
+
+def test_restore_get_reanchors_before_serving(app, session, monkeypatch, tmp_path):
+    """End to end: stale row + pending download -> served with the new location."""
+    book = _unseeded_owned(monkeypatch, session)
+    path = tmp_path / "lib" / "Brennan" / "Hellenistic"
+    path.mkdir(parents=True)
+    _kepub(path / "hellenistic.kepub", [("OEBPS/chap0021.xhtml", [
+        ("kobo.156.1", "these are techniques that can do things that we didn't even think were possible"),
+    ])])
+    book.path = os.path.join("Brennan", "Hellenistic")
+    book.data = [SimpleNamespace(name="hellenistic", format="KEPUB")]
+    monkeypatch.setattr(reanchor.config, "get_book_path", lambda: str(tmp_path / "lib"))
+    session.add(_highlight("moved", "these are techniques that can do things that we didn't even think were possible"))
+    session.commit()
+    ledger.record_download(device_id=DEVICE_ID, book_id=BOOK_ID, book_format="kepub",
+                           log=logging.getLogger("test"))
+    monkeypatch.setattr(rs, "proxy_to_kobo_reading_services",
+                        lambda **_k: pytest.fail("proxied"))
+
+    response = _get(app)
+
+    [served] = json.loads(response.get_data())["annotations"]
+    assert served["location"]["span"]["chapterFilename"] == "OEBPS/chap0021.xhtml"
+    assert served["location"]["span"]["startPath"] == "span#kobo\\.156\\.1"
+    assert served["location"]["span"]["startChar"] == 0
+    stored = session.query(ub.Annotation).one()
+    assert stored.content_id == f"{OWNED}!!OEBPS/chap0021.xhtml"

--- a/tests/unit/test_kobo_redownload_harmless.py
+++ b/tests/unit/test_kobo_redownload_harmless.py
@@ -20,7 +20,8 @@ Three layers, each with its own seen-red test here:
 
 from __future__ import annotations
 
-import io
+# ruff: noqa: F811  (the imported `sync_harness` fixture is used by parameter name)
+
 import json
 import logging
 import os
@@ -527,3 +528,70 @@ def test_restore_get_reanchors_before_serving(app, session, monkeypatch, tmp_pat
     assert served["location"]["span"]["startChar"] == 0
     stored = session.query(ub.Annotation).one()
     assert stored.content_id == f"{OWNED}!!OEBPS/chap0021.xhtml"
+
+
+def test_already_authoritative_book_is_reanchored_after_a_download(app, session, monkeypatch, tmp_path):
+    """Sticky books skip the restore path, but their rows still need new anchors."""
+    book = _unseeded_owned(monkeypatch, session)
+    state = session.query(ub.KoboAnnotationBookState).one()
+    state.authority_status = "authoritative"
+    state.ever_authoritative = True
+    state.seeded_at = datetime.now(timezone.utc)
+    path = tmp_path / "lib" / "Brennan" / "Hellenistic"
+    path.mkdir(parents=True)
+    _kepub(path / "hellenistic.kepub", [("OEBPS/chap0021.xhtml", [
+        ("kobo.156.1", "these are techniques that can do things that we didn't even think were possible"),
+    ])])
+    book.path = os.path.join("Brennan", "Hellenistic")
+    book.data = [SimpleNamespace(name="hellenistic", format="KEPUB")]
+    monkeypatch.setattr(reanchor.config, "get_book_path", lambda: str(tmp_path / "lib"))
+    session.add(_highlight("moved", "these are techniques that can do things that we didn't even think were possible"))
+    session.commit()
+    ledger.record_download(device_id=DEVICE_ID, book_id=BOOK_ID, book_format="kepub",
+                           log=logging.getLogger("test"))
+
+    considered = authority.reanchor_after_download(
+        user_id=USER_ID, book_id=BOOK_ID, device_id=DEVICE_ID, log=logging.getLogger("test"),
+        reanchor=lambda rows: reanchor.reanchor_for_book(book, OWNED, rows, log=logging.getLogger("test")),
+    )
+
+    assert considered == 1
+    stored = session.query(ub.Annotation).one()
+    assert stored.content_id == f"{OWNED}!!OEBPS/chap0021.xhtml"
+    assert stored.start_container_path == "span#kobo\\.156\\.1"
+    download = session.query(ub.KoboDeviceBookDownload).one()
+    assert (download.restore_state, download.restored_count) == ("served", 1)
+    # consumed: a second call is a no-op
+    assert authority.reanchor_after_download(
+        user_id=USER_ID, book_id=BOOK_ID, device_id=DEVICE_ID,
+        log=logging.getLogger("test"), reanchor=lambda rows: pytest.fail("re-ran"),
+    ) is None
+
+
+def test_sticky_get_after_download_serves_the_new_anchor(app, session, monkeypatch, tmp_path):
+    book = _unseeded_owned(monkeypatch, session)
+    state = session.query(ub.KoboAnnotationBookState).one()
+    state.authority_status = "authoritative"
+    state.ever_authoritative = True
+    state.seeded_at = datetime.now(timezone.utc)
+    path = tmp_path / "lib" / "Brennan" / "Hellenistic"
+    path.mkdir(parents=True)
+    _kepub(path / "hellenistic.kepub", [("OEBPS/chap0021.xhtml", [
+        ("kobo.156.1", "these are techniques that can do things that we didn't even think were possible"),
+    ])])
+    book.path = os.path.join("Brennan", "Hellenistic")
+    book.data = [SimpleNamespace(name="hellenistic", format="KEPUB")]
+    monkeypatch.setattr(reanchor.config, "get_book_path", lambda: str(tmp_path / "lib"))
+    session.add(_highlight("moved", "these are techniques that can do things that we didn't even think were possible"))
+    session.commit()
+    ledger.record_download(device_id=DEVICE_ID, book_id=BOOK_ID, book_format="kepub",
+                           log=logging.getLogger("test"))
+    monkeypatch.setattr(rs, "proxy_to_kobo_reading_services",
+                        lambda **_k: pytest.fail("proxied"))
+
+    response = _get(app)
+
+    assert response.status_code == 200, response.get_data()
+    [served] = json.loads(response.get_data())["annotations"]
+    assert served["location"]["span"]["chapterFilename"] == "OEBPS/chap0021.xhtml"
+    assert served["location"]["span"]["startPath"] == "span#kobo\\.156\\.1"


### PR DESCRIPTION
## Symptom

On the household canary a reader's book was removed from her Kobo and re-sent twice, and the re-download wiped her 22 highlights and her page.

## Observed chain (captures + app.db + logs, book 567)

1. A legitimate re-conversion advanced `last_modified`; the sync re-sent the book (expected).
2. Her re-download minted the KEPUB on demand; `convert.py` called `mark_book_modified`, so the **next** sync re-sent the book AGAIN, 25 s after she had re-found her place.
3. After each download Nickel GETs `/annotations`; the book was `unseeded`, so CWNG proxied to Kobo's cloud, which answered an empty set. Nickel replaced its local rows with nothing.
4. The re-converted KEPUB had new spine file names, so even the served rows would have pointed at nothing.

## Fix

- **A1** `helper.mark_book_format_materialised`: a derived sibling format (EPUB→KEPUB) never advances the clock; `convert.py` uses it. `DownloadUrls[].Size` leaves the entitlement fingerprint (payload schema 1→2; existing ledger rows transition silently through the declared-shape path).
- **B1** New per-device ledger `kobo_device_book_download` (auto-created). Every Kobo download arms a row; the first annotations GET from that device is served from CWNG's own rows (bypassing the seeding gates, which exist to protect a fuller device set that the download has just emptied) and promotes the book to local authority. Empty local set → proxy as before.
- **B2** `kobo_annotation_reanchor`: rows whose chapter no longer exists in the current KEPUB are re-anchored by highlighted text against the kobo spans (chapter, `span#kobo.N.M`, offsets, progress). Unmatched/ambiguous rows are served unchanged and logged, never dropped. Runs on both the restore path and the already-authoritative path.

## Tests

`tests/unit/test_kobo_redownload_harmless.py` — 15 behavioural tests; 9 red against the base source (the rest cover a new module). Neighbouring suites (1925, 1923, 1942, 1657, entitlement forensic): 193 passed, run twice. Schema pin in test_1925 updated together with the version bump, as that test instructs.

## Not yet observed

Nickel's behaviour on hardware after the served restore (position + highlights). Measured next with the kobo-pilot `owned-redownload-preserves-device-annotations` scenario on the Clara once `:dev` carries this.