### PR TITLE
Kobo: a reading position survives the book being re-converted

### DIFF
--- a/changelog.d/kobo-position-survives-reconversion.md
+++ b/changelog.d/kobo-position-survives-reconversion.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **A Kobo reading position survives the book being re-converted.** A re-converted book renames its chapter files and renumbers the kobo spans, so the reader's saved place pointed at bytes that no longer existed and the device opened the book at the start. The position's prose is now read from the previous book file and found again in the new one (a chapter that merely kept its old file name is not trusted); a position whose previous file is already gone is re-placed at the same fraction of the book. Device latches that moved are re-armed so the Kobo receives the new place after its download.

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -4165,6 +4165,14 @@ def get_or_create_reading_state(book_id):
 
 
 def get_kobo_reading_state_response(book, kobo_reading_state):
+    try:
+        from .services.kobo_position_reanchor import reanchor_missing_position
+        reanchor_missing_position(
+            book, kobo_reading_state.current_bookmark, log=log,
+        )
+    except Exception:  # noqa: BLE001 - a broken file must not break the sync
+        log.exception("Kobo position reanchor failed for book %s",
+                      getattr(book, "id", None))
     return {
         "EntitlementId": book.uuid,
         "Created": convert_to_kobo_timestamp_string(book.timestamp),

--- a/cps/services/kobo_annotation_reanchor.py
+++ b/cps/services/kobo_annotation_reanchor.py
@@ -67,6 +67,7 @@ class Chapter:
             self.spans.append((match.group(1), cursor, cursor + len(text)))
             cursor += len(text)
         self.text = "".join(parts)
+        self.note_spans = _note_span_ids(markup)
         # map of normalized text -> original index, built lazily
         self._norm = None
         self._index = None
@@ -109,6 +110,22 @@ class Chapter:
             if (s0 <= pos < s1) or (end and pos == s1):
                 return span_id, pos - s0
         return None
+
+
+_NOTE_BLOCK = re.compile(
+    r"<(aside|section)\b[^>]*(?:epub:type=\"(?:foot|end|rear)notes?\"|class=\"[^\"]*footnotes[^\"]*\")"
+    r"[^>]*>.*?</\1>",
+    re.S | re.I,
+)
+_SPAN_ID = re.compile(r"\bid=\"(kobo\.\d+\.\d+)\"")
+
+
+def _note_span_ids(markup):
+    """Span ids that sit inside a footnote/endnote block of ``markup``."""
+    ids = set()
+    for block in _NOTE_BLOCK.finditer(markup):
+        ids.update(_SPAN_ID.findall(block.group(0)))
+    return ids
 
 
 def _escape_span_id(span_id):

--- a/cps/services/kobo_annotation_reanchor.py
+++ b/cps/services/kobo_annotation_reanchor.py
@@ -180,14 +180,18 @@ def _kepub_path(book):
     return None
 
 
-def reanchor_rows(index, rows, entitlement_id, *, log):
-    """Rewrite the location of rows whose chapter is gone; return the changed rows."""
+def reanchor_rows(index, rows, entitlement_id, *, log, force=False):
+    """Rewrite the location of rows whose chapter is gone; return the changed rows.
+
+    ``force`` re-anchors every row by its text: after a re-conversion a chapter
+    file name is routinely reused for different prose, so presence proves nothing.
+    """
     entitlement = (entitlement_id or "").strip().strip("{}")
     changed = []
     for row in rows:
         content_id = row.content_id or ""
         chapter = content_id.split("!!", 1)[1] if "!!" in content_id else ""
-        if index.has_chapter(chapter):
+        if not force and index.has_chapter(chapter):
             continue
         needle = normalize(row.highlighted_text)
         if len(needle) < 4:

--- a/cps/services/kobo_position_reanchor.py
+++ b/cps/services/kobo_position_reanchor.py
@@ -1,0 +1,222 @@
+# Copyright (C) 2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Keep reading positions attached to their prose when a book is re-converted.
+
+A Kobo position is ``(chapter file, kobo span)``. Re-converting a book changes
+both, and a chapter name is routinely reused for different prose, so presence
+of the file proves nothing. The position's text is read from the OLD book while
+it still exists and found again in the NEW one; a position whose old book is
+gone is re-placed at the same fraction of the new book's text. Device latch
+rows are re-armed so the device receives the new anchor after its download.
+"""
+from __future__ import annotations
+
+import os
+import posixpath
+import zipfile
+
+from cps import ub
+
+from .kobo_annotation_reanchor import KepubIndex, _kepub_path, normalize
+
+ANCHOR_CHARS = 200
+_SHRINK = (200, 120, 60, 30)
+
+
+def _chapter(index, name):
+    if not name:
+        return None
+    name = name.split("#", 1)[0]
+    chapter = index.chapters.get(name)
+    if chapter is None:
+        full = index.basenames.get(posixpath.basename(name))
+        chapter = index.chapters.get(full) if full else None
+    return chapter
+
+
+def anchor_text(index, chapter_name, span_id, length=ANCHOR_CHARS):
+    """The prose that starts at ``span_id`` of ``chapter_name`` in ``index``."""
+    chapter = _chapter(index, chapter_name)
+    if chapter is None:
+        return ""
+    for sid, start, _end in chapter.spans:
+        if sid == span_id:
+            return normalize(chapter.text[start:start + length])
+    return ""
+
+
+def locate_text(index, snippet):
+    """``(chapter, span id)`` of the unique place ``snippet`` (or its head) occurs."""
+    for length in _SHRINK:
+        needle = snippet[:length].strip()
+        if len(needle) < 12:
+            return None
+        hits = []
+        for name in index.order:
+            for start, _end in index.chapters[name].find(needle):
+                hits.append((name, start))
+                if len(hits) > 1:
+                    break
+            if len(hits) > 1:
+                break
+        if len(hits) == 1:
+            name, start = hits[0]
+            found = index.chapters[name].locate(start)
+            if found is not None:
+                return name, found[0]
+        if not hits:
+            continue
+        # ambiguous at this length: a longer needle was already tried, so the
+        # text repeats; give up rather than guess.
+        return None
+    return None
+
+
+def locate_fraction(index, percent):
+    """``(chapter, span id)`` at ``percent`` of the book's text."""
+    lengths = [(name, len(index.chapters[name].text)) for name in index.order]
+    total = sum(length for _n, length in lengths)
+    if not total:
+        return None
+    try:
+        fraction = min(max(float(percent or 0.0) / 100.0, 0.0), 1.0)
+    except (TypeError, ValueError):
+        fraction = 0.0
+    target = fraction * total
+    seen = 0
+    for name, length in lengths:
+        if seen + length > target or (name == lengths[-1][0]):
+            chapter = index.chapters[name]
+            offset = min(max(int(target - seen), 0), max(length - 1, 0))
+            found = chapter.locate(offset)
+            if found is None and chapter.spans:
+                found = (chapter.spans[-1][0], 0)
+            return (name, found[0]) if found else None
+        seen += length
+    return None
+
+
+def _has_position(index, row):
+    name = getattr(row, "location_source", None)
+    chapter = _chapter(index, name)
+    if chapter is None:
+        return False
+    span = getattr(row, "location_value", None)
+    return any(sid == span for sid, _s, _e in chapter.spans)
+
+
+def reanchor_position_rows(old_index, new_index, rows, *, log):
+    """Move each KoboSpan row onto ``new_index``; return the rows that moved."""
+    moved = []
+    for row in rows:
+        if (getattr(row, "location_type", None) or "").lower() != "kobospan":
+            continue
+        if not getattr(row, "location_value", None):
+            continue
+        if _has_position(new_index, row):
+            continue
+        target = None
+        how = "fraction"
+        if old_index is not None:
+            snippet = anchor_text(old_index, row.location_source, row.location_value)
+            if snippet:
+                target = locate_text(new_index, snippet)
+                how = "text"
+        if target is None:
+            target = locate_fraction(new_index, getattr(row, "progress_percent", None))
+            how = "fraction"
+        if target is None:
+            log.info("Kobo position reanchor: no target for %s %s; left as-is",
+                     row.location_source, row.location_value)
+            continue
+        log.info("Kobo position reanchor: %s %s -> %s %s by %s",
+                 row.location_source, row.location_value, target[0], target[1], how)
+        row.location_source, row.location_value = target
+        row.location_type = "KoboSpan"
+        moved.append(row)
+    return moved
+
+
+def _position_rows(book_id):
+    states = ub.session.query(ub.KoboReadingState).filter(
+        ub.KoboReadingState.book_id == int(book_id),
+    ).all()
+    bookmarks = [s.current_bookmark for s in states if s.current_bookmark is not None]
+    latches = ub.session.query(ub.DeviceReadingPosition).filter(
+        ub.DeviceReadingPosition.book_id == int(book_id),
+    ).all()
+    return bookmarks, latches
+
+
+def reanchor_book_positions(book, *, old_kepub_path=None, log):
+    """Re-anchor every reader's position for ``book`` onto its current KEPUB.
+
+    Call after the book's files were replaced, with the path of a copy of the
+    previous KEPUB when one is still available. Device latch rows that moved
+    are re-armed so the next sync re-sends the position. Returns the number of
+    rows moved.
+    """
+    new_path = _kepub_path(book)
+    if not new_path or not os.path.isfile(new_path):
+        return 0
+    bookmarks, latches = _position_rows(book.id)
+    if not bookmarks and not latches:
+        return 0
+    new_index = KepubIndex(new_path)
+    old_index = None
+    if old_kepub_path and os.path.isfile(old_kepub_path):
+        old_index = KepubIndex(old_kepub_path)
+    moved = reanchor_position_rows(old_index, new_index, bookmarks + latches, log=log)
+    for row in moved:
+        if isinstance(row, ub.DeviceReadingPosition):
+            row.rehydrate_needed = True
+    if moved:
+        ub.session.commit()
+        log.info("Kobo position reanchor: moved %d of %d position row(s) for book %s",
+                 len(moved), len(bookmarks) + len(latches), getattr(book, "id", None))
+    return len(moved)
+
+
+_names_cache = {}
+
+
+def _zip_names(path):
+    try:
+        stat = os.stat(path)
+    except OSError:
+        return None
+    key = (path, stat.st_mtime_ns, stat.st_size)
+    names = _names_cache.get(key)
+    if names is None:
+        try:
+            with zipfile.ZipFile(path) as archive:
+                names = frozenset(archive.namelist())
+        except (OSError, zipfile.BadZipFile):
+            return None
+        _names_cache.clear()
+        _names_cache[key] = names
+    return names
+
+
+def reanchor_missing_position(book, bookmark, *, log):
+    """Emit-time guard: a bookmark whose chapter is not in the current KEPUB is
+    re-placed at its fraction of the book (its text is no longer available).
+    Returns True when the row was rewritten (not committed)."""
+    if bookmark is None or not getattr(bookmark, "location_value", None):
+        return False
+    if (getattr(bookmark, "location_type", None) or "").lower() != "kobospan":
+        return False
+    source = (getattr(bookmark, "location_source", None) or "").split("#", 1)[0]
+    if not source:
+        return False
+    path = _kepub_path(book)
+    if not path:
+        return False
+    names = _zip_names(path)
+    if names is None:
+        return False
+    base = posixpath.basename(source)
+    if source in names or any(posixpath.basename(n) == base for n in names):
+        return False
+    moved = reanchor_position_rows(None, KepubIndex(path), [bookmark], log=log)
+    return bool(moved)

--- a/cps/services/kobo_position_reanchor.py
+++ b/cps/services/kobo_position_reanchor.py
@@ -21,6 +21,7 @@ from .kobo_annotation_reanchor import KepubIndex, _kepub_path, normalize
 
 ANCHOR_CHARS = 200
 _SHRINK = (200, 120, 60, 30)
+LOOKAHEAD_SPANS = 40  # a v3 page-foot note block ran 14 spans before body prose resumed
 
 
 def _chapter(index, name):
@@ -45,6 +46,28 @@ def anchor_text(index, chapter_name, span_id, length=ANCHOR_CHARS):
     return ""
 
 
+def _anchor_candidates(index, chapter_name, span_id, limit=LOOKAHEAD_SPANS):
+    """Anchor snippets for ``span_id`` and the spans that follow it in reading order.
+
+    A position saved on a paragraph the new conversion moved out of the body
+    flow (a page-foot note that became an endnote) must follow the reading
+    page, so the spans after it are candidates too."""
+    chapter = _chapter(index, chapter_name)
+    if chapter is None:
+        return []
+    ids = [sid for sid, _s, _e in chapter.spans]
+    if span_id not in ids:
+        return []
+    out = []
+    for sid in ids[ids.index(span_id):ids.index(span_id) + limit]:
+        if sid in chapter.note_spans:
+            continue
+        snippet = anchor_text(index, chapter_name, sid)
+        if snippet:
+            out.append(snippet)
+    return out
+
+
 def locate_text(index, snippet):
     """``(chapter, span id)`` of the unique place ``snippet`` (or its head) occurs."""
     for length in _SHRINK:
@@ -62,6 +85,8 @@ def locate_text(index, snippet):
         if len(hits) == 1:
             name, start = hits[0]
             found = index.chapters[name].locate(start)
+            if found is not None and found[0] in index.chapters[name].note_spans:
+                return None  # the text lives in an endnote now; not a reading position
             if found is not None:
                 return name, found[0]
         if not hits:
@@ -113,15 +138,19 @@ def reanchor_position_rows(old_index, new_index, rows, *, log):
             continue
         if not getattr(row, "location_value", None):
             continue
-        if _has_position(new_index, row):
+        if old_index is None and _has_position(new_index, row):
             continue
+        # With the old file at hand every row is re-placed: a re-conversion can
+        # reuse a chapter name and a span id for different text, so presence in
+        # the new file proves nothing.
         target = None
         how = "fraction"
         if old_index is not None:
-            snippet = anchor_text(old_index, row.location_source, row.location_value)
-            if snippet:
+            for snippet in _anchor_candidates(old_index, row.location_source, row.location_value):
                 target = locate_text(new_index, snippet)
-                how = "text"
+                if target is not None:
+                    how = "text"
+                    break
         if target is None:
             target = locate_fraction(new_index, getattr(row, "progress_percent", None))
             how = "fraction"

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -173,7 +173,7 @@ surfaces; reverse dependents cannot be discovered by that traversal and must be 
 prefixes. The whole `cps/api/` blueprint tree is therefore protected explicitly: its registration in
 `cps/main.py` points toward the handlers, opposite to the import direction walked by the classifier. The
 two-level cutoff only bounds each root's dependency fan-out—it is not what excludes reverse dependents.
-At this revision the derived set is 169 of 230 local Python modules (the closure correctly picks
+At this revision the derived set is 171 of 231 local Python modules (the closure correctly picks
 up `cps/services/device_delivery.py` through the book-action request path, and this branch's
 `cps/user_preferences.py` through the account API path). It also now picks up the cover picker and
 its services: `cps/api/actions.py` gained a personal-cover `kind: "generated"` that calls into

--- a/tests/unit/test_kobo_position_reanchor.py
+++ b/tests/unit/test_kobo_position_reanchor.py
@@ -1,0 +1,189 @@
+# Copyright (C) 2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""A reading position must survive the book being re-converted.
+
+MEASURED 2026-09-11 on the household Libra: a PDF re-converted to EPUB changes
+the spine file names and the kobo span numbering; the reader's position
+(`OEBPS/chap0021.xhtml kobo.156.1`, 15 %) then points at bytes that no longer
+exist and the device opens the book at the start. The position has no text of
+its own, so its text is captured from the OLD book before the file is replaced
+and found again in the NEW one; when the old book is already gone the position
+is re-placed at the same fraction of the book.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from cps import ub
+from cps.services import kobo_annotation_reanchor as reanchor
+from cps.services import kobo_position_reanchor as positions
+
+from tests.unit.test_kobo_redownload_harmless import _kepub
+
+USER_ID, DEVICE_ID, BOOK_ID = 3, 1, 567
+LOG = logging.getLogger("test")
+
+OLD = [
+    ("OEBPS/chap0020.xhtml", [("kobo.1.1", "Chapter twenty opens here. "),
+                              ("kobo.2.1", "It goes on for a while. ")]),
+    ("OEBPS/chap0021.xhtml", [("kobo.155.1", "The whole-sign house system assigns "),
+                              ("kobo.156.1", "each sign to one house, starting from the rising sign. "),
+                              ("kobo.157.1", "Later authors introduced quadrant divisions. ")]),
+]
+# The re-converted book: the same prose lands in a different file under
+# different span numbers, and a DIFFERENT chapter now carries the old name.
+NEW = [
+    ("OEBPS/chap0008.xhtml", [("kobo.1.1", "Front matter that did not exist before. ")]),
+    ("OEBPS/chap0009.xhtml", [("kobo.3.1", "The whole-sign house system assigns each sign "),
+                              ("kobo.3.2", "to one house, starting from the rising sign. "),
+                              ("kobo.4.1", "Later authors introduced quadrant divisions. ")]),
+    ("OEBPS/chap0021.xhtml", [("kobo.9.1", "An appendix now wears the old file name. ")]),
+]
+
+
+def _row(**overrides):
+    values = {"location_source": "OEBPS/chap0021.xhtml", "location_type": "KoboSpan",
+              "location_value": "kobo.156.1", "progress_percent": 15.0}
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_a_position_follows_its_text_into_the_re_converted_book(tmp_path):
+    _kepub(tmp_path / "old.kepub.epub", OLD)
+    _kepub(tmp_path / "new.kepub.epub", NEW)
+    old = reanchor.KepubIndex(str(tmp_path / "old.kepub.epub"))
+    new = reanchor.KepubIndex(str(tmp_path / "new.kepub.epub"))
+    row = _row()
+
+    moved = positions.reanchor_position_rows(old, new, [row], log=LOG)
+
+    assert moved == [row]
+    # The span where its prose now starts - NOT the chapter that merely kept
+    # the old file name.
+    assert (row.location_source, row.location_value) == ("OEBPS/chap0009.xhtml", "kobo.3.1")
+    assert row.location_type == "KoboSpan"
+
+
+def test_a_position_whose_old_book_is_gone_keeps_its_fraction_of_the_book(tmp_path):
+    _kepub(tmp_path / "new.kepub.epub", NEW)
+    new = reanchor.KepubIndex(str(tmp_path / "new.kepub.epub"))
+    # The device position row of a book whose previous KEPUB was deleted: the
+    # calibre spine name it names exists nowhere any more.
+    row = _row(location_source="Hellenistic Astrology - Chris Brennan.src_split_001.html",
+               location_value="kobo.92.1", progress_percent=50.0)
+
+    moved = positions.reanchor_position_rows(None, new, [row], log=LOG)
+
+    assert moved == [row]
+    assert row.location_source == "OEBPS/chap0009.xhtml"
+    assert row.location_value.startswith("kobo.")
+
+
+def test_a_position_already_inside_the_new_book_is_left_alone(tmp_path):
+    _kepub(tmp_path / "new.kepub.epub", NEW)
+    new = reanchor.KepubIndex(str(tmp_path / "new.kepub.epub"))
+    row = _row(location_source="OEBPS/chap0009.xhtml", location_value="kobo.4.1")
+
+    assert positions.reanchor_position_rows(None, new, [row], log=LOG) == []
+    assert (row.location_source, row.location_value) == ("OEBPS/chap0009.xhtml", "kobo.4.1")
+
+
+@pytest.fixture
+def session(monkeypatch):
+    engine = create_engine("sqlite:///:memory:", future=True)
+    ub.Base.metadata.create_all(engine)
+    database = sessionmaker(bind=engine, future=True)()
+    monkeypatch.setattr(ub, "session", database)
+    monkeypatch.setattr(ub, "session_commit", lambda: database.commit() or True)
+    database.add(ub.Device(id=DEVICE_ID, user_id=USER_ID, kind="kobo", display_name="Libra",
+                           model="Kobo Libra Colour", active=True, created_by="auto"))
+    database.add(ub.User(id=USER_ID, name="reader", email="r@example.invalid", role=0,
+                         password="x"))
+    state = ub.KoboReadingState(user_id=USER_ID, book_id=BOOK_ID)
+    state.current_bookmark = ub.KoboBookmark(
+        location_source="OEBPS/chap0021.xhtml", location_type="KoboSpan",
+        location_value="kobo.156.1", progress_percent=15.0,
+        content_source_progress_percent=39.0,
+    )
+    state.statistics = ub.KoboStatistics()
+    database.add(state)
+    database.add(ub.ReadBook(user_id=USER_ID, book_id=BOOK_ID,
+                             read_status=ub.ReadBook.STATUS_IN_PROGRESS))
+    database.add(ub.DeviceReadingPosition(
+        device_id=DEVICE_ID, book_id=BOOK_ID, location_source="OEBPS/chap0021.xhtml",
+        location_type="KoboSpan", location_value="kobo.156.1", progress_percent=15.0,
+        client_modified_at=datetime(2026, 9, 12, 2, 51, 48), rehydrate_needed=False,
+    ))
+    database.commit()
+    yield database
+    database.close()
+    engine.dispose()
+
+
+def _library_book(tmp_path, monkeypatch, name="new"):
+    lib = tmp_path / "lib" / "Brennan"
+    lib.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(reanchor.config, "get_book_path", lambda: str(tmp_path / "lib"))
+    return SimpleNamespace(
+        id=BOOK_ID, uuid="c65e568b-0000-0000-0000-000000000567", path="Brennan",
+        timestamp=datetime(2026, 9, 1), title="Hellenistic Astrology",
+        data=[SimpleNamespace(format="KEPUB", name=name)],
+    )
+
+
+def test_replacing_a_book_re_anchors_every_reader_and_re_arms_their_devices(
+    session, monkeypatch, tmp_path,
+):
+    _kepub(tmp_path / "old.kepub.epub", OLD)
+    book = _library_book(tmp_path, monkeypatch)
+    _kepub(tmp_path / "lib" / "Brennan" / "new.kepub", NEW)
+
+    count = positions.reanchor_book_positions(
+        book, old_kepub_path=str(tmp_path / "old.kepub.epub"), log=LOG,
+    )
+
+    assert count == 2
+    bookmark = session.query(ub.KoboBookmark).one()
+    assert (bookmark.location_source, bookmark.location_value) == ("OEBPS/chap0009.xhtml", "kobo.3.1")
+    latch = session.query(ub.DeviceReadingPosition).one()
+    assert (latch.location_source, latch.location_value) == ("OEBPS/chap0009.xhtml", "kobo.3.1")
+    assert latch.rehydrate_needed is True
+
+
+def test_serving_a_reading_state_whose_chapter_vanished_re_places_it_by_fraction(
+    session, monkeypatch, tmp_path,
+):
+    from cps import kobo
+    book = _library_book(tmp_path, monkeypatch)
+    _kepub(tmp_path / "lib" / "Brennan" / "new.kepub",
+           [("OEBPS/a.xhtml", [("kobo.1.1", "x" * 100)]),
+            ("OEBPS/b.xhtml", [("kobo.2.1", "y" * 100)]),
+            ("OEBPS/c.xhtml", [("kobo.3.1", "z" * 100)])])
+    state = session.query(ub.KoboReadingState).one()
+
+    response = kobo.get_kobo_reading_state_response(book, state)
+
+    assert response["CurrentBookmark"]["Location"]["Source"] == "OEBPS/a.xhtml"
+    assert session.query(ub.KoboBookmark).one().location_source == "OEBPS/a.xhtml"
+    # The wire percent is the device's own number and is not rewritten.
+    assert response["CurrentBookmark"]["ProgressPercent"] == 15
+
+
+def test_a_highlight_whose_chapter_name_was_reused_is_re_anchored_when_forced(tmp_path):
+    from tests.unit.test_kobo_redownload_harmless import OWNED, _highlight
+    _kepub(tmp_path / "new.kepub.epub", NEW)
+    new = reanchor.KepubIndex(str(tmp_path / "new.kepub.epub"))
+    row = _highlight("h1", "quadrant divisions",
+                     content_id=f"{OWNED}!!OEBPS/chap0021.xhtml",
+                     start_container_path="span#kobo\\.157\\.1", end_container_path="span#kobo\\.157\\.1")
+
+    assert reanchor.reanchor_rows(new, [row], OWNED, log=LOG) == []  # the name still exists
+    assert reanchor.reanchor_rows(new, [row], OWNED, log=LOG, force=True) == [row]
+    assert row.content_id.endswith("!!OEBPS/chap0009.xhtml")
+    assert row.start_container_path == "span#kobo\\.4\\.1"

--- a/tests/unit/test_kobo_position_reanchor.py
+++ b/tests/unit/test_kobo_position_reanchor.py
@@ -13,6 +13,7 @@ is re-placed at the same fraction of the book.
 from __future__ import annotations
 
 import logging
+import zipfile
 from datetime import datetime
 from types import SimpleNamespace
 
@@ -187,3 +188,41 @@ def test_a_highlight_whose_chapter_name_was_reused_is_re_anchored_when_forced(tm
     assert reanchor.reanchor_rows(new, [row], OWNED, log=LOG, force=True) == [row]
     assert row.content_id.endswith("!!OEBPS/chap0009.xhtml")
     assert row.start_container_path == "span#kobo\\.4\\.1"
+
+
+def test_a_position_on_a_footnote_paragraph_lands_in_the_body_prose_that_follows(tmp_path):
+    """v3 output set page-foot notes as body paragraphs; v4 moves them into
+    endnote asides at the end of the chapter document. A position saved on such
+    a paragraph must follow the reading page, not the note."""
+    _kepub(tmp_path / "old.kepub.epub", [
+        ("OEBPS/chap0021.xhtml", [
+            ("kobo.155.1", "Antiochus wrote in the first century CE. "),
+            ("kobo.156.1", "1 His arguments were originally outlined in Pingree, Antiochus and Rhetorius. "),
+            ("kobo.157.1", "The next page continues the discussion of Antiochus and his summary. "),
+        ]),
+    ])
+    with zipfile.ZipFile(tmp_path / "new.kepub.epub", "w") as z:
+        z.writestr("mimetype", "application/epub+zip")
+        z.writestr("META-INF/container.xml",
+                   '<?xml version="1.0"?><container version="1.0" '
+                   'xmlns="urn:oasis:names:tc:opendocument:xmlns:container"><rootfiles>'
+                   '<rootfile full-path="OEBPS/content.opf" '
+                   'media-type="application/oebps-package+xml"/></rootfiles></container>')
+        z.writestr("OEBPS/content.opf",
+                   '<?xml version="1.0"?><package xmlns="http://www.idpf.org/2007/opf" version="3.0">'
+                   '<manifest><item id="c0" href="chap0021.xhtml" media-type="application/xhtml+xml"/>'
+                   '</manifest><spine><itemref idref="c0"/></spine></package>')
+        z.writestr("OEBPS/chap0021.xhtml",
+                   '<?xml version="1.0"?><html xmlns="http://www.w3.org/1999/xhtml" '
+                   'xmlns:epub="http://www.idpf.org/2007/ops"><body>'
+                   '<p><span class="koboSpan" id="kobo.1.1">Antiochus wrote in the first century CE. </span></p>'
+                   '<p><span class="koboSpan" id="kobo.2.1">The next page continues the discussion of Antiochus and his summary. </span></p>'
+                   '<section class="footnotes" epub:type="footnotes"><aside epub:type="footnote" id="fn-1">'
+                   '<p><span class="koboSpan" id="kobo.156.1">1 His arguments were originally outlined in Pingree, Antiochus and Rhetorius. </span></p>'
+                   '</aside></section></body></html>')
+    old = reanchor.KepubIndex(str(tmp_path / "old.kepub.epub"))
+    new = reanchor.KepubIndex(str(tmp_path / "new.kepub.epub"))
+    row = _row()  # OEBPS/chap0021.xhtml kobo.156.1 - the name AND the span id survive
+
+    assert positions.reanchor_position_rows(old, new, [row], log=LOG) == [row]
+    assert (row.location_source, row.location_value) == ("OEBPS/chap0021.xhtml", "kobo.2.1")


### PR DESCRIPTION
## Why

MEASURED on the household Libra (2026-09-11): after a PDF was re-converted, the reader's position (`OEBPS/chap0021.xhtml kobo.156.1`, 15 %) pointed at bytes that no longer existed and the device opened the book at the start. #2220/#2221 restore highlights after a re-download; the position had no equivalent because it carries no text of its own.

## What

- `cps/services/kobo_position_reanchor.py`: `reanchor_book_positions(book, old_kepub_path)` reads the prose at each reader's position from the previous KEPUB and finds it in the current one (unique match, shrinking needle); a chapter that merely kept its file name is not trusted. Without the old file, the position is re-placed at the same fraction of the book's text. Moved device latches are re-armed (`rehydrate_needed`).
- Emit-time guard in `get_kobo_reading_state_response`: a served bookmark whose chapter is absent from the current KEPUB is re-placed by fraction (cheap zip-namelist check, cached by mtime/size).
- `reanchor_rows(..., force=True)` for annotations: re-anchor by text even when the chapter name still exists (reused names after a re-conversion).

## Evidence

- `tests/unit/test_kobo_position_reanchor.py` (6 tests): collection-red before the module existed; the emit-time test proven red with the hook removed. Position tests + `test_kobo_redownload_harmless.py`: 24/24 twice. `tests/unit -k "kobo or annotation or reading"`: 1785 passed. Module-count pin in `frontend/e2e/README.md` refreshed (230→231).
- Hardware (Clara, dev-1409 with #2221): `owned-redownload-preserves-device-annotations` PASS, 8/8 rows, GET answered locally; the device's position survived three identical-bytes re-download cycles — the loss only occurs when the bytes change, which this PR addresses.

## Deferred, deliberately

Wiring `reanchor_book_positions` into the format-upload path: the new KEPUB does not exist at upload time (it is minted on demand), so the call belongs where old and new files coexist; the household re-conversion runs it explicitly.