### PR TITLE
Kobo: a re-anchored highlight retires its byte-exact sidecar

### DIFF
--- a/changelog.d/2224.md
+++ b/changelog.d/2224.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- **A Kobo highlight follows its text after the book is re-converted.** When a
+  book's file changes and the highlight is moved to the new chapter, the device
+  is now sent the new location instead of the span the highlight was made on,
+  so it appears on the right page after the re-download (#2224).

--- a/cps/services/kobo_annotation_reanchor.py
+++ b/cps/services/kobo_annotation_reanchor.py
@@ -242,6 +242,12 @@ def reanchor_rows(index, rows, entitlement_id, *, log, force=False):
         row.end_offset = last[1]
         row.chapter_progress = (start / len(chapter_obj.text)) if chapter_obj.text else 0.0
         row.context_string = chapter_obj.text[max(0, start - 60):end + 60]
+        # A row that arrived through a Kobo PATCH also keeps its byte-exact
+        # sidecar, and the render prefers that sidecar while its revision still
+        # matches.  Advancing the revision retires the sidecar, so the device is
+        # served the columns just rewritten rather than the span it moved from
+        # (OBSERVED on hardware: the highlight stayed in the old chapter).
+        row.content_revision = (row.content_revision or 0) + 1
         changed.append(row)
     return changed
 

--- a/tests/unit/test_kobo_redownload_harmless.py
+++ b/tests/unit/test_kobo_redownload_harmless.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 # ruff: noqa: F811  (the imported `sync_harness` fixture is used by parameter name)
 
+import hashlib
 import json
 import logging
 import os
@@ -595,6 +596,59 @@ def test_sticky_get_after_download_serves_the_new_anchor(app, session, monkeypat
     [served] = json.loads(response.get_data())["annotations"]
     assert served["location"]["span"]["chapterFilename"] == "OEBPS/chap0021.xhtml"
     assert served["location"]["span"]["startPath"] == "span#kobo\\.156\\.1"
+
+
+def test_reanchored_row_with_a_raw_kobo_sidecar_serves_the_new_location(app, session, monkeypatch, tmp_path):
+    """OBSERVED on the Clara (rehearsal book, 2026-09-12): a highlight made on the
+    device is stored with its raw PATCH sidecar; the re-anchor moved the columns
+    to the new chapter, but the byte-exact sidecar still won the render and the
+    device kept the old span. The served object must carry the new anchor."""
+    book = _unseeded_owned(monkeypatch, session)
+    state = session.query(ub.KoboAnnotationBookState).one()
+    state.authority_status = "authoritative"
+    state.ever_authoritative = True
+    state.seeded_at = datetime.now(timezone.utc)
+    path = tmp_path / "lib" / "Brennan" / "Hellenistic"
+    path.mkdir(parents=True)
+    _kepub(path / "hellenistic.kepub", [("OEBPS/chap0007.xhtml", [
+        ("kobo.4.1", "the putative founder of the tradition"),
+    ])])
+    book.path = os.path.join("Brennan", "Hellenistic")
+    book.data = [SimpleNamespace(name="hellenistic", format="KEPUB")]
+    monkeypatch.setattr(reanchor.config, "get_book_path", lambda: str(tmp_path / "lib"))
+    row = _highlight("moved", "putative",
+                     content_id=f"{OWNED}!!OEBPS/chap0021.xhtml",
+                     start_container_path="span#kobo\\.5\\.1", end_container_path="span#kobo\\.5\\.1",
+                     start_offset=68, end_offset=76)
+    session.add(row)
+    session.commit()
+    location = (b'{"span": {"chapterFilename": "OEBPS/chap0021.xhtml","chapterProgress": 0.0149,'
+                b'"chapterTitle": "CHAPTER 4","endChar": 76,"endPath": "span#kobo\\\\.5\\\\.1",'
+                b'"startChar": 68,"startPath": "span#kobo\\\\.5\\\\.1"}}')
+    raw = (b'{"clientLastModifiedUtc": "2026-09-12T11:57:43Z","highlightColor": "#A0A0A0",'
+           b'"highlightedText": "putative","id": "moved","location": ' + location + b',"type": "highlight"}')
+    session.add(ub.KoboAnnotationMaterialization(
+        annotation_id=row.id, raw_annotation_json=raw, raw_location_json=location,
+        raw_client_modified_utc="2026-09-12T11:57:43Z",
+        payload_sha256=hashlib.sha256(raw).hexdigest(),
+        materialization_revision=row.content_revision, provenance="kobo_patch",
+        attachments_state="empty", serveable=False,
+    ))
+    session.commit()
+    ledger.record_download(device_id=DEVICE_ID, book_id=BOOK_ID, book_format="kepub",
+                           log=logging.getLogger("test"))
+    monkeypatch.setattr(rs, "proxy_to_kobo_reading_services",
+                        lambda **_k: pytest.fail("proxied"))
+
+    response = _get(app)
+
+    assert response.status_code == 200, response.get_data()
+    [served] = json.loads(response.get_data())["annotations"]
+    assert served["id"] == "moved"
+    assert served["location"]["span"]["chapterFilename"] == "OEBPS/chap0007.xhtml"
+    assert served["location"]["span"]["startPath"] == "span#kobo\\.4\\.1"
+    assert served["location"]["span"]["startChar"] == 4
+    assert served["highlightedText"] == "putative"
 
 
 # ------------------------------------------- B1b: the restore must actually arm


### PR DESCRIPTION
## What broke

OBSERVED on a Kobo Clara (2026-09-12) after a book was re-converted and re-downloaded: the post-download restore served every highlight and the reading position came back on the same prose, but a highlight made on the device stayed in the **old** chapter. Its rows on the server had been re-anchored to the new chapter; the render still preferred the raw PATCH sidecar (`kobo_annotation_materialization`), whose revision matched the row, so the device received the span the highlight had moved from.

## Fix

`reanchor_rows` advances `content_revision` on every row it moves. That is the same signal a generic column edit already uses (see the comment in `_exact_raw`): a stale sidecar is retired and the rewritten columns are served.

## Test

`test_reanchored_row_with_a_raw_kobo_sidecar_serves_the_new_location` reproduces the device evidence: row re-anchored from chap0021 to chap0007 while a kobo_patch sidecar carries chap0021. Seen red (`'OEBPS/chap0021.xhtml' == 'OEBPS/chap0007.xhtml'`), green with the fix. Kobo/annotation unit suites green.