### PR TITLE
Kobo: a re-placed position survives the device echoing its old locator

### DIFF
--- a/changelog.d/kobo-reanchored-position-wins.md
+++ b/changelog.d/kobo-reanchored-position-wins.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- **A Kobo keeps the right reading position after its book is re-converted.**
+  When the server has moved a reader's position into the new file, the device
+  restating its old spot at the same progress no longer overwrites that repair,
+  so the next sync sends the reader back to the same prose instead of the old
+  anchor.

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -3741,7 +3741,12 @@ def HandleStateRequest(book_uuid):
                     location_supplied=bool(location),
                     incoming_clock=request_lm,
                     clock_accepts=True,
-                    equal_accepts=True,
+                    # An armed latch means the server holds a position it
+                    # deliberately re-placed (a re-converted book) and will
+                    # replay on the next sync. The device echoing its old
+                    # locator at the same progress with an older clock must
+                    # not overwrite that repair (OBSERVED on hardware).
+                    equal_accepts=not rehydrate_pending,
                     preserve_clock_when_missing=True,
                     block_lower_at_or_below=(
                         KOB0_COVER_RESET_PROGRESS_EPSILON

--- a/cps/services/kobo_position_reanchor.py
+++ b/cps/services/kobo_position_reanchor.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import os
 import posixpath
 import zipfile
+from datetime import datetime, timezone
 
 from cps import ub
 
@@ -196,9 +197,20 @@ def reanchor_book_positions(book, *, old_kepub_path=None, log):
     if old_kepub_path and os.path.isfile(old_kepub_path):
         old_index = KepubIndex(old_kepub_path)
     moved = reanchor_position_rows(old_index, new_index, bookmarks + latches, log=log)
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
     for row in moved:
         if isinstance(row, ub.DeviceReadingPosition):
             row.rehydrate_needed = True
+            row.server_modified_at = now
+        else:
+            # The repair is a new observation: newer than the device's own copy
+            # so Nickel takes the replay, and newer than the device's echo of
+            # the old locator so that echo cannot overwrite it.
+            row.last_modified = now
+            state = getattr(row, "kobo_reading_state", None)
+            if state is not None:
+                state.last_modified = now
+                state.priority_timestamp = now
     if moved:
         ub.session.commit()
         log.info("Kobo position reanchor: moved %d of %d position row(s) for book %s",

--- a/tests/unit/test_1942_device_reading_position.py
+++ b/tests/unit/test_1942_device_reading_position.py
@@ -417,6 +417,39 @@ def test_rehydrate_latch_survives_cover_reset_until_sync_clears_it(
     ).scalar() is False
 
 
+def test_armed_latch_keeps_the_servers_location_against_an_older_equal_progress_echo(
+        state_harness):
+    """OBSERVED on a Kobo Clara (2026-09-12): after the server re-placed a
+    position into a re-converted book, Nickel echoed its own pre-conversion
+    locator with the same progress and an older clock, and that echo replaced
+    the repair before the sync could replay it. While the latch is armed the
+    equal-progress locator refresh must not accept a clock older than the
+    stored bookmark's."""
+    from cps.services import device_reading_position as positions
+
+    harness = state_harness
+    bookmark = harness.state.current_bookmark
+    bookmark.location_value = "reanchored.80"
+    bookmark.last_modified = _clock(12)
+    positions.mark_rehydrate_needed(harness.device.id, [BOOK_ID])
+    harness.session.commit()
+
+    response = harness.put(80.0, clock="2026-08-29T11:00:00Z")
+    assert response.get_json()["RequestResult"] == "Success"
+    harness.session.expire_all()
+
+    assert harness.state.current_bookmark.location_value == "reanchored.80"
+    assert harness.state.current_bookmark.last_modified == _clock(12).replace(tzinfo=None)
+    position = harness.session.query(ub.DeviceReadingPosition).one()
+    assert position.location_value == "device.80.0", "the device journal is truthful"
+    assert position.rehydrate_needed is True
+
+    # A genuine newer reading on the device still wins while armed.
+    harness.put(81.0, clock="2026-08-29T13:00:00Z")
+    harness.session.expire_all()
+    assert harness.state.current_bookmark.location_value == "device.81.0"
+
+
 def test_armed_non_cover_backward_jump_is_not_misclassified_as_reset(
         state_harness):
     from cps.services import device_reading_position as positions

--- a/tests/unit/test_kobo_position_reanchor.py
+++ b/tests/unit/test_kobo_position_reanchor.py
@@ -157,6 +157,33 @@ def test_replacing_a_book_re_anchors_every_reader_and_re_arms_their_devices(
     assert latch.rehydrate_needed is True
 
 
+def test_a_moved_position_carries_a_fresh_clock_so_the_device_takes_it(
+    session, monkeypatch, tmp_path,
+):
+    """The replayed reading state must be newer than the device's own copy,
+    and a later echo of the old locator must read as older than the repair."""
+    _kepub(tmp_path / "old.kepub.epub", OLD)
+    book = _library_book(tmp_path, monkeypatch)
+    _kepub(tmp_path / "lib" / "Brennan" / "new.kepub", NEW)
+    device_clock = datetime(2026, 9, 12, 2, 51, 48)
+    state = session.query(ub.KoboReadingState).one()
+    state.current_bookmark.last_modified = device_clock
+    state.last_modified = state.priority_timestamp = device_clock
+    session.commit()
+
+    positions.reanchor_book_positions(
+        book, old_kepub_path=str(tmp_path / "old.kepub.epub"), log=LOG,
+    )
+
+    session.expire_all()
+    state = session.query(ub.KoboReadingState).one()
+    assert state.current_bookmark.last_modified > device_clock
+    assert state.last_modified > device_clock
+    assert state.priority_timestamp > device_clock
+    latch = session.query(ub.DeviceReadingPosition).one()
+    assert latch.server_modified_at > device_clock
+
+
 def test_serving_a_reading_state_whose_chapter_vanished_re_places_it_by_fraction(
     session, monkeypatch, tmp_path,
 ):


### PR DESCRIPTION
## What broke

OBSERVED on a Kobo Clara (2026-09-12), directly measured: the server held a re-placed position (fresh clock, latch armed) for a re-converted book. At the next sync Nickel PUT its own old locator with the same progress and an older clock. The equal-progress locator refresh in `HandleStateRequest` accepted it (the arbiter keeps the newer clock but writes the location), so the sync replayed the device's stale anchor and the reader was not moved. In a re-converted book that stale anchor names different prose.

## Fix

- `HandleStateRequest`: while the device's rehydrate latch is armed, `equal_accepts` is off, so an equal-progress echo with an older clock cannot overwrite the bookmark location. A genuine newer reading (newer clock or higher progress) still wins. Unarmed behaviour is unchanged (the existing equal/older-clock refresh test still passes).
- `reanchor_book_positions` stamps moved bookmark/state/latch rows explicitly (the ORM's `onupdate` already did it for the bookmark; now pinned by a test).

## Tests

- `test_armed_latch_keeps_the_servers_location_against_an_older_equal_progress_echo` — seen red (`'device.80.0' == 'reanchored.80'`), green with the fix; also checks a newer reading still wins while armed.
- `test_a_moved_position_carries_a_fresh_clock_so_the_device_takes_it` — pins the clock invariant the fix depends on (was already green via `onupdate`).
- 153 tests across the Kobo position/sync/re-download suites green.