### PR TITLE
Group the same book catalogued under two different titles

### DIFF
--- a/changelog.d/variant-title-duplicates.md
+++ b/changelog.d/variant-title-duplicates.md
@@ -1,0 +1,17 @@
+### Fixed
+
+- **The same book catalogued under two different titles is now found as a
+  duplicate.** Sources disagree about whether to append the series, the volume
+  or the imprint, so a library ends up holding "Golden Son" and "Golden Son
+  (Red Rising Series Book 2)", or "The Road" and "The Road (Vintage
+  International)", as unrelated books. Duplicate detection now compares titles
+  with that annotation set aside, and treats "Liu, Cixin" and "Cixin Liu" as
+  one author, so those pairs group. On a 202-book test library the scan found
+  17 additional duplicate pairs and lost none.
+- **Two volumes of a series are no longer reported as duplicates of each
+  other.** When Calibre kept the volume only in `series_index`, both books
+  carried one identical title and grouped together — and resolving that group
+  would have deleted a book the library only had one copy of. A volume check
+  now splits them apart, and a copy that declares no volume at all inside a
+  title that spans several is left out of every group rather than offered for
+  deletion.

--- a/cps/duplicate_index.py
+++ b/cps/duplicate_index.py
@@ -22,6 +22,7 @@ from .duplicates import (
     get_common_filters,
     normalize_title_for_duplicates,
     normalize_text_for_duplicates,
+    canonical_author_key,
 )
 
 from cps.cwa_db_loader import load_cwa_db
@@ -30,7 +31,7 @@ CWA_DB = load_cwa_db().CWA_DB
 
 log = logger.create()
 
-NORMALIZATION_VERSION = "duplicate-index-v3"  # v3: + accent-fold (NFKD) + punctuation-to-space, precision-preserving (D6)
+NORMALIZATION_VERSION = "duplicate-index-v4"  # v4: + title-stem (series/edition annotation) + order-independent author key
 MAX_INCREMENTAL_BOOK_IDS = 1000
 DUPLICATE_INDEX_REBUILD_BATCH_SIZE = 250
 
@@ -135,7 +136,10 @@ def build_book_key_parts(book, settings):
     # leading primary-author prefix, unlike the old Python fallback's no-author mode.
     return BookKeyParts(
         normalized_title=normalize_title_for_duplicates(title, primary_author),
-        normalized_author=normalize_text_for_duplicates(primary_author, default="unknown"),
+        # Order-independent: "Liu, Cixin" and "Cixin Liu" are one person, and
+        # the index key must agree with the Python grouping path that now uses
+        # the same helper.
+        normalized_author=canonical_author_key(primary_author),
         normalized_language=normalize_text_for_duplicates(language, default="unknown"),
         normalized_series=normalize_text_for_duplicates(series, default="no_series"),
         normalized_publisher=normalize_text_for_duplicates(publisher, default="unknown_publisher"),

--- a/cps/duplicates.py
+++ b/cps/duplicates.py
@@ -183,12 +183,18 @@ def normalize_text_for_duplicates(value, default=""):
     return text.strip()
 
 
-def generate_group_hash(title, author):
+def generate_group_hash(title, author, discriminator=None):
     """Generate MD5 hash for a duplicate group based on title and author
 
     Args:
         title: Book title (will be normalized)
         author: Primary author name (will be normalized)
+        discriminator: optional extra token that keeps two groups sharing one
+            display title apart. Sibling volumes ("Wayward Pines" #1 and #2 are
+            both stored under that exact title) split into separate groups
+            below, and without this they would hash identically — dismissing
+            one would silently dismiss the other. Omitted for every
+            single-group title, so existing dismissals keep their hashes.
 
     Returns:
         32-character MD5 hash string
@@ -198,6 +204,8 @@ def generate_group_hash(title, author):
 
     # Create composite key
     composite = f"{normalized_title}|{normalized_author}"
+    if discriminator is not None:
+        composite = f"{composite}|{discriminator}"
 
     # Generate MD5 hash
     return hashlib.md5(composite.encode('utf-8')).hexdigest()
@@ -224,7 +232,194 @@ def normalize_title_for_duplicates(title, primary_author=None):
         author_prefix = f"{author_norm}, "
         if cmp.startswith(author_prefix):
             text = cmp[len(author_prefix):]
-    return normalize_text_for_duplicates(text, default="untitled")
+    return canonical_title_stem(text)
+
+
+# --- Variant-title duplicates ------------------------------------------------
+#
+# normalize_text_for_duplicates keeps every word and number, which is what
+# stops two distinct books from colliding. The cost is that ONE book catalogued
+# twice under two different titles is invisible: sources disagree about whether
+# to append the series, the volume or the imprint, so a library ends up holding
+#
+#     "Golden Son"       and   "Golden Son (Red Rising Series Book 2)"
+#     "The Road"         and   "The Road (Vintage International)"
+#     "Pines"            and   "Pines (Wayward Pines)"
+#
+# as unrelated books. Those are real rows from the library this was developed
+# against; none of them grouped.
+#
+# Stripping the annotation alone would be unsafe in the other direction. Books
+# in a series share a stem ("Wayward Pines (Book 1)" / "(Book 2)"), and
+# execute-resolution DELETES books — so the volume is handled explicitly, as a
+# filter applied AFTER grouping rather than as part of the key. Keying it
+# directly was measured and rejected: it split genuine duplicates whenever one
+# copy had been imported without series metadata and the other had it.
+
+# Words that mark a parenthetical as annotation rather than title content.
+_ANNOTATION_MARKERS = ('book', 'books', 'series', 'edition', 'volume', 'vol',
+                       'trilogy', 'saga', 'omnibus', 'collection', 'chronicles')
+# Scaffolding that sits directly in front of a volume number.
+_VOLUME_LABEL = r'(?:book|bk|vol|volume|part|no|num|#)'
+_ROMAN_VALUES = {'i': 1, 'ii': 2, 'iii': 3, 'iv': 4, 'v': 5, 'vi': 6,
+                 'vii': 7, 'viii': 8, 'ix': 9, 'x': 10, 'xi': 11, 'xii': 12}
+
+
+def _strip_trailing_bracket_groups(text):
+    """Repeatedly drop a trailing "(...)" or "[...]" group.
+
+    End-anchored deliberately: a parenthetical in the MIDDLE of a title is far
+    more likely to be title-distinguishing than noise. This is what collapses
+    "The Road (Vintage International)" — an imprint carries no marker word, so
+    the marker rule below cannot catch it.
+    """
+    previous = None
+    while previous != text:
+        previous = text
+        text = re.sub(r'\s*[\(\[][^()\[\]]*[\)\]]\s*$', ' ', text).strip()
+    return text
+
+
+def _strip_annotation_brackets(text):
+    """Drop a bracket group ANYWHERE that names a series, volume or edition."""
+    def replace(match):
+        inner = match.group(0).lower()
+        return ' ' if any(word in inner for word in _ANNOTATION_MARKERS) else match.group(0)
+    return re.sub(r'[\(\[][^()\[\]]*[\)\]]', replace, text)
+
+
+def canonical_title_stem(title):
+    """The title with series/edition/imprint annotation removed.
+
+    The volume LABEL is dropped but its NUMBER is kept ("Book 12" -> "12"), so
+    "Wool Book 12" and "Wool Book 13" still differ in the stem itself and never
+    reach the volume filter at all.
+    """
+    raw = title if title is not None and str(title) else "untitled"
+    # Square brackets are a tagging convention, not title punctuation:
+    # "[Wayward Pines 01] Pines", "[2013]", "[Kindle Edition]". They are
+    # stripped wherever they sit, including a LEADING tag that no marker word
+    # would catch. Parentheses get the narrower treatment below, because they
+    # genuinely appear inside real titles far more often than brackets do.
+    stem = re.sub(r'\s*\[[^\[\]]*\]\s*', ' ', str(raw))
+    stem = _strip_annotation_brackets(stem)
+    stem = _strip_trailing_bracket_groups(stem)
+    stem = re.sub(_VOLUME_LABEL + r'\.?\s+(\d+)', r'\1', stem, flags=re.IGNORECASE)
+    stem = normalize_text_for_duplicates(stem, default="untitled")
+    # A title that is nothing BUT an annotation ("(Boxed Set)") must not
+    # normalize to the empty string, or every such book would collide.
+    return stem or normalize_text_for_duplicates(raw, default="untitled")
+
+
+def canonical_author_key(author):
+    """Order-independent author key.
+
+    Calibre stores "Liu, Cixin" where another source says "Cixin Liu", and the
+    two hash apart today — which kept "The Dark Forest" and "The Dark Forest
+    (The Three-Body Problem)" in separate groups even once the title rule
+    collapsed their stems. Sorting the name tokens reconciles the two spellings
+    without being able to merge two different people: it only reorders tokens
+    they were already spelled with.
+
+    Bracketed repeats and domain tokens are dropped first — "Liu, Cixin [Liu,
+    Cixin] || chenjin5.com" is a real author record, where the domain is a
+    scraper's watermark rather than a contributor.
+    """
+    raw = str(author) if author is not None else ''
+    raw = re.sub(r'\[[^\]]*\]', ' ', raw)
+    raw = re.sub(r'[\w-]+\.[a-z]{2,}\b', ' ', raw, flags=re.IGNORECASE)
+    cleaned = ' '.join(sorted(normalize_text_for_duplicates(raw, default='').split()))
+    if cleaned:
+        return cleaned
+    # Everything was stripped (an author recorded ONLY as a domain): fall back
+    # to the original text rather than collapsing every such book together.
+    return ' '.join(sorted(normalize_text_for_duplicates(author, default='unknown').split()))
+
+
+def _volume_number_in(text):
+    """The volume a fragment names, or None.
+
+    Digits are read up to 999 only: a four-digit number is a year or part of a
+    title ("1984", "2001"), never a volume. A roman numeral counts when it is
+    two or more letters, or when a volume label precedes it — a lone "I" is
+    also an English word and an initial.
+    """
+    if not text:
+        return None
+    low = str(text).lower()
+    match = re.search(_VOLUME_LABEL + r'\.?\s*(\d{1,3})\b', low)
+    if match:
+        return int(match.group(1))
+    match = re.search(_VOLUME_LABEL + r'\.?\s*([ivx]{1,5})\b', low)
+    if match and match.group(1) in _ROMAN_VALUES:
+        return _ROMAN_VALUES[match.group(1)]
+    match = re.search(r'\b([ivx]{2,5})\b', low)
+    if match and match.group(1) in _ROMAN_VALUES:
+        return _ROMAN_VALUES[match.group(1)]
+    match = re.search(r'\b(\d{1,3})\s*$', low.strip())
+    if match:
+        return int(match.group(1))
+    return None
+
+
+def declared_volume(title, series_index=None, has_series=False):
+    """The volume this book DECLARES, or None when it declares none.
+
+    None means "does not say", NOT "volume 1" — the difference is what lets a
+    copy imported without series metadata still group with the same book that
+    has it.
+    """
+    raw = str(title) if title is not None else ''
+    annotations = ' '.join(re.findall(r'[\(\[][^()\[\]]*[\)\]]', raw))
+    volume = _volume_number_in(annotations)
+    if volume is None:
+        volume = _volume_number_in(raw)
+    if volume is None and has_series and series_index is not None:
+        try:
+            index = float(series_index)
+            if index.is_integer() and 1 <= index <= 999:
+                volume = int(index)
+        except (TypeError, ValueError):
+            pass
+    return volume
+
+
+def split_on_volume_conflict(members):
+    """Partition one stem group so sibling volumes are never grouped together.
+
+    Applied AFTER grouping, never as part of the key, with the asymmetry a
+    volume check needs: it never creates a group, it only refuses one.
+
+      - nobody declares a volume        -> one group, unchanged
+      - exactly one volume declared     -> one group; copies declaring nothing
+                                           are the same book with thinner
+                                           metadata, not a different volume
+      - two or more volumes declared    -> split per volume, and any copy that
+                                           declares NOTHING is dropped from
+                                           every group: the stem spans more
+                                           than one volume, nothing says which
+                                           this copy is, and an ambiguous book
+                                           must never be offered for automatic
+                                           deletion
+
+    This also tightens an existing false positive: sibling volumes stored under
+    one identical title (Calibre keeps the volume only in series_index) group
+    together today, and auto-resolution would delete one of them.
+
+    Args:
+        members: list of (item, volume_or_None) pairs.
+
+    Returns:
+        list of lists of item, each list one group.
+    """
+    volumes = {volume for _, volume in members if volume is not None}
+    if len(volumes) <= 1:
+        return [[item for item, _ in members]]
+    by_volume = {}
+    for item, volume in members:
+        if volume is not None:
+            by_volume.setdefault(volume, []).append(item)
+    return [by_volume[volume] for volume in sorted(by_volume)]
 
 
 def validate_resolution_strategy(strategy):
@@ -982,7 +1177,11 @@ def find_duplicate_books_python(use_title, use_author, use_language, use_series,
             key_parts.append(normalize_title_for_duplicates(title, primary_author))
 
         if use_author:
-            key_parts.append(primary_author.lower().strip() if primary_author else "unknown")
+            # canonical_author_key, not .lower().strip(): "Liu, Cixin" and
+            # "Cixin Liu" are one person and must land in one group. This also
+            # brings this path in line with duplicate_index, which already
+            # routed the author through the shared normalizer.
+            key_parts.append(canonical_author_key(primary_author) if primary_author else "unknown")
         
         if use_language:
             # Get primary language code
@@ -1025,10 +1224,46 @@ def find_duplicate_books_python(use_title, use_author, use_language, use_series,
         grouped_books[key].append(book)
     
     print(f"[cwa-duplicates] Grouped books into {len(grouped_books)} unique combinations based on selected criteria", flush=True)
-    
+
+    # Volume filter (see split_on_volume_conflict): the title stem intentionally
+    # ignores a "(Book 2)"-style annotation so one book catalogued two ways
+    # converges, which means sibling volumes can now share a stem. Split them
+    # back apart before anything is offered for resolution. Only a stem that
+    # actually spans several declared volumes is touched, so the vast majority
+    # of groups pass through unchanged and keep their existing group_hash.
+    split_groups = []
+    for key, books in grouped_books.items():
+        if len(books) < 2:
+            continue
+        members = [
+            (book, declared_volume(
+                book.title,
+                getattr(book, 'series_index', None),
+                bool(getattr(book, 'series', None)),
+            ))
+            for book in books
+        ]
+        partitions = split_on_volume_conflict(members)
+        # A discriminator is only needed when one stem produced several groups;
+        # leaving it None otherwise keeps every existing dismissal hash valid.
+        needs_discriminator = len(partitions) > 1
+        for partition in partitions:
+            if len(partition) > 1:
+                discriminator = None
+                if needs_discriminator:
+                    # Compare by id: SQLAlchemy instances are matched by
+                    # identity, and a group is small enough that this is cheap.
+                    partition_ids = {book.id for book in partition}
+                    volumes = {volume for book, volume in members
+                               if book.id in partition_ids and volume is not None}
+                    discriminator = next(iter(volumes)) if len(volumes) == 1 else None
+                split_groups.append((key, partition, discriminator))
+    if len(split_groups) != sum(1 for books in grouped_books.values() if len(books) > 1):
+        print("[cwa-duplicates] Volume filter adjusted grouping for series siblings", flush=True)
+
     # Filter to only groups with duplicates and prepare display data
     duplicate_groups = []
-    for key, books in grouped_books.items():
+    for key, books, volume_discriminator in split_groups:
         if len(books) > 1:
             # Sort books by timestamp (newest first)
             books.sort(key=lambda x: _timestamp_or_default(x.timestamp, _AWARE_MIN), reverse=True)
@@ -1058,7 +1293,7 @@ def find_duplicate_books_python(use_title, use_author, use_language, use_series,
                 display_author = books[0].author_names.split(',')[0].strip()
             
             # Generate group hash for dismiss tracking
-            group_hash = generate_group_hash(display_title, display_author)
+            group_hash = generate_group_hash(display_title, display_author, volume_discriminator)
             
             duplicate_groups.append({
                 'title': display_title,

--- a/tests/unit/test_duplicate_detection_normalize.py
+++ b/tests/unit/test_duplicate_detection_normalize.py
@@ -90,7 +90,8 @@ def test_titleless_books_never_share_a_key():
 
 def test_index_normalization_version_bumped():
     # changing the normalizer must change the fingerprint so the index rebuilds
-    assert duplicate_index.NORMALIZATION_VERSION == "duplicate-index-v3"
+    # v4: title stem (series/edition annotation) + order-independent author key
+    assert duplicate_index.NORMALIZATION_VERSION == "duplicate-index-v4"
 
 
 # --- selection strategy: which copy is kept --------------------------------

--- a/tests/unit/test_duplicate_unicode_normalization.py
+++ b/tests/unit/test_duplicate_unicode_normalization.py
@@ -117,9 +117,18 @@ class TestD6IndexSurface:
         m = re.search(r"def build_book_key_parts\(book, settings\):(.*?)\ndef ", IDX_SRC, re.S)
         assert m, "build_book_key_parts not found"
         body = m.group(1)
-        assert body.count("normalize_text_for_duplicates(") >= 4, (
+        # The author part now routes through canonical_author_key, which makes
+        # the key order-independent ("Liu, Cixin" == "Cixin Liu") and itself
+        # delegates to normalize_text_for_duplicates -- so the D6 no-drift
+        # intent holds, with one fewer literal call in this body.
+        shared_calls = (body.count("normalize_text_for_duplicates(")
+                        + body.count("canonical_author_key("))
+        assert shared_calls >= 4, (
             "author/language/series/publisher key parts must use the shared "
             "normalizer so all keying surfaces agree (D6)"
+        )
+        assert "canonical_author_key(" in body, (
+            "the author key part must use the order-independent helper"
         )
         assert ".lower().strip()" not in body, (
             "raw .lower().strip() must not survive in build_book_key_parts"

--- a/tests/unit/test_duplicate_variant_titles.py
+++ b/tests/unit/test_duplicate_variant_titles.py
@@ -1,0 +1,180 @@
+"""Variant-title duplicates: one book catalogued under two different titles.
+
+The normalizer keeps every word and number, so a book held twice under two
+different titles never grouped: sources disagree about whether to append the
+series, the volume or the imprint. Measured on a 202-book library, the scan
+returned 54 groups, every one an exact title+author collision and not a single
+variant pair.
+
+These pin both directions, because the widened key is only safe with the volume
+filter that accompanies it — duplicate resolution DELETES books:
+
+  - RECALL: "Golden Son" == "Golden Son (Red Rising Series Book 2)",
+    "The Road" == "The Road (Vintage International)", and "Liu, Cixin" ==
+    "Cixin Liu" so the author order two sources disagree on still groups;
+  - PRECISION (data-safety core): sibling volumes that share a stem must NEVER
+    group — including the pre-existing false positive where Calibre keeps the
+    volume only in series_index and both siblings carry one identical title;
+  - the ambiguity rule: inside a stem spanning several volumes, a copy that
+    declares no volume is excluded from every group rather than risked;
+  - group-hash stability: a single-group title keeps the hash it had, so
+    existing dismissals survive, while a split pair hashes apart.
+
+RED on main (no stem, no author reordering, no volume filter); GREEN on branch.
+"""
+from cps.duplicates import (
+    canonical_author_key,
+    canonical_title_stem,
+    declared_volume,
+    generate_group_hash,
+    normalize_title_for_duplicates,
+    split_on_volume_conflict,
+)
+from cps import duplicate_index
+
+
+def _groups(books):
+    """Group (title, author, series, series_index) tuples the way the scan does."""
+    buckets = {}
+    for index, (title, author, series, series_index) in enumerate(books):
+        key = (normalize_title_for_duplicates(title, author), canonical_author_key(author))
+        buckets.setdefault(key, []).append(
+            (index, declared_volume(title, series_index, bool(series)))
+        )
+    out = []
+    for members in buckets.values():
+        out.extend([g for g in split_on_volume_conflict(members) if len(g) > 1])
+    return out
+
+
+# --- RECALL: the same book written two ways collapses -----------------------
+
+def test_series_annotation_is_not_part_of_the_title():
+    assert canonical_title_stem("Golden Son (Red Rising Series Book 2)") == \
+           canonical_title_stem("Golden Son")
+
+
+def test_imprint_annotation_is_not_part_of_the_title():
+    # No marker word here, so this relies on the end-anchored trailing strip.
+    assert canonical_title_stem("The Road (Vintage International)") == \
+           canonical_title_stem("The Road")
+
+
+def test_bracketed_series_tag_is_not_part_of_the_title():
+    assert canonical_title_stem("[Wayward Pines 01] Pines") == canonical_title_stem("Pines")
+
+
+def test_author_order_does_not_matter():
+    assert canonical_author_key("Liu, Cixin") == canonical_author_key("Cixin Liu")
+
+
+def test_author_watermarks_are_ignored():
+    # A real record: a bracketed repeat of the name plus a scraper's domain.
+    assert canonical_author_key("Liu, Cixin [Liu, Cixin] || chenjin5.com") == \
+           canonical_author_key("Cixin Liu")
+
+
+def test_same_book_two_titles_groups():
+    assert len(_groups([
+        ("Golden Son", "Pierce Brown", "Red Rising", 2),
+        ("Golden Son (Red Rising Series Book 2)", "Pierce Brown", "Red Rising", 2),
+    ])) == 1
+
+
+def test_thinner_metadata_still_groups():
+    # One copy imported without series metadata: "declares nothing" is not
+    # "declares volume 1", so it must still group with its twin.
+    assert len(_groups([
+        ("Summer Frost", "Blake Crouch", "Forward", 1),
+        ("Summer Frost", "Blake Crouch", None, None),
+    ])) == 1
+
+
+# --- PRECISION: distinct books must never group -----------------------------
+
+def test_sibling_volumes_sharing_a_stem_never_group():
+    assert _groups([
+        ("Wayward Pines (Book 1)", "Blake Crouch", "Wayward Pines", 1),
+        ("Wayward Pines (Book 2)", "Blake Crouch", "Wayward Pines", 2),
+    ]) == []
+
+
+def test_identically_titled_siblings_never_group():
+    # Calibre keeps the volume ONLY in series_index here, so these two share an
+    # identical title and grouped together before the volume filter existed —
+    # auto-resolve would have deleted one.
+    assert _groups([
+        ("Wayward Pines", "Blake Crouch", "Wayward Pines", 1),
+        ("Wayward Pines", "Blake Crouch", "Wayward Pines", 2),
+    ]) == []
+
+
+def test_subtitled_siblings_never_group():
+    assert _groups([
+        ("Mistborn: The Final Empire", "Brandon Sanderson", "Mistborn", 1),
+        ("Mistborn: The Well of Ascension", "Brandon Sanderson", "Mistborn", 2),
+    ]) == []
+
+
+def test_numbered_titles_keep_their_number():
+    # The volume LABEL is dropped but the NUMBER survives into the stem.
+    assert canonical_title_stem("Wool Book 12") != canonical_title_stem("Wool Book 13")
+
+
+def test_roman_numbered_siblings_never_group():
+    assert _groups([
+        ("The Dark Tower I: The Gunslinger", "Stephen King", "The Dark Tower", 1),
+        ("The Dark Tower II: The Drawing of the Three", "Stephen King", "The Dark Tower", 2),
+    ]) == []
+
+
+def test_same_title_different_authors_never_group():
+    assert _groups([
+        ("Dark Matter", "Blake Crouch", None, None),
+        ("Dark Matter", "Michelle Paver", None, None),
+    ]) == []
+
+
+def test_four_digit_numbers_are_not_volumes():
+    # "1984" is a title and "2001" a year; neither may be read as a volume.
+    assert declared_volume("1984") is None
+    assert declared_volume("2001: A Space Odyssey") is None
+
+
+def test_annotation_only_title_does_not_collapse_to_empty():
+    # Otherwise every such book would share one empty stem and group together.
+    assert canonical_title_stem("(Boxed Set)") != ""
+
+
+# --- the ambiguity rule -----------------------------------------------------
+
+def test_volume_ambiguous_copy_is_excluded_from_every_group():
+    # Stem spans volumes 1 and 2; the third copy declares nothing, so nothing
+    # says which volume it is and it must not be offered for deletion.
+    partitions = split_on_volume_conflict([("a", 1), ("b", 2), ("c", None)])
+    assert all("c" not in partition for partition in partitions)
+
+
+def test_single_declared_volume_absorbs_undeclared_copies():
+    partitions = split_on_volume_conflict([("a", 2), ("b", None)])
+    assert partitions == [["a", "b"]]
+
+
+# --- group-hash stability ---------------------------------------------------
+
+def test_group_hash_unchanged_without_a_discriminator():
+    # Existing dismissals must survive: an unsplit group hashes as before.
+    assert generate_group_hash("Dune", "Frank Herbert") == \
+           generate_group_hash("Dune", "Frank Herbert", None)
+
+
+def test_split_groups_hash_apart():
+    # Two groups sharing one display title would otherwise dismiss together.
+    assert generate_group_hash("Wayward Pines", "Blake Crouch", 1) != \
+           generate_group_hash("Wayward Pines", "Blake Crouch", 2)
+
+
+# --- index surface ----------------------------------------------------------
+
+def test_index_normalization_version_rotated():
+    assert duplicate_index.NORMALIZATION_VERSION == "duplicate-index-v4"


### PR DESCRIPTION
# Group the same book catalogued under two different titles

## The problem

Duplicate detection keys on an exact hash of the normalized title and author.
`normalize_text_for_duplicates` folds accents and punctuation only — which is
deliberate and correct: keeping every word and number is what stops two
distinct books from colliding, and the existing tests pin exactly that.

The cost is that **one** book held twice under two *different* titles never
groups. Sources disagree about whether to append the series, the volume or the
imprint, so a library ends up holding these as unrelated books:

| | |
|---|---|
| `Golden Son` | `Golden Son (Red Rising Series Book 2)` |
| `The Road` | `The Road (Vintage International)` |
| `The Dark Forest` | `The Dark Forest (The Three-Body Problem)` |
| `Pines` | `Pines (Wayward Pines)` |
| `The Last Town` | `The Last Town (The Wayward Pines Trilogy 3)` |

Measured on a 202-book library: the scan returned **54 groups, every one an
exact title+author collision, and not a single variant pair**.

## Approach

Widening the key alone would be unsafe, so this is two halves that only work
together. Sibling volumes share a stem (`Wayward Pines (Book 1)` /
`(Book 2)`), and `execute-resolution` **deletes books**.

1. **`canonical_title_stem()`** sets series/edition/imprint annotation aside.
   The volume *label* is dropped but its *number* kept (`Book 12` → `12`), so
   `Wool Book 12` and `Wool Book 13` still differ in the stem itself and never
   reach the volume filter. Square brackets are stripped wherever they sit — a
   leading `[Wayward Pines 01]` carries no marker word — while parentheses get
   the narrower end-anchored and marker-word treatment, because they appear
   inside real titles far more often than brackets do.

2. **`canonical_author_key()`** sorts name tokens so `Liu, Cixin` and
   `Cixin Liu` are one author, after dropping bracketed repeats and domain
   watermarks (`Liu, Cixin [Liu, Cixin] || chenjin5.com` is a real author
   record). It cannot merge two different people — it only reorders tokens
   they were already spelled with. This also brings the Python grouping path
   back in line with `duplicate_index`, which had drifted to a raw
   `.lower().strip()`.

3. **`split_on_volume_conflict()`** applies the volume *after* grouping, never
   as part of the key, with the asymmetry a volume check needs: it never
   creates a group, it only refuses one.
   - nobody declares a volume → one group, unchanged
   - exactly one declared → one group; copies declaring nothing are the same
     book with thinner metadata
   - two or more declared → split per volume, and a copy declaring **nothing**
     is dropped from every group, because the stem spans several volumes and
     nothing says which this copy is

**Keying the volume directly was tried first and rejected on measurement**: it
split genuine duplicates whenever one copy had been imported without series
metadata and its twin had it — 5 such pairs in the test library
(`Summer Frost`, `The Three-Body Problem`).

## User-visible result

- The pairs above are now found as duplicates. On the 202-book library: **+17
  duplicate pairs, 0 lost**.
- **An existing false positive is closed.** Where Calibre kept the volume only
  in `series_index`, two siblings carried one identical title and grouped
  together — resolving that group would have deleted a book the library had
  only one copy of. They now split.

## Verification

- New `tests/unit/test_duplicate_variant_titles.py` — 20 cases: 8 recall, 8
  precision/data-safety (sibling volumes, subtitled siblings, `Book 12` vs
  `13`, same title different authors, four-digit numbers are not volumes), the
  ambiguity rule, and group-hash stability.
- Full unit suite in the release container, branch vs an unmodified `main`
  checkout of the same commit: **78 failed / 89 errors on both**, 205 skipped
  on both, passing 8634 → 8654. The +20 is exactly this PR's new test file, so
  the pre-existing failures are untouched and nothing new broke. Every
  duplicate-related test passes on the branch (353 passed; the 15 errors in
  `test_1167_duplicate_notification_revalidates_cache` reproduce identically
  on unmodified `main` and are environmental, not caused here).
- End-to-end with these modules mounted into the container against the
  202-book library: **54 → 53 groups**, the five variant pairs merged, no
  other group altered, no errors in the log.
- Also run against two unmodified real libraries (78 and 55 books) to check
  for false positives: the 78-book library reports 0 groups before and after;
  the 55-book one gains exactly 1 true duplicate.

## Compatibility

- `NORMALIZATION_VERSION` → `duplicate-index-v4`, so the on-disk index
  rebuilds rather than mixing old and new keys.
- `generate_group_hash` takes an optional `discriminator` so two groups
  sharing one display title hash apart. It is omitted for every single-group
  title, so **existing dismissals keep their hashes**.
- The D6 source guard in `test_duplicate_unicode_normalization` now counts
  `canonical_author_key` alongside the shared normalizer; the helper delegates
  to `normalize_text_for_duplicates`, so the no-drift intent is unchanged.

## Deliberately left out

- No fuzzy or edit-distance matching. Every rule here is a structural one that
  can be explained from the title text or Calibre's own metadata; nothing
  matches on similarity.
- Subtitles after a colon are untouched. `Mistborn: The Final Empire` and
  `Mistborn: The Well of Ascension` must stay distinct, and stripping
  subtitles would collapse them.
- No new settings. If the stem behaviour should be operator-toggleable, say so
  and I will add a criterion alongside the existing `duplicate_detection_*`
  flags.

## Authorship

The code, tests and this description were written by an AI (Claude) working
from my direction, against my own library; I reviewed the change, ran the
verification above, and am accountable for it. Flagging it explicitly rather
than leaving it implicit. No new dependencies, license changes, or external
service URLs.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
