### PR TITLE
Service status endpoints no longer 500 before the service's first run

### DIFF
--- a/changelog.d/service-log-status-before-first-run.md
+++ b/changelog.d/service-log-status-before-first-run.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **The Convert Library and EPUB Fixer pages no longer error before their
+  first run.** Each service writes its log only when it first runs, so on a
+  fresh install the file does not exist yet — and the status both pages poll
+  read it without checking, returning a 500 and writing a
+  `FileNotFoundError` traceback to the container log for as long as the page
+  stayed open. A service that has never run now simply reports no progress. A
+  log that exists but cannot be read (after a `PUID`/`PGID` change, say)
+  degrades the same way instead of failing the request.

--- a/cps/cwa_functions.py
+++ b/cps/cwa_functions.py
@@ -1998,6 +1998,29 @@ def _service_log_path(filename: str) -> str:
     """Resolve a service log beneath the active config directory."""
     return constants.config_path(filename)
 
+
+def _read_service_log(filename: str) -> str:
+    """A service log's contents, or "" when it does not exist yet.
+
+    A service writes its log only on its first run, so on any install where
+    Convert Library or the EPUB Fixer has never been started the file is
+    simply absent. The status endpoints read it on every poll, and an
+    unguarded open() turned that ordinary state into a 500 with a
+    FileNotFoundError traceback in the container log, for as long as the
+    admin page stayed open.
+
+    Empty is the honest answer: extract_progress("") already yields
+    {"current": 0, "total": 0}, which the page renders as "nothing running".
+    OSError rather than FileNotFoundError alone so an unreadable log (bad
+    permissions after a UID change, for instance) degrades the same way
+    instead of failing the request.
+    """
+    try:
+        with open(_service_log_path(filename), 'r') as log:
+            return log.read()
+    except OSError:
+        return ""
+
 ##———————————————————END OF SHARED VARIABLES & FUNCTIONS———————————————————————##
 
 def convert_library_start(queue):
@@ -2018,12 +2041,9 @@ def empty_tmp_con_dir(tmp_conversion_dir) -> None:
         print(f"[cwa-functions]: An error occurred while emptying {tmp_conversion_dir}. See the following error: {e}")
 
 def is_convert_library_finished() -> bool:
-    log_path = _service_log_path("convert-library.log")
-    with open(log_path, 'r') as log:
-        if "NextGen Convert Library Service - Run Ended: " in log.read():
-            return True
-        else:
-            return False
+    # A missing log means the service has not written anything yet, which is
+    # "not finished" -- the same answer the read would have given.
+    return "NextGen Convert Library Service - Run Ended: " in _read_service_log("convert-library.log")
 
 def kill_convert_library(queue):
     trigger_file = Path(tempfile.gettempdir() + "/.kill_convert_library_trigger")
@@ -2152,8 +2172,7 @@ def cancel_convert_library():
 @login_required_if_no_ano
 @admin_required
 def get_status():
-    with open(_service_log_path("convert-library.log"), 'r') as f:
-        status = f.read()
+    status = _read_service_log("convert-library.log")
     progress = extract_progress(status)
     statusList = {'status':status,
                   'progress':progress}
@@ -2174,12 +2193,8 @@ def epub_fixer_start(queue, input_file: str | None = None):
     queue.put(ef_process)
 
 def is_epub_fixer_finished() -> bool:
-    log_path = _service_log_path("epub-fixer.log")
-    with open(log_path, 'r') as log:
-        if "NextGen Kindle EPUB Fixer Service - Run Ended: " in log.read():
-            return True
-        else:
-            return False
+    # See is_convert_library_finished: absent log == not finished.
+    return "NextGen Kindle EPUB Fixer Service - Run Ended: " in _read_service_log("epub-fixer.log")
 
 def kill_epub_fixer(queue):
     trigger_file = Path(tempfile.gettempdir() + "/.kill_epub_fixer_trigger")
@@ -2361,8 +2376,7 @@ def cancel_epub_fixer():
 @login_required_if_no_ano
 @admin_required
 def get_status():
-    with open(_service_log_path("epub-fixer.log"), 'r') as f:
-        status = f.read()
+    status = _read_service_log("epub-fixer.log")
     progress = extract_progress(status)
     statusList = {'status':status,
                   'progress':progress}

--- a/tests/unit/test_service_status_before_first_run.py
+++ b/tests/unit/test_service_status_before_first_run.py
@@ -1,0 +1,103 @@
+# Calibre-Web Automated – fork of Calibre-Web
+# Copyright (C) 2024-2026 Calibre-Web-NextGen contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Service status endpoints on an install where the service never ran.
+
+Convert Library and the EPUB Fixer each write their log only on their first
+run, so on a fresh install the file is simply absent. Both status endpoints
+read it on every poll of their admin page, and the read was unguarded:
+
+    FileNotFoundError: [Errno 2] No such file or directory:
+        '/config/convert-library.log'
+
+which Flask turned into a 500 plus a traceback in the container log, repeating
+for as long as the page stayed open. Observed on a real install immediately
+after migrating from upstream CWA, where Convert Library had never been run.
+
+These pin the read helper rather than the routes, since the routes need an
+app context: a missing log reads as empty, an unreadable one degrades the same
+way, a present one is returned intact, and the "finished" predicates answer
+False instead of raising.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import re
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+SRC = (REPO_ROOT / "cps" / "cwa_functions.py").read_text()
+
+
+def _read_service_log(tmp_path, filename, contents=None, mode=None):
+    """Exercise the real helper body against a temp config dir."""
+    if contents is not None:
+        target = tmp_path / filename
+        target.write_text(contents)
+        if mode is not None:
+            target.chmod(mode)
+
+    def _service_log_path(name):
+        return str(tmp_path / name)
+
+    # The helper is small and has no imports of its own; run its real source
+    # so this test tracks the shipped implementation rather than a copy.
+    body = re.search(r"def _read_service_log\(filename: str\) -> str:.*?\n(?=\n\S|\ndef )",
+                     SRC, re.S)
+    assert body, "_read_service_log not found in cwa_functions.py"
+    namespace = {"_service_log_path": _service_log_path}
+    exec(compile(body.group(0), "cwa_functions.py", "exec"), namespace)
+    return namespace["_read_service_log"](filename)
+
+
+def test_missing_log_reads_as_empty(tmp_path):
+    assert _read_service_log(tmp_path, "convert-library.log") == ""
+
+
+def test_missing_epub_fixer_log_reads_as_empty(tmp_path):
+    assert _read_service_log(tmp_path, "epub-fixer.log") == ""
+
+
+def test_existing_log_is_returned_intact(tmp_path):
+    assert _read_service_log(tmp_path, "convert-library.log", "3/10 converted\n") == "3/10 converted\n"
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses file permissions, so the log stays readable")
+def test_unreadable_log_degrades_to_empty(tmp_path):
+    # A log left unreadable (e.g. after a PUID/PGID change) must not 500 either.
+    assert _read_service_log(tmp_path, "convert-library.log", "x", mode=0o000) == ""
+
+
+def test_empty_status_yields_zero_progress():
+    # What the status endpoint does with the empty string the helper returns.
+    namespace = {"re": re}
+    body = re.search(r"def extract_progress\(log_content\):.*?\n(?=\n\S|\ndef )", SRC, re.S)
+    assert body, "extract_progress not found"
+    exec(compile(body.group(0), "cwa_functions.py", "exec"), namespace)
+    assert namespace["extract_progress"]("") == {"current": 0, "total": 0}
+
+
+def test_status_routes_no_longer_open_the_log_directly():
+    # Guard against the unguarded open() coming back on either service.
+    for route in ("convert-library-status", "epub-fixer-status"):
+        m = re.search(rf"@\w+\.route\('/{route}'.*?\ndef get_status\(\):(.*?)return json\.dumps",
+                      SRC, re.S)
+        assert m, f"{route} handler not found"
+        assert "open(" not in m.group(1), (
+            f"/{route} must read its log through _read_service_log so a service "
+            "that has never run returns empty instead of raising"
+        )
+
+
+def test_finished_predicates_use_the_guarded_read():
+    for fn in ("is_convert_library_finished", "is_epub_fixer_finished"):
+        m = re.search(rf"def {fn}\(\).*?\n(?=\n\S|\ndef )", SRC, re.S)
+        assert m, f"{fn} not found"
+        assert "_read_service_log(" in m.group(0), f"{fn} must use the guarded read"
+        assert "open(" not in m.group(0), f"{fn} must not open the log directly"


### PR DESCRIPTION
# Service status endpoints no longer 500 before the service's first run

## The problem

Convert Library and the EPUB Fixer each write their log only when they first
run, so on any install where one has never been started the file is simply
absent. Both status endpoints read it on every poll of their admin page, with
an unguarded `open()`:

```
GET /convert-library-status  ->  500
FileNotFoundError: [Errno 2] No such file or directory: '/config/convert-library.log'
```

and a traceback in the container log for as long as the page stayed open.

Found on a real install immediately after migrating from upstream CWA, where
Convert Library had never been run. The same latent bug sits on
`/epub-fixer-status` — it only stays hidden where that log happens to exist
already, which is why one of the two endpoints returned 200 on the same server.

## Approach

Adds `_read_service_log()` next to the existing `_service_log_path()`, and
routes both status handlers and both "finished" predicates through it.

Empty is the honest answer for a service that has never run:
`extract_progress("")` already returns `{"current": 0, "total": 0}`, which the
page renders as nothing running. An absent log likewise means "not finished" —
the same answer the read would have given had the file existed.

It catches `OSError` rather than `FileNotFoundError` alone, so a log that
exists but cannot be read (after a `PUID`/`PGID` change, say) degrades the same
way instead of failing the request.

## Verification

Against v4.1.43 with `convert-library.log` deliberately absent:

| | before | after |
|---|---|---|
| `/convert-library-status` | **500** + traceback | `200` `{"status": "", "progress": {"current": 0, "total": 0}}` |
| `/epub-fixer-status` | 500 when its log is absent | `200`, same shape |

Container logs no traceback afterwards.

New `tests/unit/test_service_status_before_first_run.py` covers the missing,
present and unreadable cases, that an empty status yields zero progress, and
source guards so neither handler nor predicate can go back to opening the log
directly. Existing `cwa_functions` / convert-library / epub-fixer unit tests
pass unchanged (56 passed, 1 skipped).

## Deliberately left out

The writer-side `open(..., 'a')` calls are untouched: those run inside a
service that has already created its log, and appending would create it anyway.
Only the read paths, which can legitimately run before any service has, are
guarded.

## Authorship

The code, tests and this description were written by an AI (Claude) working
from my direction, against my own install; I reviewed the change, ran the
verification above, and am accountable for it. Flagging it explicitly rather
than leaving it implicit. No new dependencies, license changes, or external
service URLs.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
